### PR TITLE
Require advancement element in every intro/exit step

### DIFF
--- a/src/schemas/treatment.test.ts
+++ b/src/schemas/treatment.test.ts
@@ -6,6 +6,8 @@ import {
   discussionSchema,
   elementsSchema,
   elementSchema,
+  introStepsSchema,
+  exitStepsSchema,
   mediaPlayerSchema,
   promptSchema,
   treatmentFileSchema,
@@ -515,6 +517,143 @@ test("mediaPlayer: startAt < stopAt is valid", () => {
     startAt: 10,
     stopAt: 90,
   });
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(true);
+});
+
+// ----------- introStepsSchema / exitStepsSchema: advancement element requirement ------------
+
+test("intro step with submitButton is valid", () => {
+  const result = introStepsSchema.safeParse([
+    {
+      name: "consent",
+      elements: [
+        { type: "prompt", file: "intro/consent.md" },
+        { type: "submitButton", buttonText: "I agree" },
+      ],
+    },
+  ]);
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(true);
+});
+
+test("intro step with only prompt and no submitButton is invalid", () => {
+  const result = introStepsSchema.safeParse([
+    {
+      name: "consent",
+      elements: [{ type: "prompt", file: "intro/consent.md" }],
+    },
+  ]);
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(false);
+});
+
+test("intro step with survey element and no submitButton is invalid", () => {
+  const result = introStepsSchema.safeParse([
+    {
+      name: "party_affiliation",
+      elements: [{ type: "survey", surveyName: "PoliticalPartyUS" }],
+    },
+  ]);
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(false);
+});
+
+test("intro step with survey element and submitButton is valid", () => {
+  const result = introStepsSchema.safeParse([
+    {
+      name: "party_affiliation",
+      elements: [
+        { type: "survey", surveyName: "PoliticalPartyUS" },
+        { type: "submitButton", buttonText: "Continue" },
+      ],
+    },
+  ]);
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(true);
+});
+
+test("intro step with qualtrics element auto-submits (no submitButton needed)", () => {
+  const result = introStepsSchema.safeParse([
+    {
+      name: "screener",
+      elements: [
+        {
+          type: "qualtrics",
+          url: "https://upenn.qualtrics.com/jfe/form/SV_xxx",
+        },
+      ],
+    },
+  ]);
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(true);
+});
+
+test("intro step with mediaPlayer submitOnComplete auto-submits (no submitButton needed)", () => {
+  const result = introStepsSchema.safeParse([
+    {
+      name: "watch_video",
+      elements: [
+        {
+          type: "mediaPlayer",
+          url: "shared/intro.mp4",
+          submitOnComplete: true,
+        },
+      ],
+    },
+  ]);
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(true);
+});
+
+test("intro step with mediaPlayer without submitOnComplete requires submitButton", () => {
+  const result = introStepsSchema.safeParse([
+    {
+      name: "watch_video",
+      elements: [{ type: "mediaPlayer", url: "shared/intro.mp4" }],
+    },
+  ]);
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(false);
+});
+
+test("exit step with submitButton is valid", () => {
+  const result = exitStepsSchema.safeParse([
+    {
+      name: "debrief",
+      elements: [
+        { type: "prompt", file: "exit/debrief.md" },
+        { type: "submitButton", buttonText: "Done" },
+      ],
+    },
+  ]);
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(true);
+});
+
+test("exit step with only prompt and no submitButton is invalid", () => {
+  const result = exitStepsSchema.safeParse([
+    {
+      name: "debrief",
+      elements: [{ type: "prompt", file: "exit/debrief.md" }],
+    },
+  ]);
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(false);
+});
+
+test("exit step with qualtrics auto-submits (no submitButton needed)", () => {
+  const result = exitStepsSchema.safeParse([
+    {
+      name: "exit_survey",
+      elements: [
+        {
+          type: "qualtrics",
+          url: "https://upenn.qualtrics.com/jfe/form/SV_yyy",
+        },
+      ],
+    },
+  ]);
   if (!result.success) console.log(result.error.message);
   expect(result.success).toBe(true);
 });

--- a/src/schemas/treatment.test.ts
+++ b/src/schemas/treatment.test.ts
@@ -548,25 +548,11 @@ test("intro step with only prompt and no submitButton is invalid", () => {
   expect(result.success).toBe(false);
 });
 
-test("intro step with survey element and no submitButton is invalid", () => {
+test("intro step with survey element auto-submits (no submitButton needed)", () => {
   const result = introStepsSchema.safeParse([
     {
       name: "party_affiliation",
       elements: [{ type: "survey", surveyName: "PoliticalPartyUS" }],
-    },
-  ]);
-  if (!result.success) console.log(result.error.message);
-  expect(result.success).toBe(false);
-});
-
-test("intro step with survey element and submitButton is valid", () => {
-  const result = introStepsSchema.safeParse([
-    {
-      name: "party_affiliation",
-      elements: [
-        { type: "survey", surveyName: "PoliticalPartyUS" },
-        { type: "submitButton", buttonText: "Continue" },
-      ],
     },
   ]);
   if (!result.success) console.log(result.error.message);

--- a/src/schemas/treatment.ts
+++ b/src/schemas/treatment.ts
@@ -1079,12 +1079,13 @@ export const introExitStepsBaseSchema = altTemplateContext(
 export const introExitStepsSchema = introExitStepsBaseSchema;
 
 // Returns true if the element allows the step to advance without a separate
-// submitButton: qualtrics auto-submits on survey completion; mediaPlayer
+// submitButton: survey/qualtrics auto-submit on completion; mediaPlayer
 // auto-submits when submitOnComplete is set.
 function isAutoAdvanceElement(element: ElementType): boolean {
   if (!element || typeof element !== "object") return false;
   const el = element as Record<string, unknown>;
   if (el.type === "submitButton") return true;
+  if (el.type === "survey") return true;
   if (el.type === "qualtrics") return true;
   if (el.type === "mediaPlayer" && el.submitOnComplete === true) return true;
   return false;
@@ -1135,7 +1136,7 @@ export const introStepsSchema = introExitStepsBaseSchema.superRefine(
             code: z.ZodIssueCode.custom,
             path: [stepIdx, "elements"],
             message:
-              "Intro/exit step must include at least one submitButton element, or a qualtrics or mediaPlayer element with submitOnComplete.",
+              "Intro/exit step must include at least one submitButton element, or a survey, qualtrics, or mediaPlayer element with submitOnComplete.",
           });
         }
       }
@@ -1167,7 +1168,7 @@ export const exitStepsSchema = introExitStepsBaseSchema.superRefine(
             code: z.ZodIssueCode.custom,
             path: [stepIdx, "elements"],
             message:
-              "Intro/exit step must include at least one submitButton element, or a qualtrics or mediaPlayer element with submitOnComplete.",
+              "Intro/exit step must include at least one submitButton element, or a survey, qualtrics, or mediaPlayer element with submitOnComplete.",
           });
         }
       }

--- a/src/schemas/treatment.ts
+++ b/src/schemas/treatment.ts
@@ -1078,10 +1078,11 @@ export const introExitStepsBaseSchema = altTemplateContext(
 // Backwards compatibility export for downstream packages still referencing the legacy name.
 export const introExitStepsSchema = introExitStepsBaseSchema;
 
-// Returns true if the element allows the step to advance without a separate
-// submitButton: survey/qualtrics auto-submit on completion; mediaPlayer
-// auto-submits when submitOnComplete is set.
-function isAutoAdvanceElement(element: ElementType): boolean {
+// Returns true if the element satisfies the advancement requirement for an
+// intro/exit step: submitButton (explicit), survey/qualtrics (auto-submit on
+// completion), or mediaPlayer with submitOnComplete: true (auto-submits when
+// playback ends).
+function isAdvancementElement(element: ElementType): boolean {
   if (!element || typeof element !== "object") return false;
   const el = element as Record<string, unknown>;
   if (el.type === "submitButton") return true;
@@ -1108,21 +1109,29 @@ export const introStepsSchema = introExitStepsBaseSchema.superRefine(
               message: `Prompt element in intro/exit steps cannot be shared.`,
             });
           }
-          if ("position" in element) {
+          if (element && typeof element === "object" && "position" in element) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               path: [stepIdx, "elements", elementIdx, "position"],
               message: `Elements in intro steps cannot have a 'position' field.`,
             });
           }
-          if ("showToPositions" in element) {
+          if (
+            element &&
+            typeof element === "object" &&
+            "showToPositions" in element
+          ) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               path: [stepIdx, "elements", elementIdx],
               message: `Elements in intro steps cannot have a 'showToPositions' field.`,
             });
           }
-          if ("hideFromPositions" in element) {
+          if (
+            element &&
+            typeof element === "object" &&
+            "hideFromPositions" in element
+          ) {
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               path: [stepIdx, "elements", elementIdx],
@@ -1131,12 +1140,12 @@ export const introStepsSchema = introExitStepsBaseSchema.superRefine(
           }
         });
 
-        if (!step.elements.some(isAutoAdvanceElement)) {
+        if (!step.elements.some(isAdvancementElement)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: [stepIdx, "elements"],
             message:
-              "Intro/exit step must include at least one submitButton element, or a survey, qualtrics, or mediaPlayer element with submitOnComplete.",
+              "Intro/exit step must include at least one advancement element: submitButton, survey, qualtrics, or mediaPlayer with submitOnComplete: true.",
           });
         }
       }
@@ -1163,12 +1172,12 @@ export const exitStepsSchema = introExitStepsBaseSchema.superRefine(
           }
         });
 
-        if (!step.elements.some(isAutoAdvanceElement)) {
+        if (!step.elements.some(isAdvancementElement)) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: [stepIdx, "elements"],
             message:
-              "Intro/exit step must include at least one submitButton element, or a survey, qualtrics, or mediaPlayer element with submitOnComplete.",
+              "Intro/exit step must include at least one advancement element: submitButton, survey, qualtrics, or mediaPlayer with submitOnComplete: true.",
           });
         }
       }

--- a/src/schemas/treatment.ts
+++ b/src/schemas/treatment.ts
@@ -1078,6 +1078,18 @@ export const introExitStepsBaseSchema = altTemplateContext(
 // Backwards compatibility export for downstream packages still referencing the legacy name.
 export const introExitStepsSchema = introExitStepsBaseSchema;
 
+// Returns true if the element allows the step to advance without a separate
+// submitButton: qualtrics auto-submits on survey completion; mediaPlayer
+// auto-submits when submitOnComplete is set.
+function isAutoAdvanceElement(element: ElementType): boolean {
+  if (!element || typeof element !== "object") return false;
+  const el = element as Record<string, unknown>;
+  if (el.type === "submitButton") return true;
+  if (el.type === "qualtrics") return true;
+  if (el.type === "mediaPlayer" && el.submitOnComplete === true) return true;
+  return false;
+}
+
 export const introStepsSchema = introExitStepsBaseSchema.superRefine(
   (data, ctx) => {
     data?.forEach((step: IntroExitStepType, stepIdx: number) => {
@@ -1117,6 +1129,15 @@ export const introStepsSchema = introExitStepsBaseSchema.superRefine(
             });
           }
         });
+
+        if (!step.elements.some(isAutoAdvanceElement)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [stepIdx, "elements"],
+            message:
+              "Intro/exit step must include at least one submitButton element, or a qualtrics or mediaPlayer element with submitOnComplete.",
+          });
+        }
       }
     });
   },
@@ -1140,6 +1161,15 @@ export const exitStepsSchema = introExitStepsBaseSchema.superRefine(
             });
           }
         });
+
+        if (!step.elements.some(isAutoAdvanceElement)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [stepIdx, "elements"],
+            message:
+              "Intro/exit step must include at least one submitButton element, or a qualtrics or mediaPlayer element with submitOnComplete.",
+          });
+        }
       }
     });
   },


### PR DESCRIPTION
## Summary

- Every intro and exit step must now contain at least one element that lets the participant advance: a `submitButton`, a `survey` element (auto-submits on completion), a `qualtrics` element (auto-submits on completion), or a `mediaPlayer` with `submitOnComplete: true`
- Adds `isAutoAdvanceElement()` helper in `treatment.ts` and wires the check into both `introStepsSchema` and `exitStepsSchema` via `superRefine`

## Test plan

- [ ] Intro step with only a `prompt` → invalid (no advancement element)
- [ ] Intro step with only a `survey` → valid (auto-submits on completion)
- [ ] Intro step with `qualtrics` → valid (auto-submits on completion)
- [ ] Intro step with `mediaPlayer` + `submitOnComplete: true` → valid (auto-submits)
- [ ] Intro step with `mediaPlayer` without `submitOnComplete` → invalid
- [ ] Exit step with only a `prompt` → invalid
- [ ] Exit step with `qualtrics` → valid

Closes #30