### PR TITLE
Add custom helper text option to TrackedLink element

### DIFF
--- a/docs/researcher/elements.md
+++ b/docs/researcher/elements.md
@@ -239,6 +239,26 @@ An instrumented external link that records click/blur/focus events and time spen
       value: deliberation_lab
 ```
 
+By default a short helper line appears below the link reminding participants the
+link opens in a new tab. Override it with `helperText` to give task-specific
+guidance, or set it to an empty string to hide the helper entirely:
+
+```yaml
+- type: trackedLink
+  name: signup_link
+  url: https://example.org/form
+  displayText: Complete the bonus signup form
+  helperText: "You'll need about 5 minutes. Return here when you're done."
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `name` | string | yes | Storage key for the tracking record |
+| `url` | string | yes | Destination URL |
+| `displayText` | string | yes | Visible link text |
+| `helperText` | string | no | Text shown below the link. Defaults to "Link opens in a new tab. Return to this tab to complete the study." Pass an empty string to hide. |
+| `urlParams` | list | no | Query parameters appended to the URL (see Qualtrics example) |
+
 ## Shared Notepad
 
 A collaborative text editor (backed by Etherpad) where participants can write together.

--- a/docs/researcher/syntax-reference.md
+++ b/docs/researcher/syntax-reference.md
@@ -79,7 +79,7 @@ All elements accept: `name?`, `desc?`, `file?`, `displayTime?`, `hideTime?`, `sh
 | `mediaPlayer` | `url` (required), `name`, `controls?`, `syncToStageTime?`, `submitOnComplete?`, `startAt?`, `stopAt?`, `stepDuration?`, `playVideo?`, `playAudio?`, `captionsFile?`, `allowScrubOutsideBounds?` |
 | `survey` | `surveyName` (required) |
 | `qualtrics` | `url` (required), `urlParams?` |
-| `trackedLink` | `name` (required), `url` (required), `displayText` (required), `urlParams?` |
+| `trackedLink` | `name` (required), `url` (required), `displayText` (required), `helperText?`, `urlParams?` |
 | `sharedNotepad` | _(no extra fields)_ |
 | `talkMeter` | _(no extra fields)_ |
 

--- a/src/components/Element.tsx
+++ b/src/components/Element.tsx
@@ -57,6 +57,7 @@ export interface ElementConfig {
   buttonText?: string;
   url?: string;
   displayText?: string;
+  helperText?: string;
   urlParams?: Array<{
     key: string;
     value?: unknown;

--- a/src/components/Element.tsx
+++ b/src/components/Element.tsx
@@ -277,6 +277,7 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
           name={element.name ?? ""}
           url={element.url ?? ""}
           displayText={element.displayText ?? ""}
+          helperText={element.helperText}
           resolvedParams={resolvedParams}
           save={wrappedSave}
           getElapsedTime={getElapsedTime}

--- a/src/components/elements/TrackedLink.ct.tsx
+++ b/src/components/elements/TrackedLink.ct.tsx
@@ -34,7 +34,9 @@ test("link opens in new tab", async ({ mount }) => {
   await expect(component.locator("a")).toHaveAttribute("rel", /noreferrer/);
 });
 
-test("shows helper text about new tab", async ({ mount }) => {
+test("shows default helper text when helperText prop is omitted", async ({
+  mount,
+}) => {
   const component = await mount(
     <TrackedLink
       name="signup"
@@ -45,7 +47,46 @@ test("shows helper text about new tab", async ({ mount }) => {
       progressLabel="game_0_test"
     />,
   );
-  await expect(component).toContainText("opens in a new tab");
+  await expect(component).toContainText(
+    "Link opens in a new tab. Return to this tab to complete the study.",
+  );
+});
+
+test("renders custom helperText when provided", async ({ mount }) => {
+  const component = await mount(
+    <TrackedLink
+      name="signup"
+      url="https://example.org/form"
+      displayText="Open form"
+      helperText="You'll need about 5 minutes. Return here when done."
+      save={() => {}}
+      getElapsedTime={() => 0}
+      progressLabel="game_0_test"
+    />,
+  );
+  await expect(component).toContainText(
+    "You'll need about 5 minutes. Return here when done.",
+  );
+  // Default text should not appear when custom helperText is provided
+  await expect(component).not.toContainText(
+    "Return to this tab to complete the study",
+  );
+});
+
+test("empty helperText hides the helper line entirely", async ({ mount }) => {
+  const component = await mount(
+    <TrackedLink
+      name="signup"
+      url="https://example.org/form"
+      displayText="Open form"
+      helperText=""
+      save={() => {}}
+      getElapsedTime={() => 0}
+      progressLabel="game_0_test"
+    />,
+  );
+  await expect(component).not.toContainText("opens in a new tab");
+  await expect(component.locator("p")).toHaveCount(0);
 });
 
 test("appends resolved params to URL", async ({ mount }) => {

--- a/src/components/elements/TrackedLink.tsx
+++ b/src/components/elements/TrackedLink.tsx
@@ -25,12 +25,16 @@ export interface TrackedLinkProps {
   name: string;
   url: string;
   displayText: string;
+  helperText?: string;
   resolvedParams?: ResolvedParam[];
   save: (key: string, value: unknown) => void;
   getElapsedTime: () => number;
   progressLabel: string;
   setAllowIdle?: (allow: boolean) => void;
 }
+
+const DEFAULT_HELPER_TEXT =
+  "Link opens in a new tab. Return to this tab to complete the study.";
 
 interface LinkEvent {
   type: string;
@@ -55,12 +59,14 @@ export function TrackedLink({
   name,
   url,
   displayText,
+  helperText,
   resolvedParams = [],
   save,
   getElapsedTime,
   progressLabel,
   setAllowIdle,
 }: TrackedLinkProps) {
+  const resolvedHelperText = helperText ?? DEFAULT_HELPER_TEXT;
   const awayTrackerRef = useRef<{ startedAt: number; clickAt: number } | null>(
     null,
   );
@@ -176,15 +182,17 @@ export function TrackedLink({
         <span>{displayText}</span>
         <ExternalLinkIcon />
       </a>
-      <p
-        style={{
-          fontSize: "0.75rem",
-          color: "var(--score-text-muted, #6b7280)",
-          margin: 0,
-        }}
-      >
-        Link opens in a new tab. Return to this tab to complete the study.
-      </p>
+      {resolvedHelperText && (
+        <p
+          style={{
+            fontSize: "0.75rem",
+            color: "var(--score-text-muted, #6b7280)",
+            margin: 0,
+          }}
+        >
+          {resolvedHelperText}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/schemas/resolved.ts
+++ b/src/schemas/resolved.ts
@@ -86,6 +86,7 @@ const resolvedElementBaseSchema = z.object({
   buttonText: z.string().optional(),
   url: z.string().optional(),
   displayText: z.string().optional(),
+  helperText: z.string().optional(),
   reference: z.string().optional(),
   position: positionSelectorSchema.optional(),
   surveyName: z.string().optional(),

--- a/src/schemas/treatment.test.ts
+++ b/src/schemas/treatment.test.ts
@@ -187,6 +187,35 @@ test("tracked link element validation", () => {
   expect(result.success).toBe(true);
 });
 
+test("tracked link with custom helperText", () => {
+  const elements = [
+    {
+      type: "trackedLink",
+      name: "signup_link",
+      url: "https://example.org",
+      displayText: "Open signup form",
+      helperText: "You'll need about 5 minutes. Return here when done.",
+    },
+  ];
+  const result = elementsSchema.safeParse(elements);
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(true);
+});
+
+test("tracked link rejects non-string helperText", () => {
+  const elements = [
+    {
+      type: "trackedLink",
+      name: "signup_link",
+      url: "https://example.org",
+      displayText: "Open signup form",
+      helperText: 42,
+    },
+  ];
+  const result = elementsSchema.safeParse(elements);
+  expect(result.success).toBe(false);
+});
+
 test("validate entire file", () => {
   const fileJson = {
     templates: [

--- a/src/schemas/treatment.ts
+++ b/src/schemas/treatment.ts
@@ -860,6 +860,7 @@ const trackedLinkSchema = elementBaseSchema
     name: nameSchema,
     url: urlSchema,
     displayText: z.string().min(1),
+    helperText: z.string().optional(),
     urlParams: z
       .array(trackedLinkParamSchema, {
         invalid_type_error:


### PR DESCRIPTION
## Summary
- Add optional `helperText` field to `trackedLink` element schema
- Custom text replaces the default "Link opens in a new tab..." helper line
- Empty string hides the helper line entirely
- Default behavior unchanged when `helperText` is omitted

Closes #6

## Changes
- **Schema** (`treatment.ts`): `helperText: z.string().optional()` on `trackedLinkSchema`
- **Resolved schema** (`resolved.ts`): mirror field in resolved element base
- **TrackedLink component**: accept `helperText` prop with default fallback; empty string hides `<p>`
- **Element router**: pass `element.helperText` through to TrackedLink
- **Tests**: 2 new schema tests + 3 new CT tests (default, custom, empty)
- **Docs**: researcher elements guide + syntax reference updated

## Test plan
- [x] Schema accepts valid `helperText` string on trackedLink
- [x] Schema rejects non-string `helperText`
- [x] Default helper text renders when prop omitted
- [x] Custom helper text renders and replaces default
- [x] Empty string hides helper line entirely
- [x] All 279 vitest tests pass
- [x] All Element + TrackedLink CT tests pass (19/19)
- [x] Lint and format clean (zero new warnings)

https://claude.ai/code/session_015BdkvRDH7JMxVjUboRMi75