### PR TITLE
Add additionalFields to fillTemplates and getUnresolvedFields utility

### DIFF
--- a/src/templates/fillTemplates.test.ts
+++ b/src/templates/fillTemplates.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-return */
 
 import { expect, test } from "vitest";
-import { fillTemplates } from "./fillTemplates.js";
+import { fillTemplates, getUnresolvedFields } from "./fillTemplates.js";
 
 test("template with simple object field", () => {
   const templates = [
@@ -443,4 +443,245 @@ test("boolean field values substituted correctly", () => {
     obj: { template: "boolField", fields: { flag: true } },
   });
   expect(result).toEqual({ enabled: true });
+});
+
+// ----------------------------------------------------------------
+// additionalFields (#22)
+// ----------------------------------------------------------------
+
+test("additionalFields resolves platform-provided placeholders", () => {
+  const templates = [
+    {
+      templateName: "stage",
+      templateContent: {
+        name: "rate_${dimension}",
+        url: "${clipUrl}",
+        startAt: "${clipStartAt}",
+      },
+    },
+  ];
+
+  const result = fillTemplates({
+    templates,
+    obj: { template: "stage", fields: { dimension: "engagement" } },
+    additionalFields: {
+      clipUrl: "https://cdn.example.com/clip1.mp4",
+      clipStartAt: 12.5,
+    },
+  });
+  expect(result).toEqual({
+    name: "rate_engagement",
+    url: "https://cdn.example.com/clip1.mp4",
+    startAt: 12.5,
+  });
+});
+
+test("additionalFields without additionalFields behaves identically", () => {
+  const templates = [
+    {
+      templateName: "simple",
+      templateContent: { name: "${n}" },
+    },
+  ];
+
+  const result = fillTemplates({
+    templates,
+    obj: { template: "simple", fields: { n: "hello" } },
+  });
+  expect(result).toEqual({ name: "hello" });
+});
+
+test("researcher fields and additionalFields coexist", () => {
+  const templates = [
+    {
+      templateName: "mixed",
+      templateContent: {
+        researcherField: "${myField}",
+        platformField: "${platformValue}",
+      },
+    },
+  ];
+
+  const result = fillTemplates({
+    templates,
+    obj: { template: "mixed", fields: { myField: "from researcher" } },
+    additionalFields: { platformValue: "from platform" },
+  });
+  expect(result).toEqual({
+    researcherField: "from researcher",
+    platformField: "from platform",
+  });
+});
+
+test("broadcast + additionalFields work together", () => {
+  const templates = [
+    {
+      templateName: "rating",
+      templateContent: {
+        name: "rate_${dimension}",
+        clip: "${clipUrl}",
+      },
+    },
+  ];
+
+  const result = fillTemplates({
+    templates,
+    obj: {
+      template: "rating",
+      broadcast: {
+        d0: [{ dimension: "engagement" }, { dimension: "confidence" }],
+      },
+    },
+    additionalFields: { clipUrl: "https://cdn.example.com/clip1.mp4" },
+  });
+  expect(result).toEqual([
+    {
+      name: "rate_engagement",
+      clip: "https://cdn.example.com/clip1.mp4",
+    },
+    {
+      name: "rate_confidence",
+      clip: "https://cdn.example.com/clip1.mp4",
+    },
+  ]);
+});
+
+test("missing additionalFields still triggers error", () => {
+  const templates = [
+    {
+      templateName: "needsMore",
+      templateContent: {
+        a: "${provided}",
+        b: "${missing}",
+      },
+    },
+  ];
+
+  expect(() =>
+    fillTemplates({
+      templates,
+      obj: { template: "needsMore" },
+      additionalFields: { provided: "here" },
+    }),
+  ).toThrow("Missing fields");
+});
+
+test("additionalFields with object values", () => {
+  const templates = [
+    {
+      templateName: "config",
+      templateContent: { settings: "${platformConfig}" },
+    },
+  ];
+
+  const result = fillTemplates({
+    templates,
+    obj: { template: "config" },
+    additionalFields: {
+      platformConfig: { quality: "high", fps: 30 },
+    },
+  });
+  expect(result).toEqual({
+    settings: { quality: "high", fps: 30 },
+  });
+});
+
+// ----------------------------------------------------------------
+// getUnresolvedFields (#23)
+// ----------------------------------------------------------------
+
+test("getUnresolvedFields returns platform placeholders", () => {
+  const templates = [
+    {
+      templateName: "stage",
+      templateContent: {
+        name: "rate_${dimension}",
+        url: "${clipUrl}",
+        startAt: "${clipStartAt}",
+        stopAt: "${clipStopAt}",
+      },
+    },
+  ];
+
+  const fields = getUnresolvedFields({
+    templates,
+    obj: { template: "stage", fields: { dimension: "engagement" } },
+  });
+  expect(fields.sort()).toEqual(
+    ["clipUrl", "clipStartAt", "clipStopAt"].sort(),
+  );
+});
+
+test("getUnresolvedFields returns empty when all fields resolved", () => {
+  const templates = [
+    {
+      templateName: "complete",
+      templateContent: { name: "${n}" },
+    },
+  ];
+
+  const fields = getUnresolvedFields({
+    templates,
+    obj: { template: "complete", fields: { n: "done" } },
+  });
+  expect(fields).toEqual([]);
+});
+
+test("getUnresolvedFields with broadcast resolves researcher fields", () => {
+  const templates = [
+    {
+      templateName: "rating",
+      templateContent: {
+        name: "rate_${dimension}",
+        clip: "${clipUrl}",
+      },
+    },
+  ];
+
+  const fields = getUnresolvedFields({
+    templates,
+    obj: {
+      template: "rating",
+      broadcast: {
+        d0: [{ dimension: "engagement" }, { dimension: "confidence" }],
+      },
+    },
+  });
+  // dimension is resolved by broadcast, clipUrl remains
+  expect(fields).toEqual(["clipUrl"]);
+});
+
+test("getUnresolvedFields does not throw", () => {
+  const templates = [
+    {
+      templateName: "incomplete",
+      templateContent: { a: "${x}", b: "${y}", c: "${z}" },
+    },
+  ];
+
+  // Should not throw — returns the unresolved fields instead
+  const fields = getUnresolvedFields({
+    templates,
+    obj: { template: "incomplete" },
+  });
+  expect(fields.sort()).toEqual(["x", "y", "z"]);
+});
+
+test("getUnresolvedFields returns unique names", () => {
+  const templates = [
+    {
+      templateName: "repeated",
+      templateContent: {
+        a: "${same}",
+        b: "prefix_${same}_suffix",
+        c: "${same}",
+      },
+    },
+  ];
+
+  const fields = getUnresolvedFields({
+    templates,
+    obj: { template: "repeated" },
+  });
+  expect(fields).toEqual(["same"]);
 });

--- a/src/templates/fillTemplates.ts
+++ b/src/templates/fillTemplates.ts
@@ -215,9 +215,11 @@ export function recursivelyFillTemplates({
 export function fillTemplates({
   obj,
   templates,
+  additionalFields,
 }: {
   obj: any;
   templates: any[];
+  additionalFields?: Record<string, any>;
 }): any {
   let newObj = recursivelyFillTemplates({ obj, templates });
 
@@ -231,6 +233,14 @@ export function fillTemplates({
     templatesRemaining = JSON.stringify(newObj).match(templatesRemainingRegex);
   }
 
+  // Apply platform-provided fields after template expansion
+  if (additionalFields && Object.keys(additionalFields).length > 0) {
+    newObj = substituteFields({
+      templateContent: newObj,
+      fields: additionalFields,
+    });
+  }
+
   // Check that all fields are filled
   const doubleCheckRegex = /\$\{[a-zA-Z0-9_]+\}/g;
   const missingFields = JSON.stringify(newObj).match(doubleCheckRegex);
@@ -239,4 +249,40 @@ export function fillTemplates({
   }
 
   return newObj;
+}
+
+/**
+ * Expand researcher-defined templates and return the set of placeholder
+ * names that remain unresolved. Useful for platforms to discover which
+ * additionalFields a treatment file expects.
+ *
+ * Does NOT throw on unresolved fields — that's the point.
+ */
+export function getUnresolvedFields({
+  obj,
+  templates,
+}: {
+  obj: any;
+  templates: any[];
+}): string[] {
+  let newObj = recursivelyFillTemplates({ obj, templates });
+
+  // Handle remaining template references (same loop as fillTemplates)
+  const templatesRemainingRegex = /"template":/g;
+  let templatesRemaining = JSON.stringify(newObj).match(
+    templatesRemainingRegex,
+  );
+  while (templatesRemaining) {
+    newObj = recursivelyFillTemplates({ obj: newObj, templates });
+    templatesRemaining = JSON.stringify(newObj).match(templatesRemainingRegex);
+  }
+
+  // Collect unresolved field names
+  const fieldRegex = /\$\{([a-zA-Z0-9_]+)\}/g;
+  const matches = JSON.stringify(newObj).matchAll(fieldRegex);
+  const fields = new Set<string>();
+  for (const match of matches) {
+    fields.add(match[1]);
+  }
+  return [...fields];
 }

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -3,4 +3,5 @@ export {
   expandTemplate,
   recursivelyFillTemplates,
   fillTemplates,
+  getUnresolvedFields,
 } from "./fillTemplates.js";


### PR DESCRIPTION
## Summary

- `fillTemplates()` accepts optional `additionalFields` for platform-provided runtime values (#22)
- `getUnresolvedFields()` returns placeholder names that remain after template expansion (#23)

## Use case

An annotation platform writes treatment files with clip-specific placeholders (`${clipUrl}`, `${clipStartAt}`). The platform provides these values per-task at runtime via `additionalFields`. `getUnresolvedFields()` lets the platform validate task configs before sessions begin.

## Changes

- `src/templates/fillTemplates.ts`: `additionalFields` parameter + `getUnresolvedFields()` function
- `src/templates/index.ts`: export `getUnresolvedFields`
- `src/templates/fillTemplates.test.ts`: 11 new tests

## Test plan

- [x] additionalFields resolves platform placeholders
- [x] Without additionalFields behaves identically
- [x] Researcher fields and additionalFields coexist
- [x] Broadcast + additionalFields work together
- [x] Missing additionalFields still triggers error
- [x] Object/array additionalFields values
- [x] getUnresolvedFields returns platform placeholders
- [x] getUnresolvedFields returns empty when all resolved
- [x] getUnresolvedFields with broadcast resolves researcher fields
- [x] getUnresolvedFields does not throw
- [x] getUnresolvedFields returns unique names

Closes #22, closes #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)