### PR TITLE
Require .prompt.md extension, allow arbitrary prompt names

### DIFF
--- a/docs/engineer/api-reference.md
+++ b/docs/engineer/api-reference.md
@@ -29,7 +29,7 @@ All schemas are [Zod](https://zod.dev/) objects. Use `.safeParse(data)` for vali
 | `promptFileSchema` | Parses raw markdown → `{ metadata, body, responseItems }` with full validation |
 | `metadataTypeSchema` | Prompt metadata field types (name, type, rows, min/max, etc.) |
 | `metadataRefineSchema` | Cross-field metadata rules (e.g., slider requires min/max/interval) |
-| `metadataLogicalSchema(fileName)` | Factory: validates `name` matches the given file path |
+| `metadataLogicalSchema` | Alias for `metadataRefineSchema` (name field is optional, no filename matching) |
 | `validateSliderLabels(metadata, items)` | Checks labelPts length matches response item count |
 
 ### Types

--- a/docs/engineer/integration-guide.md
+++ b/docs/engineer/integration-guide.md
@@ -61,7 +61,7 @@ if (!result.success) {
 ```typescript
 import { promptFileSchema } from "stagebook";
 
-const markdown = readFileSync("prompts/question.md", "utf-8");
+const markdown = readFileSync("prompts/question.prompt.md", "utf-8");
 const result = promptFileSchema.safeParse(markdown);
 
 if (result.success) {

--- a/docs/engineer/platform-requirements.md
+++ b/docs/engineer/platform-requirements.md
@@ -207,14 +207,14 @@ For example, given this file structure:
 ```
 my-study/
   study.treatments.yaml
-  consent.md
+  consent.prompt.md
   prompts/
-    question.md
+    question.prompt.md
   images/
     diagram.png
 ```
 
-The treatment file references `file: consent.md`, `file: prompts/question.md`, `file: images/diagram.png`. The platform resolves these relative to `my-study/`.
+The treatment file references `file: consent.prompt.md`, `file: prompts/question.prompt.md`, `file: images/diagram.png`. The platform resolves these relative to `my-study/`.
 
 ### `getAssetURL(path: string): string`
 

--- a/docs/researcher/conditions.md
+++ b/docs/researcher/conditions.md
@@ -131,7 +131,7 @@ Show content when 80%+ agree:
 
 ```yaml
 - type: prompt
-  file: game/consensus_reached.md
+  file: game/consensus_reached.prompt.md
   conditions:
     - reference: prompt.topic_vote
       position: percentAgreement

--- a/docs/researcher/discussions.md
+++ b/docs/researcher/discussions.md
@@ -12,7 +12,7 @@ gameStages:
       showTitle: false
     elements:
       - type: prompt
-        file: game/discussion_prompt.md
+        file: game/discussion_prompt.prompt.md
       - type: submitButton
         buttonText: End Discussion
 ```

--- a/docs/researcher/elements.md
+++ b/docs/researcher/elements.md
@@ -18,7 +18,7 @@ Renders a question or informational text from a Markdown file. This is the most 
 
 ```yaml
 - type: prompt
-  file: game/discussion_prompt.md
+  file: game/discussion_prompt.prompt.md
   name: topicA_prompt        # optional — names the saved response
   shared: true               # optional — single response editable by all participants
 ```
@@ -27,7 +27,7 @@ Renders a question or informational text from a Markdown file. This is the most 
 
 ```yaml
 elements:
-  - game/discussion_prompt.md   # equivalent to { type: prompt, file: "..." }
+  - game/discussion_prompt.prompt.md   # equivalent to { type: prompt, file: "..." }
   - type: submitButton
 ```
 
@@ -462,7 +462,7 @@ Show wrap-up instructions in the last minute:
 
 ```yaml
 - type: prompt
-  file: game/wrapup.md
+  file: game/wrapup.prompt.md
   displayTime: 540    # 9 minutes into a 10-minute stage
 ```
 
@@ -470,7 +470,7 @@ Show an element only to position 0, only after a condition is met:
 
 ```yaml
 - type: prompt
-  file: game/leader_instructions.md
+  file: game/leader_instructions.prompt.md
   showToPositions: [0]
   conditions:
     - reference: prompt.readiness_check

--- a/docs/researcher/prompts.md
+++ b/docs/researcher/prompts.md
@@ -27,7 +27,7 @@ type: multipleChoice
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | no | Optional identifier. If provided, must match the file path. Omit for new prompt files — provenance is tracked automatically via the file path. |
+| `name` | string | no | Optional human-readable identifier. Can be any string. |
 | `type` | enum | yes | `multipleChoice`, `openResponse`, `noResponse`, `listSorter`, `slider` |
 | `notes` | string | no | Internal notes (not displayed) |
 

--- a/docs/researcher/syntax-reference.md
+++ b/docs/researcher/syntax-reference.md
@@ -166,7 +166,7 @@ Three sections separated by `---`:
 ```markdown
 ---
 type: multipleChoice | openResponse | noResponse | listSorter | slider
-name: path/to/file.md   # optional — provenance tracked via file path
+name: My Prompt         # optional — human-readable identifier
 ---
 Markdown body text
 ---
@@ -174,6 +174,6 @@ Markdown body text
 - Response option 2
 ```
 
-`name` is optional. If provided, must match the file path. Provenance is tracked automatically via the source file path.
+`name` is optional. Can be any string — use it as a human-readable identifier. Prompt files must use the `.prompt.md` extension.
 
 Slider requires `min`, `max`, `interval` in metadata. Slider initializes without a visible thumb (anti-anchoring).

--- a/docs/researcher/treatment-files.md
+++ b/docs/researcher/treatment-files.md
@@ -39,7 +39,7 @@ introSequences:
       - name: Consent
         elements:
           - type: prompt
-            file: intro/consent.md
+            file: intro/consent.prompt.md
           - type: submitButton
 
       - name: Pre-Survey
@@ -63,7 +63,7 @@ treatments:
           showTitle: false
         elements:
           - type: prompt
-            file: game/discussion_prompt.md
+            file: game/discussion_prompt.prompt.md
           - type: submitButton
             buttonText: Leave Discussion
 
@@ -71,14 +71,14 @@ treatments:
         duration: 120
         elements:
           - type: prompt
-            file: game/post_discussion.md
+            file: game/post_discussion.prompt.md
           - type: submitButton
 
     exitSequence:
       - name: Debrief
         elements:
           - type: prompt
-            file: exit/debrief.md
+            file: exit/debrief.prompt.md
           - type: submitButton
             buttonText: Finish
 ```
@@ -103,10 +103,10 @@ When players join a group, each is assigned a zero-based position index (0, 1, 2
 ```yaml
 elements:
   - type: prompt
-    file: game/democrat_instructions.md
+    file: game/democrat_instructions.prompt.md
     showToPositions: [0]
   - type: prompt
-    file: game/republican_instructions.md
+    file: game/republican_instructions.prompt.md
     showToPositions: [1]
 ```
 

--- a/packages/stagebook/src/schemas/promptFile.test.ts
+++ b/packages/stagebook/src/schemas/promptFile.test.ts
@@ -91,24 +91,21 @@ test("invalid: shuffleOptions provided but type is noResponse", () => {
 
 // ----------- Logical Schema (metadataLogicalSchema) ------------
 
-test("valid logical schema with matching file name", () => {
-  const filename = "mock-prompt-files/prompt.md";
+test("valid logical schema with arbitrary name", () => {
   const metadata = {
-    name: filename,
+    name: "any name the author wants",
     type: "openResponse",
   };
-  const result = metadataLogicalSchema(filename).safeParse(metadata);
+  const result = metadataLogicalSchema.safeParse(metadata);
   expect(result.success).toBe(true);
 });
 
-test("invalid: metadata name does not match filename", () => {
-  const filename = "mock-prompt-files/prompt.md";
+test("valid logical schema without name", () => {
   const metadata = {
-    name: "mock-prompt-files/WRONG.md",
     type: "openResponse",
   };
-  const result = metadataLogicalSchema(filename).safeParse(metadata);
-  expect(result.success).toBe(false);
+  const result = metadataLogicalSchema.safeParse(metadata);
+  expect(result.success).toBe(true);
 });
 
 // ----------- Slider Type Validation ------------

--- a/packages/stagebook/src/schemas/promptFile.ts
+++ b/packages/stagebook/src/schemas/promptFile.ts
@@ -177,17 +177,7 @@ export const metadataRefineSchema = z
     }
   });
 
-// Function to validate that the metadata name matches the file name (when name is provided)
-export const metadataLogicalSchema = (fileName: string) =>
-  metadataRefineSchema.superRefine((data, ctx) => {
-    if (data.name !== undefined && data.name !== fileName) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `name must match file path (got "${data.name}", expected "${fileName}")`,
-        path: ["name"],
-      });
-    }
-  });
+export const metadataLogicalSchema = metadataRefineSchema;
 
 export type MetadataType = z.infer<typeof metadataTypeSchema>;
 export type MetadataRefineType = z.infer<typeof metadataRefineSchema>;

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -90,10 +90,19 @@ test("break name requirements", () => {
   const element = {
     type: "prompt",
     name: "This name has !!! some serious \\ issues that *(&@#$( need fixing 123 and change to fill in the 64 character limit etc etc etc etc",
-    file: "projects/example/testDisplay00.md",
+    file: "projects/example/testDisplay00.prompt.md",
   };
   const result = promptSchema.safeParse(element);
   if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(false);
+});
+
+test("prompt file must use .prompt.md extension", () => {
+  const element = {
+    type: "prompt",
+    file: "projects/example/consent.md",
+  };
+  const result = promptSchema.safeParse(element);
   expect(result.success).toBe(false);
 });
 
@@ -102,7 +111,7 @@ test("prompt element validation", () => {
   const element = {
     type: "prompt",
     name: "namedPrompt",
-    file: "projects/example/testDisplay00.md",
+    file: "projects/example/testDisplay00.prompt.md",
     conditions: [
       {
         reference: "prompt.namedPrompt",
@@ -139,12 +148,12 @@ test("multiple elements validation", () => {
   const elements = [
     {
       type: "prompt",
-      file: "projects/example/testDisplay00.md",
+      file: "projects/example/testDisplay00.prompt.md",
     },
     {
       type: "prompt",
       name: "namedPrompt2",
-      file: "projects/example/testDisplay01.md",
+      file: "projects/example/testDisplay01.prompt.md",
       conditions: [
         {
           reference: "prompt.namedPrompt",
@@ -226,7 +235,7 @@ test("validate entire file", () => {
         templateContent: {
           type: "prompt",
           name: "namedPrompt",
-          file: "projects/example/testDisplay00.md",
+          file: "projects/example/testDisplay00.prompt.md",
         },
       },
     ],
@@ -240,7 +249,7 @@ test("validate entire file", () => {
               {
                 type: "prompt",
                 name: "namedPrompt",
-                file: "projects/example/testDisplay00.md",
+                file: "projects/example/testDisplay00.prompt.md",
                 conditions: [
                   {
                     reference: "prompt.namedPrompt",
@@ -274,7 +283,7 @@ test("validate entire file", () => {
               {
                 type: "prompt",
                 name: "namedPrompt",
-                file: "projects/example/testDisplay00.md",
+                file: "projects/example/testDisplay00.prompt.md",
                 conditions: [
                   {
                     reference: "prompt.namedPrompt",
@@ -293,7 +302,7 @@ test("validate entire file", () => {
               {
                 type: "prompt",
                 name: "namedPrompt2",
-                file: "projects/example/testDisplay01.md",
+                file: "projects/example/testDisplay01.prompt.md",
                 conditions: [
                   {
                     reference: "prompt.namedPrompt",
@@ -558,7 +567,7 @@ test("intro step with submitButton is valid", () => {
     {
       name: "consent",
       elements: [
-        { type: "prompt", file: "intro/consent.md" },
+        { type: "prompt", file: "intro/consent.prompt.md" },
         { type: "submitButton", buttonText: "I agree" },
       ],
     },
@@ -571,7 +580,7 @@ test("intro step with only prompt and no submitButton is invalid", () => {
   const result = introStepsSchema.safeParse([
     {
       name: "consent",
-      elements: [{ type: "prompt", file: "intro/consent.md" }],
+      elements: [{ type: "prompt", file: "intro/consent.prompt.md" }],
     },
   ]);
   if (!result.success) console.log(result.error.message);
@@ -638,7 +647,7 @@ test("exit step with submitButton is valid", () => {
     {
       name: "debrief",
       elements: [
-        { type: "prompt", file: "exit/debrief.md" },
+        { type: "prompt", file: "exit/debrief.prompt.md" },
         { type: "submitButton", buttonText: "Done" },
       ],
     },
@@ -651,7 +660,7 @@ test("exit step with only prompt and no submitButton is invalid", () => {
   const result = exitStepsSchema.safeParse([
     {
       name: "debrief",
-      elements: [{ type: "prompt", file: "exit/debrief.md" }],
+      elements: [{ type: "prompt", file: "exit/debrief.prompt.md" }],
     },
   ]);
   if (!result.success) console.log(result.error.message);

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -46,13 +46,12 @@ export type DescriptionType = z.infer<typeof descriptionSchema>;
 // TODO: check that file exists
 export const fileSchema = z.string().optional();
 
-export const promptFileSchema = z
+export const promptFilePathSchema = z
   .string()
   .refine((s) => s.endsWith(".prompt.md"), {
     message:
       'Prompt files must use the .prompt.md extension (e.g., "myPrompt.prompt.md")',
-  })
-  .optional();
+  });
 
 export type FileType = z.infer<typeof fileSchema>;
 
@@ -739,12 +738,12 @@ const displaySchema = elementBaseSchema
 export const promptSchema = elementBaseSchema
   .extend({
     type: z.literal("prompt"),
-    file: promptFileSchema,
+    file: promptFilePathSchema,
     shared: z.boolean().optional(),
   })
   .strict();
 
-const promptShorthandSchema = promptFileSchema.transform((str) => {
+const promptShorthandSchema = promptFilePathSchema.transform((str) => {
   const newElement = {
     type: "prompt",
     file: str,

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -384,7 +384,7 @@ const templateBroadcastAxisNameSchema = z.string().regex(/^d\d+$/, {
   message: "String must start with 'd' followed by a nonnegative integer",
 });
 
-const templateBroadcastAxisValuesSchema: any = z.lazy(() =>
+const templateBroadcastAxisValuesSchema: z.ZodType = z.lazy(() =>
   z
     .array(templateFieldsSchema)
     .nonempty()
@@ -1046,26 +1046,28 @@ export const stageSchema = altTemplateContext(
       const duration = data.duration;
       if (typeof duration !== "number" || !Array.isArray(data.elements)) return;
 
-      data.elements.forEach((element: any, elementIndex: number) => {
-        if (!element || typeof element !== "object") return;
+      data.elements.forEach(
+        (element: Record<string, unknown>, elementIndex: number) => {
+          if (!element || typeof element !== "object") return;
 
-        const timeFields = [
-          "displayTime",
-          "hideTime",
-          "startTime",
-          "endTime",
-        ] as const;
-        for (const field of timeFields) {
-          const value = element[field];
-          if (typeof value === "number" && value > duration) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              path: ["elements", elementIndex, field],
-              message: `${field} (${value}) exceeds stage duration (${duration}) for element "${element.name || element.type}"`,
-            });
+          const timeFields = [
+            "displayTime",
+            "hideTime",
+            "startTime",
+            "endTime",
+          ] as const;
+          for (const field of timeFields) {
+            const value = element[field];
+            if (typeof value === "number" && value > duration) {
+              ctx.addIssue({
+                code: z.ZodIssueCode.custom,
+                path: ["elements", elementIndex, field],
+                message: `${field} (${value}) exceeds stage duration (${duration}) for element "${String(element.name || element.type)}"`,
+              });
+            }
           }
-        }
-      });
+        },
+      );
     }),
 );
 export type StageType = z.infer<typeof stageSchema>;
@@ -1306,11 +1308,15 @@ export const treatmentSchema = altTemplateContext(
       }
       gameStages?.forEach(
         (
-          stage: { elements: any[]; name: any; discussion?: any },
-          stageIndex: string | number,
+          stage: {
+            elements?: Record<string, unknown>[];
+            name?: string;
+            discussion?: Record<string, unknown>;
+          },
+          stageIndex: number,
         ) => {
           stage?.elements?.forEach(
-            (element: any, elementIndex: string | number) => {
+            (element: Record<string, unknown>, elementIndex: number) => {
               ["showToPositions", "hideFromPositions"].forEach((key) => {
                 const positions = element[key];
                 if (Array.isArray(positions)) {
@@ -1384,31 +1390,33 @@ export const treatmentSchema = altTemplateContext(
               }
 
               const assigned = new Set<number>();
-              rooms.forEach((room: any, roomIndex: number) => {
-                const inc = room?.includePositions;
-                if (Array.isArray(inc)) {
-                  inc.forEach((pos: any, posIndex: number) => {
-                    if (typeof pos === "number") {
-                      assigned.add(pos);
-                      if (pos >= playerCount) {
-                        ctx.addIssue({
-                          code: z.ZodIssueCode.custom,
-                          path: [
-                            "gameStages",
-                            stageIndex,
-                            "discussion",
-                            "rooms",
-                            roomIndex,
-                            "includePositions",
-                            posIndex,
-                          ],
-                          message: `includePositions index ${pos} in discussion room exceeds playerCount of ${playerCount}.`,
-                        });
+              rooms.forEach(
+                (room: Record<string, unknown>, roomIndex: number) => {
+                  const inc = room?.includePositions;
+                  if (Array.isArray(inc)) {
+                    inc.forEach((pos: unknown, posIndex: number) => {
+                      if (typeof pos === "number") {
+                        assigned.add(pos);
+                        if (pos >= playerCount) {
+                          ctx.addIssue({
+                            code: z.ZodIssueCode.custom,
+                            path: [
+                              "gameStages",
+                              stageIndex,
+                              "discussion",
+                              "rooms",
+                              roomIndex,
+                              "includePositions",
+                              posIndex,
+                            ],
+                            message: `includePositions index ${pos} in discussion room exceeds playerCount of ${playerCount}.`,
+                          });
+                        }
                       }
-                    }
-                  });
-                }
-              });
+                    });
+                  }
+                },
+              );
 
               const missing = candidatePositions.filter(
                 (p) => !assigned.has(p),
@@ -1473,7 +1481,7 @@ export const templateContentSchema = z.any().superRefine((data, ctx) => {
 
   interface Issue {
     code: string;
-    path: any[];
+    path: (string | number)[];
     keys?: string[];
   }
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -46,6 +46,14 @@ export type DescriptionType = z.infer<typeof descriptionSchema>;
 // TODO: check that file exists
 export const fileSchema = z.string().optional();
 
+export const promptFileSchema = z
+  .string()
+  .refine((s) => s.endsWith(".prompt.md"), {
+    message:
+      'Prompt files must use the .prompt.md extension (e.g., "myPrompt.prompt.md")',
+  })
+  .optional();
+
 export type FileType = z.infer<typeof fileSchema>;
 
 export const urlSchema = z
@@ -731,12 +739,12 @@ const displaySchema = elementBaseSchema
 export const promptSchema = elementBaseSchema
   .extend({
     type: z.literal("prompt"),
-    file: fileSchema,
+    file: promptFileSchema,
     shared: z.boolean().optional(),
   })
   .strict();
 
-const promptShorthandSchema = fileSchema.transform((str) => {
+const promptShorthandSchema = promptFileSchema.transform((str) => {
   const newElement = {
     type: "prompt",
     file: str,

--- a/packages/stagebook/src/templates/fillTemplates.test.ts
+++ b/packages/stagebook/src/templates/fillTemplates.test.ts
@@ -1000,7 +1000,9 @@ test("multi-dimensional broadcast + additionalFields", () => {
 
   expect(result).toHaveLength(6);
   expect(
-    result.every((item: any) => item.url === "https://cdn.test/v.mp4"),
+    result.every(
+      (item: Record<string, unknown>) => item.url === "https://cdn.test/v.mp4",
+    ),
   ).toBe(true);
   expect(result[0].name).toBe("0_0");
   expect(result[5].name).toBe("1_2");


### PR DESCRIPTION
## Summary
Closes #67

- Prompt `file:` references in treatment schemas now require `.prompt.md` extension (e.g., `myPrompt.prompt.md`)
- Prompt metadata `name` field is fully optional with no filename-matching constraint — authors can use any name or omit it
- `metadataLogicalSchema` simplified to an alias for `metadataRefineSchema` (no longer a factory function)
- All docs updated: researcher guides, engineer guides, syntax reference, API reference

## Why

The `.prompt.md` convention lets tooling (VS Code extension, viewer app) identify prompt files unambiguously without content sniffing, while preserving standard markdown rendering for tools that don't know about stagebook. See discussion in #67.

## Test plan
- [x] New test: prompt element with `.md` file is rejected
- [x] Existing tests updated to use `.prompt.md` references
- [x] Prompt metadata tests updated: arbitrary name accepted, omitted name accepted
- [x] 458/458 tests pass
- [x] Lint clean (0 errors)
- [x] All docs examples use `.prompt.md` — no stale `.md` prompt references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)