### PR TITLE
Skip getTextContent for elements without file field

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/stagebook/src/components/StagebookProvider.test.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.test.tsx
@@ -123,15 +123,20 @@ describe("StagebookProvider + useStagebookContext", () => {
 
 // Helper to render a hook inside a StagebookProvider
 function renderUseTextContent(
-  path: string,
+  initialPath: string,
   ctx: StagebookContext,
-): { result: { current: TextContentResult }; unmount: () => void } {
+): {
+  result: { current: TextContentResult };
+  rerender: (path: string) => void;
+  unmount: () => void;
+} {
   const result = { current: undefined as unknown as TextContentResult };
   const container = document.createElement("div");
   let root: Root;
+  let currentPath = initialPath;
 
   function Harness(): ReactNode {
-    result.current = useTextContent(path);
+    result.current = useTextContent(currentPath);
     return null;
   }
 
@@ -146,6 +151,16 @@ function renderUseTextContent(
 
   return {
     result,
+    rerender: (path: string) => {
+      currentPath = path;
+      act(() => {
+        root.render(
+          <StagebookProvider value={ctx}>
+            <Harness />
+          </StagebookProvider>,
+        );
+      });
+    },
     unmount: () => act(() => root.unmount()),
   };
 }
@@ -175,6 +190,30 @@ describe("useTextContent", () => {
     expect(getTextContent).toHaveBeenCalledWith("prompts/hello.md");
     expect(result.current.data).toBe("# Hello");
     expect(result.current.isLoading).toBe(false);
+    unmount();
+  });
+
+  test("resets data when path changes from non-empty to empty", async () => {
+    const getTextContent = vi.fn(() => Promise.resolve("# Hello"));
+    const ctx = createMockContext({ getTextContent });
+
+    const { result, rerender, unmount } = renderUseTextContent(
+      "prompts/hello.md",
+      ctx,
+    );
+
+    await act(() => Promise.resolve());
+
+    expect(result.current.data).toBe("# Hello");
+    expect(result.current.isLoading).toBe(false);
+
+    rerender("");
+    await act(() => Promise.resolve());
+
+    expect(getTextContent).toHaveBeenCalledTimes(1);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
     unmount();
   });
 

--- a/packages/stagebook/src/components/StagebookProvider.test.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.test.tsx
@@ -1,6 +1,14 @@
+// @vitest-environment jsdom
 import { describe, test, expect, vi } from "vitest";
-import React from "react";
-import { type StagebookContext } from "./StagebookProvider.js";
+import React, { type ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  type StagebookContext,
+  StagebookProvider,
+  useTextContent,
+  type TextContentResult,
+} from "./StagebookProvider.js";
 
 // We test the provider/hooks via a simple test component pattern
 // that captures hook return values into a ref we can assert on.
@@ -110,5 +118,76 @@ describe("StagebookProvider + useStagebookContext", () => {
       // Outside React entirely, it throws a different React error
       useStagebookContext();
     }).toThrow();
+  });
+});
+
+// Helper to render a hook inside a StagebookProvider
+function renderUseTextContent(
+  path: string,
+  ctx: StagebookContext,
+): { result: { current: TextContentResult }; unmount: () => void } {
+  const result = { current: undefined as unknown as TextContentResult };
+  const container = document.createElement("div");
+  let root: Root;
+
+  function Harness(): ReactNode {
+    result.current = useTextContent(path);
+    return null;
+  }
+
+  act(() => {
+    root = createRoot(container);
+    root.render(
+      <StagebookProvider value={ctx}>
+        <Harness />
+      </StagebookProvider>,
+    );
+  });
+
+  return {
+    result,
+    unmount: () => act(() => root.unmount()),
+  };
+}
+
+describe("useTextContent", () => {
+  test("does not call getTextContent when path is empty", async () => {
+    const getTextContent = vi.fn(() => Promise.resolve("content"));
+    const ctx = createMockContext({ getTextContent });
+
+    const { unmount } = renderUseTextContent("", ctx);
+
+    // Let any pending microtasks flush
+    await act(() => Promise.resolve());
+
+    expect(getTextContent).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  test("calls getTextContent when path is non-empty", async () => {
+    const getTextContent = vi.fn(() => Promise.resolve("# Hello"));
+    const ctx = createMockContext({ getTextContent });
+
+    const { result, unmount } = renderUseTextContent("prompts/hello.md", ctx);
+
+    await act(() => Promise.resolve());
+
+    expect(getTextContent).toHaveBeenCalledWith("prompts/hello.md");
+    expect(result.current.data).toBe("# Hello");
+    expect(result.current.isLoading).toBe(false);
+    unmount();
+  });
+
+  test("returns not-loading with no data for empty path", async () => {
+    const ctx = createMockContext();
+
+    const { result, unmount } = renderUseTextContent("", ctx);
+
+    await act(() => Promise.resolve());
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.data).toBeUndefined();
+    expect(result.current.error).toBeUndefined();
+    unmount();
   });
 });

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -102,10 +102,12 @@ export interface TextContentResult {
 export function useTextContent(path: string): TextContentResult {
   const { getTextContent } = useStagebookContext();
   const [data, setData] = useState<string | undefined>(undefined);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(!path ? false : true);
   const [error, setError] = useState<Error | undefined>(undefined);
 
   useEffect(() => {
+    if (!path) return;
+
     let cancelled = false;
     setIsLoading(true);
     setError(undefined);

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -102,11 +102,16 @@ export interface TextContentResult {
 export function useTextContent(path: string): TextContentResult {
   const { getTextContent } = useStagebookContext();
   const [data, setData] = useState<string | undefined>(undefined);
-  const [isLoading, setIsLoading] = useState(!path ? false : true);
+  const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | undefined>(undefined);
 
   useEffect(() => {
-    if (!path) return;
+    if (!path) {
+      setData(undefined);
+      setError(undefined);
+      setIsLoading(false);
+      return;
+    }
 
     let cancelled = false;
     setIsLoading(true);


### PR DESCRIPTION
## Summary
- `useTextContent` now early-returns when `path` is empty, avoiding unnecessary `getTextContent("")` calls for elements that don't have a `file:` field (e.g., `mediaPlayer`, `submitButton`)
- Adds tests for `useTextContent` covering both empty and non-empty path behavior

Fixes #71

## Test plan
- [x] New tests: `useTextContent` does not call `getTextContent` with empty path
- [x] New tests: `useTextContent` calls `getTextContent` and returns data for non-empty path
- [x] New tests: `useTextContent` returns `isLoading: false` with no data/error for empty path
- [x] Full test suite passes (521 tests across both workspaces)
- [x] Lint clean
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)