### PR TITLE
Add locked single-playback mode for mediaPlayer

### DIFF
--- a/docs/researcher/elements.md
+++ b/docs/researcher/elements.md
@@ -108,9 +108,28 @@ Use a direct URL for any video/audio file, or a YouTube URL for embedded YouTube
   url: https://example.com/study/clip.mp4
 ```
 
-### Sync mode (default)
+### Play-once mode (default)
 
-By default each participant controls their own playback independently.
+By default the video autoplays once with no participant controls. If the browser blocks autoplay (no prior user interaction on the page), a one-time play button appears and disappears after the participant clicks it. This is the right mode when participants should watch a video exactly once without pausing or rewinding.
+
+```yaml
+- type: mediaPlayer
+  name: intro_video
+  url: https://example.com/study/clip.mp4
+```
+
+You can also set this explicitly:
+
+```yaml
+- type: mediaPlayer
+  name: intro_video
+  url: https://example.com/study/clip.mp4
+  playback: once
+```
+
+### Manual mode (with controls)
+
+When you add `controls`, the playback mode automatically switches to `manual` — the participant controls their own playback. You can also set `playback: manual` explicitly.
 
 ```yaml
 - type: mediaPlayer
@@ -143,6 +162,7 @@ Ties video time to stage elapsed time so all participants stay in sync. Hides al
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `url` | string | required | Direct media URL or YouTube URL |
+| `playback` | `"once"` or `"manual"` | `"once"` | `"once"`: autoplay with no controls; `"manual"`: participant uses controls. Defaults to `"once"` unless `controls` or `syncToStageTime` is set |
 | `playVideo` | boolean | `true` | Show the video track (set `false` for audio-only) |
 | `playAudio` | boolean | `true` | Unmute audio |
 | `captionsFile` | string | — | Path to a `.vtt` captions file |

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -262,6 +262,7 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
             element.allowScrubOutsideBounds as boolean | undefined
           }
           stepDuration={element.stepDuration as number | undefined}
+          playback={element.playback as "once" | "manual" | undefined}
           controls={
             element.controls as
               | {

--- a/packages/stagebook/src/components/elements/MediaPlayer.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.tsx
@@ -122,6 +122,7 @@ export function MediaPlayer({
 
   const eventsRef = useRef<VideoEvent[]>([]);
   const videoRef = useRef<HTMLVideoElement>(null);
+  const autoplayAttemptedRef = useRef(false);
 
   const [isPaused, setIsPaused] = useState(true);
   const [showPlayOnce, setShowPlayOnce] = useState(false);
@@ -137,8 +138,11 @@ export function MediaPlayer({
   // Clear any prior error state when the source changes (e.g. parent
   // swaps to a different clip). Without this the player would stay
   // stuck in the error state forever after a single load failure.
+  // Also reset autoplay state so a new URL gets a fresh attempt.
   useEffect(() => {
     setLoadError(null);
+    autoplayAttemptedRef.current = false;
+    setShowPlayOnce(false);
   }, [url]);
 
   // YouTube-only: handle registered by YouTubePlayer once the IFrame API is ready
@@ -405,7 +409,6 @@ export function MediaPlayer({
 
   // Autoplay for "once" mode: attempt .play() once metadata is loaded.
   // If the browser blocks it (no prior user interaction), show a fallback button.
-  const autoplayAttemptedRef = useRef(false);
   useEffect(() => {
     if (effectivePlayback !== "once") return;
     if (autoplayAttemptedRef.current) return;
@@ -630,6 +633,9 @@ export function MediaPlayer({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      // "once" mode: no keyboard controls
+      if (effectivePlayback === "once") return;
+
       // YouTube: only Space/K play-pause and J/L/Arrow seek work
       if (ytHandle) {
         switch (e.key) {
@@ -736,7 +742,13 @@ export function MediaPlayer({
           break;
       }
     },
-    [seek, stepDuration, playbackRate, enterFastScrubForward],
+    [
+      effectivePlayback,
+      seek,
+      stepDuration,
+      playbackRate,
+      enterFastScrubForward,
+    ],
   );
 
   const handleKeyUp = useCallback(
@@ -1192,12 +1204,19 @@ export function MediaPlayer({
 
           {showPlayOnce && (
             <button
+              type="button"
               data-testid="mediaPlayer-playOnce"
               aria-label="Play video"
               onClick={() => {
                 setShowPlayOnce(false);
                 const v = videoRef.current;
-                if (v) void v.play();
+                if (!v) {
+                  setShowPlayOnce(true);
+                  return;
+                }
+                void v.play().catch(() => {
+                  setShowPlayOnce(true);
+                });
               }}
               style={{
                 position: "absolute",
@@ -1233,12 +1252,19 @@ export function MediaPlayer({
       {/* Audio-only: play-once fallback button */}
       {!playVideo && showPlayOnce && (
         <button
+          type="button"
           data-testid="mediaPlayer-playOnce"
           aria-label="Play audio"
           onClick={() => {
             setShowPlayOnce(false);
             const v = videoRef.current;
-            if (v) void v.play();
+            if (!v) {
+              setShowPlayOnce(true);
+              return;
+            }
+            void v.play().catch(() => {
+              setShowPlayOnce(true);
+            });
           }}
           style={{
             background: "rgba(28,28,30,0.96)",

--- a/packages/stagebook/src/components/elements/MediaPlayer.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.tsx
@@ -55,6 +55,7 @@ export interface MediaPlayerProps {
   stopAt?: number;
   allowScrubOutsideBounds?: boolean;
   stepDuration?: number;
+  playback?: "once" | "manual";
   controls?: {
     playPause?: boolean;
     seek?: boolean;
@@ -93,10 +94,20 @@ export function MediaPlayer({
   stopAt,
   allowScrubOutsideBounds = false,
   stepDuration = 1,
+  playback,
   controls,
 }: MediaPlayerProps) {
   const youtubeVideoId = isYouTubeURL(url);
   const saveKey = `mediaPlayer_${name}`;
+
+  // Effective playback mode: explicit value wins; otherwise "once" when no
+  // controls or syncToStageTime are configured (avoids the frozen-frame state
+  // where the video has no way to start).
+  const hasAnyControls =
+    controls !== undefined &&
+    (controls.playPause || controls.seek || controls.step || controls.speed);
+  const effectivePlayback =
+    playback ?? (hasAnyControls || syncToStageTime ? "manual" : "once");
 
   // Defense-in-depth: reject dangerous URL protocols. Element.tsx already
   // resolves relative paths via getAssetURL(), so this guards against
@@ -113,6 +124,7 @@ export function MediaPlayer({
   const videoRef = useRef<HTMLVideoElement>(null);
 
   const [isPaused, setIsPaused] = useState(true);
+  const [showPlayOnce, setShowPlayOnce] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState<number>(0);
@@ -390,6 +402,23 @@ export function MediaPlayer({
       videoRef.current.currentTime = startAt;
     }
   }, []); // mount-only: reads initial values of getElapsedTime/startAt
+
+  // Autoplay for "once" mode: attempt .play() once metadata is loaded.
+  // If the browser blocks it (no prior user interaction), show a fallback button.
+  const autoplayAttemptedRef = useRef(false);
+  useEffect(() => {
+    if (effectivePlayback !== "once") return;
+    if (autoplayAttemptedRef.current) return;
+    const v = videoRef.current;
+    if (!v) return;
+    // Wait for metadata: duration is set in handleLoadedMetadata
+    if (duration === 0) return;
+
+    autoplayAttemptedRef.current = true;
+    void v.play().catch(() => {
+      setShowPlayOnce(true);
+    });
+  }, [effectivePlayback, duration]);
 
   const recordEvent = useCallback(
     (
@@ -1160,7 +1189,70 @@ export function MediaPlayer({
               <HTML5Controls {...html5ControlsProps} />
             </div>
           )}
+
+          {showPlayOnce && (
+            <button
+              data-testid="mediaPlayer-playOnce"
+              aria-label="Play video"
+              onClick={() => {
+                setShowPlayOnce(false);
+                const v = videoRef.current;
+                if (v) void v.play();
+              }}
+              style={{
+                position: "absolute",
+                top: "50%",
+                left: "50%",
+                transform: "translate(-50%, -50%)",
+                background: "rgba(0,0,0,0.6)",
+                border: "none",
+                borderRadius: "50%",
+                width: 64,
+                height: 64,
+                cursor: "pointer",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "#fff",
+              }}
+            >
+              <svg
+                width={32}
+                height={32}
+                viewBox="0 0 24 24"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <polygon points="6,3 20,12 6,21" />
+              </svg>
+            </button>
+          )}
         </div>
+      )}
+
+      {/* Audio-only: play-once fallback button */}
+      {!playVideo && showPlayOnce && (
+        <button
+          data-testid="mediaPlayer-playOnce"
+          aria-label="Play audio"
+          onClick={() => {
+            setShowPlayOnce(false);
+            const v = videoRef.current;
+            if (v) void v.play();
+          }}
+          style={{
+            background: "rgba(28,28,30,0.96)",
+            border: "1px solid rgba(255,255,255,0.2)",
+            borderRadius: "0.5rem",
+            padding: "0.75rem 1.5rem",
+            cursor: "pointer",
+            color: "#fff",
+            fontSize: "0.875rem",
+            fontWeight: 500,
+          }}
+        >
+          Play
+        </button>
       )}
 
       {/* Audio-only: flat controls bar (always visible — no hover needed) */}

--- a/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
+++ b/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
@@ -1242,7 +1242,7 @@ test("ArrowLeft seeks backward 1 second", async ({ mount }) => {
 
 test("L key seeks forward 10 seconds", async ({ mount }) => {
   const component = await mount(
-    <MockMediaPlayer url="/sample-video.mp4" name="test" />,
+    <MockMediaPlayer url="/sample-video.mp4" name="test" playback="manual" />,
   );
   const video = component.locator('[data-testid="mediaPlayer-video"]');
   await video.evaluate((el) => {
@@ -1266,7 +1266,7 @@ test("L key seeks forward 10 seconds", async ({ mount }) => {
 
 test("J key seeks backward 10 seconds", async ({ mount }) => {
   const component = await mount(
-    <MockMediaPlayer url="/sample-video.mp4" name="test" />,
+    <MockMediaPlayer url="/sample-video.mp4" name="test" playback="manual" />,
   );
   const video = component.locator('[data-testid="mediaPlayer-video"]');
   await video.evaluate((el) => {
@@ -1290,7 +1290,12 @@ test("J key seeks backward 10 seconds", async ({ mount }) => {
 
 test("Period key steps forward by stepDuration", async ({ mount }) => {
   const component = await mount(
-    <MockMediaPlayer url="/sample-video.mp4" name="test" stepDuration={0.5} />,
+    <MockMediaPlayer
+      url="/sample-video.mp4"
+      name="test"
+      stepDuration={0.5}
+      playback="manual"
+    />,
   );
   const video = component.locator('[data-testid="mediaPlayer-video"]');
   await video.evaluate((el) => {
@@ -1314,7 +1319,12 @@ test("Period key steps forward by stepDuration", async ({ mount }) => {
 
 test("Comma key steps backward by stepDuration", async ({ mount }) => {
   const component = await mount(
-    <MockMediaPlayer url="/sample-video.mp4" name="test" stepDuration={0.5} />,
+    <MockMediaPlayer
+      url="/sample-video.mp4"
+      name="test"
+      stepDuration={0.5}
+      playback="manual"
+    />,
   );
   const video = component.locator('[data-testid="mediaPlayer-video"]');
   await video.evaluate((el) => {
@@ -1339,7 +1349,12 @@ test("Comma key steps backward by stepDuration", async ({ mount }) => {
 test("ArrowLeft clamps to startAt boundary", async ({ mount }) => {
   // ct=10.5, startAt=10: seek(-1) → max(9.5, 10) = 10
   const component = await mount(
-    <MockMediaPlayer url="/sample-video.mp4" name="test" startAt={10} />,
+    <MockMediaPlayer
+      url="/sample-video.mp4"
+      name="test"
+      startAt={10}
+      playback="manual"
+    />,
   );
   const video = component.locator('[data-testid="mediaPlayer-video"]');
   await video.evaluate((el) => {
@@ -2055,7 +2070,7 @@ test("playback once: shows play button when autoplay is blocked", async ({
   page,
 }) => {
   // Block the video from loading so no real loadedmetadata fires
-  await page.route("**/blocked.mp4", () => {});
+  await page.route("**/blocked.mp4", (route) => route.abort());
 
   const component = await mount(
     <MockMediaPlayer url="/blocked.mp4" name="test" playback="once" />,
@@ -2085,7 +2100,7 @@ test("playback once: play button disappears after click", async ({
   mount,
   page,
 }) => {
-  await page.route("**/blocked.mp4", () => {});
+  await page.route("**/blocked.mp4", (route) => route.abort());
 
   const component = await mount(
     <MockMediaPlayer url="/blocked.mp4" name="test" playback="once" />,
@@ -2139,7 +2154,7 @@ test("default playback is 'once' when no controls or syncToStageTime", async ({
   page,
 }) => {
   // No playback, no controls, no syncToStageTime — should behave like "once"
-  await page.route("**/blocked.mp4", () => {});
+  await page.route("**/blocked.mp4", (route) => route.abort());
 
   const component = await mount(
     <MockMediaPlayer url="/blocked.mp4" name="test" />,

--- a/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
+++ b/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
@@ -459,7 +459,11 @@ test("save is called with play event data when video plays", async ({
   mount,
 }) => {
   const component = await mount(
-    <MockMediaPlayer url="/sample-video.mp4" name="test_vid" />,
+    <MockMediaPlayer
+      url="/sample-video.mp4"
+      name="test_vid"
+      playback="manual"
+    />,
   );
 
   await component
@@ -492,7 +496,11 @@ test("save is called with pause event data when video pauses", async ({
   mount,
 }) => {
   const component = await mount(
-    <MockMediaPlayer url="/sample-video.mp4" name="test_vid" />,
+    <MockMediaPlayer
+      url="/sample-video.mp4"
+      name="test_vid"
+      playback="manual"
+    />,
   );
 
   await component
@@ -515,7 +523,11 @@ test("save is called with pause event data when video pauses", async ({
 
 test("save log accumulates multiple events", async ({ mount }) => {
   const component = await mount(
-    <MockMediaPlayer url="/sample-video.mp4" name="test_vid" />,
+    <MockMediaPlayer
+      url="/sample-video.mp4"
+      name="test_vid"
+      playback="manual"
+    />,
   );
 
   const video = component.locator('[data-testid="mediaPlayer-video"]');
@@ -635,7 +647,12 @@ test("save records stopAt event when timeupdate exceeds stopAt", async ({
   mount,
 }) => {
   const component = await mount(
-    <MockMediaPlayer url="/sample-video.mp4" name="test" stopAt={5} />,
+    <MockMediaPlayer
+      url="/sample-video.mp4"
+      name="test"
+      stopAt={5}
+      playback="manual"
+    />,
   );
 
   await component
@@ -2010,4 +2027,139 @@ test("audio-only: no video viewport element", async ({ mount, page }) => {
   await expect(
     component.locator('[data-testid="mediaPlayer-viewport"]'),
   ).not.toBeAttached();
+});
+
+// -- playback: "once" --
+
+test("playback once: attempts autoplay on mount", async ({ mount }) => {
+  const component = await mount(
+    <MockMediaPlayer url="/sample-video.mp4" name="test" playback="once" />,
+  );
+  const video = component.locator('[data-testid="mediaPlayer-video"]');
+
+  // Set up the mock so .play() resolves (autoplay succeeds)
+  await setupVideoMock(video);
+
+  // The component should have attempted to play
+  const saveLog = component.locator('[data-testid="save-log"]');
+  await expect
+    .poll(async () => {
+      const text = await saveLog.textContent();
+      return text ?? "";
+    })
+    .toMatch(/"type":"play"/);
+});
+
+test("playback once: shows play button when autoplay is blocked", async ({
+  mount,
+  page,
+}) => {
+  // Block the video from loading so no real loadedmetadata fires
+  await page.route("**/blocked.mp4", () => {});
+
+  const component = await mount(
+    <MockMediaPlayer url="/blocked.mp4" name="test" playback="once" />,
+  );
+  const video = component.locator('[data-testid="mediaPlayer-video"]');
+
+  // Override .play() to reject, set duration, fire loadedmetadata — all in one
+  // evaluate so the autoplay effect fires with the rejection in place.
+  await video.evaluate((el) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any).play = () =>
+      Promise.reject(new DOMException("NotAllowedError"));
+    Object.defineProperty(el, "duration", {
+      get: () => 60,
+      configurable: true,
+    });
+    el.dispatchEvent(new Event("loadedmetadata"));
+  });
+
+  // Fallback play button should appear
+  await expect(
+    component.locator('[data-testid="mediaPlayer-playOnce"]'),
+  ).toBeVisible();
+});
+
+test("playback once: play button disappears after click", async ({
+  mount,
+  page,
+}) => {
+  await page.route("**/blocked.mp4", () => {});
+
+  const component = await mount(
+    <MockMediaPlayer url="/blocked.mp4" name="test" playback="once" />,
+  );
+  const video = component.locator('[data-testid="mediaPlayer-video"]');
+
+  // First .play() rejects (autoplay blocked), subsequent calls succeed
+  await video.evaluate((el) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const v = el as any;
+    v.__callCount = 0;
+    v.play = () => {
+      v.__callCount++;
+      if (v.__callCount === 1) {
+        return Promise.reject(new DOMException("NotAllowedError"));
+      }
+      el.dispatchEvent(new Event("play"));
+      return Promise.resolve();
+    };
+    Object.defineProperty(el, "duration", {
+      get: () => 60,
+      configurable: true,
+    });
+    el.dispatchEvent(new Event("loadedmetadata"));
+  });
+
+  const playBtn = component.locator('[data-testid="mediaPlayer-playOnce"]');
+  await expect(playBtn).toBeVisible();
+
+  // Click the button — second .play() call succeeds
+  await playBtn.click();
+
+  // Button should disappear
+  await expect(playBtn).not.toBeAttached();
+});
+
+test("playback once: no VCR controls shown", async ({ mount }) => {
+  const component = await mount(
+    <MockMediaPlayer url="/sample-video.mp4" name="test" playback="once" />,
+  );
+  await expect(
+    component.locator('[data-testid="mediaPlayer-controls"]'),
+  ).not.toBeAttached();
+  await expect(
+    component.locator('[data-testid="mediaPlayer-playPause"]'),
+  ).not.toBeAttached();
+});
+
+test("default playback is 'once' when no controls or syncToStageTime", async ({
+  mount,
+  page,
+}) => {
+  // No playback, no controls, no syncToStageTime — should behave like "once"
+  await page.route("**/blocked.mp4", () => {});
+
+  const component = await mount(
+    <MockMediaPlayer url="/blocked.mp4" name="test" />,
+  );
+  const video = component.locator('[data-testid="mediaPlayer-video"]');
+
+  // Reject .play(), set duration, fire loadedmetadata — all in one evaluate
+  await video.evaluate((el) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any).play = () =>
+      Promise.reject(new DOMException("NotAllowedError"));
+    Object.defineProperty(el, "duration", {
+      get: () => 60,
+      configurable: true,
+    });
+    el.dispatchEvent(new Event("loadedmetadata"));
+  });
+
+  // Should show the play-once button (proving "once" is the default)
+  await expect(
+    component.locator('[data-testid="mediaPlayer-playOnce"]'),
+  ).toBeVisible();
 });

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -448,6 +448,7 @@ test("mediaPlayer: full config with all fields", () => {
     stepDuration: 0.033,
     syncToStageTime: false,
     submitOnComplete: true,
+    playback: "once",
     controls: {
       playPause: true,
       seek: true,
@@ -558,6 +559,46 @@ test("mediaPlayer: startAt < stopAt is valid", () => {
   });
   if (!result.success) console.log(result.error.message);
   expect(result.success).toBe(true);
+});
+
+test("mediaPlayer: playback 'once' is valid", () => {
+  const result = mediaPlayerSchema.safeParse({
+    type: "mediaPlayer",
+    url: "shared/footage.mp4",
+    playback: "once",
+  });
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(true);
+});
+
+test("mediaPlayer: playback 'manual' is valid", () => {
+  const result = mediaPlayerSchema.safeParse({
+    type: "mediaPlayer",
+    url: "shared/footage.mp4",
+    playback: "manual",
+  });
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(true);
+});
+
+test("mediaPlayer: playback rejects invalid value", () => {
+  const result = mediaPlayerSchema.safeParse({
+    type: "mediaPlayer",
+    url: "shared/footage.mp4",
+    playback: "loop",
+  });
+  expect(result.success).toBe(false);
+});
+
+test("mediaPlayer: playback is optional (defaults to 'once')", () => {
+  const result = mediaPlayerSchema.safeParse({
+    type: "mediaPlayer",
+    url: "shared/footage.mp4",
+  });
+  expect(result.success).toBe(true);
+  if (result.success) {
+    expect(result.data.playback).toBeUndefined();
+  }
 });
 
 // ----------- introStepsSchema / exitStepsSchema: advancement element requirement ------------

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -448,7 +448,7 @@ test("mediaPlayer: full config with all fields", () => {
     stepDuration: 0.033,
     syncToStageTime: false,
     submitOnComplete: true,
-    playback: "once",
+    playback: "manual",
     controls: {
       playPause: true,
       seek: true,
@@ -590,7 +590,7 @@ test("mediaPlayer: playback rejects invalid value", () => {
   expect(result.success).toBe(false);
 });
 
-test("mediaPlayer: playback is optional (defaults to 'once')", () => {
+test("mediaPlayer: playback is optional (omitted in schema, component defaults to 'once')", () => {
   const result = mediaPlayerSchema.safeParse({
     type: "mediaPlayer",
     url: "shared/footage.mp4",
@@ -599,6 +599,37 @@ test("mediaPlayer: playback is optional (defaults to 'once')", () => {
   if (result.success) {
     expect(result.data.playback).toBeUndefined();
   }
+});
+
+test("mediaPlayer: playback 'once' with controls is invalid", () => {
+  const result = elementSchema.safeParse({
+    type: "mediaPlayer",
+    url: "shared/footage.mp4",
+    playback: "once",
+    controls: { playPause: true },
+  });
+  expect(result.success).toBe(false);
+});
+
+test("mediaPlayer: playback 'once' with syncToStageTime is invalid", () => {
+  const result = elementSchema.safeParse({
+    type: "mediaPlayer",
+    url: "shared/footage.mp4",
+    playback: "once",
+    syncToStageTime: true,
+  });
+  expect(result.success).toBe(false);
+});
+
+test("mediaPlayer: playback 'manual' with controls is valid", () => {
+  const result = elementSchema.safeParse({
+    type: "mediaPlayer",
+    url: "shared/footage.mp4",
+    playback: "manual",
+    controls: { playPause: true },
+  });
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(true);
 });
 
 // ----------- introStepsSchema / exitStepsSchema: advancement element requirement ------------

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -820,6 +820,7 @@ export const mediaPlayerSchema = elementBaseSchema
     stepDuration: z.number().positive().optional(),
     syncToStageTime: z.boolean().optional(),
     submitOnComplete: z.boolean().optional(),
+    playback: z.enum(["once", "manual"]).optional(),
     controls: mediaPlayerControlsSchema,
   })
   .strict();

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -1002,6 +1002,27 @@ export const elementSchema = altTemplateContext(
           path: ["controls"],
         });
       }
+      const mpPlayback = data as {
+        playback?: string;
+        controls?: Record<string, boolean>;
+        syncToStageTime?: boolean;
+      };
+      if (mpPlayback.playback === "once" && mpPlayback.controls) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'controls cannot be specified when playback is "once" (participant controls are disabled)',
+          path: ["controls"],
+        });
+      }
+      if (mpPlayback.playback === "once" && mpPlayback.syncToStageTime) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'playback "once" cannot be combined with syncToStageTime (use syncToStageTime without playback instead)',
+          path: ["playback"],
+        });
+      }
     }
   }),
 );


### PR DESCRIPTION
## Summary
- New `playback` field on `mediaPlayer` schema with two modes: `"once"` (autoplay, no controls) and `"manual"` (participant controls playback)
- Default is `"once"` when no `controls` or `syncToStageTime` is configured, eliminating the previous dead state (frozen first frame with no way to start)
- When autoplay is blocked by the browser, a one-time play button appears and disappears after click
- Version bump to 0.2.0 (new feature, minor behavioral change to defaults)

Fixes #84

## Test plan
- [x] Schema tests: `playback: "once"` and `"manual"` accepted, invalid values rejected, optional field
- [x] CT test: autoplay attempted on mount in "once" mode
- [x] CT test: fallback play button shown when browser blocks autoplay
- [x] CT test: play button disappears after click
- [x] CT test: no VCR controls shown in "once" mode
- [x] CT test: default behavior (no controls/sync) uses "once" mode
- [x] Existing event recording tests updated with explicit `playback="manual"` to preserve behavior
- [x] Full test suite: 466 vitest + 329 CT + 60 viewer tests pass
- [x] Lint clean, build succeeds
- [x] Researcher docs updated with playback modes and options table

🤖 Generated with [Claude Code](https://claude.com/claude-code)