### PR TITLE
Fix last missed SCORE reference in Playwright HTML

### DIFF
--- a/playwright/index.html
+++ b/playwright/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>SCORE Component Tests</title>
+    <title>Stagebook Component Tests</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Fixes the last remaining `SCORE` reference missed during the rename to Stagebook (#57)
- Updates `<title>` in `playwright/index.html` from "SCORE Component Tests" to "Stagebook Component Tests"
- Verified: build passes, all 457 tests pass, lint clean (0 errors)

## Test plan
- [x] `npm run build` — passes
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 457/457 pass
- [x] Case-insensitive grep for remaining SCORE references — none found (remaining `score` hits are the generic English word in survey paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)