### PR TITLE
Add resolved schema types, remove unsafe eslint-disables (#2)

### DIFF
--- a/src/components/Stage.tsx
+++ b/src/components/Stage.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/unbound-method, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/unbound-method */
 import React, { useRef } from "react";
 import { useScoreContext } from "./ScoreProvider.js";
 import { Element, type ElementConfig } from "./Element.js";
@@ -9,6 +9,7 @@ import { SubmissionConditionalRender } from "./conditions/SubmissionConditionalR
 import { ScrollIndicator } from "./scroll/ScrollIndicator.js";
 import { useScrollAwareness } from "./scroll/useScrollAwareness.js";
 import type { DiscussionType } from "../schemas/treatment.js";
+import type { Condition } from "./conditions/ConditionsConditionalRender.js";
 
 // Max-width per element type — wider for surveys/qualtrics/video
 function maxWidthForElement(element: ElementConfig): string {
@@ -58,7 +59,7 @@ function WrappedElement({
         position={position}
       >
         <ConditionsConditionalRender
-          conditions={(element.conditions as never[]) ?? []}
+          conditions={(element.conditions as Condition[]) ?? []}
           resolve={resolve}
         >
           <div
@@ -151,7 +152,9 @@ export function Stage({ stage, onSubmit }: StageProps) {
 
   // Two-column layout: discussion on left, elements on right
   if (showDiscussion && renderDiscussion && stage.discussion) {
-    const discussionConditions = stage.discussion.conditions;
+    const discussionConditions = stage.discussion.conditions as
+      | Condition[]
+      | undefined;
 
     const discussionPage = (
       <div
@@ -207,7 +210,7 @@ export function Stage({ stage, onSubmit }: StageProps) {
       >
         {discussionConditions && discussionConditions.length > 0 ? (
           <ConditionsConditionalRender
-            conditions={discussionConditions as never[]}
+            conditions={discussionConditions}
             resolve={resolve}
             fallback={
               <div

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -72,3 +72,17 @@ export {
   type TreatmentFileType,
   type DiscussionType,
 } from "./treatment.js";
+
+export {
+  resolvedElementSchema,
+  resolvedStageSchema,
+  resolvedIntroExitStepSchema,
+  resolvedTreatmentSchema,
+  resolvedConditionSchema,
+  resolvedConditionsSchema,
+  type ResolvedElementType,
+  type ResolvedStageType,
+  type ResolvedIntroExitStepType,
+  type ResolvedTreatmentType,
+  type ResolvedConditionType,
+} from "./resolved.js";

--- a/src/schemas/resolved.ts
+++ b/src/schemas/resolved.ts
@@ -1,0 +1,166 @@
+/**
+ * Resolved (post-hydration) schemas for component consumption.
+ *
+ * These schemas describe what treatment data looks like AFTER template
+ * expansion — no template contexts, no ${field} placeholders. They provide
+ * proper TypeScript types for Stage, Element, and other component props.
+ *
+ * The full schemas in treatment.ts (with altTemplateContext wrappers) are
+ * used for validating raw treatment files. These resolved schemas are used
+ * by rendering components that only see hydrated data.
+ */
+import { z } from "zod";
+import {
+  nameSchema,
+  descriptionSchema,
+  durationSchema,
+  displayTimeSchema,
+  hideTimeSchema,
+  positionSchema,
+  positionSelectorSchema,
+  showToPositionsSchema,
+  hideFromPositionsSchema,
+  discussionSchema,
+  referenceSchema,
+} from "./treatment.js";
+
+// ----------------------------------------------------------------
+// Resolved condition — no template placeholders in values
+// ----------------------------------------------------------------
+
+const resolvedConditionSchema = z
+  .object({
+    reference: referenceSchema,
+    position: z
+      .enum(["shared", "player", "all", "any", "percentAgreement"])
+      .or(z.number().nonnegative().int())
+      .optional(),
+    comparator: z.enum([
+      "exists",
+      "doesNotExist",
+      "equals",
+      "doesNotEqual",
+      "isAbove",
+      "isBelow",
+      "isAtLeast",
+      "isAtMost",
+      "hasLengthAtLeast",
+      "hasLengthAtMost",
+      "includes",
+      "doesNotInclude",
+      "matches",
+      "doesNotMatch",
+      "isOneOf",
+      "isNotOneOf",
+    ]),
+    value: z
+      .union([
+        z.string(),
+        z.number(),
+        z.boolean(),
+        z.array(z.string().or(z.number())),
+      ])
+      .optional(),
+  })
+  .strict();
+
+const resolvedConditionsSchema = z.array(resolvedConditionSchema).optional();
+
+// ----------------------------------------------------------------
+// Resolved element — concrete type union, no placeholders
+// ----------------------------------------------------------------
+
+const resolvedElementBaseSchema = z.object({
+  type: z.string(),
+  name: nameSchema.optional(),
+  desc: descriptionSchema.optional(),
+  file: z.string().optional(),
+  displayTime: displayTimeSchema.optional(),
+  hideTime: hideTimeSchema.optional(),
+  showToPositions: showToPositionsSchema.optional(),
+  hideFromPositions: hideFromPositionsSchema.optional(),
+  conditions: resolvedConditionsSchema,
+  tags: z.array(z.string()).optional(),
+  // Allow additional fields for specific element types
+  shared: z.boolean().optional(),
+  buttonText: z.string().optional(),
+  url: z.string().optional(),
+  displayText: z.string().optional(),
+  reference: z.string().optional(),
+  position: positionSelectorSchema.optional(),
+  surveyName: z.string().optional(),
+  startTime: z.number().optional(),
+  endTime: z.number().optional(),
+  warnTimeRemaining: z.number().optional(),
+  style: z.enum(["thin", "regular", "thick", ""]).optional(),
+  width: z.number().optional(),
+  urlParams: z
+    .array(
+      z.object({
+        key: z.string(),
+        value: z.union([z.string(), z.number(), z.boolean()]).optional(),
+        reference: z.string().optional(),
+        position: positionSelectorSchema.optional(),
+      }),
+    )
+    .optional(),
+});
+
+export const resolvedElementSchema = resolvedElementBaseSchema;
+export type ResolvedElementType = z.infer<typeof resolvedElementSchema>;
+
+// ----------------------------------------------------------------
+// Resolved stage — concrete duration, resolved elements
+// ----------------------------------------------------------------
+
+export const resolvedStageSchema = z.object({
+  name: nameSchema,
+  desc: descriptionSchema.optional(),
+  discussion: discussionSchema.optional(),
+  duration: durationSchema,
+  elements: z.array(resolvedElementSchema).nonempty(),
+});
+export type ResolvedStageType = z.infer<typeof resolvedStageSchema>;
+
+// ----------------------------------------------------------------
+// Resolved intro/exit step — no duration, no position visibility
+// ----------------------------------------------------------------
+
+export const resolvedIntroExitStepSchema = z.object({
+  name: nameSchema,
+  desc: descriptionSchema.optional(),
+  elements: z.array(resolvedElementSchema).nonempty(),
+});
+export type ResolvedIntroExitStepType = z.infer<
+  typeof resolvedIntroExitStepSchema
+>;
+
+// ----------------------------------------------------------------
+// Resolved treatment — concrete playerCount, resolved stages
+// ----------------------------------------------------------------
+
+export const resolvedTreatmentSchema = z.object({
+  name: nameSchema,
+  desc: descriptionSchema.optional(),
+  playerCount: z.number(),
+  groupComposition: z
+    .array(
+      z.object({
+        desc: descriptionSchema.optional(),
+        position: positionSchema,
+        title: z.string().max(25).optional(),
+        conditions: resolvedConditionsSchema,
+      }),
+    )
+    .optional(),
+  gameStages: z.array(resolvedStageSchema).nonempty(),
+  exitSequence: z.array(resolvedIntroExitStepSchema).optional(),
+});
+export type ResolvedTreatmentType = z.infer<typeof resolvedTreatmentSchema>;
+
+// ----------------------------------------------------------------
+// Re-export resolved condition type
+// ----------------------------------------------------------------
+
+export { resolvedConditionSchema, resolvedConditionsSchema };
+export type ResolvedConditionType = z.infer<typeof resolvedConditionSchema>;


### PR DESCRIPTION
## Summary

Adds post-hydration schema types for component consumption and cleans up type safety in Stage.tsx.

## Changes

**New: `src/schemas/resolved.ts`**
- `ResolvedElementType` — concrete element with typed fields
- `ResolvedStageType` — stage with concrete duration and resolved elements
- `ResolvedTreatmentType` — treatment with resolved stages and exit sequence
- `ResolvedIntroExitStepType` — intro/exit step
- `ResolvedConditionType` — condition with typed comparator enum

**Cleanup: `Stage.tsx`**
- Removed `eslint-disable` for `no-unsafe-assignment` and `no-unsafe-member-access`
- Replaced `as never[]` casts with proper `as Condition[]` types
- Typed `discussionConditions` as `Condition[] | undefined`
- Lint: 0 errors (was 3 unsafe errors)

## Test plan
- [x] All 160 vitest tests pass
- [x] All 146 Playwright CT tests pass
- [x] `npm run lint`: 0 errors, 9 warnings (unchanged, all in treatment.ts)

Closes #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)