### PR TITLE
Fix viewer deploy path on GitHub Pages

### DIFF
--- a/.github/workflows/deploy-viewer.yml
+++ b/.github/workflows/deploy-viewer.yml
@@ -30,9 +30,10 @@ jobs:
       - run: npm ci
       - run: npm run build -w stagebook
       - run: npm run build -w stagebook-viewer
+      - run: mkdir -p _site/viewer && cp -r apps/viewer/dist/* _site/viewer/
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: apps/viewer/dist
+          path: _site
       - id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- The viewer was returning 404s on GitHub Pages because the built assets were uploaded to the Pages root (`/stagebook/`) but the HTML references them at `/stagebook/viewer/`
- Fix: copy `apps/viewer/dist` into `_site/viewer/` before uploading, so the URL structure matches the Vite `base` config

## Test plan

- [ ] After merge, verify https://deliberation-lab.github.io/stagebook/viewer/ loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)