### PR TITLE
Fix publish workflow: build stagebook before tests

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,7 +21,6 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
-      - run: npm run build -w stagebook
-      - run: npm test
       - run: npm run build
+      - run: npm test
       - run: npm publish -w stagebook --provenance --access public

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,6 +21,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
+      - run: npm run build -w stagebook
       - run: npm test
       - run: npm run build
       - run: npm publish -w stagebook --provenance --access public


### PR DESCRIPTION
## Summary
- The publish workflow ran `npm test` before `npm run build`, causing viewer tests to fail because they can't resolve the `stagebook` package entry without build output
- Adds `npm run build -w stagebook` before `npm test`, matching the CI workflow

This caused the v0.2.0 publish to fail. After merge, we'll need to re-run the release or delete and re-create the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)