### PR TITLE
Fix npm publish: Node 24 + OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -15,11 +15,14 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
+          registry-url: "https://registry.npmjs.org/"
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
       - run: npm run build
       - run: npm test
-      - run: npm publish -w stagebook --provenance --access public
+      - name: Publish to npm
+        working-directory: ./packages/stagebook
+        run: npm publish --provenance --access public

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -88,7 +88,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/deliberation-lab/stagebook.git"
+    "url": "git+https://github.com/deliberation-lab/stagebook.git"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- Upgrade to Node 24 in publish workflow — ships npm 11+ which has native OIDC trusted publishing (npm 10.x on Node 22 doesn't support it)
- Restore `registry-url` — needed for `setup-node` to configure the OIDC handshake
- Publish from `working-directory: ./packages/stagebook` instead of `-w` flag for more reliable provenance metadata
- Normalize `repository.url` to `git+https://` to avoid provenance normalization warning

No `NPM_TOKEN` needed — authentication is handled entirely via GitHub OIDC + npm trusted publisher config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)