### PR TITLE
Fix OIDC trusted publishing: remove registry-url

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           node-version: 22
           cache: npm
-          registry-url: https://registry.npmjs.org
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check


### PR DESCRIPTION
## Summary
- Remove `registry-url` from `actions/setup-node` to fix npm OIDC trusted publishing
- `setup-node` with `registry-url` injects a placeholder `NODE_AUTH_TOKEN` (`XXXXX-XXXXX-XXXXX-XXXXX`) that overrides npm's native OIDC auto-detection, causing the publish to fail with a 404
- Without `registry-url`, npm CLI (>= 9) detects the GitHub OIDC environment and exchanges the id-token for a short-lived npm publish token automatically

This should fix the v0.2.0 publish failure. After merge, we'll delete and re-create the release tag again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)