### PR TITLE
Add MIT license, rename to unscoped stagebook, add publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npx playwright install --with-deps chromium
-      - run: npm run test:ct -w @deliberation-lab/stagebook
+      - run: npm run test:ct -w stagebook
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm test
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npx playwright install --with-deps chromium
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,26 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run format:check
+      - run: npm test
+      - run: npm run build
+      - run: npm publish -w stagebook --provenance --access public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ This is an **npm workspaces monorepo** with two packages:
 ```
 stagebook/                          # workspace root
 ├── packages/
-│   └── stagebook/                  # npm library: @deliberation-lab/stagebook
+│   └── stagebook/                  # npm library: stagebook
 │       ├── src/
 │       │   ├── schemas/
 │       │   │   ├── treatment.ts          # treatmentFileSchema, element/stage/condition/discussion/template schemas + types
@@ -87,7 +87,7 @@ stagebook/                          # workspace root
 │       │   │   └── form/                 # RadioGroup, CheckboxGroup, TextArea, Slider, ListSorter, Markdown, Button
 │       │   └── index.ts                  # top-level re-exports (schemas, utils, templates)
 │       ├── playwright/                   # Playwright CT test infrastructure
-│       ├── package.json                  # @deliberation-lab/stagebook
+│       ├── package.json                  # stagebook
 │       ├── tsconfig.json
 │       ├── tsup.config.ts                # dual CJS/ESM + dts generation
 │       ├── vitest.config.ts
@@ -96,7 +96,7 @@ stagebook/                          # workspace root
 ├── apps/
 │   └── viewer/                     # Vite SPA: interactive study previewer
 │       ├── src/
-│       ├── package.json            # @deliberation-lab/stagebook-viewer (private)
+│       ├── package.json            # stagebook-viewer (private)
 │       ├── tsconfig.json
 │       └── vite.config.ts
 ├── docs/                           # repo-level documentation
@@ -111,13 +111,13 @@ stagebook/                          # workspace root
 ### Workspaces
 
 - **Root scripts** delegate to all workspaces: `npm run build`, `npm test`, `npm run lint`
-- **Library-specific commands**: `npm run build -w @deliberation-lab/stagebook`
-- **Viewer-specific commands**: `npm run dev -w @deliberation-lab/stagebook-viewer`
+- **Library-specific commands**: `npm run build -w stagebook`
+- **Viewer-specific commands**: `npm run dev -w stagebook-viewer`
 - The viewer imports the library via workspace link (resolves to source, not published npm)
 
 ### Package Exports
 
-- `@deliberation-lab/stagebook` — schemas, utils, templates (no React dependency)
-- `@deliberation-lab/stagebook/components` — React components, StagebookProvider (peer-depends on React)
+- `stagebook` — schemas, utils, templates (no React dependency)
+- `stagebook/components` — React components, StagebookProvider (peer-depends on React)
 
 Each directory has an `index.ts` barrel; `src/index.ts` re-exports the full public API for the main entrypoint.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 James Houghton
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Peer dependencies: `zod >= 3.23`, `js-yaml >= 4`. React components additionally 
 ### Validating a treatment file
 
 ```typescript
-import { treatmentFileSchema } from "@deliberation-lab/stagebook";
+import { treatmentFileSchema } from "stagebook";
 import { load as loadYaml } from "js-yaml";
 
 const config = loadYaml(yamlString);
@@ -46,7 +46,7 @@ if (!result.success) {
 `promptFileSchema` takes raw markdown, parses it, and validates structure, metadata, response format, and slider labels in a single pass:
 
 ```typescript
-import { promptFileSchema } from "@deliberation-lab/stagebook";
+import { promptFileSchema } from "stagebook";
 
 const result = promptFileSchema.safeParse(markdownString);
 
@@ -63,7 +63,7 @@ if (result.success) {
 ### Evaluating conditions
 
 ```typescript
-import { compare } from "@deliberation-lab/stagebook";
+import { compare } from "stagebook";
 
 compare(5, "isAbove", 3); // true
 compare("hello", "includes", "ell"); // true
@@ -76,7 +76,7 @@ The 16 canonical comparators: `exists`, `doesNotExist`, `equals`, `doesNotEqual`
 ### Parsing reference strings
 
 ```typescript
-import { getReferenceKeyAndPath } from "@deliberation-lab/stagebook";
+import { getReferenceKeyAndPath } from "stagebook";
 
 getReferenceKeyAndPath("survey.bigFive.result.score");
 // { referenceKey: "survey_bigFive", path: ["result", "score"] }
@@ -90,7 +90,7 @@ Supported namespaces: `survey`, `submitButton`, `qualtrics`, `prompt`, `trackedL
 ### Expanding templates
 
 ```typescript
-import { fillTemplates } from "@deliberation-lab/stagebook";
+import { fillTemplates } from "stagebook";
 
 const result = fillTemplates({
   obj: treatmentConfig,

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "@deliberation-lab/stagebook-viewer",
+  "name": "stagebook-viewer",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "dev": "vite",
@@ -9,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@deliberation-lab/stagebook": "*",
+    "stagebook": "*",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },

--- a/docs/engineer/api-reference.md
+++ b/docs/engineer/api-reference.md
@@ -46,7 +46,7 @@ import type {
   ConditionType,
   MetadataType,
   PromptFileType,
-} from "@deliberation-lab/stagebook";
+} from "stagebook";
 ```
 
 ## Utilities
@@ -56,7 +56,7 @@ import type {
 Evaluate a condition comparator.
 
 ```typescript
-import { compare, type Comparator } from "@deliberation-lab/stagebook";
+import { compare, type Comparator } from "stagebook";
 
 compare(5, "isAbove", 3);              // true
 compare(undefined, "doesNotEqual", "x"); // true (undefined != anything)
@@ -73,7 +73,7 @@ compare("hello", "matches", "\\d+");    // false
 Parse a DSL reference string into a storage key and nested path.
 
 ```typescript
-import { getReferenceKeyAndPath } from "@deliberation-lab/stagebook";
+import { getReferenceKeyAndPath } from "stagebook";
 
 getReferenceKeyAndPath("survey.bigFive.result.score");
 // { referenceKey: "survey_bigFive", path: ["result", "score"] }
@@ -92,7 +92,7 @@ Supported namespaces: `survey`, `submitButton`, `qualtrics`, `prompt`, `trackedL
 Traverse a nested object by path array.
 
 ```typescript
-import { getNestedValueByPath } from "@deliberation-lab/stagebook";
+import { getNestedValueByPath } from "stagebook";
 
 getNestedValueByPath({ a: { b: { c: 42 } } }, ["a", "b", "c"]); // 42
 getNestedValueByPath({ a: 1 }, ["x"]);                           // undefined
@@ -104,7 +104,7 @@ getNestedValueByPath({ a: 1 });                                   // { a: 1 }
 Expand all template references in a structure.
 
 ```typescript
-import { fillTemplates } from "@deliberation-lab/stagebook";
+import { fillTemplates } from "stagebook";
 
 const expanded = fillTemplates({
   obj: rawTreatments,
@@ -121,7 +121,7 @@ Also exported: `expandTemplate`, `substituteFields`, `recursivelyFillTemplates` 
 ### StagebookProvider
 
 ```tsx
-import { StagebookProvider, type StagebookContext } from "@deliberation-lab/stagebook/components";
+import { StagebookProvider, type StagebookContext } from "stagebook/components";
 
 <StagebookProvider value={context}>
   {children}
@@ -141,7 +141,7 @@ import { StagebookProvider, type StagebookContext } from "@deliberation-lab/stag
 ### Stage
 
 ```tsx
-import { Stage, type StageConfig } from "@deliberation-lab/stagebook/components";
+import { Stage, type StageConfig } from "stagebook/components";
 
 <Stage stage={stageConfig} onSubmit={handleSubmit} />
 ```
@@ -153,7 +153,7 @@ Requires StagebookProvider. Renders a complete stage: lays out elements with con
 ### Element Router
 
 ```tsx
-import { Element, type ElementConfig } from "@deliberation-lab/stagebook/components";
+import { Element, type ElementConfig } from "stagebook/components";
 
 <Element element={elementConfig} onSubmit={handleSubmit} stageDuration={300} />
 ```

--- a/docs/engineer/architecture.md
+++ b/docs/engineer/architecture.md
@@ -106,7 +106,7 @@ Some elements temporarily expect the participant to be away (watching a video, f
 
 ## CSS theming
 
-Stagebook ships a default stylesheet (`@deliberation-lab/stagebook/styles`) with CSS custom properties for all themeable values. Platforms override these on `:root`:
+Stagebook ships a default stylesheet (`stagebook/styles`) with CSS custom properties for all themeable values. Platforms override these on `:root`:
 
 ```css
 :root {

--- a/docs/engineer/integration-guide.md
+++ b/docs/engineer/integration-guide.md
@@ -5,7 +5,7 @@ This guide explains how to add Stagebook as a dependency and implement the platf
 ## Installation
 
 ```bash
-npm install @deliberation-lab/stagebook
+npm install stagebook
 ```
 
 Peer dependencies (install if not already present):
@@ -20,10 +20,10 @@ Stagebook exports from two entry points:
 
 ```typescript
 // Schemas, validators, and utilities — no React dependency
-import { treatmentFileSchema, compare, fillTemplates } from "@deliberation-lab/stagebook";
+import { treatmentFileSchema, compare, fillTemplates } from "stagebook";
 
 // React components — requires React 18+
-import { StagebookProvider, Element, Markdown, Button } from "@deliberation-lab/stagebook/components";
+import { StagebookProvider, Element, Markdown, Button } from "stagebook/components";
 ```
 
 ## Validating Treatment Files
@@ -31,7 +31,7 @@ import { StagebookProvider, Element, Markdown, Button } from "@deliberation-lab/
 The most basic integration is validation. Use this in build tools, CI pipelines, or editor extensions:
 
 ```typescript
-import { treatmentFileSchema, fillTemplates } from "@deliberation-lab/stagebook";
+import { treatmentFileSchema, fillTemplates } from "stagebook";
 import { load as loadYaml } from "js-yaml";
 import { readFileSync } from "fs";
 
@@ -59,7 +59,7 @@ if (!result.success) {
 ## Validating Prompt Files
 
 ```typescript
-import { promptFileSchema } from "@deliberation-lab/stagebook";
+import { promptFileSchema } from "stagebook";
 
 const markdown = readFileSync("prompts/question.md", "utf-8");
 const result = promptFileSchema.safeParse(markdown);
@@ -81,7 +81,7 @@ if (result.success) {
 Before passing treatment data to Stagebook's rendering components, the platform must **hydrate** it — expand templates, validate, and resolve all placeholders. Stagebook components expect fully resolved data with no template contexts or `${field}` placeholders remaining.
 
 ```typescript
-import { treatmentFileSchema, fillTemplates } from "@deliberation-lab/stagebook";
+import { treatmentFileSchema, fillTemplates } from "stagebook";
 import { load as loadYaml } from "js-yaml";
 
 // 1. Load and parse YAML
@@ -115,7 +115,7 @@ To render Stagebook elements, your platform must implement the `StagebookContext
 ### The Interface
 
 ```typescript
-import type { StagebookContext } from "@deliberation-lab/stagebook/components";
+import type { StagebookContext } from "stagebook/components";
 
 const context: StagebookContext = {
   // Read experiment state by DSL reference string.
@@ -178,8 +178,8 @@ const context: StagebookContext = {
 Stagebook provides a `Stage` component that handles all element layout, conditional rendering, and discussion placement. The platform just provides the context and the hydrated stage config:
 
 ```tsx
-import { StagebookProvider, Stage } from "@deliberation-lab/stagebook/components";
-import type { StagebookContext } from "@deliberation-lab/stagebook/components";
+import { StagebookProvider, Stage } from "stagebook/components";
+import type { StagebookContext } from "stagebook/components";
 
 function GameStage({ stageConfig, onSubmit }) {
   const context = useYourPlatformContext(); // your platform's hooks
@@ -235,7 +235,7 @@ Components don't need to know which phase they're in.
 Form components work without StagebookProvider. Use them anywhere in your app:
 
 ```tsx
-import { Markdown, Button, Separator } from "@deliberation-lab/stagebook/components";
+import { Markdown, Button, Separator } from "stagebook/components";
 
 function ConsentPage({ consentText, onAccept }) {
   return (
@@ -261,7 +261,7 @@ import {
   compare,
   getReferenceKeyAndPath,
   fillTemplates,
-} from "@deliberation-lab/stagebook";
+} from "stagebook";
 
 // Validate a treatment
 treatmentFileSchema.safeParse(config);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "license": "MIT",
       "workspaces": [
         "packages/*",
         "apps/*"
@@ -15,12 +16,13 @@
       }
     },
     "apps/viewer": {
-      "name": "@deliberation-lab/stagebook-viewer",
+      "name": "stagebook-viewer",
       "version": "0.1.0",
+      "license": "MIT",
       "dependencies": {
-        "@deliberation-lab/stagebook": "*",
         "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react-dom": "^19.2.4",
+        "stagebook": "*"
       },
       "devDependencies": {
         "@types/react": "^19.2.14",
@@ -513,14 +515,6 @@
       "engines": {
         "node": ">=20.19.0"
       }
-    },
-    "node_modules/@deliberation-lab/stagebook": {
-      "resolved": "packages/stagebook",
-      "link": true
-    },
-    "node_modules/@deliberation-lab/stagebook-viewer": {
-      "resolved": "apps/viewer",
-      "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.7",
@@ -6425,6 +6419,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stagebook": {
+      "resolved": "packages/stagebook",
+      "link": true
+    },
+    "node_modules/stagebook-viewer": {
+      "resolved": "apps/viewer",
+      "link": true
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -9078,7 +9080,6 @@
       }
     },
     "packages/stagebook": {
-      "name": "@deliberation-lab/stagebook",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "private": true,
+  "license": "MIT",
   "workspaces": ["packages/*", "apps/*"],
   "scripts": {
     "build": "npm run build --workspaces --if-present",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@deliberation-lab/stagebook",
+  "name": "stagebook",
   "version": "0.1.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",

--- a/packages/stagebook/src/components/index.ts
+++ b/packages/stagebook/src/components/index.ts
@@ -1,4 +1,4 @@
-// @deliberation-lab/stagebook/components
+// stagebook/components
 // React components for rendering Stagebook elements
 
 // Context provider and hooks

--- a/packages/stagebook/src/index.ts
+++ b/packages/stagebook/src/index.ts
@@ -1,4 +1,4 @@
-// @deliberation-lab/stagebook
+// stagebook
 // Schemas, validators, and utilities for interactive social science experiments
 
 export * from "./schemas/index.js";

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -1,9 +1,9 @@
 /*
- * @deliberation-lab/stagebook default styles
+ * stagebook default styles
  *
  * Import this in your app entry point if you want Stagebook's CSS-variable
  * defaults and the Inter font to be available globally:
- *   import "@deliberation-lab/stagebook/styles";
+ *   import "stagebook/styles";
  *
  * This file is OPTIONAL. Stagebook components ship visual styling as inline
  * styles backed by CSS custom properties with sensible fallbacks, so the


### PR DESCRIPTION
## Summary
- Add MIT license (copyright James Houghton)
- Rename package from `@deliberation-lab/stagebook` to `stagebook` for simpler npm installation
- Add GitHub Actions publish workflow using OIDC trusted publishers (no npm token needed)
- Update all references in source, docs, CI, and CLAUDE.md

## Setup after merge
1. `npm publish` once locally to create the package on npmjs.com
2. Configure trusted publishing on npmjs.com (package settings > Trusted Publishers)
3. Future releases: create a GitHub release and the workflow publishes automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)