### PR TITLE
Viewer app: interactive study previewer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - run: npm run build -w stagebook
       - run: npm test
 
   test-ct:

--- a/.github/workflows/deploy-viewer.yml
+++ b/.github/workflows/deploy-viewer.yml
@@ -1,0 +1,38 @@
+name: Deploy Viewer
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build & Deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build -w stagebook
+      - run: npm run build -w stagebook-viewer
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/viewer/dist
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b && vite build && cp dist/index.html dist/404.html",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -7,18 +7,23 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
-    "stagebook": "*",
+    "js-yaml": "^4.1.1",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "stagebook": "*"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.5.2",
     "typescript": "^5.5.0",
-    "vite": "^6.3.3"
+    "vite": "^6.3.3",
+    "vitest": "^4.1.4"
   }
 }

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -12,10 +12,12 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@tailwindcss/vite": "^4.2.2",
     "js-yaml": "^4.1.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "stagebook": "*"
+    "stagebook": "*",
+    "tailwindcss": "^4.2.2"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -1,7 +1,11 @@
 import { useState, useCallback, useEffect } from "react";
 import type { TreatmentFileType } from "stagebook";
 import { loadTreatmentFromUrl } from "./lib/loader";
-import { expandTreatmentFile } from "./lib/treatment";
+import {
+  expandTreatmentFile,
+  TreatmentValidationError,
+  type ValidationIssue,
+} from "./lib/treatment";
 import { LandingPage } from "./components/LandingPage";
 import { TreatmentPicker } from "./components/TreatmentPicker";
 import { FieldForm } from "./components/FieldForm";
@@ -31,7 +35,12 @@ type AppState =
       selectedIntroIndex: number;
       selectedTreatmentIndex: number;
     }
-  | { phase: "error"; message: string; url?: string };
+  | {
+      phase: "error";
+      message: string;
+      url?: string;
+      validationIssues?: ValidationIssue[];
+    };
 
 export function App() {
   const [state, setState] = useState<AppState>({ phase: "landing" });
@@ -41,17 +50,44 @@ export function App() {
     try {
       const { treatmentFile, unresolvedFields, rawBaseUrl } =
         await loadTreatmentFromUrl(url);
-      setState({
-        phase: "selecting",
-        treatmentFile,
-        rawBaseUrl,
-        unresolvedFields,
-      });
+
+      const needsPicker =
+        treatmentFile.introSequences.length > 1 ||
+        treatmentFile.treatments.length > 1;
+
+      if (needsPicker) {
+        setState({
+          phase: "selecting",
+          treatmentFile,
+          rawBaseUrl,
+          unresolvedFields,
+        });
+      } else if (unresolvedFields.length > 0) {
+        setState({
+          phase: "fields",
+          treatmentFile,
+          rawBaseUrl,
+          unresolvedFields,
+          selectedIntroIndex: 0,
+          selectedTreatmentIndex: 0,
+        });
+      } else {
+        setState({
+          phase: "viewing",
+          treatmentFile,
+          rawBaseUrl,
+          selectedIntroIndex: 0,
+          selectedTreatmentIndex: 0,
+        });
+      }
     } catch (err) {
+      const validationIssues =
+        err instanceof TreatmentValidationError ? err.issues : undefined;
       setState({
         phase: "error",
         message: err instanceof Error ? err.message : String(err),
         url,
+        validationIssues,
       });
     }
   }, []);
@@ -76,6 +112,7 @@ export function App() {
       return (
         <ErrorScreen
           message={state.message}
+          validationIssues={state.validationIssues}
           onRetry={state.url ? () => handleLoad(state.url!) : undefined}
           onBack={() => setState({ phase: "landing" })}
         />
@@ -83,59 +120,31 @@ export function App() {
 
     case "selecting": {
       const { treatmentFile, rawBaseUrl, unresolvedFields } = state;
-      const needsPicker =
-        treatmentFile.introSequences.length > 1 ||
-        treatmentFile.treatments.length > 1;
-
-      if (needsPicker) {
-        return (
-          <TreatmentPicker
-            treatmentFile={treatmentFile}
-            onSelect={(introIndex, treatmentIndex) => {
-              if (unresolvedFields.length > 0) {
-                setState({
-                  phase: "fields",
-                  treatmentFile,
-                  rawBaseUrl,
-                  unresolvedFields,
-                  selectedIntroIndex: introIndex,
-                  selectedTreatmentIndex: treatmentIndex,
-                });
-              } else {
-                setState({
-                  phase: "viewing",
-                  treatmentFile,
-                  rawBaseUrl,
-                  selectedIntroIndex: introIndex,
-                  selectedTreatmentIndex: treatmentIndex,
-                });
-              }
-            }}
-          />
-        );
-      }
-
-      // Single intro + single treatment — skip picker
-      if (unresolvedFields.length > 0) {
-        setState({
-          phase: "fields",
-          treatmentFile,
-          rawBaseUrl,
-          unresolvedFields,
-          selectedIntroIndex: 0,
-          selectedTreatmentIndex: 0,
-        });
-        return null;
-      }
-
-      setState({
-        phase: "viewing",
-        treatmentFile,
-        rawBaseUrl,
-        selectedIntroIndex: 0,
-        selectedTreatmentIndex: 0,
-      });
-      return null;
+      return (
+        <TreatmentPicker
+          treatmentFile={treatmentFile}
+          onSelect={(introIndex, treatmentIndex) => {
+            if (unresolvedFields.length > 0) {
+              setState({
+                phase: "fields",
+                treatmentFile,
+                rawBaseUrl,
+                unresolvedFields,
+                selectedIntroIndex: introIndex,
+                selectedTreatmentIndex: treatmentIndex,
+              });
+            } else {
+              setState({
+                phase: "viewing",
+                treatmentFile,
+                rawBaseUrl,
+                selectedIntroIndex: introIndex,
+                selectedTreatmentIndex: treatmentIndex,
+              });
+            }
+          }}
+        />
+      );
     }
 
     case "fields": {
@@ -189,43 +198,97 @@ function LoadingScreen({ url }: { url: string }) {
 
 function ErrorScreen({
   message,
+  validationIssues,
   onRetry,
   onBack,
 }: {
   message: string;
+  validationIssues?: ValidationIssue[];
   onRetry?: () => void;
   onBack: () => void;
 }) {
   return (
     <div style={centeredStyle}>
-      <p style={{ color: "#ef4444", fontWeight: 600 }}>Failed to load</p>
-      <p
-        style={{
-          color: "#6b7280",
-          fontSize: "0.875rem",
-          marginTop: "0.5rem",
-          maxWidth: "36rem",
-          wordBreak: "break-word",
-        }}
-      >
-        {message}
-      </p>
-      <div style={{ marginTop: "1rem", display: "flex", gap: "0.5rem" }}>
-        {onRetry && (
-          <button onClick={onRetry} style={buttonStyle}>
-            Retry
-          </button>
+      <div style={{ maxWidth: "36rem", width: "100%", padding: "2rem" }}>
+        <p style={{ color: "#ef4444", fontWeight: 600 }}>Failed to load</p>
+
+        {validationIssues ? (
+          <>
+            <p
+              style={{
+                color: "#6b7280",
+                fontSize: "0.875rem",
+                marginTop: "0.5rem",
+              }}
+            >
+              The treatment file has validation errors:
+            </p>
+            <ul style={issueListStyle}>
+              {validationIssues.map((issue, i) => (
+                <li key={i} style={issueItemStyle}>
+                  <code style={issuePathStyle}>{issue.path}</code>
+                  <span>{issue.message}</span>
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <p
+            style={{
+              color: "#6b7280",
+              fontSize: "0.875rem",
+              marginTop: "0.5rem",
+              wordBreak: "break-word",
+            }}
+          >
+            {message}
+          </p>
         )}
-        <button
-          onClick={onBack}
-          style={{ ...buttonStyle, backgroundColor: "#6b7280" }}
-        >
-          Back
-        </button>
+
+        <div style={{ marginTop: "1rem", display: "flex", gap: "0.5rem" }}>
+          {onRetry && (
+            <button onClick={onRetry} style={buttonStyle}>
+              Retry
+            </button>
+          )}
+          <button
+            onClick={onBack}
+            style={{ ...buttonStyle, backgroundColor: "#6b7280" }}
+          >
+            Back
+          </button>
+        </div>
       </div>
     </div>
   );
 }
+
+const issueListStyle: React.CSSProperties = {
+  listStyle: "none",
+  padding: 0,
+  marginTop: "0.75rem",
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+};
+
+const issueItemStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.125rem",
+  padding: "0.5rem 0.75rem",
+  backgroundColor: "#fef2f2",
+  borderRadius: "0.375rem",
+  border: "1px solid #fecaca",
+  fontSize: "0.875rem",
+  color: "#374151",
+};
+
+const issuePathStyle: React.CSSProperties = {
+  fontSize: "0.75rem",
+  color: "#9ca3af",
+  fontFamily: "monospace",
+};
 
 const centeredStyle: React.CSSProperties = {
   display: "flex",

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -1,8 +1,246 @@
+import { useState, useCallback, useEffect } from "react";
+import type { TreatmentFileType } from "stagebook";
+import { loadTreatmentFromUrl } from "./lib/loader";
+import { expandTreatmentFile } from "./lib/treatment";
+import { LandingPage } from "./components/LandingPage";
+import { TreatmentPicker } from "./components/TreatmentPicker";
+import { FieldForm } from "./components/FieldForm";
+import { Viewer } from "./components/Viewer";
+
+type AppState =
+  | { phase: "landing" }
+  | { phase: "loading"; url: string }
+  | {
+      phase: "selecting";
+      treatmentFile: TreatmentFileType;
+      rawBaseUrl: string;
+      unresolvedFields: string[];
+    }
+  | {
+      phase: "fields";
+      treatmentFile: TreatmentFileType;
+      rawBaseUrl: string;
+      unresolvedFields: string[];
+      selectedIntroIndex: number;
+      selectedTreatmentIndex: number;
+    }
+  | {
+      phase: "viewing";
+      treatmentFile: TreatmentFileType;
+      rawBaseUrl: string;
+      selectedIntroIndex: number;
+      selectedTreatmentIndex: number;
+    }
+  | { phase: "error"; message: string; url?: string };
+
 export function App() {
+  const [state, setState] = useState<AppState>({ phase: "landing" });
+
+  const handleLoad = useCallback(async (url: string) => {
+    setState({ phase: "loading", url });
+    try {
+      const { treatmentFile, unresolvedFields, rawBaseUrl } =
+        await loadTreatmentFromUrl(url);
+      setState({
+        phase: "selecting",
+        treatmentFile,
+        rawBaseUrl,
+        unresolvedFields,
+      });
+    } catch (err) {
+      setState({
+        phase: "error",
+        message: err instanceof Error ? err.message : String(err),
+        url,
+      });
+    }
+  }, []);
+
+  // Auto-load from ?url= parameter
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const url = params.get("url");
+    if (url && state.phase === "landing") {
+      handleLoad(url);
+    }
+  }, [handleLoad, state.phase]);
+
+  switch (state.phase) {
+    case "landing":
+      return <LandingPage onLoad={handleLoad} />;
+
+    case "loading":
+      return <LoadingScreen url={state.url} />;
+
+    case "error":
+      return (
+        <ErrorScreen
+          message={state.message}
+          onRetry={state.url ? () => handleLoad(state.url!) : undefined}
+          onBack={() => setState({ phase: "landing" })}
+        />
+      );
+
+    case "selecting": {
+      const { treatmentFile, rawBaseUrl, unresolvedFields } = state;
+      const needsPicker =
+        treatmentFile.introSequences.length > 1 ||
+        treatmentFile.treatments.length > 1;
+
+      if (needsPicker) {
+        return (
+          <TreatmentPicker
+            treatmentFile={treatmentFile}
+            onSelect={(introIndex, treatmentIndex) => {
+              if (unresolvedFields.length > 0) {
+                setState({
+                  phase: "fields",
+                  treatmentFile,
+                  rawBaseUrl,
+                  unresolvedFields,
+                  selectedIntroIndex: introIndex,
+                  selectedTreatmentIndex: treatmentIndex,
+                });
+              } else {
+                setState({
+                  phase: "viewing",
+                  treatmentFile,
+                  rawBaseUrl,
+                  selectedIntroIndex: introIndex,
+                  selectedTreatmentIndex: treatmentIndex,
+                });
+              }
+            }}
+          />
+        );
+      }
+
+      // Single intro + single treatment — skip picker
+      if (unresolvedFields.length > 0) {
+        setState({
+          phase: "fields",
+          treatmentFile,
+          rawBaseUrl,
+          unresolvedFields,
+          selectedIntroIndex: 0,
+          selectedTreatmentIndex: 0,
+        });
+        return null;
+      }
+
+      setState({
+        phase: "viewing",
+        treatmentFile,
+        rawBaseUrl,
+        selectedIntroIndex: 0,
+        selectedTreatmentIndex: 0,
+      });
+      return null;
+    }
+
+    case "fields": {
+      const {
+        treatmentFile,
+        rawBaseUrl,
+        unresolvedFields,
+        selectedIntroIndex,
+        selectedTreatmentIndex,
+      } = state;
+      return (
+        <FieldForm
+          unresolvedFields={unresolvedFields}
+          onSubmit={(values) => {
+            const { result } = expandTreatmentFile(treatmentFile, values);
+            setState({
+              phase: "viewing",
+              treatmentFile: result,
+              rawBaseUrl,
+              selectedIntroIndex,
+              selectedTreatmentIndex,
+            });
+          }}
+        />
+      );
+    }
+
+    case "viewing":
+      return (
+        <Viewer
+          treatmentFile={state.treatmentFile}
+          rawBaseUrl={state.rawBaseUrl}
+          selectedIntroIndex={state.selectedIntroIndex}
+          selectedTreatmentIndex={state.selectedTreatmentIndex}
+          onBack={() => setState({ phase: "landing" })}
+        />
+      );
+  }
+}
+
+function LoadingScreen({ url }: { url: string }) {
   return (
-    <div>
-      <h1>Stagebook Viewer</h1>
-      <p>Interactive study previewer — coming soon.</p>
+    <div style={centeredStyle}>
+      <p style={{ color: "#6b7280" }}>Loading treatment file...</p>
+      <p style={{ fontSize: "0.75rem", color: "#9ca3af", marginTop: "0.5rem" }}>
+        {url}
+      </p>
     </div>
   );
 }
+
+function ErrorScreen({
+  message,
+  onRetry,
+  onBack,
+}: {
+  message: string;
+  onRetry?: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <div style={centeredStyle}>
+      <p style={{ color: "#ef4444", fontWeight: 600 }}>Failed to load</p>
+      <p
+        style={{
+          color: "#6b7280",
+          fontSize: "0.875rem",
+          marginTop: "0.5rem",
+          maxWidth: "36rem",
+          wordBreak: "break-word",
+        }}
+      >
+        {message}
+      </p>
+      <div style={{ marginTop: "1rem", display: "flex", gap: "0.5rem" }}>
+        {onRetry && (
+          <button onClick={onRetry} style={buttonStyle}>
+            Retry
+          </button>
+        )}
+        <button
+          onClick={onBack}
+          style={{ ...buttonStyle, backgroundColor: "#6b7280" }}
+        >
+          Back
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const centeredStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  height: "100vh",
+};
+
+const buttonStyle: React.CSSProperties = {
+  padding: "0.5rem 1rem",
+  borderRadius: "0.375rem",
+  border: "none",
+  backgroundColor: "#3b82f6",
+  color: "white",
+  cursor: "pointer",
+  fontSize: "0.875rem",
+};

--- a/apps/viewer/src/components/FieldForm.tsx
+++ b/apps/viewer/src/components/FieldForm.tsx
@@ -1,0 +1,120 @@
+import { useState } from "react";
+
+interface FieldFormProps {
+  unresolvedFields: string[];
+  onSubmit: (values: Record<string, string>) => void;
+}
+
+export function FieldForm({ unresolvedFields, onSubmit }: FieldFormProps) {
+  const [values, setValues] = useState<Record<string, string>>(
+    Object.fromEntries(unresolvedFields.map((f) => [f, ""])),
+  );
+
+  const allFilled = unresolvedFields.every((f) => values[f]?.trim());
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (allFilled) onSubmit(values);
+  };
+
+  return (
+    <div style={containerStyle}>
+      <div style={cardStyle}>
+        <h1 style={titleStyle}>Fill in remaining fields</h1>
+        <p style={subtitleStyle}>
+          These template fields weren't resolved during expansion. Provide
+          values to continue.
+        </p>
+
+        <form onSubmit={handleSubmit} style={formStyle}>
+          {unresolvedFields.map((field) => (
+            <div
+              key={field}
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "0.25rem",
+              }}
+            >
+              <label htmlFor={`field-${field}`} style={labelStyle}>
+                {"${" + field + "}"}
+              </label>
+              <input
+                id={`field-${field}`}
+                type="text"
+                value={values[field] ?? ""}
+                onChange={(e) =>
+                  setValues((prev) => ({ ...prev, [field]: e.target.value }))
+                }
+                style={inputStyle}
+              />
+            </div>
+          ))}
+          <button type="submit" disabled={!allFilled} style={buttonStyle}>
+            Continue
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+const containerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: "100vh",
+  backgroundColor: "#f9fafb",
+};
+
+const cardStyle: React.CSSProperties = {
+  maxWidth: "32rem",
+  width: "100%",
+  padding: "2rem",
+};
+
+const titleStyle: React.CSSProperties = {
+  fontSize: "1.25rem",
+  fontWeight: 700,
+  color: "#1f2937",
+  margin: 0,
+};
+
+const subtitleStyle: React.CSSProperties = {
+  color: "#6b7280",
+  marginTop: "0.5rem",
+  fontSize: "0.875rem",
+};
+
+const formStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.75rem",
+  marginTop: "1.5rem",
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: "0.875rem",
+  fontWeight: 500,
+  color: "#374151",
+  fontFamily: "monospace",
+};
+
+const inputStyle: React.CSSProperties = {
+  padding: "0.5rem 0.75rem",
+  borderRadius: "0.375rem",
+  border: "1px solid #d1d5db",
+  fontSize: "0.875rem",
+};
+
+const buttonStyle: React.CSSProperties = {
+  padding: "0.5rem 1rem",
+  borderRadius: "0.375rem",
+  border: "none",
+  backgroundColor: "#3b82f6",
+  color: "white",
+  cursor: "pointer",
+  fontSize: "0.875rem",
+  fontWeight: 500,
+  marginTop: "0.5rem",
+};

--- a/apps/viewer/src/components/LandingPage.tsx
+++ b/apps/viewer/src/components/LandingPage.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+
+interface LandingPageProps {
+  onLoad: (url: string) => void;
+}
+
+export function LandingPage({ onLoad }: LandingPageProps) {
+  const [url, setUrl] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (url.trim()) {
+      onLoad(url.trim());
+    }
+  };
+
+  return (
+    <div style={containerStyle}>
+      <div style={cardStyle}>
+        <h1 style={titleStyle}>Stagebook Viewer</h1>
+        <p style={subtitleStyle}>
+          Walk through a study from the participant's perspective.
+        </p>
+
+        <form onSubmit={handleSubmit} style={formStyle}>
+          <label htmlFor="url-input" style={labelStyle}>
+            GitHub URL to a treatment YAML file
+          </label>
+          <input
+            id="url-input"
+            type="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://github.com/org/repo/blob/main/treatments/study.yaml"
+            style={inputStyle}
+          />
+          <button type="submit" disabled={!url.trim()} style={buttonStyle}>
+            Load study
+          </button>
+        </form>
+
+        <p style={hintStyle}>
+          Paste a link to any treatment YAML file hosted on GitHub. The viewer
+          fetches it directly — no backend needed.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+const containerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: "100vh",
+  backgroundColor: "#f9fafb",
+};
+
+const cardStyle: React.CSSProperties = {
+  maxWidth: "32rem",
+  width: "100%",
+  padding: "2rem",
+};
+
+const titleStyle: React.CSSProperties = {
+  fontSize: "1.5rem",
+  fontWeight: 700,
+  color: "#1f2937",
+  margin: 0,
+};
+
+const subtitleStyle: React.CSSProperties = {
+  color: "#6b7280",
+  marginTop: "0.5rem",
+  fontSize: "0.875rem",
+};
+
+const formStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+  marginTop: "1.5rem",
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: "0.875rem",
+  fontWeight: 500,
+  color: "#374151",
+};
+
+const inputStyle: React.CSSProperties = {
+  padding: "0.5rem 0.75rem",
+  borderRadius: "0.375rem",
+  border: "1px solid #d1d5db",
+  fontSize: "0.875rem",
+};
+
+const buttonStyle: React.CSSProperties = {
+  padding: "0.5rem 1rem",
+  borderRadius: "0.375rem",
+  border: "none",
+  backgroundColor: "#3b82f6",
+  color: "white",
+  cursor: "pointer",
+  fontSize: "0.875rem",
+  fontWeight: 500,
+  marginTop: "0.5rem",
+};
+
+const hintStyle: React.CSSProperties = {
+  fontSize: "0.75rem",
+  color: "#9ca3af",
+  marginTop: "1.5rem",
+  lineHeight: 1.5,
+};

--- a/apps/viewer/src/components/SkeletonPlaceholder.tsx
+++ b/apps/viewer/src/components/SkeletonPlaceholder.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+
+interface SkeletonPlaceholderProps {
+  type: string;
+  config?: Record<string, unknown>;
+}
+
+export function SkeletonPlaceholder({
+  type,
+  config,
+}: SkeletonPlaceholderProps) {
+  const labels: Record<string, string> = {
+    discussion:
+      "Discussion element — requires live session with multiple participants",
+    survey: "Survey element — requires external survey platform",
+    sharedNotepad:
+      "Shared notepad — requires live session with multiple participants",
+    talkMeter: "Talk meter — requires live audio session",
+    qualtrics: "Qualtrics survey — requires external integration",
+  };
+
+  const label = labels[type] ?? `${type} — platform-coupled element`;
+
+  return (
+    <div style={containerStyle}>
+      <div style={iconStyle}>&#9641;</div>
+      <p style={labelStyle}>{label}</p>
+      {config && Object.keys(config).length > 0 && (
+        <details style={detailsStyle}>
+          <summary style={summaryStyle}>Configuration</summary>
+          <pre style={preStyle}>{JSON.stringify(config, null, 2)}</pre>
+        </details>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Create the platform-coupled renderer functions for the mock context.
+ */
+export function createSkeletonRenderers() {
+  return {
+    renderDiscussion: (config: Record<string, unknown>) => (
+      <SkeletonPlaceholder type="discussion" config={config} />
+    ),
+    renderSurvey: (config: {
+      surveyName: string;
+      onComplete: (results: unknown) => void;
+    }) => (
+      <SkeletonPlaceholder
+        type="survey"
+        config={{ surveyName: config.surveyName }}
+      />
+    ),
+    renderSharedNotepad: (config: { padName: string }) => (
+      <SkeletonPlaceholder
+        type="sharedNotepad"
+        config={{ padName: config.padName }}
+      />
+    ),
+    renderTalkMeter: () => <SkeletonPlaceholder type="talkMeter" />,
+  };
+}
+
+// --- Styles ---
+
+const containerStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: "0.5rem",
+  padding: "2rem",
+  border: "2px dashed #d1d5db",
+  borderRadius: "0.5rem",
+  backgroundColor: "#f9fafb",
+  minHeight: "8rem",
+};
+
+const iconStyle: React.CSSProperties = {
+  fontSize: "1.5rem",
+  color: "#9ca3af",
+};
+
+const labelStyle: React.CSSProperties = {
+  fontSize: "0.8125rem",
+  color: "#6b7280",
+  textAlign: "center" as const,
+  margin: 0,
+};
+
+const detailsStyle: React.CSSProperties = {
+  width: "100%",
+  maxWidth: "24rem",
+};
+
+const summaryStyle: React.CSSProperties = {
+  fontSize: "0.75rem",
+  color: "#9ca3af",
+  cursor: "pointer",
+};
+
+const preStyle: React.CSSProperties = {
+  fontSize: "0.6875rem",
+  color: "#6b7280",
+  backgroundColor: "white",
+  padding: "0.5rem",
+  borderRadius: "0.25rem",
+  border: "1px solid #e5e7eb",
+  overflow: "auto",
+  maxHeight: "10rem",
+};

--- a/apps/viewer/src/components/StageNav.tsx
+++ b/apps/viewer/src/components/StageNav.tsx
@@ -1,0 +1,80 @@
+import type { ViewerStep } from "../lib/steps";
+
+interface StageNavProps {
+  steps: ViewerStep[];
+  currentIndex: number;
+  onSelect: (index: number) => void;
+}
+
+export function StageNav({ steps, currentIndex, onSelect }: StageNavProps) {
+  const hasPrev = currentIndex > 0;
+  const hasNext = currentIndex < steps.length - 1;
+
+  return (
+    <div style={navStyle}>
+      <button
+        onClick={() => onSelect(currentIndex - 1)}
+        disabled={!hasPrev}
+        style={arrowStyle}
+        aria-label="Previous stage"
+      >
+        &#9664;
+      </button>
+
+      <select
+        value={currentIndex}
+        onChange={(e) => onSelect(Number(e.target.value))}
+        style={selectStyle}
+      >
+        {steps.map((step) => (
+          <option key={step.index} value={step.index}>
+            [{step.phase}] {step.name}
+          </option>
+        ))}
+      </select>
+
+      <button
+        onClick={() => onSelect(currentIndex + 1)}
+        disabled={!hasNext}
+        style={arrowStyle}
+        aria-label="Next stage"
+      >
+        &#9654;
+      </button>
+
+      <span style={counterStyle}>
+        {currentIndex + 1} / {steps.length}
+      </span>
+    </div>
+  );
+}
+
+const navStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.25rem",
+};
+
+const arrowStyle: React.CSSProperties = {
+  background: "none",
+  border: "1px solid #d1d5db",
+  borderRadius: "0.25rem",
+  cursor: "pointer",
+  padding: "0.25rem 0.5rem",
+  fontSize: "0.625rem",
+  color: "#374151",
+};
+
+const selectStyle: React.CSSProperties = {
+  padding: "0.25rem 0.5rem",
+  borderRadius: "0.25rem",
+  border: "1px solid #d1d5db",
+  fontSize: "0.75rem",
+  maxWidth: "14rem",
+};
+
+const counterStyle: React.CSSProperties = {
+  fontSize: "0.75rem",
+  color: "#9ca3af",
+  marginLeft: "0.25rem",
+};

--- a/apps/viewer/src/components/StateInspector.tsx
+++ b/apps/viewer/src/components/StateInspector.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { getReferenceKeyAndPath } from "stagebook";
 import { ViewerStateStore } from "../lib/store";
 import { extractStageReferences } from "../lib/references";
 import type { ViewerStep } from "../lib/steps";
@@ -96,16 +97,29 @@ function ReferenceEditor({
   const currentValue = values[0] !== undefined ? String(values[0]) : "";
 
   const handleChange = (newValue: string) => {
-    // Parse the reference to get the store key, then write directly
-    // For now, store as a simple value under the reference key
-    const parts = reference.split(".");
-    const type = parts[0];
-    const name = parts[1];
-    if (type && name) {
-      const key = `${type}_${name}`;
-      // For prompts, wrap in { value: ... } since resolve extracts .value
-      const stored = type === "prompt" ? { value: newValue } : newValue;
-      store.set(position, key, stored, stageIndex);
+    const { referenceKey, path } = getReferenceKeyAndPath(reference);
+
+    if (path.length === 0) {
+      // No nested path — store the value directly
+      store.set(position, referenceKey, newValue, stageIndex);
+    } else {
+      // Nested path (e.g., prompt → path=["value"]) — preserve existing
+      // object structure and write the value at the correct path
+      const existing = store.get(position, referenceKey)?.value;
+      const obj =
+        existing && typeof existing === "object" && !Array.isArray(existing)
+          ? { ...(existing as Record<string, unknown>) }
+          : {};
+      let cursor: Record<string, unknown> = obj;
+      for (let i = 0; i < path.length - 1; i++) {
+        const seg = path[i];
+        if (typeof cursor[seg] !== "object" || cursor[seg] === null) {
+          cursor[seg] = {};
+        }
+        cursor = cursor[seg] as Record<string, unknown>;
+      }
+      cursor[path[path.length - 1]] = newValue;
+      store.set(position, referenceKey, obj, stageIndex);
     }
   };
 

--- a/apps/viewer/src/components/StateInspector.tsx
+++ b/apps/viewer/src/components/StateInspector.tsx
@@ -1,0 +1,308 @@
+import { useState } from "react";
+import { ViewerStateStore } from "../lib/store";
+import { extractStageReferences } from "../lib/references";
+import type { ViewerStep } from "../lib/steps";
+
+interface StateInspectorProps {
+  store: ViewerStateStore;
+  currentStep: ViewerStep;
+  stageIndex: number;
+  position: number;
+  playerCount: number;
+}
+
+export function StateInspector({
+  store,
+  currentStep,
+  stageIndex,
+  position,
+  playerCount,
+}: StateInspectorProps) {
+  const [showAll, setShowAll] = useState(false);
+
+  const references = extractStageReferences(
+    currentStep.elements as Record<string, unknown>[],
+  );
+
+  const isSubmitted = store.getSubmitted(stageIndex);
+  const elapsedTime = store.getElapsedTime(stageIndex);
+
+  return (
+    <div style={containerStyle}>
+      <div style={sectionHeaderStyle}>This stage</div>
+
+      {/* Viewer controls */}
+      <div style={controlGroupStyle}>
+        <label style={controlLabelStyle}>
+          <input
+            type="checkbox"
+            checked={isSubmitted}
+            onChange={(e) => store.setSubmitted(stageIndex, e.target.checked)}
+            style={checkboxStyle}
+          />
+          submitted
+        </label>
+      </div>
+
+      {currentStep.duration !== undefined && (
+        <div style={controlGroupStyle}>
+          <label style={controlLabelStyle}>elapsed (sec)</label>
+          <input
+            type="number"
+            value={elapsedTime}
+            min={0}
+            max={currentStep.duration}
+            onChange={(e) =>
+              store.setElapsedTime(stageIndex, Number(e.target.value))
+            }
+            style={numberInputStyle}
+          />
+        </div>
+      )}
+
+      {/* References relevant to this stage */}
+      {references.length > 0 && (
+        <>
+          <div style={{ ...sectionHeaderStyle, marginTop: "1rem" }}>
+            Referenced state
+          </div>
+          {references.map((ref) => (
+            <ReferenceEditor
+              key={ref}
+              reference={ref}
+              store={store}
+              position={position}
+              stageIndex={stageIndex}
+            />
+          ))}
+        </>
+      )}
+
+      {references.length === 0 && (
+        <p style={emptyStyle}>No external references on this stage.</p>
+      )}
+
+      {/* All state expansion */}
+      <button onClick={() => setShowAll(!showAll)} style={expandButtonStyle}>
+        {showAll ? "▾ Hide all state" : "▸ Show all state"}
+      </button>
+
+      {showAll && (
+        <AllState
+          store={store}
+          currentStageIndex={stageIndex}
+          playerCount={playerCount}
+        />
+      )}
+    </div>
+  );
+}
+
+function ReferenceEditor({
+  reference,
+  store,
+  position,
+  stageIndex,
+}: {
+  reference: string;
+  store: ViewerStateStore;
+  position: number;
+  stageIndex: number;
+}) {
+  const values = store.resolve(reference, position);
+  const currentValue = values[0] !== undefined ? String(values[0]) : "";
+
+  const handleChange = (newValue: string) => {
+    // Parse the reference to get the store key, then write directly
+    // For now, store as a simple value under the reference key
+    const parts = reference.split(".");
+    const type = parts[0];
+    const name = parts[1];
+    if (type && name) {
+      const key = `${type}_${name}`;
+      // For prompts, wrap in { value: ... } since resolve extracts .value
+      const stored = type === "prompt" ? { value: newValue } : newValue;
+      store.set(position, key, stored, stageIndex);
+    }
+  };
+
+  return (
+    <div style={refGroupStyle}>
+      <label style={refLabelStyle}>{reference}</label>
+      <input
+        type="text"
+        value={currentValue}
+        onChange={(e) => handleChange(e.target.value)}
+        placeholder="(not set)"
+        style={refInputStyle}
+      />
+    </div>
+  );
+}
+
+function AllState({
+  store,
+  currentStageIndex,
+  playerCount,
+}: {
+  store: ViewerStateStore;
+  currentStageIndex: number;
+  playerCount: number;
+}) {
+  const allEntries = store.getAll();
+
+  if (allEntries.length === 0) {
+    return <p style={emptyStyle}>No state values stored yet.</p>;
+  }
+
+  return (
+    <div style={allStateStyle}>
+      {allEntries.map(({ positionKey, storeKey, entry }) => {
+        const isFuture = entry.setOnStageIndex > currentStageIndex;
+        const posLabel =
+          positionKey === "shared"
+            ? "shared"
+            : `pos ${positionKey}${positionKey < playerCount ? "" : " (out of range)"}`;
+
+        return (
+          <div
+            key={`${String(positionKey)}-${storeKey}`}
+            style={{
+              ...allStateItemStyle,
+              opacity: isFuture ? 0.4 : 1,
+            }}
+          >
+            <div style={allStateKeyStyle}>
+              <span>{storeKey}</span>
+              <span style={allStateBadgeStyle}>{posLabel}</span>
+            </div>
+            <div style={allStateValueStyle}>
+              {typeof entry.value === "object"
+                ? JSON.stringify(entry.value)
+                : String(entry.value)}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// --- Styles ---
+
+const containerStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.25rem",
+};
+
+const sectionHeaderStyle: React.CSSProperties = {
+  fontSize: "0.6875rem",
+  fontWeight: 600,
+  color: "#6b7280",
+  textTransform: "uppercase" as const,
+  letterSpacing: "0.05em",
+  marginBottom: "0.25rem",
+};
+
+const controlGroupStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+  fontSize: "0.8125rem",
+};
+
+const controlLabelStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.375rem",
+  color: "#374151",
+  fontSize: "0.8125rem",
+  cursor: "pointer",
+};
+
+const checkboxStyle: React.CSSProperties = {
+  cursor: "pointer",
+};
+
+const numberInputStyle: React.CSSProperties = {
+  width: "5rem",
+  padding: "0.125rem 0.375rem",
+  border: "1px solid #d1d5db",
+  borderRadius: "0.25rem",
+  fontSize: "0.8125rem",
+};
+
+const refGroupStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.125rem",
+  marginBottom: "0.375rem",
+};
+
+const refLabelStyle: React.CSSProperties = {
+  fontSize: "0.75rem",
+  color: "#6b7280",
+  fontFamily: "monospace",
+};
+
+const refInputStyle: React.CSSProperties = {
+  padding: "0.25rem 0.375rem",
+  border: "1px solid #d1d5db",
+  borderRadius: "0.25rem",
+  fontSize: "0.8125rem",
+};
+
+const emptyStyle: React.CSSProperties = {
+  fontSize: "0.75rem",
+  color: "#9ca3af",
+  marginTop: "0.5rem",
+};
+
+const expandButtonStyle: React.CSSProperties = {
+  background: "none",
+  border: "none",
+  color: "#6b7280",
+  fontSize: "0.75rem",
+  cursor: "pointer",
+  textAlign: "left" as const,
+  padding: "0.25rem 0",
+  marginTop: "1rem",
+};
+
+const allStateStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.375rem",
+  marginTop: "0.25rem",
+};
+
+const allStateItemStyle: React.CSSProperties = {
+  padding: "0.375rem 0.5rem",
+  backgroundColor: "white",
+  borderRadius: "0.25rem",
+  border: "1px solid #e5e7eb",
+  fontSize: "0.75rem",
+};
+
+const allStateKeyStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  fontFamily: "monospace",
+  color: "#374151",
+};
+
+const allStateBadgeStyle: React.CSSProperties = {
+  fontSize: "0.625rem",
+  color: "#9ca3af",
+  backgroundColor: "#f3f4f6",
+  padding: "0.0625rem 0.375rem",
+  borderRadius: "0.25rem",
+};
+
+const allStateValueStyle: React.CSSProperties = {
+  color: "#6b7280",
+  marginTop: "0.125rem",
+  wordBreak: "break-all" as const,
+};

--- a/apps/viewer/src/components/StateInspector.tsx
+++ b/apps/viewer/src/components/StateInspector.tsx
@@ -25,7 +25,6 @@ export function StateInspector({
   );
 
   const isSubmitted = store.getSubmitted(stageIndex);
-  const elapsedTime = store.getElapsedTime(stageIndex);
 
   return (
     <div style={containerStyle}>
@@ -43,22 +42,6 @@ export function StateInspector({
           submitted
         </label>
       </div>
-
-      {currentStep.duration !== undefined && (
-        <div style={controlGroupStyle}>
-          <label style={controlLabelStyle}>elapsed (sec)</label>
-          <input
-            type="number"
-            value={elapsedTime}
-            min={0}
-            max={currentStep.duration}
-            onChange={(e) =>
-              store.setElapsedTime(stageIndex, Number(e.target.value))
-            }
-            style={numberInputStyle}
-          />
-        </div>
-      )}
 
       {/* References relevant to this stage */}
       {references.length > 0 && (
@@ -223,14 +206,6 @@ const controlLabelStyle: React.CSSProperties = {
 
 const checkboxStyle: React.CSSProperties = {
   cursor: "pointer",
-};
-
-const numberInputStyle: React.CSSProperties = {
-  width: "5rem",
-  padding: "0.125rem 0.375rem",
-  border: "1px solid #d1d5db",
-  borderRadius: "0.25rem",
-  fontSize: "0.8125rem",
 };
 
 const refGroupStyle: React.CSSProperties = {

--- a/apps/viewer/src/components/TimeScrubber.tsx
+++ b/apps/viewer/src/components/TimeScrubber.tsx
@@ -1,0 +1,241 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import { extractTimeBreakpoints } from "../lib/timeBreakpoints";
+import type { ViewerStep } from "../lib/steps";
+
+interface TimeScrubberProps {
+  currentStep: ViewerStep;
+  elapsedTime: number;
+  onTimeChange: (seconds: number) => void;
+}
+
+const SPEEDS = [1, 2, 5, 10];
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+export function TimeScrubber({
+  currentStep,
+  elapsedTime,
+  onTimeChange,
+}: TimeScrubberProps) {
+  const duration = currentStep.duration;
+  if (duration === undefined) return null;
+
+  return (
+    <TimeScrubberInner
+      duration={duration}
+      elements={currentStep.elements as Record<string, unknown>[]}
+      elapsedTime={elapsedTime}
+      onTimeChange={onTimeChange}
+    />
+  );
+}
+
+function TimeScrubberInner({
+  duration,
+  elements,
+  elapsedTime,
+  onTimeChange,
+}: {
+  duration: number;
+  elements: Record<string, unknown>[];
+  elapsedTime: number;
+  onTimeChange: (seconds: number) => void;
+}) {
+  const [playing, setPlaying] = useState(false);
+  const [speed, setSpeed] = useState(1);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Playback
+  useEffect(() => {
+    if (!playing) {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      return;
+    }
+    const tickMs = 50;
+    intervalRef.current = setInterval(() => {
+      onTimeChange(Math.min(duration, elapsedTime + (speed * tickMs) / 1000));
+    }, tickMs);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [playing, speed, elapsedTime, duration, onTimeChange]);
+
+  // Pause at end
+  useEffect(() => {
+    if (elapsedTime >= duration) setPlaying(false);
+  }, [elapsedTime, duration]);
+
+  const breakpoints = extractTimeBreakpoints(elements);
+
+  const handleTrackClick = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      const track = trackRef.current;
+      if (!track) return;
+      const rect = track.getBoundingClientRect();
+      const fraction = Math.max(
+        0,
+        Math.min(1, (e.clientX - rect.left) / rect.width),
+      );
+      onTimeChange(Math.round(fraction * duration));
+    },
+    [duration, onTimeChange],
+  );
+
+  const fraction = duration > 0 ? elapsedTime / duration : 0;
+
+  return (
+    <div style={containerStyle}>
+      <button
+        onClick={() => {
+          if (elapsedTime >= duration) onTimeChange(0);
+          setPlaying(!playing);
+        }}
+        style={playButtonStyle}
+        aria-label={playing ? "Pause" : "Play"}
+      >
+        {playing ? "⏸" : "▶"}
+      </button>
+
+      <button
+        onClick={() => {
+          const idx = SPEEDS.indexOf(speed);
+          setSpeed(SPEEDS[(idx + 1) % SPEEDS.length]);
+        }}
+        style={speedButtonStyle}
+        title="Playback speed"
+      >
+        {speed}x
+      </button>
+
+      <span style={timeStyle}>{formatTime(elapsedTime)}</span>
+
+      <div ref={trackRef} onClick={handleTrackClick} style={trackStyle}>
+        {/* Progress fill */}
+        <div
+          style={{
+            ...fillStyle,
+            width: `${fraction * 100}%`,
+          }}
+        />
+        {/* Breakpoint markers */}
+        {breakpoints.map((t) => (
+          <div
+            key={t}
+            onClick={(e) => {
+              e.stopPropagation();
+              onTimeChange(t);
+            }}
+            style={{
+              ...markerStyle,
+              left: `${(t / duration) * 100}%`,
+            }}
+            title={`${t}s`}
+          />
+        ))}
+        {/* Thumb */}
+        <div
+          style={{
+            ...thumbStyle,
+            left: `${fraction * 100}%`,
+          }}
+        />
+      </div>
+
+      <span style={timeStyle}>{formatTime(duration)}</span>
+    </div>
+  );
+}
+
+// --- Styles ---
+
+const containerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.375rem",
+  minWidth: 0,
+  flex: 1,
+};
+
+const playButtonStyle: React.CSSProperties = {
+  background: "none",
+  border: "1px solid #d1d5db",
+  borderRadius: "0.25rem",
+  cursor: "pointer",
+  padding: "0.125rem 0.375rem",
+  fontSize: "0.75rem",
+  lineHeight: 1,
+  flexShrink: 0,
+};
+
+const speedButtonStyle: React.CSSProperties = {
+  background: "none",
+  border: "1px solid #d1d5db",
+  borderRadius: "0.25rem",
+  cursor: "pointer",
+  padding: "0.125rem 0.375rem",
+  fontSize: "0.625rem",
+  fontWeight: 600,
+  color: "#6b7280",
+  minWidth: "2rem",
+  textAlign: "center" as const,
+  flexShrink: 0,
+};
+
+const timeStyle: React.CSSProperties = {
+  fontSize: "0.6875rem",
+  color: "#6b7280",
+  fontVariantNumeric: "tabular-nums",
+  flexShrink: 0,
+  minWidth: "2.25rem",
+};
+
+const trackStyle: React.CSSProperties = {
+  position: "relative",
+  height: "1.25rem",
+  flex: 1,
+  minWidth: "4rem",
+  cursor: "pointer",
+  display: "flex",
+  alignItems: "center",
+};
+
+const fillStyle: React.CSSProperties = {
+  position: "absolute",
+  left: 0,
+  top: "50%",
+  transform: "translateY(-50%)",
+  height: "0.25rem",
+  backgroundColor: "#3b82f6",
+  borderRadius: "0.125rem",
+};
+
+const markerStyle: React.CSSProperties = {
+  position: "absolute",
+  top: "50%",
+  transform: "translate(-50%, -50%)",
+  width: "0.5rem",
+  height: "0.5rem",
+  borderRadius: "50%",
+  backgroundColor: "#d1d5db",
+  border: "1px solid #9ca3af",
+  cursor: "pointer",
+  zIndex: 1,
+};
+
+const thumbStyle: React.CSSProperties = {
+  position: "absolute",
+  top: "50%",
+  transform: "translate(-50%, -50%)",
+  width: "0.75rem",
+  height: "0.75rem",
+  borderRadius: "50%",
+  backgroundColor: "#3b82f6",
+  border: "2px solid white",
+  boxShadow: "0 1px 3px rgba(0,0,0,0.2)",
+  zIndex: 2,
+};

--- a/apps/viewer/src/components/TimeScrubber.tsx
+++ b/apps/viewer/src/components/TimeScrubber.tsx
@@ -202,6 +202,8 @@ const trackStyle: React.CSSProperties = {
   cursor: "pointer",
   display: "flex",
   alignItems: "center",
+  background:
+    "linear-gradient(to right, #e5e7eb, #e5e7eb) no-repeat center / 100% 0.25rem",
 };
 
 const fillStyle: React.CSSProperties = {

--- a/apps/viewer/src/components/TimeScrubber.tsx
+++ b/apps/viewer/src/components/TimeScrubber.tsx
@@ -48,27 +48,23 @@ function TimeScrubberInner({
   const [playing, setPlaying] = useState(false);
   const [speed, setSpeed] = useState(1);
   const trackRef = useRef<HTMLDivElement>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const elapsedRef = useRef(elapsedTime);
+  elapsedRef.current = elapsedTime;
 
-  // Playback
+  // Playback — interval reads elapsed from ref to avoid teardown every tick
   useEffect(() => {
-    if (!playing) {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-      return;
-    }
+    if (!playing) return;
     const tickMs = 50;
-    intervalRef.current = setInterval(() => {
-      onTimeChange(Math.min(duration, elapsedTime + (speed * tickMs) / 1000));
+    const id = setInterval(() => {
+      const next = Math.min(
+        duration,
+        elapsedRef.current + (speed * tickMs) / 1000,
+      );
+      onTimeChange(next);
+      if (next >= duration) setPlaying(false);
     }, tickMs);
-    return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
-    };
-  }, [playing, speed, elapsedTime, duration, onTimeChange]);
-
-  // Pause at end
-  useEffect(() => {
-    if (elapsedTime >= duration) setPlaying(false);
-  }, [elapsedTime, duration]);
+    return () => clearInterval(id);
+  }, [playing, speed, duration, onTimeChange]);
 
   const breakpoints = extractTimeBreakpoints(elements);
 
@@ -124,7 +120,8 @@ function TimeScrubberInner({
         />
         {/* Breakpoint markers */}
         {breakpoints.map((t) => (
-          <div
+          <button
+            type="button"
             key={t}
             onClick={(e) => {
               e.stopPropagation();
@@ -134,7 +131,7 @@ function TimeScrubberInner({
               ...markerStyle,
               left: `${(t / duration) * 100}%`,
             }}
-            title={`${t}s`}
+            aria-label={`Jump to ${t} seconds`}
           />
         ))}
         {/* Thumb */}

--- a/apps/viewer/src/components/TreatmentPicker.tsx
+++ b/apps/viewer/src/components/TreatmentPicker.tsx
@@ -1,0 +1,144 @@
+import type { TreatmentFileType } from "stagebook";
+
+interface TreatmentPickerProps {
+  treatmentFile: TreatmentFileType;
+  onSelect: (introIndex: number, treatmentIndex: number) => void;
+}
+
+export function TreatmentPicker({
+  treatmentFile,
+  onSelect,
+}: TreatmentPickerProps) {
+  const { introSequences, treatments } = treatmentFile;
+  const multipleIntros = introSequences.length > 1;
+  const multipleTreatments = treatments.length > 1;
+
+  // If only one dimension needs selection, auto-select the other
+  const handleTreatmentClick = (treatmentIndex: number) => {
+    if (multipleIntros) return; // need intro selection too — handled below
+    onSelect(0, treatmentIndex);
+  };
+
+  // For the rare case of multiple intros + multiple treatments,
+  // show both lists with a two-step selection. For now, keep it
+  // simple: single combined selection.
+  return (
+    <div style={containerStyle}>
+      <div style={cardStyle}>
+        <h1 style={titleStyle}>Select a configuration</h1>
+
+        {multipleTreatments && (
+          <>
+            <h2 style={sectionStyle}>Treatments</h2>
+            <div style={listStyle}>
+              {treatments.map(
+                (
+                  t: {
+                    name: string;
+                    playerCount: number;
+                    gameStages: unknown[];
+                  },
+                  i: number,
+                ) => (
+                  <button
+                    key={t.name}
+                    onClick={() => handleTreatmentClick(i)}
+                    style={optionStyle}
+                  >
+                    <span style={optionNameStyle}>{t.name}</span>
+                    <span style={optionDetailStyle}>
+                      {t.playerCount} player{t.playerCount !== 1 ? "s" : ""},{" "}
+                      {t.gameStages.length} stage
+                      {t.gameStages.length !== 1 ? "s" : ""}
+                    </span>
+                  </button>
+                ),
+              )}
+            </div>
+          </>
+        )}
+
+        {multipleIntros && (
+          <>
+            <h2 style={sectionStyle}>Intro Sequences</h2>
+            <div style={listStyle}>
+              {introSequences.map(
+                (intro: { name: string; introSteps: unknown[] }, i: number) => (
+                  <button
+                    key={intro.name}
+                    onClick={() => onSelect(i, 0)}
+                    style={optionStyle}
+                  >
+                    <span style={optionNameStyle}>{intro.name}</span>
+                    <span style={optionDetailStyle}>
+                      {intro.introSteps.length} step
+                      {intro.introSteps.length !== 1 ? "s" : ""}
+                    </span>
+                  </button>
+                ),
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const containerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: "100vh",
+  backgroundColor: "#f9fafb",
+};
+
+const cardStyle: React.CSSProperties = {
+  maxWidth: "32rem",
+  width: "100%",
+  padding: "2rem",
+};
+
+const titleStyle: React.CSSProperties = {
+  fontSize: "1.25rem",
+  fontWeight: 700,
+  color: "#1f2937",
+  margin: 0,
+};
+
+const sectionStyle: React.CSSProperties = {
+  fontSize: "0.875rem",
+  fontWeight: 600,
+  color: "#374151",
+  marginTop: "1.5rem",
+  marginBottom: "0.5rem",
+};
+
+const listStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+};
+
+const optionStyle: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "0.75rem 1rem",
+  borderRadius: "0.375rem",
+  border: "1px solid #e5e7eb",
+  backgroundColor: "white",
+  cursor: "pointer",
+  textAlign: "left",
+};
+
+const optionNameStyle: React.CSSProperties = {
+  fontWeight: 500,
+  color: "#1f2937",
+  fontSize: "0.875rem",
+};
+
+const optionDetailStyle: React.CSSProperties = {
+  color: "#9ca3af",
+  fontSize: "0.75rem",
+};

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -1,0 +1,280 @@
+import { useState, useMemo, useCallback, useSyncExternalStore } from "react";
+import type { TreatmentFileType } from "stagebook";
+import { StagebookProvider, Stage } from "stagebook/components";
+import { flattenSteps } from "../lib/steps";
+import { ViewerStateStore } from "../lib/store";
+import { createViewerContext } from "../lib/context";
+import { StageNav } from "./StageNav";
+
+interface ViewerProps {
+  treatmentFile: TreatmentFileType;
+  rawBaseUrl: string;
+  selectedIntroIndex: number;
+  selectedTreatmentIndex: number;
+  onBack: () => void;
+}
+
+export function Viewer({
+  treatmentFile,
+  rawBaseUrl,
+  selectedIntroIndex,
+  selectedTreatmentIndex,
+  onBack,
+}: ViewerProps) {
+  const treatment = treatmentFile.treatments[selectedTreatmentIndex];
+  const introSequence = treatmentFile.introSequences[selectedIntroIndex];
+
+  const steps = useMemo(
+    () => flattenSteps(introSequence, treatment),
+    [introSequence, treatment],
+  );
+
+  const [stageIndex, setStageIndex] = useState(0);
+  const [position, setPosition] = useState(0);
+  const [store] = useState(() => new ViewerStateStore());
+
+  // Subscribe to store changes so the UI re-renders
+  useSyncExternalStore(
+    useCallback((cb: () => void) => store.onChange(cb), [store]),
+    useCallback(() => ({}), []),
+  );
+
+  const currentStep = steps[stageIndex];
+  const isSubmitted = store.getSubmitted(stageIndex);
+
+  const handleSubmit = useCallback(() => {
+    store.setSubmitted(stageIndex, true);
+  }, [store, stageIndex]);
+
+  const handleNext = useCallback(() => {
+    if (stageIndex < steps.length - 1) {
+      setStageIndex(stageIndex + 1);
+    }
+  }, [stageIndex, steps.length]);
+
+  const ctx = useMemo(
+    () =>
+      createViewerContext({
+        store,
+        position,
+        stageIndex,
+        playerCount: treatment.playerCount,
+        rawBaseUrl,
+        onSubmit: handleSubmit,
+      }),
+    [
+      store,
+      position,
+      stageIndex,
+      treatment.playerCount,
+      rawBaseUrl,
+      handleSubmit,
+    ],
+  );
+
+  if (!currentStep) return null;
+
+  const stageConfig = {
+    name: currentStep.name,
+    duration: currentStep.duration,
+    elements: currentStep.elements,
+  };
+
+  return (
+    <div style={layoutStyle}>
+      {/* Header */}
+      <header style={headerStyle}>
+        <div style={headerLeftStyle}>
+          <button onClick={onBack} style={backButtonStyle}>
+            &larr;
+          </button>
+          <span style={treatmentNameStyle}>{treatment.name}</span>
+        </div>
+        <StageNav
+          steps={steps}
+          currentIndex={stageIndex}
+          onSelect={setStageIndex}
+        />
+        <div style={positionSwitcherStyle}>
+          <label htmlFor="position-select" style={positionLabelStyle}>
+            Position
+          </label>
+          <select
+            id="position-select"
+            value={position}
+            onChange={(e) => setPosition(Number(e.target.value))}
+            style={positionSelectStyle}
+          >
+            {Array.from({ length: treatment.playerCount }, (_, i) => (
+              <option key={i} value={i}>
+                {i}
+              </option>
+            ))}
+          </select>
+        </div>
+      </header>
+
+      <div style={bodyStyle}>
+        {/* Sidebar placeholder — state inspector will go here in chunk 4 */}
+        <aside style={sidebarStyle}>
+          <div style={sidebarHeaderStyle}>State Inspector</div>
+          <p style={sidebarPlaceholderStyle}>Coming in chunk 4</p>
+        </aside>
+
+        {/* Main content */}
+        <main style={mainStyle}>
+          {isSubmitted ? (
+            <div style={submittedOverlayStyle}>
+              <p style={submittedTextStyle}>
+                Waiting for other participants...
+              </p>
+              <button onClick={handleNext} style={nextButtonStyle}>
+                Next &rarr;
+              </button>
+              <button
+                onClick={() => store.setSubmitted(stageIndex, false)}
+                style={toggleSubmitStyle}
+              >
+                Show stage again
+              </button>
+            </div>
+          ) : (
+            <StagebookProvider value={ctx}>
+              <Stage stage={stageConfig} onSubmit={handleSubmit} />
+            </StagebookProvider>
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+// --- Styles ---
+
+const layoutStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  height: "100vh",
+};
+
+const headerStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  padding: "0.5rem 1rem",
+  borderBottom: "1px solid #e5e7eb",
+  backgroundColor: "white",
+  gap: "1rem",
+  flexShrink: 0,
+};
+
+const headerLeftStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+};
+
+const backButtonStyle: React.CSSProperties = {
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  fontSize: "1.25rem",
+  color: "#6b7280",
+  padding: "0.25rem",
+};
+
+const treatmentNameStyle: React.CSSProperties = {
+  fontWeight: 600,
+  fontSize: "0.875rem",
+  color: "#1f2937",
+};
+
+const positionSwitcherStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+};
+
+const positionLabelStyle: React.CSSProperties = {
+  fontSize: "0.75rem",
+  color: "#6b7280",
+};
+
+const positionSelectStyle: React.CSSProperties = {
+  padding: "0.25rem 0.5rem",
+  borderRadius: "0.25rem",
+  border: "1px solid #d1d5db",
+  fontSize: "0.75rem",
+};
+
+const bodyStyle: React.CSSProperties = {
+  display: "flex",
+  flex: 1,
+  overflow: "hidden",
+};
+
+const sidebarStyle: React.CSSProperties = {
+  width: "var(--viewer-sidebar-width)",
+  flexShrink: 0,
+  borderRight: "1px solid #e5e7eb",
+  backgroundColor: "#fafafa",
+  overflow: "auto",
+  padding: "1rem",
+};
+
+const sidebarHeaderStyle: React.CSSProperties = {
+  fontSize: "0.75rem",
+  fontWeight: 600,
+  color: "#6b7280",
+  textTransform: "uppercase" as const,
+  letterSpacing: "0.05em",
+};
+
+const sidebarPlaceholderStyle: React.CSSProperties = {
+  fontSize: "0.75rem",
+  color: "#9ca3af",
+  marginTop: "0.5rem",
+};
+
+const mainStyle: React.CSSProperties = {
+  flex: 1,
+  overflow: "auto",
+  padding: "1.5rem",
+  display: "flex",
+  justifyContent: "center",
+};
+
+const submittedOverlayStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: "1rem",
+  height: "100%",
+  width: "100%",
+};
+
+const submittedTextStyle: React.CSSProperties = {
+  color: "#6b7280",
+  fontSize: "0.875rem",
+};
+
+const nextButtonStyle: React.CSSProperties = {
+  padding: "0.5rem 1.5rem",
+  borderRadius: "0.375rem",
+  border: "none",
+  backgroundColor: "#3b82f6",
+  color: "white",
+  cursor: "pointer",
+  fontSize: "0.875rem",
+  fontWeight: 500,
+};
+
+const toggleSubmitStyle: React.CSSProperties = {
+  background: "none",
+  border: "none",
+  color: "#9ca3af",
+  fontSize: "0.75rem",
+  cursor: "pointer",
+  textDecoration: "underline",
+};

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -36,7 +36,7 @@ export function Viewer({
   // Subscribe to store changes so the UI re-renders
   useSyncExternalStore(
     useCallback((cb: () => void) => store.onChange(cb), [store]),
-    useCallback(() => ({}), []),
+    useCallback(() => store.getVersion(), [store]),
   );
 
   const currentStep = steps[stageIndex];
@@ -52,6 +52,30 @@ export function Viewer({
     }
   }, [stageIndex, steps.length]);
 
+  // getTextContent and getAssetURL only depend on rawBaseUrl, so keep
+  // them stable across stage/position changes to avoid re-fetch loops
+  // in useTextContent (which has getTextContent as an effect dependency).
+  const stableContentFns = useMemo(() => {
+    const cache = new Map<string, Promise<string>>();
+    return {
+      getTextContent(path: string): Promise<string> {
+        const cached = cache.get(path);
+        if (cached) return cached;
+        const promise = fetch(rawBaseUrl + path).then((res) => {
+          if (!res.ok) {
+            throw new Error(`Failed to fetch ${path} (HTTP ${res.status})`);
+          }
+          return res.text();
+        });
+        cache.set(path, promise);
+        return promise;
+      },
+      getAssetURL(path: string): string {
+        return rawBaseUrl + path;
+      },
+    };
+  }, [rawBaseUrl]);
+
   const ctx = useMemo(
     () =>
       createViewerContext({
@@ -59,16 +83,16 @@ export function Viewer({
         position,
         stageIndex,
         playerCount: treatment.playerCount,
-        rawBaseUrl,
         onSubmit: handleSubmit,
+        ...stableContentFns,
       }),
     [
       store,
       position,
       stageIndex,
       treatment.playerCount,
-      rawBaseUrl,
       handleSubmit,
+      stableContentFns,
     ],
   );
 

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -69,12 +69,17 @@ export function Viewer({
       getTextContent(path: string): Promise<string> {
         const cached = cache.get(path);
         if (cached) return cached;
-        const promise = fetch(rawBaseUrl + path).then((res) => {
-          if (!res.ok) {
-            throw new Error(`Failed to fetch ${path} (HTTP ${res.status})`);
-          }
-          return res.text();
-        });
+        const promise = fetch(rawBaseUrl + path)
+          .then((res) => {
+            if (!res.ok) {
+              throw new Error(`Failed to fetch ${path} (HTTP ${res.status})`);
+            }
+            return res.text();
+          })
+          .catch((err) => {
+            cache.delete(path);
+            throw err;
+          });
         cache.set(path, promise);
         return promise;
       },
@@ -118,7 +123,7 @@ export function Viewer({
       {/* Header */}
       <header style={headerStyle}>
         <div style={headerLeftStyle}>
-          <button onClick={onBack} style={backButtonStyle}>
+          <button aria-label="Back" onClick={onBack} style={backButtonStyle}>
             &larr;
           </button>
           <span style={treatmentNameStyle}>{treatment.name}</span>

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -5,6 +5,7 @@ import { flattenSteps } from "../lib/steps";
 import { ViewerStateStore } from "../lib/store";
 import { createViewerContext } from "../lib/context";
 import { StageNav } from "./StageNav";
+import { StateInspector } from "./StateInspector";
 
 interface ViewerProps {
   treatmentFile: TreatmentFileType;
@@ -139,10 +140,14 @@ export function Viewer({
       </header>
 
       <div style={bodyStyle}>
-        {/* Sidebar placeholder — state inspector will go here in chunk 4 */}
         <aside style={sidebarStyle}>
-          <div style={sidebarHeaderStyle}>State Inspector</div>
-          <p style={sidebarPlaceholderStyle}>Coming in chunk 4</p>
+          <StateInspector
+            store={store}
+            currentStep={currentStep}
+            stageIndex={stageIndex}
+            position={position}
+            playerCount={treatment.playerCount}
+          />
         </aside>
 
         {/* Main content */}
@@ -244,20 +249,6 @@ const sidebarStyle: React.CSSProperties = {
   backgroundColor: "#fafafa",
   overflow: "auto",
   padding: "1rem",
-};
-
-const sidebarHeaderStyle: React.CSSProperties = {
-  fontSize: "0.75rem",
-  fontWeight: 600,
-  color: "#6b7280",
-  textTransform: "uppercase" as const,
-  letterSpacing: "0.05em",
-};
-
-const sidebarPlaceholderStyle: React.CSSProperties = {
-  fontSize: "0.75rem",
-  color: "#9ca3af",
-  marginTop: "0.5rem",
 };
 
 const mainStyle: React.CSSProperties = {

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -6,6 +6,7 @@ import { ViewerStateStore } from "../lib/store";
 import { createViewerContext } from "../lib/context";
 import { StageNav } from "./StageNav";
 import { StateInspector } from "./StateInspector";
+import { TimeScrubber } from "./TimeScrubber";
 
 interface ViewerProps {
   treatmentFile: TreatmentFileType;
@@ -52,6 +53,11 @@ export function Viewer({
       setStageIndex(stageIndex + 1);
     }
   }, [stageIndex, steps.length]);
+
+  const handleTimeChange = useCallback(
+    (seconds: number) => store.setElapsedTime(stageIndex, seconds),
+    [store, stageIndex],
+  );
 
   // getTextContent and getAssetURL only depend on rawBaseUrl, so keep
   // them stable across stage/position changes to avoid re-fetch loops
@@ -119,6 +125,11 @@ export function Viewer({
           steps={steps}
           currentIndex={stageIndex}
           onSelect={setStageIndex}
+        />
+        <TimeScrubber
+          currentStep={currentStep}
+          elapsedTime={store.getElapsedTime(stageIndex)}
+          onTimeChange={handleTimeChange}
         />
         <div style={positionSwitcherStyle}>
           <label htmlFor="position-select" style={positionLabelStyle}>

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -7,6 +7,7 @@ import { createViewerContext } from "../lib/context";
 import { StageNav } from "./StageNav";
 import { StateInspector } from "./StateInspector";
 import { TimeScrubber } from "./TimeScrubber";
+import { createSkeletonRenderers } from "./SkeletonPlaceholder";
 
 interface ViewerProps {
   treatmentFile: TreatmentFileType;
@@ -92,6 +93,7 @@ export function Viewer({
         playerCount: treatment.playerCount,
         onSubmit: handleSubmit,
         ...stableContentFns,
+        renderers: createSkeletonRenderers(),
       }),
     [
       store,

--- a/apps/viewer/src/index.css
+++ b/apps/viewer/src/index.css
@@ -1,4 +1,3 @@
-@import "tailwindcss";
 @import "stagebook/styles";
 
 /* Viewer-specific layout */

--- a/apps/viewer/src/index.css
+++ b/apps/viewer/src/index.css
@@ -1,0 +1,12 @@
+@import "tailwindcss";
+@import "stagebook/styles";
+
+/* Viewer-specific layout */
+:root {
+  --viewer-sidebar-width: 320px;
+  --viewer-header-height: auto;
+}
+
+body {
+  margin: 0;
+}

--- a/apps/viewer/src/lib/context.test.ts
+++ b/apps/viewer/src/lib/context.test.ts
@@ -2,11 +2,12 @@ import { describe, it, expect, vi } from "vitest";
 import { createViewerContext } from "./context";
 import { ViewerStateStore } from "./store";
 
+const BASE_URL = "https://raw.githubusercontent.com/org/repo/main/treatments/";
+
 function makeContext(overrides?: {
   position?: number;
   stageIndex?: number;
   playerCount?: number;
-  rawBaseUrl?: string;
   onSubmit?: () => void;
 }) {
   const store = new ViewerStateStore();
@@ -15,10 +16,10 @@ function makeContext(overrides?: {
     position: overrides?.position ?? 0,
     stageIndex: overrides?.stageIndex ?? 0,
     playerCount: overrides?.playerCount ?? 2,
-    rawBaseUrl:
-      overrides?.rawBaseUrl ??
-      "https://raw.githubusercontent.com/org/repo/main/treatments/",
     onSubmit: overrides?.onSubmit ?? (() => {}),
+    getAssetURL: (path: string) => BASE_URL + path,
+    getTextContent: (path: string) =>
+      fetch(BASE_URL + path).then((r) => r.text()),
   });
   return { store, ctx };
 }
@@ -90,22 +91,21 @@ describe("createViewerContext", () => {
   });
 
   describe("getTextContent", () => {
-    it("fetches from the raw GitHub URL and caches", async () => {
-      const mockFetch = vi.fn().mockResolvedValue({
-        ok: true,
-        text: () => Promise.resolve("file contents"),
+    it("delegates to the provided getTextContent function", async () => {
+      const mockGetTextContent = vi.fn().mockResolvedValue("file contents");
+      const store = new ViewerStateStore();
+      const ctx = createViewerContext({
+        store,
+        position: 0,
+        stageIndex: 0,
+        playerCount: 2,
+        onSubmit: () => {},
+        getAssetURL: (path: string) => BASE_URL + path,
+        getTextContent: mockGetTextContent,
       });
-      vi.stubGlobal("fetch", mockFetch);
-
-      const { ctx } = makeContext();
-      const result1 = await ctx.getTextContent("prompts/q1.prompt.md");
-      const result2 = await ctx.getTextContent("prompts/q1.prompt.md");
-
-      expect(result1).toBe("file contents");
-      expect(result2).toBe("file contents");
-      expect(mockFetch).toHaveBeenCalledTimes(1);
-
-      vi.unstubAllGlobals();
+      const result = await ctx.getTextContent("prompts/q1.prompt.md");
+      expect(result).toBe("file contents");
+      expect(mockGetTextContent).toHaveBeenCalledWith("prompts/q1.prompt.md");
     });
   });
 

--- a/apps/viewer/src/lib/context.test.ts
+++ b/apps/viewer/src/lib/context.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from "vitest";
+import { createViewerContext } from "./context";
+import { ViewerStateStore } from "./store";
+
+function makeContext(overrides?: {
+  position?: number;
+  stageIndex?: number;
+  playerCount?: number;
+  rawBaseUrl?: string;
+  onSubmit?: () => void;
+}) {
+  const store = new ViewerStateStore();
+  const ctx = createViewerContext({
+    store,
+    position: overrides?.position ?? 0,
+    stageIndex: overrides?.stageIndex ?? 0,
+    playerCount: overrides?.playerCount ?? 2,
+    rawBaseUrl:
+      overrides?.rawBaseUrl ??
+      "https://raw.githubusercontent.com/org/repo/main/treatments/",
+    onSubmit: overrides?.onSubmit ?? (() => {}),
+  });
+  return { store, ctx };
+}
+
+describe("createViewerContext", () => {
+  describe("save and resolve", () => {
+    it("save writes to store and resolve reads back", () => {
+      const { ctx } = makeContext();
+      ctx.save("prompt_q1", { value: "yes" });
+      const values = ctx.resolve("prompt.q1", "player");
+      expect(values).toEqual(["yes"]);
+    });
+
+    it("defaults to player scope", () => {
+      const { store, ctx } = makeContext({ position: 0 });
+      ctx.save("prompt_q1", { value: "yes" });
+      // Should be stored under position 0
+      expect(store.get(0, "prompt_q1")).toBeDefined();
+      expect(store.get("shared", "prompt_q1")).toBeUndefined();
+    });
+
+    it("respects shared scope", () => {
+      const { store, ctx } = makeContext();
+      ctx.save("prompt_q1", { value: "shared-val" }, "shared");
+      expect(store.get("shared", "prompt_q1")).toBeDefined();
+    });
+
+    it("resolve with numeric string position reads that position", () => {
+      const { store, ctx } = makeContext({ position: 0 });
+      store.save("prompt_q1", { value: "from-pos-1" }, "player", 1, 0);
+      const values = ctx.resolve("prompt.q1", "1");
+      expect(values).toEqual(["from-pos-1"]);
+    });
+
+    it("resolve with 'all' returns values from all positions", () => {
+      const { store, ctx } = makeContext();
+      store.save("prompt_q1", { value: "a" }, "player", 0, 0);
+      store.save("prompt_q1", { value: "b" }, "player", 1, 0);
+      const values = ctx.resolve("prompt.q1", "all");
+      expect(values).toEqual(["a", "b"]);
+    });
+
+    it("resolve with 'any' returns values from all positions", () => {
+      const { store, ctx } = makeContext();
+      store.save("prompt_q1", { value: "a" }, "player", 0, 0);
+      store.save("prompt_q1", { value: "b" }, "player", 1, 0);
+      const values = ctx.resolve("prompt.q1", "any");
+      expect(values).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("submit", () => {
+    it("calls the onSubmit callback", () => {
+      const onSubmit = vi.fn();
+      const { ctx } = makeContext({ onSubmit });
+      ctx.submit();
+      expect(onSubmit).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("getAssetURL", () => {
+    it("constructs a raw GitHub URL relative to the base", () => {
+      const { ctx } = makeContext();
+      const url = ctx.getAssetURL("images/photo.png");
+      expect(url).toBe(
+        "https://raw.githubusercontent.com/org/repo/main/treatments/images/photo.png",
+      );
+    });
+  });
+
+  describe("getTextContent", () => {
+    it("fetches from the raw GitHub URL and caches", async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: () => Promise.resolve("file contents"),
+      });
+      vi.stubGlobal("fetch", mockFetch);
+
+      const { ctx } = makeContext();
+      const result1 = await ctx.getTextContent("prompts/q1.prompt.md");
+      const result2 = await ctx.getTextContent("prompts/q1.prompt.md");
+
+      expect(result1).toBe("file contents");
+      expect(result2).toBe("file contents");
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+
+      vi.unstubAllGlobals();
+    });
+  });
+
+  describe("metadata fields", () => {
+    it("exposes position, playerCount, playerId", () => {
+      const { ctx } = makeContext({ position: 1, playerCount: 3 });
+      expect(ctx.position).toBe(1);
+      expect(ctx.playerCount).toBe(3);
+      expect(ctx.playerId).toBe("viewer");
+    });
+
+    it("exposes isSubmitted based on store state", () => {
+      const { store, ctx } = makeContext({ stageIndex: 2 });
+      expect(ctx.isSubmitted).toBe(false);
+      store.setSubmitted(2, true);
+      expect(ctx.isSubmitted).toBe(true);
+    });
+
+    it("exposes getElapsedTime from store", () => {
+      const { store, ctx } = makeContext({ stageIndex: 1 });
+      expect(ctx.getElapsedTime()).toBe(0);
+      store.setElapsedTime(1, 30);
+      expect(ctx.getElapsedTime()).toBe(30);
+    });
+  });
+});

--- a/apps/viewer/src/lib/context.ts
+++ b/apps/viewer/src/lib/context.ts
@@ -6,8 +6,9 @@ export interface ViewerContextOptions {
   position: number;
   stageIndex: number;
   playerCount: number;
-  rawBaseUrl: string;
   onSubmit: () => void;
+  getTextContent: (path: string) => Promise<string>;
+  getAssetURL: (path: string) => string;
 }
 
 /**
@@ -19,10 +20,15 @@ export interface ViewerContextOptions {
 export function createViewerContext(
   options: ViewerContextOptions,
 ): StagebookContext {
-  const { store, position, stageIndex, playerCount, rawBaseUrl, onSubmit } =
-    options;
-
-  const textContentCache = new Map<string, Promise<string>>();
+  const {
+    store,
+    position,
+    stageIndex,
+    playerCount,
+    onSubmit,
+    getTextContent,
+    getAssetURL,
+  } = options;
 
   return {
     resolve(reference: string, positionArg?: string): unknown[] {
@@ -46,24 +52,8 @@ export function createViewerContext(
       onSubmit();
     },
 
-    getAssetURL(path: string): string {
-      return rawBaseUrl + path;
-    },
-
-    getTextContent(path: string): Promise<string> {
-      const cached = textContentCache.get(path);
-      if (cached) return cached;
-
-      const promise = fetch(rawBaseUrl + path).then((res) => {
-        if (!res.ok) {
-          throw new Error(`Failed to fetch ${path} (HTTP ${res.status})`);
-        }
-        return res.text();
-      });
-
-      textContentCache.set(path, promise);
-      return promise;
-    },
+    getAssetURL,
+    getTextContent,
 
     progressLabel: `game_${stageIndex}`,
     playerId: "viewer",

--- a/apps/viewer/src/lib/context.ts
+++ b/apps/viewer/src/lib/context.ts
@@ -9,6 +9,15 @@ export interface ViewerContextOptions {
   onSubmit: () => void;
   getTextContent: (path: string) => Promise<string>;
   getAssetURL: (path: string) => string;
+  renderers?: Partial<
+    Pick<
+      StagebookContext,
+      | "renderDiscussion"
+      | "renderSurvey"
+      | "renderSharedNotepad"
+      | "renderTalkMeter"
+    >
+  >;
 }
 
 /**
@@ -28,6 +37,7 @@ export function createViewerContext(
     onSubmit,
     getTextContent,
     getAssetURL,
+    renderers,
   } = options;
 
   return {
@@ -63,6 +73,8 @@ export function createViewerContext(
     get isSubmitted() {
       return store.getSubmitted(stageIndex);
     },
+
+    ...renderers,
   };
 }
 

--- a/apps/viewer/src/lib/context.ts
+++ b/apps/viewer/src/lib/context.ts
@@ -1,0 +1,101 @@
+import type { StagebookContext } from "stagebook/components";
+import { ViewerStateStore } from "./store";
+
+export interface ViewerContextOptions {
+  store: ViewerStateStore;
+  position: number;
+  stageIndex: number;
+  playerCount: number;
+  rawBaseUrl: string;
+  onSubmit: () => void;
+}
+
+/**
+ * Create a mock StagebookContext backed by a ViewerStateStore.
+ *
+ * This is the bridge between the viewer's state management and
+ * the stagebook component rendering contract.
+ */
+export function createViewerContext(
+  options: ViewerContextOptions,
+): StagebookContext {
+  const { store, position, stageIndex, playerCount, rawBaseUrl, onSubmit } =
+    options;
+
+  const textContentCache = new Map<string, Promise<string>>();
+
+  return {
+    resolve(reference: string, positionArg?: string): unknown[] {
+      const mapped = mapPosition(positionArg, position);
+      if (typeof mapped === "number" || mapped === "shared") {
+        return store.resolve(reference, mapped);
+      }
+      // "all", "any", "percentAgreement" → return from all player positions
+      return store.resolve(reference);
+    },
+
+    save(key: string, value: unknown, scope?: "player" | "shared"): void {
+      store.save(key, value, scope ?? "player", position, stageIndex);
+    },
+
+    getElapsedTime(): number {
+      return store.getElapsedTime(stageIndex);
+    },
+
+    submit(): void {
+      onSubmit();
+    },
+
+    getAssetURL(path: string): string {
+      return rawBaseUrl + path;
+    },
+
+    getTextContent(path: string): Promise<string> {
+      const cached = textContentCache.get(path);
+      if (cached) return cached;
+
+      const promise = fetch(rawBaseUrl + path).then((res) => {
+        if (!res.ok) {
+          throw new Error(`Failed to fetch ${path} (HTTP ${res.status})`);
+        }
+        return res.text();
+      });
+
+      textContentCache.set(path, promise);
+      return promise;
+    },
+
+    progressLabel: `game_${stageIndex}`,
+    playerId: "viewer",
+    position,
+    playerCount,
+
+    get isSubmitted() {
+      return store.getSubmitted(stageIndex);
+    },
+  };
+}
+
+function mapPosition(
+  positionArg: string | undefined,
+  currentPosition: number,
+): number | "shared" | "all" {
+  if (positionArg === undefined || positionArg === "player") {
+    return currentPosition;
+  }
+  if (positionArg === "shared") {
+    return "shared";
+  }
+  if (
+    positionArg === "all" ||
+    positionArg === "any" ||
+    positionArg === "percentAgreement"
+  ) {
+    return "all";
+  }
+  const num = Number(positionArg);
+  if (!Number.isNaN(num)) {
+    return num;
+  }
+  return currentPosition;
+}

--- a/apps/viewer/src/lib/github.test.ts
+++ b/apps/viewer/src/lib/github.test.ts
@@ -49,6 +49,35 @@ describe("parseGitHubUrl", () => {
     });
   });
 
+  it("parses a raw.githubusercontent.com URL", () => {
+    const result = parseGitHubUrl(
+      "https://raw.githubusercontent.com/org/repo/main/treatments/study.yaml",
+    );
+    expect(result).toEqual({
+      owner: "org",
+      repo: "repo",
+      branch: "main",
+      filePath: "treatments/study.yaml",
+      rawFileUrl:
+        "https://raw.githubusercontent.com/org/repo/main/treatments/study.yaml",
+      rawBaseUrl: "https://raw.githubusercontent.com/org/repo/main/treatments/",
+    });
+  });
+
+  it("parses a raw.githubusercontent.com URL at repo root", () => {
+    const result = parseGitHubUrl(
+      "https://raw.githubusercontent.com/org/repo/main/file.yaml",
+    );
+    expect(result).toEqual({
+      owner: "org",
+      repo: "repo",
+      branch: "main",
+      filePath: "file.yaml",
+      rawFileUrl: "https://raw.githubusercontent.com/org/repo/main/file.yaml",
+      rawBaseUrl: "https://raw.githubusercontent.com/org/repo/main/",
+    });
+  });
+
   it("throws on a non-GitHub URL", () => {
     expect(() =>
       parseGitHubUrl("https://gitlab.com/org/repo/blob/main/file.yaml"),

--- a/apps/viewer/src/lib/github.test.ts
+++ b/apps/viewer/src/lib/github.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { parseGitHubUrl } from "./github";
+
+describe("parseGitHubUrl", () => {
+  it("parses a standard GitHub blob URL", () => {
+    const result = parseGitHubUrl(
+      "https://github.com/deliberation-lab/example/blob/main/treatments/study1.yaml",
+    );
+    expect(result).toEqual({
+      owner: "deliberation-lab",
+      repo: "example",
+      branch: "main",
+      filePath: "treatments/study1.yaml",
+      rawFileUrl:
+        "https://raw.githubusercontent.com/deliberation-lab/example/main/treatments/study1.yaml",
+      rawBaseUrl:
+        "https://raw.githubusercontent.com/deliberation-lab/example/main/treatments/",
+    });
+  });
+
+  it("handles nested paths", () => {
+    const result = parseGitHubUrl(
+      "https://github.com/org/repo/blob/feature-branch/deep/nested/path/treatment.yaml",
+    );
+    expect(result).toEqual({
+      owner: "org",
+      repo: "repo",
+      branch: "feature-branch",
+      filePath: "deep/nested/path/treatment.yaml",
+      rawFileUrl:
+        "https://raw.githubusercontent.com/org/repo/feature-branch/deep/nested/path/treatment.yaml",
+      rawBaseUrl:
+        "https://raw.githubusercontent.com/org/repo/feature-branch/deep/nested/path/",
+    });
+  });
+
+  it("handles a file at the repo root", () => {
+    const result = parseGitHubUrl(
+      "https://github.com/org/repo/blob/main/treatment.yaml",
+    );
+    expect(result).toEqual({
+      owner: "org",
+      repo: "repo",
+      branch: "main",
+      filePath: "treatment.yaml",
+      rawFileUrl:
+        "https://raw.githubusercontent.com/org/repo/main/treatment.yaml",
+      rawBaseUrl: "https://raw.githubusercontent.com/org/repo/main/",
+    });
+  });
+
+  it("throws on a non-GitHub URL", () => {
+    expect(() =>
+      parseGitHubUrl("https://gitlab.com/org/repo/blob/main/file.yaml"),
+    ).toThrow();
+  });
+
+  it("throws on a GitHub URL without blob path", () => {
+    expect(() => parseGitHubUrl("https://github.com/org/repo")).toThrow();
+  });
+
+  it("throws on an invalid URL", () => {
+    expect(() => parseGitHubUrl("not-a-url")).toThrow();
+  });
+});

--- a/apps/viewer/src/lib/github.ts
+++ b/apps/viewer/src/lib/github.ts
@@ -8,9 +8,11 @@ export interface GitHubUrlParts {
 }
 
 /**
- * Parse a GitHub blob URL into its components and derive raw.githubusercontent.com URLs.
+ * Parse a GitHub URL into its components and derive raw.githubusercontent.com URLs.
  *
- * Expects: https://github.com/{owner}/{repo}/blob/{branch}/{path}
+ * Accepts:
+ *   https://github.com/{owner}/{repo}/blob/{branch}/{path}
+ *   https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{path}
  */
 export function parseGitHubUrl(url: string): GitHubUrlParts {
   let parsed: URL;
@@ -20,26 +22,46 @@ export function parseGitHubUrl(url: string): GitHubUrlParts {
     throw new Error(`Invalid URL: ${url}`);
   }
 
-  if (parsed.hostname !== "github.com") {
-    throw new Error(`Not a GitHub URL: ${url}`);
-  }
-
-  // pathname: /{owner}/{repo}/blob/{branch}/{...filePath}
   const segments = parsed.pathname.split("/").filter(Boolean);
 
-  if (segments.length < 4 || segments[2] !== "blob") {
+  if (parsed.hostname === "raw.githubusercontent.com") {
+    // raw URL: /{owner}/{repo}/{branch}/{...filePath}
+    if (segments.length < 4) {
+      throw new Error(`No file path found in raw URL: ${url}`);
+    }
+    const owner = segments[0];
+    const repo = segments[1];
+    const branch = segments[2];
+    const filePath = segments.slice(3).join("/");
+    return buildResult(owner, repo, branch, filePath, url);
+  }
+
+  if (parsed.hostname === "github.com") {
+    // blob URL: /{owner}/{repo}/blob/{branch}/{...filePath}
+    if (segments.length >= 5 && segments[2] === "blob") {
+      const owner = segments[0];
+      const repo = segments[1];
+      const branch = segments[3];
+      const filePath = segments.slice(4).join("/");
+      return buildResult(owner, repo, branch, filePath, url);
+    }
     throw new Error(
       `Expected a GitHub blob URL (github.com/owner/repo/blob/branch/path): ${url}`,
     );
   }
 
-  const owner = segments[0];
-  const repo = segments[1];
-  const branch = segments[3];
-  const filePath = segments.slice(4).join("/");
+  throw new Error(`Not a GitHub URL: ${url}`);
+}
 
+function buildResult(
+  owner: string,
+  repo: string,
+  branch: string,
+  filePath: string,
+  originalUrl: string,
+): GitHubUrlParts {
   if (!filePath) {
-    throw new Error(`No file path found in URL: ${url}`);
+    throw new Error(`No file path found in URL: ${originalUrl}`);
   }
 
   const dirPath = filePath.includes("/")

--- a/apps/viewer/src/lib/github.ts
+++ b/apps/viewer/src/lib/github.ts
@@ -1,0 +1,53 @@
+export interface GitHubUrlParts {
+  owner: string;
+  repo: string;
+  branch: string;
+  filePath: string;
+  rawFileUrl: string;
+  rawBaseUrl: string;
+}
+
+/**
+ * Parse a GitHub blob URL into its components and derive raw.githubusercontent.com URLs.
+ *
+ * Expects: https://github.com/{owner}/{repo}/blob/{branch}/{path}
+ */
+export function parseGitHubUrl(url: string): GitHubUrlParts {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+
+  if (parsed.hostname !== "github.com") {
+    throw new Error(`Not a GitHub URL: ${url}`);
+  }
+
+  // pathname: /{owner}/{repo}/blob/{branch}/{...filePath}
+  const segments = parsed.pathname.split("/").filter(Boolean);
+
+  if (segments.length < 4 || segments[2] !== "blob") {
+    throw new Error(
+      `Expected a GitHub blob URL (github.com/owner/repo/blob/branch/path): ${url}`,
+    );
+  }
+
+  const owner = segments[0];
+  const repo = segments[1];
+  const branch = segments[3];
+  const filePath = segments.slice(4).join("/");
+
+  if (!filePath) {
+    throw new Error(`No file path found in URL: ${url}`);
+  }
+
+  const dirPath = filePath.includes("/")
+    ? filePath.substring(0, filePath.lastIndexOf("/") + 1)
+    : "";
+
+  const rawFileUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${filePath}`;
+  const rawBaseUrl = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${dirPath}`;
+
+  return { owner, repo, branch, filePath, rawFileUrl, rawBaseUrl };
+}

--- a/apps/viewer/src/lib/loader.test.ts
+++ b/apps/viewer/src/lib/loader.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { loadTreatmentFromUrl } from "./loader";
+
+const MINIMAL_YAML = `
+introSequences:
+  - name: intro1
+    introSteps:
+      - name: consent
+        elements:
+          - type: submitButton
+            buttonText: Continue
+
+treatments:
+  - name: treatment1
+    playerCount: 2
+    gameStages:
+      - name: stage1
+        duration: 10
+        elements:
+          - type: prompt
+            name: q1
+            file: prompts/q1.prompt.md
+`;
+
+function mockFetch(body: string, ok = true) {
+  return vi.fn().mockResolvedValue({
+    ok,
+    status: ok ? 200 : 404,
+    text: () => Promise.resolve(body),
+  });
+}
+
+describe("loadTreatmentFromUrl", () => {
+  it("fetches, parses, and expands a treatment file", async () => {
+    const fetch = mockFetch(MINIMAL_YAML);
+    const result = await loadTreatmentFromUrl(
+      "https://github.com/org/repo/blob/main/treatment.yaml",
+      fetch,
+    );
+    expect(fetch).toHaveBeenCalledWith(
+      "https://raw.githubusercontent.com/org/repo/main/treatment.yaml",
+    );
+    expect(result.treatmentFile.treatments).toHaveLength(1);
+    expect(result.treatmentFile.treatments[0].name).toBe("treatment1");
+    expect(result.unresolvedFields).toEqual([]);
+    expect(result.rawBaseUrl).toBe(
+      "https://raw.githubusercontent.com/org/repo/main/",
+    );
+  });
+
+  it("throws on fetch failure", async () => {
+    const fetch = mockFetch("Not Found", false);
+    await expect(
+      loadTreatmentFromUrl(
+        "https://github.com/org/repo/blob/main/treatment.yaml",
+        fetch,
+      ),
+    ).rejects.toThrow("Failed to fetch");
+  });
+
+  it("throws on invalid YAML", async () => {
+    const fetch = mockFetch("{{bad yaml");
+    await expect(
+      loadTreatmentFromUrl(
+        "https://github.com/org/repo/blob/main/treatment.yaml",
+        fetch,
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/apps/viewer/src/lib/loader.test.ts
+++ b/apps/viewer/src/lib/loader.test.ts
@@ -38,7 +38,9 @@ describe("loadTreatmentFromUrl", () => {
       fetch,
     );
     expect(fetch).toHaveBeenCalledWith(
-      "https://raw.githubusercontent.com/org/repo/main/treatment.yaml",
+      expect.stringContaining(
+        "https://raw.githubusercontent.com/org/repo/main/treatment.yaml",
+      ),
     );
     expect(result.treatmentFile.treatments).toHaveLength(1);
     expect(result.treatmentFile.treatments[0].name).toBe("treatment1");

--- a/apps/viewer/src/lib/loader.ts
+++ b/apps/viewer/src/lib/loader.ts
@@ -22,7 +22,9 @@ export async function loadTreatmentFromUrl(
 ): Promise<LoadResult> {
   const { rawFileUrl, rawBaseUrl } = parseGitHubUrl(githubUrl);
 
-  const response = await fetchFn(rawFileUrl);
+  // Cache-bust: raw.githubusercontent.com has aggressive CDN caching
+  const bustUrl = `${rawFileUrl}?t=${Date.now()}`;
+  const response = await fetchFn(bustUrl);
   if (!response.ok) {
     throw new Error(
       `Failed to fetch treatment file (HTTP ${response.status}): ${rawFileUrl}`,

--- a/apps/viewer/src/lib/loader.ts
+++ b/apps/viewer/src/lib/loader.ts
@@ -1,0 +1,37 @@
+import { parseGitHubUrl } from "./github";
+import { parseTreatmentYaml, expandTreatmentFile } from "./treatment";
+import type { TreatmentFileType } from "stagebook";
+
+export interface LoadResult {
+  treatmentFile: TreatmentFileType;
+  unresolvedFields: string[];
+  rawBaseUrl: string;
+}
+
+type FetchFn = (
+  url: string,
+) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
+
+/**
+ * Load a treatment file from a GitHub URL.
+ * Accepts an injectable fetch function for testing.
+ */
+export async function loadTreatmentFromUrl(
+  githubUrl: string,
+  fetchFn: FetchFn = globalThis.fetch,
+): Promise<LoadResult> {
+  const { rawFileUrl, rawBaseUrl } = parseGitHubUrl(githubUrl);
+
+  const response = await fetchFn(rawFileUrl);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch treatment file (HTTP ${response.status}): ${rawFileUrl}`,
+    );
+  }
+
+  const yaml = await response.text();
+  const parsed = parseTreatmentYaml(yaml);
+  const { result, unresolvedFields } = expandTreatmentFile(parsed);
+
+  return { treatmentFile: result, unresolvedFields, rawBaseUrl };
+}

--- a/apps/viewer/src/lib/references.test.ts
+++ b/apps/viewer/src/lib/references.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { extractStageReferences } from "./references";
+
+describe("extractStageReferences", () => {
+  it("extracts condition references from elements", () => {
+    const elements = [
+      {
+        type: "prompt" as const,
+        name: "q2",
+        file: "prompts/q2.prompt.md",
+        conditions: [
+          { reference: "prompt.q1", comparator: "equals", value: "yes" },
+        ],
+      },
+    ];
+    const refs = extractStageReferences(elements);
+    expect(refs).toContain("prompt.q1");
+  });
+
+  it("extracts display element references", () => {
+    const elements = [
+      {
+        type: "display" as const,
+        name: "showVote",
+        reference: "prompt.vote",
+        position: "0",
+      },
+    ];
+    const refs = extractStageReferences(elements);
+    expect(refs).toContain("prompt.vote");
+  });
+
+  it("extracts multiple references and deduplicates", () => {
+    const elements = [
+      {
+        type: "prompt" as const,
+        name: "q2",
+        file: "prompts/q2.prompt.md",
+        conditions: [
+          { reference: "prompt.q1", comparator: "equals", value: "yes" },
+          { reference: "prompt.q1", comparator: "equals", value: "no" },
+          {
+            reference: "survey.TIPI.result.score",
+            comparator: "isAbove",
+            value: 3,
+          },
+        ],
+      },
+      {
+        type: "display" as const,
+        name: "d1",
+        reference: "prompt.q1",
+      },
+    ];
+    const refs = extractStageReferences(elements);
+    expect(refs).toEqual(["prompt.q1", "survey.TIPI.result.score"]);
+  });
+
+  it("returns empty array for elements with no references", () => {
+    const elements = [
+      { type: "submitButton" as const, buttonText: "Next" },
+      {
+        type: "prompt" as const,
+        name: "q1",
+        file: "prompts/q1.prompt.md",
+      },
+    ];
+    const refs = extractStageReferences(elements);
+    expect(refs).toEqual([]);
+  });
+});

--- a/apps/viewer/src/lib/references.ts
+++ b/apps/viewer/src/lib/references.ts
@@ -1,0 +1,32 @@
+/**
+ * Scan a stage's elements and extract DSL references that affect rendering.
+ * These are the values the state inspector should display for the current stage.
+ */
+export function extractStageReferences(
+  elements: Record<string, unknown>[],
+): string[] {
+  const refs = new Set<string>();
+
+  for (const element of elements) {
+    // Condition references
+    if (Array.isArray(element.conditions)) {
+      for (const condition of element.conditions) {
+        if (
+          condition &&
+          typeof condition === "object" &&
+          "reference" in condition &&
+          typeof condition.reference === "string"
+        ) {
+          refs.add(condition.reference);
+        }
+      }
+    }
+
+    // Display element references
+    if (element.type === "display" && typeof element.reference === "string") {
+      refs.add(element.reference);
+    }
+  }
+
+  return [...refs];
+}

--- a/apps/viewer/src/lib/steps.test.ts
+++ b/apps/viewer/src/lib/steps.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest";
+import { flattenSteps, type ViewerStep } from "./steps";
+
+describe("flattenSteps", () => {
+  const introSequence = {
+    name: "intro1",
+    introSteps: [
+      {
+        name: "consent",
+        elements: [{ type: "submitButton" as const, buttonText: "I agree" }],
+      },
+      {
+        name: "demographics",
+        elements: [
+          {
+            type: "prompt" as const,
+            name: "age",
+            file: "prompts/age.prompt.md",
+          },
+          { type: "submitButton" as const, buttonText: "Continue" },
+        ],
+      },
+    ],
+  };
+
+  const treatment = {
+    name: "treatment1",
+    playerCount: 2,
+    gameStages: [
+      {
+        name: "round1",
+        duration: 60,
+        elements: [
+          {
+            type: "prompt" as const,
+            name: "vote",
+            file: "prompts/vote.prompt.md",
+          },
+        ],
+      },
+      {
+        name: "round2",
+        duration: 120,
+        elements: [
+          {
+            type: "prompt" as const,
+            name: "vote2",
+            file: "prompts/vote2.prompt.md",
+          },
+        ],
+      },
+    ],
+    exitSequence: [
+      {
+        name: "debrief",
+        elements: [
+          {
+            type: "prompt" as const,
+            name: "feedback",
+            file: "prompts/feedback.prompt.md",
+          },
+          { type: "submitButton" as const, buttonText: "Finish" },
+        ],
+      },
+    ],
+  };
+
+  it("produces a flat list of steps in order: intro, game, exit", () => {
+    const steps = flattenSteps(introSequence, treatment);
+    expect(steps.map((s) => s.name)).toEqual([
+      "consent",
+      "demographics",
+      "round1",
+      "round2",
+      "debrief",
+    ]);
+  });
+
+  it("tags each step with its phase", () => {
+    const steps = flattenSteps(introSequence, treatment);
+    expect(steps.map((s) => s.phase)).toEqual([
+      "intro",
+      "intro",
+      "game",
+      "game",
+      "exit",
+    ]);
+  });
+
+  it("preserves stage properties like duration", () => {
+    const steps = flattenSteps(introSequence, treatment);
+    const round1 = steps.find((s) => s.name === "round1")!;
+    expect(round1.duration).toBe(60);
+  });
+
+  it("works without an exit sequence", () => {
+    const noExit = { ...treatment, exitSequence: undefined };
+    const steps = flattenSteps(introSequence, noExit);
+    expect(steps.map((s) => s.name)).toEqual([
+      "consent",
+      "demographics",
+      "round1",
+      "round2",
+    ]);
+  });
+
+  it("assigns sequential indices", () => {
+    const steps = flattenSteps(introSequence, treatment);
+    expect(steps.map((s) => s.index)).toEqual([0, 1, 2, 3, 4]);
+  });
+});

--- a/apps/viewer/src/lib/steps.ts
+++ b/apps/viewer/src/lib/steps.ts
@@ -1,0 +1,67 @@
+import type { ElementType } from "stagebook";
+
+export type Phase = "intro" | "game" | "exit";
+
+export interface ViewerStep {
+  index: number;
+  phase: Phase;
+  name: string;
+  elements: ElementType[];
+  duration?: number;
+}
+
+interface IntroSequence {
+  name: string;
+  introSteps: { name: string; elements: ElementType[] }[];
+}
+
+interface Treatment {
+  name: string;
+  playerCount: number;
+  gameStages: { name: string; duration?: number; elements: ElementType[] }[];
+  exitSequence?: { name: string; elements: ElementType[] }[];
+}
+
+/**
+ * Flatten a selected intro sequence and treatment into a single
+ * ordered list of steps the viewer can navigate.
+ */
+export function flattenSteps(
+  introSequence: IntroSequence,
+  treatment: Treatment,
+): ViewerStep[] {
+  let index = 0;
+  const steps: ViewerStep[] = [];
+
+  for (const step of introSequence.introSteps) {
+    steps.push({
+      index: index++,
+      phase: "intro",
+      name: step.name,
+      elements: step.elements,
+    });
+  }
+
+  for (const stage of treatment.gameStages) {
+    steps.push({
+      index: index++,
+      phase: "game",
+      name: stage.name,
+      elements: stage.elements,
+      duration: stage.duration,
+    });
+  }
+
+  if (treatment.exitSequence) {
+    for (const step of treatment.exitSequence) {
+      steps.push({
+        index: index++,
+        phase: "exit",
+        name: step.name,
+        elements: step.elements,
+      });
+    }
+  }
+
+  return steps;
+}

--- a/apps/viewer/src/lib/store.test.ts
+++ b/apps/viewer/src/lib/store.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "vitest";
+import { ViewerStateStore } from "./store";
+
+describe("ViewerStateStore", () => {
+  describe("save and get", () => {
+    it("stores and retrieves a player-scoped value", () => {
+      const store = new ViewerStateStore();
+      store.save("prompt_q1", { value: "yes" }, "player", 0, 2);
+      expect(store.get(0, "prompt_q1")).toEqual({
+        value: { value: "yes" },
+        setOnStageIndex: 2,
+      });
+    });
+
+    it("stores and retrieves a shared-scoped value", () => {
+      const store = new ViewerStateStore();
+      store.save("prompt_q1", { value: "yes" }, "shared", 0, 1);
+      expect(store.get("shared", "prompt_q1")).toEqual({
+        value: { value: "yes" },
+        setOnStageIndex: 1,
+      });
+    });
+
+    it("overwrites an existing value", () => {
+      const store = new ViewerStateStore();
+      store.save("prompt_q1", { value: "yes" }, "player", 0, 1);
+      store.save("prompt_q1", { value: "no" }, "player", 0, 2);
+      expect(store.get(0, "prompt_q1")?.value).toEqual({ value: "no" });
+      expect(store.get(0, "prompt_q1")?.setOnStageIndex).toBe(2);
+    });
+
+    it("returns undefined for missing keys", () => {
+      const store = new ViewerStateStore();
+      expect(store.get(0, "prompt_missing")).toBeUndefined();
+    });
+  });
+
+  describe("getAll", () => {
+    it("returns all entries across positions", () => {
+      const store = new ViewerStateStore();
+      store.save("prompt_q1", { value: "a" }, "player", 0, 0);
+      store.save("prompt_q1", { value: "b" }, "player", 1, 0);
+      store.save("prompt_q2", { value: "c" }, "shared", 0, 1);
+
+      const all = store.getAll();
+      expect(all).toHaveLength(3);
+    });
+  });
+
+  describe("resolve", () => {
+    it("resolves a prompt reference for a specific position", () => {
+      const store = new ViewerStateStore();
+      store.save("prompt_q1", { value: "yes" }, "player", 0, 0);
+      const values = store.resolve("prompt.q1", 0);
+      expect(values).toEqual(["yes"]);
+    });
+
+    it("resolves a prompt reference across all positions", () => {
+      const store = new ViewerStateStore();
+      store.save("prompt_q1", { value: "yes" }, "player", 0, 0);
+      store.save("prompt_q1", { value: "no" }, "player", 1, 0);
+      const values = store.resolve("prompt.q1");
+      expect(values).toEqual(["yes", "no"]);
+    });
+
+    it("resolves a shared reference", () => {
+      const store = new ViewerStateStore();
+      store.save("prompt_q1", { value: "shared-val" }, "shared", 0, 0);
+      const values = store.resolve("prompt.q1", "shared");
+      expect(values).toEqual(["shared-val"]);
+    });
+
+    it("returns empty array for missing references", () => {
+      const store = new ViewerStateStore();
+      const values = store.resolve("prompt.missing", 0);
+      expect(values).toEqual([]);
+    });
+
+    it("navigates nested paths for non-prompt types", () => {
+      const store = new ViewerStateStore();
+      store.save("survey_TIPI", { result: { score: 4.5 } }, "player", 0, 0);
+      const values = store.resolve("survey.TIPI.result.score", 0);
+      expect(values).toEqual([4.5]);
+    });
+  });
+
+  describe("submitted and elapsedTime", () => {
+    it("tracks submitted state per stage", () => {
+      const store = new ViewerStateStore();
+      expect(store.getSubmitted(0)).toBe(false);
+      store.setSubmitted(0, true);
+      expect(store.getSubmitted(0)).toBe(true);
+      store.setSubmitted(0, false);
+      expect(store.getSubmitted(0)).toBe(false);
+    });
+
+    it("tracks elapsed time per stage", () => {
+      const store = new ViewerStateStore();
+      expect(store.getElapsedTime(0)).toBe(0);
+      store.setElapsedTime(0, 45);
+      expect(store.getElapsedTime(0)).toBe(45);
+    });
+  });
+
+  describe("set (direct write for inspector)", () => {
+    it("allows setting a value directly by position and key", () => {
+      const store = new ViewerStateStore();
+      store.set(0, "prompt_q1", { value: "injected" }, 1);
+      expect(store.get(0, "prompt_q1")).toEqual({
+        value: { value: "injected" },
+        setOnStageIndex: 1,
+      });
+    });
+  });
+
+  describe("onChange", () => {
+    it("notifies listeners on save", () => {
+      const store = new ViewerStateStore();
+      const calls: unknown[] = [];
+      store.onChange(() => calls.push("changed"));
+      store.save("prompt_q1", { value: "yes" }, "player", 0, 0);
+      expect(calls).toEqual(["changed"]);
+    });
+
+    it("notifies listeners on set", () => {
+      const store = new ViewerStateStore();
+      const calls: unknown[] = [];
+      store.onChange(() => calls.push("changed"));
+      store.set(0, "prompt_q1", { value: "yes" }, 0);
+      expect(calls).toEqual(["changed"]);
+    });
+
+    it("returns an unsubscribe function", () => {
+      const store = new ViewerStateStore();
+      const calls: unknown[] = [];
+      const unsub = store.onChange(() => calls.push("changed"));
+      store.save("prompt_q1", { value: "a" }, "player", 0, 0);
+      unsub();
+      store.save("prompt_q1", { value: "b" }, "player", 0, 0);
+      expect(calls).toEqual(["changed"]);
+    });
+  });
+});

--- a/apps/viewer/src/lib/store.ts
+++ b/apps/viewer/src/lib/store.ts
@@ -1,0 +1,145 @@
+import { getReferenceKeyAndPath, getNestedValueByPath } from "stagebook";
+
+export type PositionKey = number | "shared";
+
+export interface StoreEntry {
+  value: unknown;
+  setOnStageIndex: number;
+}
+
+export interface StoreRecord {
+  positionKey: PositionKey;
+  storeKey: string;
+  entry: StoreEntry;
+}
+
+type Listener = () => void;
+
+export class ViewerStateStore {
+  private data = new Map<PositionKey, Map<string, StoreEntry>>();
+  private submitted = new Map<number, boolean>();
+  private elapsed = new Map<number, number>();
+  private listeners = new Set<Listener>();
+
+  /** Write a value via the save() contract (position-scoped or shared). */
+  save(
+    key: string,
+    value: unknown,
+    scope: "player" | "shared",
+    position: number,
+    stageIndex: number,
+  ): void {
+    const posKey: PositionKey = scope === "shared" ? "shared" : position;
+    this.set(posKey, key, value, stageIndex);
+  }
+
+  /** Direct write — used by the state inspector to inject values. */
+  set(
+    positionKey: PositionKey,
+    storeKey: string,
+    value: unknown,
+    stageIndex: number,
+  ): void {
+    let bucket = this.data.get(positionKey);
+    if (!bucket) {
+      bucket = new Map();
+      this.data.set(positionKey, bucket);
+    }
+    bucket.set(storeKey, { value, setOnStageIndex: stageIndex });
+    this.notify();
+  }
+
+  /** Read a single entry by position and key. */
+  get(positionKey: PositionKey, storeKey: string): StoreEntry | undefined {
+    return this.data.get(positionKey)?.get(storeKey);
+  }
+
+  /** Return all entries across all positions. */
+  getAll(): StoreRecord[] {
+    const records: StoreRecord[] = [];
+    for (const [positionKey, bucket] of this.data) {
+      for (const [storeKey, entry] of bucket) {
+        records.push({ positionKey, storeKey, entry });
+      }
+    }
+    return records;
+  }
+
+  /**
+   * Resolve a DSL reference (e.g. "prompt.q1") against the store.
+   * If position is a number, returns that position's value.
+   * If position is "shared", returns the shared value.
+   * If position is undefined, returns values from all player positions.
+   */
+  resolve(reference: string, position?: number | "shared"): unknown[] {
+    const { referenceKey, path } = getReferenceKeyAndPath(reference);
+
+    if (position === "shared") {
+      return this.resolveOne("shared", referenceKey, path);
+    }
+
+    if (position !== undefined) {
+      return this.resolveOne(position, referenceKey, path);
+    }
+
+    // No position specified — collect from all player positions
+    const values: unknown[] = [];
+    for (const [posKey, bucket] of this.data) {
+      if (posKey === "shared") continue;
+      const entry = bucket.get(referenceKey);
+      if (entry !== undefined) {
+        const resolved = getNestedValueByPath(entry.value, path);
+        if (resolved !== undefined) {
+          values.push(resolved);
+        }
+      }
+    }
+    return values;
+  }
+
+  private resolveOne(
+    posKey: PositionKey,
+    referenceKey: string,
+    path: string[],
+  ): unknown[] {
+    const entry = this.data.get(posKey)?.get(referenceKey);
+    if (entry === undefined) return [];
+    const resolved = getNestedValueByPath(entry.value, path);
+    return resolved !== undefined ? [resolved] : [];
+  }
+
+  // --- Submitted ---
+
+  getSubmitted(stageIndex: number): boolean {
+    return this.submitted.get(stageIndex) ?? false;
+  }
+
+  setSubmitted(stageIndex: number, value: boolean): void {
+    this.submitted.set(stageIndex, value);
+    this.notify();
+  }
+
+  // --- Elapsed time ---
+
+  getElapsedTime(stageIndex: number): number {
+    return this.elapsed.get(stageIndex) ?? 0;
+  }
+
+  setElapsedTime(stageIndex: number, seconds: number): void {
+    this.elapsed.set(stageIndex, seconds);
+    this.notify();
+  }
+
+  // --- Change notification ---
+
+  onChange(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  private notify(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}

--- a/apps/viewer/src/lib/store.ts
+++ b/apps/viewer/src/lib/store.ts
@@ -20,6 +20,7 @@ export class ViewerStateStore {
   private submitted = new Map<number, boolean>();
   private elapsed = new Map<number, number>();
   private listeners = new Set<Listener>();
+  private version = 0;
 
   /** Write a value via the save() contract (position-scoped or shared). */
   save(
@@ -132,12 +133,18 @@ export class ViewerStateStore {
 
   // --- Change notification ---
 
+  /** Monotonic version counter — stable snapshot for useSyncExternalStore. */
+  getVersion(): number {
+    return this.version;
+  }
+
   onChange(listener: Listener): () => void {
     this.listeners.add(listener);
     return () => this.listeners.delete(listener);
   }
 
   private notify(): void {
+    this.version++;
     for (const listener of this.listeners) {
       listener();
     }

--- a/apps/viewer/src/lib/timeBreakpoints.test.ts
+++ b/apps/viewer/src/lib/timeBreakpoints.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { extractTimeBreakpoints } from "./timeBreakpoints";
+
+describe("extractTimeBreakpoints", () => {
+  it("extracts displayTime and hideTime from elements", () => {
+    const elements = [
+      { type: "prompt", name: "q1", file: "q1.prompt.md", displayTime: 15 },
+      {
+        type: "prompt",
+        name: "q2",
+        file: "q2.prompt.md",
+        displayTime: 30,
+        hideTime: 90,
+      },
+      { type: "submitButton", buttonText: "Next" },
+    ];
+    const breakpoints = extractTimeBreakpoints(elements);
+    expect(breakpoints).toEqual([15, 30, 90]);
+  });
+
+  it("deduplicates and sorts", () => {
+    const elements = [
+      { type: "prompt", name: "q1", file: "q1.prompt.md", displayTime: 30 },
+      {
+        type: "prompt",
+        name: "q2",
+        file: "q2.prompt.md",
+        displayTime: 30,
+        hideTime: 10,
+      },
+    ];
+    const breakpoints = extractTimeBreakpoints(elements);
+    expect(breakpoints).toEqual([10, 30]);
+  });
+
+  it("returns empty array when no time values", () => {
+    const elements = [
+      { type: "prompt", name: "q1", file: "q1.prompt.md" },
+      { type: "submitButton", buttonText: "Next" },
+    ];
+    const breakpoints = extractTimeBreakpoints(elements);
+    expect(breakpoints).toEqual([]);
+  });
+
+  it("ignores zero values", () => {
+    const elements = [
+      {
+        type: "prompt",
+        name: "q1",
+        file: "q1.prompt.md",
+        displayTime: 0,
+        hideTime: 60,
+      },
+    ];
+    const breakpoints = extractTimeBreakpoints(elements);
+    expect(breakpoints).toEqual([60]);
+  });
+});

--- a/apps/viewer/src/lib/timeBreakpoints.ts
+++ b/apps/viewer/src/lib/timeBreakpoints.ts
@@ -1,0 +1,21 @@
+/**
+ * Extract sorted, unique time breakpoints from a stage's elements.
+ * These are the moments where the visible content changes due to
+ * displayTime or hideTime thresholds.
+ */
+export function extractTimeBreakpoints(
+  elements: Record<string, unknown>[],
+): number[] {
+  const times = new Set<number>();
+
+  for (const element of elements) {
+    if (typeof element.displayTime === "number" && element.displayTime > 0) {
+      times.add(element.displayTime);
+    }
+    if (typeof element.hideTime === "number" && element.hideTime > 0) {
+      times.add(element.hideTime);
+    }
+  }
+
+  return [...times].sort((a, b) => a - b);
+}

--- a/apps/viewer/src/lib/treatment.test.ts
+++ b/apps/viewer/src/lib/treatment.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import { parseTreatmentYaml, expandTreatmentFile } from "./treatment";
+
+const MINIMAL_YAML = `
+introSequences:
+  - name: intro1
+    introSteps:
+      - name: consent
+        elements:
+          - type: submitButton
+            buttonText: Continue
+
+treatments:
+  - name: treatment1
+    playerCount: 2
+    gameStages:
+      - name: stage1
+        duration: 10
+        elements:
+          - type: prompt
+            name: q1
+            file: prompts/q1.prompt.md
+`;
+
+const MULTI_TREATMENT_YAML = `
+introSequences:
+  - name: intro1
+    introSteps:
+      - name: consent
+        elements:
+          - type: submitButton
+            buttonText: Continue
+
+treatments:
+  - name: control
+    playerCount: 1
+    gameStages:
+      - name: stage1
+        duration: 10
+        elements:
+          - type: prompt
+            name: q1
+            file: prompts/q1.prompt.md
+  - name: experimental
+    playerCount: 2
+    gameStages:
+      - name: stage1
+        duration: 15
+        elements:
+          - type: prompt
+            name: q1
+            file: prompts/q1.prompt.md
+`;
+
+const TEMPLATE_YAML = `
+templates:
+  - templateName: questionStage
+    contentType: stage
+    templateContent:
+      name: "\${topic}"
+      duration: 60
+      elements:
+        - type: prompt
+          name: "\${topic}"
+          file: "prompts/\${topic}.prompt.md"
+
+introSequences:
+  - name: intro1
+    introSteps:
+      - name: consent
+        elements:
+          - type: submitButton
+            buttonText: Continue
+
+treatments:
+  - name: treatment1
+    playerCount: 1
+    gameStages:
+      - template: questionStage
+        fields:
+          topic: climate
+      - template: questionStage
+        fields:
+          topic: economy
+`;
+
+const UNRESOLVED_FIELD_YAML = `
+templates:
+  - templateName: questionStage
+    contentType: stage
+    templateContent:
+      name: "\${topic}"
+      duration: 60
+      elements:
+        - type: prompt
+          name: "\${topic}"
+          file: "prompts/\${topic}.prompt.md"
+
+introSequences:
+  - name: intro1
+    introSteps:
+      - name: consent
+        elements:
+          - type: submitButton
+            buttonText: Continue
+
+treatments:
+  - name: treatment1
+    playerCount: 1
+    gameStages:
+      - template: questionStage
+        fields:
+          topic: "\${userTopic}"
+`;
+
+describe("parseTreatmentYaml", () => {
+  it("parses a minimal valid treatment file", () => {
+    const result = parseTreatmentYaml(MINIMAL_YAML);
+    expect(result.introSequences).toHaveLength(1);
+    expect(result.introSequences[0].name).toBe("intro1");
+    expect(result.treatments).toHaveLength(1);
+    expect(result.treatments[0].name).toBe("treatment1");
+    expect(result.treatments[0].gameStages).toHaveLength(1);
+  });
+
+  it("parses multiple treatments", () => {
+    const result = parseTreatmentYaml(MULTI_TREATMENT_YAML);
+    expect(result.treatments).toHaveLength(2);
+    expect(result.treatments[0].name).toBe("control");
+    expect(result.treatments[1].name).toBe("experimental");
+  });
+
+  it("throws on invalid YAML", () => {
+    expect(() => parseTreatmentYaml("{{not: valid: yaml:")).toThrow();
+  });
+
+  it("throws on valid YAML that fails schema validation", () => {
+    const badYaml = `
+introSequences:
+  - name: intro1
+    introSteps: []
+treatments: []
+`;
+    expect(() => parseTreatmentYaml(badYaml)).toThrow();
+  });
+});
+
+describe("expandTreatmentFile", () => {
+  it("passes through a file with no templates", () => {
+    const parsed = parseTreatmentYaml(MINIMAL_YAML);
+    const { result, unresolvedFields } = expandTreatmentFile(parsed);
+    expect(unresolvedFields).toEqual([]);
+    expect(result.treatments).toHaveLength(1);
+  });
+
+  it("expands templates into concrete stages", () => {
+    const parsed = parseTreatmentYaml(TEMPLATE_YAML);
+    const { result, unresolvedFields } = expandTreatmentFile(parsed);
+    expect(unresolvedFields).toEqual([]);
+    expect(result.treatments[0].gameStages).toHaveLength(2);
+    expect(result.treatments[0].gameStages[0].name).toBe("climate");
+    expect(result.treatments[0].gameStages[1].name).toBe("economy");
+  });
+
+  it("detects unresolved fields", () => {
+    const parsed = parseTreatmentYaml(UNRESOLVED_FIELD_YAML);
+    const { unresolvedFields } = expandTreatmentFile(parsed);
+    expect(unresolvedFields).toContain("userTopic");
+  });
+
+  it("resolves fields when additionalFields are provided", () => {
+    const parsed = parseTreatmentYaml(UNRESOLVED_FIELD_YAML);
+    const { result, unresolvedFields } = expandTreatmentFile(parsed, {
+      userTopic: "housing",
+    });
+    expect(unresolvedFields).toEqual([]);
+    expect(result.treatments[0].gameStages[0].name).toBe("housing");
+  });
+});

--- a/apps/viewer/src/lib/treatment.ts
+++ b/apps/viewer/src/lib/treatment.ts
@@ -5,17 +5,35 @@ import {
   type TreatmentFileType,
 } from "stagebook";
 
+export interface ValidationIssue {
+  path: string;
+  message: string;
+}
+
+export class TreatmentValidationError extends Error {
+  issues: ValidationIssue[];
+
+  constructor(issues: ValidationIssue[]) {
+    const summary = issues.map((i) => `  ${i.path}: ${i.message}`).join("\n");
+    super(`Treatment file validation failed:\n${summary}`);
+    this.name = "TreatmentValidationError";
+    this.issues = issues;
+  }
+}
+
 /**
  * Parse a YAML string as a treatment file, validating against the schema.
- * Throws on invalid YAML or schema validation failure.
+ * Throws TreatmentValidationError with structured issues on failure.
  */
 export function parseTreatmentYaml(yaml: string): TreatmentFileType {
   const raw = loadYaml(yaml);
   const result = treatmentFileSchema.safeParse(raw);
   if (!result.success) {
-    throw new Error(
-      `Treatment file validation failed:\n${result.error.message}`,
-    );
+    const issues: ValidationIssue[] = result.error.issues.map((issue) => ({
+      path: issue.path.join(".") || "(root)",
+      message: issue.message,
+    }));
+    throw new TreatmentValidationError(issues);
   }
   return result.data;
 }

--- a/apps/viewer/src/lib/treatment.ts
+++ b/apps/viewer/src/lib/treatment.ts
@@ -1,0 +1,41 @@
+import { load as loadYaml } from "js-yaml";
+import {
+  fillTemplates,
+  treatmentFileSchema,
+  type TreatmentFileType,
+} from "stagebook";
+
+/**
+ * Parse a YAML string as a treatment file, validating against the schema.
+ * Throws on invalid YAML or schema validation failure.
+ */
+export function parseTreatmentYaml(yaml: string): TreatmentFileType {
+  const raw = loadYaml(yaml);
+  const result = treatmentFileSchema.safeParse(raw);
+  if (!result.success) {
+    throw new Error(
+      `Treatment file validation failed:\n${result.error.message}`,
+    );
+  }
+  return result.data;
+}
+
+/**
+ * Expand templates in a parsed treatment file and detect unresolved fields.
+ * Optionally provide additionalFields to resolve remaining placeholders.
+ */
+export function expandTreatmentFile(
+  treatmentFile: TreatmentFileType,
+  additionalFields?: Record<string, unknown>,
+): { result: TreatmentFileType; unresolvedFields: string[] } {
+  // Strip template definitions before expansion — they contain
+  // placeholder syntax that would be falsely flagged as unresolved.
+  const { templates, ...withoutTemplates } = treatmentFile;
+  const { result, unresolvedFields } = fillTemplates({
+    obj: withoutTemplates,
+    templates: templates ?? [],
+    additionalFields,
+    allowUnresolved: true,
+  });
+  return { result: result as TreatmentFileType, unresolvedFields };
+}

--- a/apps/viewer/src/main.tsx
+++ b/apps/viewer/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import "./index.css";
 import { App } from "./App";
 
 createRoot(document.getElementById("root")!).render(

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   base: "/stagebook/viewer/",
 });

--- a/apps/viewer/vitest.config.ts
+++ b/apps/viewer/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,16 +20,279 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "js-yaml": "^4.1.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "stagebook": "*"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.5.2",
         "typescript": "^5.5.0",
-        "vite": "^6.3.3"
+        "vite": "^6.3.3",
+        "vitest": "^4.1.4"
+      }
+    },
+    "apps/viewer/node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/viewer/node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/viewer/node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/viewer/node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/viewer/node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/viewer/node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/viewer/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/viewer/node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/viewer/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "apps/viewer/node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/viewer/node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/viewer/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "apps/viewer/node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "apps/viewer/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -1629,6 +1892,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
@@ -1946,6 +2216,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1955,6 +2236,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2564,7 +2852,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
@@ -3980,7 +4267,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -5643,6 +5929,17 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/onetime": {
       "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,10 +20,12 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@tailwindcss/vite": "^4.2.2",
         "js-yaml": "^4.1.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "stagebook": "*"
+        "stagebook": "*",
+        "tailwindcss": "^4.2.2"
       },
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
@@ -1457,7 +1459,6 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1468,7 +1469,6 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1479,7 +1479,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1489,14 +1488,12 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1549,7 +1546,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1563,7 +1559,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1577,7 +1572,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1591,7 +1585,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1605,7 +1598,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1619,7 +1611,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1633,7 +1624,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1647,7 +1637,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1661,7 +1650,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1675,7 +1663,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1689,7 +1676,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1703,7 +1689,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1717,7 +1702,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1731,7 +1715,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1745,7 +1728,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1759,7 +1741,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1773,7 +1754,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1787,7 +1767,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1801,7 +1780,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1815,7 +1793,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1829,7 +1806,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1843,7 +1819,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1857,7 +1832,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1871,7 +1845,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1885,7 +1858,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1903,7 +1875,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
       "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
@@ -1919,7 +1890,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
       "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
@@ -1946,7 +1916,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1963,7 +1932,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1980,7 +1948,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1997,7 +1964,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2014,7 +1980,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2031,7 +1996,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2048,7 +2012,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2065,7 +2028,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2082,7 +2044,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2107,7 +2068,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2129,7 +2089,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2146,7 +2105,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2160,7 +2118,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
       "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/node": "4.2.2",
@@ -2248,7 +2205,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -3373,7 +3329,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3411,7 +3366,6 @@
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
       "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -3876,7 +3830,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3953,7 +3906,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -4240,7 +4192,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -4401,7 +4352,6 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
-      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -4434,13 +4384,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4456,13 +4404,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4478,13 +4424,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4500,13 +4444,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4522,13 +4464,11 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4544,13 +4484,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4566,13 +4504,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4588,13 +4524,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4610,13 +4544,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4632,13 +4564,11 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4654,13 +4584,11 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4853,7 +4781,6 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -5862,7 +5789,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6101,7 +6027,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -6188,7 +6113,6 @@
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
       "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6548,7 +6472,6 @@
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -6692,7 +6615,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6893,14 +6815,12 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
       "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6958,7 +6878,6 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -6975,7 +6894,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6993,7 +6911,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7452,7 +7369,6 @@
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -8065,7 +7981,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8082,7 +7997,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8099,7 +8013,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8116,7 +8029,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8133,7 +8045,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8150,7 +8061,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8167,7 +8077,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8184,7 +8093,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8201,7 +8109,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8218,7 +8125,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8235,7 +8141,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8252,7 +8157,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8269,7 +8173,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8286,7 +8189,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8303,7 +8205,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8320,7 +8221,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8337,7 +8237,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8354,7 +8253,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8371,7 +8269,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8388,7 +8285,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8405,7 +8301,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8422,7 +8317,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8439,7 +8333,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8456,7 +8349,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8473,7 +8365,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8490,7 +8381,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8504,7 +8394,6 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -8546,7 +8435,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -8564,7 +8452,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8579,7 +8466,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9330,7 +9216,7 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -157,7 +157,8 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
       if (promptError) {
         return (
           <p style={{ color: "#dc2626", fontSize: "0.875rem" }}>
-            Error loading prompt: {promptError.message}
+            Error loading prompt{element.file ? ` "${element.file}"` : ""}:{" "}
+            {promptError.message}
           </p>
         );
       }
@@ -173,7 +174,8 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
               fontSize: "0.875rem",
             }}
           >
-            Error parsing prompt: {parsed.error.issues[0]?.message}
+            Error parsing prompt{element.file ? ` "${element.file}"` : ""}:{" "}
+            {parsed.error.issues[0]?.message}
           </p>
         );
       }

--- a/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
+++ b/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
@@ -1942,7 +1942,22 @@ test("time display updates after loadedmetadata and timeupdate", async ({
 
 test("audio-only: controls always visible while playing (no hover needed)", async ({
   mount,
+  page,
 }) => {
+  // Intercept the media request to prevent network errors that would
+  // set loadError and hide controls (see #72).
+  // Serve a minimal valid WAV so the video element doesn't fire onerror
+  // (which would set loadError and hide controls — see #72).
+  await page.route("**/test.mp3", (route) =>
+    route.fulfill({
+      contentType: "audio/wav",
+      body: Buffer.from(
+        "UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=",
+        "base64",
+      ),
+    }),
+  );
+
   const component = await mount(
     <MockMediaPlayer
       url="https://example.com/test.mp3"
@@ -1971,7 +1986,19 @@ test("audio-only: controls always visible while playing (no hover needed)", asyn
   ).toBeVisible();
 });
 
-test("audio-only: no video viewport element", async ({ mount }) => {
+test("audio-only: no video viewport element", async ({ mount, page }) => {
+  // Serve a minimal valid WAV so the video element doesn't fire onerror
+  // (which would set loadError and hide controls — see #72).
+  await page.route("**/test.mp3", (route) =>
+    route.fulfill({
+      contentType: "audio/wav",
+      body: Buffer.from(
+        "UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=",
+        "base64",
+      ),
+    }),
+  );
+
   const component = await mount(
     <MockMediaPlayer
       url="https://example.com/test.mp3"


### PR DESCRIPTION
## Summary

- Implements the viewer app specified in #62 — a static SPA that renders Stagebook treatment files so researchers can walk through studies from the participant's perspective
- Pure client-side (no backend), fetches treatment YAML from GitHub, renders stages using the real Stagebook components with a mock `StagebookContext`
- 60 viewer-specific tests covering the full data pipeline

## What's included

**Data layer** (chunk 1-2):
- GitHub URL parsing (blob + raw URLs), treatment YAML fetch/parse/validate, template expansion with unresolved field detection
- `ViewerStateStore` with resolve/save, change notification, and version tracking
- Mock `StagebookContext` factory bridging the store to Stagebook components

**UI** (chunk 3-5):
- Landing page with URL input + `?url=` auto-load
- Treatment picker + unfilled field form
- Three-panel viewer: header (nav + time scrubber + position) / sidebar (state inspector) / main (stage rendering)
- Stage navigation with phase-grouped dropdown + prev/next
- Time scrubber with playback (1x/2x/5x/10x), breakpoint markers from displayTime/hideTime
- State inspector showing references relevant to the current stage, with edit controls and "all state" expansion
- Skeleton placeholders for platform-coupled elements (discussion, survey, etc.)
- Structured validation error display

**Infrastructure**:
- GitHub Pages deployment workflow (`deploy-viewer.yml`)
- Tailwind CSS + `stagebook/styles` integration
- Prompt error messages now include file path (library change in `Element.tsx`)

## Test plan

- [ ] Load a treatment file from a GitHub URL — verify stages render
- [ ] Navigate between stages with the dropdown and prev/next arrows
- [ ] Use the time scrubber to see time-conditional elements appear/disappear
- [ ] Play the time scrubber and verify playback at different speeds
- [ ] Switch participant position and verify position-conditional rendering
- [ ] Click Submit → verify "waiting" screen → click "Next" → verify advance
- [ ] Edit state values in the inspector → verify stage re-renders accordingly
- [ ] Load a file with validation errors → verify structured error display
- [ ] Load a file with templates → verify treatment picker / field form

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)