### PR TITLE
Add Zod error path to YAML source position mapping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, vscode-extension]
   push:
-    branches: [main]
+    branches: [main, vscode-extension]
 
 jobs:
   lint:

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -14,7 +14,10 @@
   "engines": {
     "vscode": "^1.115.0"
   },
-  "categories": ["Programming Languages", "Linters"],
+  "categories": [
+    "Programming Languages",
+    "Linters"
+  ],
   "main": "./dist/extension.js",
   "activationEvents": [
     "onLanguage:treatmentsYaml",
@@ -24,14 +27,22 @@
     "languages": [
       {
         "id": "treatmentsYaml",
-        "aliases": ["Treatments YAML"],
-        "extensions": [".treatments.yaml"],
+        "aliases": [
+          "Treatments YAML"
+        ],
+        "extensions": [
+          ".treatments.yaml"
+        ],
         "configuration": "./language-configuration.json"
       },
       {
         "id": "stagebookPrompt",
-        "aliases": ["Stagebook Prompt"],
-        "extensions": [".prompt.md"]
+        "aliases": [
+          "Stagebook Prompt"
+        ],
+        "extensions": [
+          ".prompt.md"
+        ]
       }
     ],
     "grammars": [
@@ -61,15 +72,14 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "js-yaml": "^4.1.1",
     "stagebook": "*",
+    "yaml": "^2.8.3",
     "zod": "^3.23.0"
   },
   "devDependencies": {
-    "@vscode/vsce": "^3.0.0",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "@types/vscode": "1.115.0",
+    "@vscode/vsce": "^3.0.0",
     "esbuild": "^0.25.0",
     "typescript": "^5.5.0",
     "vitest": "^4.1.4"

--- a/apps/vscode/src/lib/yamlPositionMap.test.ts
+++ b/apps/vscode/src/lib/yamlPositionMap.test.ts
@@ -448,6 +448,83 @@ describe("remapErrorPath", () => {
   });
 });
 
+describe("remapErrorPath — array templateContent", () => {
+  it("accounts for array templateContent expanding into multiple siblings", () => {
+    const arrayTemplates = [
+      {
+        templateName: "twoElements",
+        templateContent: [
+          { type: "prompt", file: "q1.prompt.md" },
+          { type: "separator" },
+        ],
+      },
+    ];
+    const original = {
+      templates: arrayTemplates,
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [
+            {
+              name: "s1",
+              elements: [{ template: "twoElements" }, { type: "submitButton" }],
+            },
+          ],
+        },
+      ],
+    };
+    // Template expands [0] into 2 items, so submitButton shifts to index 2
+    const result = remapErrorPath(
+      ["treatments", 0, "gameStages", 0, "elements", 2, "type"],
+      original,
+      arrayTemplates,
+    );
+    // Index 2 is the submitButton (non-template), not from the template
+    expect(result).toEqual([
+      "treatments",
+      0,
+      "gameStages",
+      0,
+      "elements",
+      2,
+      "type",
+    ]);
+  });
+
+  it("remaps errors within array-expanded template content", () => {
+    const arrayTemplates = [
+      {
+        templateName: "twoElements",
+        templateContent: [
+          { type: "prompt", file: "q1.prompt.md" },
+          { type: "separator" },
+        ],
+      },
+    ];
+    const original = {
+      templates: arrayTemplates,
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [
+            {
+              name: "s1",
+              elements: [{ template: "twoElements" }, { type: "submitButton" }],
+            },
+          ],
+        },
+      ],
+    };
+    // Error at expanded index 1 — second item from the array template
+    const result = remapErrorPath(
+      ["treatments", 0, "gameStages", 0, "elements", 1, "type"],
+      original,
+      arrayTemplates,
+    );
+    expect(result).toEqual(["templates", 0, "templateContent", "type"]);
+  });
+});
+
 describe("pathToRange — type mismatches", () => {
   it("returns null for a string segment on a sequence node", () => {
     const src = `items:

--- a/apps/vscode/src/lib/yamlPositionMap.test.ts
+++ b/apps/vscode/src/lib/yamlPositionMap.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect } from "vitest";
+import {
+  pathToRange,
+  extractYamlErrors,
+  remapErrorPath,
+} from "./yamlPositionMap";
+
+describe("pathToRange", () => {
+  describe("scalar values", () => {
+    it("finds a top-level scalar", () => {
+      const src = `name: study1
+playerCount: 3`;
+      const range = pathToRange(src, ["name"]);
+      expect(range).toEqual({
+        startLine: 0,
+        startCol: 6,
+        endLine: 0,
+        endCol: 12,
+      });
+    });
+
+    it("finds a numeric value", () => {
+      const src = `name: study1
+playerCount: 3`;
+      const range = pathToRange(src, ["playerCount"]);
+      expect(range).toEqual({
+        startLine: 1,
+        startCol: 13,
+        endLine: 1,
+        endCol: 14,
+      });
+    });
+  });
+
+  describe("nested objects", () => {
+    it("finds a value nested one level deep", () => {
+      const src = `treatment:
+  name: study1
+  playerCount: 3`;
+      const range = pathToRange(src, ["treatment", "name"]);
+      expect(range).toEqual({
+        startLine: 1,
+        startCol: 8,
+        endLine: 1,
+        endCol: 14,
+      });
+    });
+
+    it("finds a value nested multiple levels deep", () => {
+      const src = `treatments:
+  - name: study1
+    gameStages:
+      - name: stage1
+        duration: 300`;
+      const range = pathToRange(src, [
+        "treatments",
+        0,
+        "gameStages",
+        0,
+        "duration",
+      ]);
+      expect(range).toEqual({
+        startLine: 4,
+        startCol: 18,
+        endLine: 4,
+        endCol: 21,
+      });
+    });
+  });
+
+  describe("array items", () => {
+    it("finds an array item by index", () => {
+      const src = `items:
+  - first
+  - second
+  - third`;
+      const range = pathToRange(src, ["items", 1]);
+      expect(range).toEqual({
+        startLine: 2,
+        startCol: 4,
+        endLine: 2,
+        endCol: 10,
+      });
+    });
+
+    it("finds a property inside an array item", () => {
+      const src = `elements:
+  - type: prompt
+    file: prompts/q1.prompt.md
+  - type: separator
+    style: thin`;
+      const range = pathToRange(src, ["elements", 1, "style"]);
+      expect(range).toEqual({
+        startLine: 4,
+        startCol: 11,
+        endLine: 4,
+        endCol: 15,
+      });
+    });
+  });
+
+  describe("missing paths", () => {
+    it("returns null for a path that does not exist", () => {
+      const src = `name: study1`;
+      const range = pathToRange(src, ["missing"]);
+      expect(range).toBeNull();
+    });
+
+    it("returns null for an out-of-bounds array index", () => {
+      const src = `items:
+  - first`;
+      const range = pathToRange(src, ["items", 5]);
+      expect(range).toBeNull();
+    });
+
+    it("returns null for an empty path on a document with no contents", () => {
+      const src = ``;
+      const range = pathToRange(src, ["anything"]);
+      expect(range).toBeNull();
+    });
+  });
+
+  describe("empty path", () => {
+    it("returns the range of the root node", () => {
+      const src = `name: study1`;
+      const range = pathToRange(src, []);
+      expect(range).not.toBeNull();
+      expect(range!.startLine).toBe(0);
+    });
+  });
+
+  describe("deeply nested paths", () => {
+    it("handles 6+ levels of nesting", () => {
+      const src = `treatments:
+  - name: t1
+    gameStages:
+      - name: s1
+        elements:
+          - type: prompt
+            conditions:
+              - comparator: equals
+                value: yes`;
+      const range = pathToRange(src, [
+        "treatments",
+        0,
+        "gameStages",
+        0,
+        "elements",
+        0,
+        "conditions",
+        0,
+        "value",
+      ]);
+      expect(range).toEqual({
+        startLine: 8,
+        startCol: 23,
+        endLine: 8,
+        endCol: 26,
+      });
+    });
+  });
+});
+
+describe("extractYamlErrors", () => {
+  it("returns no errors for valid YAML", () => {
+    const src = `name: study1
+playerCount: 3`;
+    const errors = extractYamlErrors(src);
+    expect(errors).toEqual([]);
+  });
+
+  it("returns an error for bad indentation", () => {
+    const src = `name: study1
+  bad indentation: here
+ worse: there`;
+    const errors = extractYamlErrors(src);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toHaveProperty("line");
+    expect(errors[0]).toHaveProperty("message");
+  });
+
+  it("returns an error for a missing value after colon", () => {
+    const src = `name:
+  key1: value1
+  key2:
+  key3`;
+    const errors = extractYamlErrors(src);
+    // key3 without colon could be parsed as a scalar or cause an error
+    // depending on context — just verify we get structured output
+    expect(Array.isArray(errors)).toBe(true);
+  });
+
+  it("detects duplicate keys", () => {
+    const src = `name: first
+name: second
+playerCount: 3`;
+    const errors = extractYamlErrors(src);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toMatch(/unique|duplicate/i);
+  });
+});
+
+describe("remapErrorPath", () => {
+  const templates = [
+    {
+      templateName: "myStage",
+      templateContent: {
+        name: "stage1",
+        duration: 300,
+        elements: [{ type: "prompt", file: "bad/path.md" }],
+      },
+    },
+  ];
+
+  describe("non-template paths", () => {
+    it("returns the original path when no templates are involved", () => {
+      const original = {
+        treatments: [{ name: "t1", playerCount: 3 }],
+      };
+      const result = remapErrorPath(
+        ["treatments", 0, "name"],
+        original,
+        templates,
+      );
+      expect(result).toEqual(["treatments", 0, "name"]);
+    });
+  });
+
+  describe("simple template expansion", () => {
+    it("remaps a path through a template context to the template definition", () => {
+      const original = {
+        templates,
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [{ template: "myStage" }],
+          },
+        ],
+      };
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 0, "elements", 0, "file"],
+        original,
+        templates,
+      );
+      expect(result).toEqual([
+        "templates",
+        0,
+        "templateContent",
+        "elements",
+        0,
+        "file",
+      ]);
+    });
+
+    it("remaps a top-level property of expanded template content", () => {
+      const original = {
+        templates,
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [{ template: "myStage" }],
+          },
+        ],
+      };
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 0, "duration"],
+        original,
+        templates,
+      );
+      expect(result).toEqual(["templates", 0, "templateContent", "duration"]);
+    });
+  });
+
+  describe("broadcast expansion", () => {
+    it("remaps paths through broadcast-expanded items to the template", () => {
+      // Broadcast expands one template context into multiple array items.
+      // Both expanded items [0] and [1] came from the same template at
+      // original index 0, so both should remap to that template's content.
+      const original = {
+        templates,
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [
+              {
+                template: "myStage",
+                broadcast: { d0: [{ topic: "a" }, { topic: "b" }] },
+              },
+            ],
+          },
+        ],
+      };
+      // Error in the second broadcast-expanded item
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 1, "elements", 0, "file"],
+        original,
+        templates,
+      );
+      expect(result).toEqual([
+        "templates",
+        0,
+        "templateContent",
+        "elements",
+        0,
+        "file",
+      ]);
+    });
+  });
+
+  describe("mixed arrays", () => {
+    it("remaps correctly when templates are mixed with non-template items", () => {
+      const original = {
+        templates,
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [
+              { name: "intro", duration: 60, elements: [] },
+              { template: "myStage" },
+            ],
+          },
+        ],
+      };
+      // Error at expanded index 1 — the template was at original index 1
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 1, "elements", 0, "file"],
+        original,
+        templates,
+      );
+      expect(result).toEqual([
+        "templates",
+        0,
+        "templateContent",
+        "elements",
+        0,
+        "file",
+      ]);
+    });
+
+    it("does not remap a non-template item after a template in the array", () => {
+      const original = {
+        templates,
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [
+              { template: "myStage" },
+              { name: "final", duration: 60, elements: [] },
+            ],
+          },
+        ],
+      };
+      // Error at expanded index 1 — this is the non-template item at original index 1
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 1, "name"],
+        original,
+        templates,
+      );
+      expect(result).toEqual(["treatments", 0, "gameStages", 1, "name"]);
+    });
+  });
+
+  describe("template not found", () => {
+    it("returns the original path if the referenced template does not exist", () => {
+      const original = {
+        templates: [],
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [{ template: "nonexistent" }],
+          },
+        ],
+      };
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 0, "duration"],
+        original,
+        [],
+      );
+      expect(result).toEqual(["treatments", 0, "gameStages", 0, "duration"]);
+    });
+  });
+});

--- a/apps/vscode/src/lib/yamlPositionMap.test.ts
+++ b/apps/vscode/src/lib/yamlPositionMap.test.ts
@@ -3,6 +3,7 @@ import {
   pathToRange,
   extractYamlErrors,
   remapErrorPath,
+  createPositionMapper,
 } from "./yamlPositionMap";
 
 describe("pathToRange", () => {
@@ -378,5 +379,146 @@ describe("remapErrorPath", () => {
       );
       expect(result).toEqual(["treatments", 0, "gameStages", 0, "duration"]);
     });
+  });
+
+  describe("multiple templates in one array", () => {
+    it("remaps to the correct template when multiple templates appear in sequence", () => {
+      const twoTemplates = [
+        {
+          templateName: "stageA",
+          templateContent: { name: "a", elements: [] },
+        },
+        {
+          templateName: "stageB",
+          templateContent: { name: "b", elements: [] },
+        },
+      ];
+      const original = {
+        templates: twoTemplates,
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [{ template: "stageA" }, { template: "stageB" }],
+          },
+        ],
+      };
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 1, "name"],
+        original,
+        twoTemplates,
+      );
+      expect(result).toEqual(["templates", 1, "templateContent", "name"]);
+    });
+  });
+
+  describe("multi-dimension broadcast", () => {
+    it("remaps paths through a multi-dimension broadcast expansion", () => {
+      const original = {
+        templates,
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [
+              {
+                template: "myStage",
+                broadcast: {
+                  d0: [{ topic: "a" }, { topic: "b" }],
+                  d1: [{ group: "x" }, { group: "y" }],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      // 2 * 2 = 4 expanded items; index 3 is the last one
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 3, "elements", 0, "file"],
+        original,
+        templates,
+      );
+      expect(result).toEqual([
+        "templates",
+        0,
+        "templateContent",
+        "elements",
+        0,
+        "file",
+      ]);
+    });
+  });
+});
+
+describe("pathToRange — type mismatches", () => {
+  it("returns null for a string segment on a sequence node", () => {
+    const src = `items:
+  - first
+  - second`;
+    const range = pathToRange(src, ["items", "notANumber"]);
+    expect(range).toBeNull();
+  });
+
+  it("returns null for a numeric segment on a map node", () => {
+    const src = `name: study1`;
+    const range = pathToRange(src, [0]);
+    expect(range).toBeNull();
+  });
+});
+
+describe("pathToRange — multiline values", () => {
+  it("handles block scalar (pipe) spanning multiple lines", () => {
+    const src = `description: |
+  line one
+  line two
+name: next`;
+    const range = pathToRange(src, ["description"]);
+    expect(range).not.toBeNull();
+    expect(range!.endLine).toBeGreaterThan(range!.startLine);
+  });
+});
+
+describe("createPositionMapper", () => {
+  it("resolves multiple paths from a single parse", () => {
+    const src = `treatments:
+  - name: study1
+    playerCount: 3`;
+    const mapper = createPositionMapper(src);
+
+    const nameRange = mapper.resolve(["treatments", 0, "name"]);
+    const countRange = mapper.resolve(["treatments", 0, "playerCount"]);
+
+    expect(nameRange).toEqual({
+      startLine: 1,
+      startCol: 10,
+      endLine: 1,
+      endCol: 16,
+    });
+    expect(countRange).toEqual({
+      startLine: 2,
+      startCol: 17,
+      endLine: 2,
+      endCol: 18,
+    });
+  });
+
+  it("returns the same result as pathToRange", () => {
+    const src = `elements:
+  - type: prompt
+    file: prompts/q1.prompt.md`;
+    const mapper = createPositionMapper(src);
+
+    const fromMapper = mapper.resolve(["elements", 0, "file"]);
+    const fromDirect = pathToRange(src, ["elements", 0, "file"]);
+
+    expect(fromMapper).toEqual(fromDirect);
+  });
+
+  it("toJSON returns the parsed JS object", () => {
+    const src = `name: study1
+playerCount: 3`;
+    const mapper = createPositionMapper(src);
+    const obj = mapper.toJSON() as Record<string, unknown>;
+
+    expect(obj.name).toBe("study1");
+    expect(obj.playerCount).toBe(3);
   });
 });

--- a/apps/vscode/src/lib/yamlPositionMap.ts
+++ b/apps/vscode/src/lib/yamlPositionMap.ts
@@ -32,16 +32,15 @@ function offsetToLineCol(
 }
 
 /**
- * Given a YAML source string and a path (e.g. from a Zod issue),
- * return the source range of the value node at that path.
- *
- * Returns null if the path cannot be resolved.
+ * Resolve a path to a source range within a pre-parsed YAML document.
+ * This is the core AST-walking logic shared by pathToRange and
+ * createPositionMapper.
  */
-export function pathToRange(
+function resolvePathInDoc(
+  doc: ReturnType<typeof parseDocument>,
   source: string,
   path: (string | number)[],
 ): SourceRange | null {
-  const doc = parseDocument(source, { uniqueKeys: false });
   if (!doc.contents) return null;
 
   let node = doc.contents;
@@ -72,6 +71,49 @@ export function pathToRange(
     startCol: start.col,
     endLine: end.line,
     endCol: end.col,
+  };
+}
+
+/**
+ * Given a YAML source string and a path (e.g. from a Zod issue),
+ * return the source range of the value node at that path.
+ *
+ * Returns null if the path cannot be resolved.
+ *
+ * For resolving many paths against the same document, use
+ * createPositionMapper() instead to avoid re-parsing.
+ */
+export function pathToRange(
+  source: string,
+  path: (string | number)[],
+): SourceRange | null {
+  const doc = parseDocument(source, { uniqueKeys: false });
+  return resolvePathInDoc(doc, source, path);
+}
+
+export interface PositionMapper {
+  /** Resolve a path to a source range. Returns null if the path cannot be resolved. */
+  resolve(path: (string | number)[]): SourceRange | null;
+  /** Get the parsed JS object (for passing to Zod or remapErrorPath). */
+  toJSON(): unknown;
+}
+
+/**
+ * Parse a YAML source string once and return a mapper that can
+ * resolve many paths to source ranges without re-parsing.
+ *
+ * Use this in the validation pipeline where a single document
+ * may produce many Zod errors that each need position mapping.
+ */
+export function createPositionMapper(source: string): PositionMapper {
+  const doc = parseDocument(source, { uniqueKeys: false });
+  return {
+    resolve(path) {
+      return resolvePathInDoc(doc, source, path);
+    },
+    toJSON() {
+      return doc.toJSON();
+    },
   };
 }
 
@@ -121,7 +163,7 @@ function isTemplateContext(obj: unknown): obj is { template: string } {
   return (
     typeof obj === "object" &&
     obj !== null &&
-    "template" in obj &&
+    Object.hasOwn(obj, "template") &&
     typeof (obj as Record<string, unknown>).template === "string"
   );
 }
@@ -224,6 +266,7 @@ export function remapErrorPath(
       !Array.isArray(current) &&
       typeof segment === "string"
     ) {
+      if (!Object.hasOwn(current, segment)) return errorPath;
       current = (current as Record<string, unknown>)[segment];
       consumed.push(segment);
     } else {

--- a/apps/vscode/src/lib/yamlPositionMap.ts
+++ b/apps/vscode/src/lib/yamlPositionMap.ts
@@ -47,7 +47,8 @@ function resolvePathInDoc(
 
   for (const segment of path) {
     if (isMap(node) && typeof segment === "string") {
-      const pair = node.items.find(
+      // findLast: YAML keeps the last value for duplicate keys
+      const pair = node.items.findLast(
         (p) => isScalar(p.key) && p.key.value === segment,
       );
       if (!pair) return null;
@@ -170,20 +171,26 @@ function isTemplateContext(obj: unknown): obj is { template: string } {
 
 /**
  * Count how many items a template context expands into.
- * Without broadcast: 1. With broadcast: product of all dimension lengths.
+ * Base count is 1 for object templateContent, or templateContent.length
+ * for array templateContent. Multiplied by broadcast dimensions.
  */
-function countExpandedItems(context: Record<string, unknown>): number {
+function countExpandedItems(
+  context: Record<string, unknown>,
+  templateContent: unknown,
+): number {
+  const baseCount = Array.isArray(templateContent) ? templateContent.length : 1;
+
   const broadcast = context.broadcast;
   if (!broadcast || typeof broadcast !== "object" || Array.isArray(broadcast)) {
-    return 1;
+    return Math.max(baseCount, 1);
   }
-  let count = 1;
+  let broadcastMultiplier = 1;
   for (const dim of Object.values(broadcast as Record<string, unknown>)) {
     if (Array.isArray(dim)) {
-      count *= dim.length;
+      broadcastMultiplier *= dim.length;
     }
   }
-  return Math.max(count, 1);
+  return Math.max(baseCount * broadcastMultiplier, 1);
 }
 
 /**
@@ -199,7 +206,7 @@ function countExpandedItems(context: Record<string, unknown>): number {
 export function remapErrorPath(
   errorPath: (string | number)[],
   originalObj: Record<string, unknown>,
-  templates: { templateName: string }[],
+  templates: { templateName: string; templateContent?: unknown }[],
 ): (string | number)[] {
   const path = [...errorPath];
   let current: unknown = originalObj;
@@ -226,9 +233,7 @@ export function remapErrorPath(
             continue;
           }
 
-          const expandedCount = countExpandedItems(
-            item as Record<string, unknown>,
-          );
+          const expandedCount = info.expandedCount;
 
           if (
             segment >= expandedIndex &&
@@ -280,7 +285,7 @@ export function remapErrorPath(
 
 function resolveTemplate(
   context: { template: string },
-  templates: { templateName: string }[],
+  templates: { templateName: string; templateContent?: unknown }[],
 ): TemplateInfo | null {
   const idx = templates.findIndex((t) => t.templateName === context.template);
   if (idx === -1) return null;
@@ -289,6 +294,7 @@ function resolveTemplate(
     templateIndex: idx,
     expandedCount: countExpandedItems(
       context as unknown as Record<string, unknown>,
+      templates[idx].templateContent,
     ),
   };
 }

--- a/apps/vscode/src/lib/yamlPositionMap.ts
+++ b/apps/vscode/src/lib/yamlPositionMap.ts
@@ -1,0 +1,251 @@
+import { parseDocument, isMap, isSeq, isScalar } from "yaml";
+
+export interface SourceRange {
+  startLine: number;
+  startCol: number;
+  endLine: number;
+  endCol: number;
+}
+
+export interface YamlError {
+  line: number;
+  col: number;
+  message: string;
+}
+
+/**
+ * Convert a character offset to a 0-based line and column.
+ */
+function offsetToLineCol(
+  source: string,
+  offset: number,
+): { line: number; col: number } {
+  let line = 0;
+  let lastNewline = -1;
+  for (let i = 0; i < offset && i < source.length; i++) {
+    if (source[i] === "\n") {
+      line++;
+      lastNewline = i;
+    }
+  }
+  return { line, col: offset - lastNewline - 1 };
+}
+
+/**
+ * Given a YAML source string and a path (e.g. from a Zod issue),
+ * return the source range of the value node at that path.
+ *
+ * Returns null if the path cannot be resolved.
+ */
+export function pathToRange(
+  source: string,
+  path: (string | number)[],
+): SourceRange | null {
+  const doc = parseDocument(source, { uniqueKeys: false });
+  if (!doc.contents) return null;
+
+  let node = doc.contents;
+
+  for (const segment of path) {
+    if (isMap(node) && typeof segment === "string") {
+      const pair = node.items.find(
+        (p) => isScalar(p.key) && p.key.value === segment,
+      );
+      if (!pair) return null;
+      node = pair.value as typeof node;
+    } else if (isSeq(node) && typeof segment === "number") {
+      const item = node.items[segment];
+      if (!item) return null;
+      node = item as typeof node;
+    } else {
+      return null;
+    }
+  }
+
+  if (!node || !node.range) return null;
+
+  const [startOffset, endOffset] = node.range;
+  const start = offsetToLineCol(source, startOffset);
+  const end = offsetToLineCol(source, endOffset);
+  return {
+    startLine: start.line,
+    startCol: start.col,
+    endLine: end.line,
+    endCol: end.col,
+  };
+}
+
+/**
+ * Extract YAML syntax errors and duplicate key warnings from a source string.
+ *
+ * Returns structured errors with line positions and messages.
+ */
+export function extractYamlErrors(source: string): YamlError[] {
+  const doc = parseDocument(source, { uniqueKeys: true });
+  const errors: YamlError[] = [];
+
+  for (const err of doc.errors) {
+    const pos = err.pos?.[0];
+    if (pos !== undefined) {
+      const { line, col } = offsetToLineCol(source, pos);
+      errors.push({ line, col, message: err.message });
+    } else {
+      errors.push({ line: 0, col: 0, message: err.message });
+    }
+  }
+
+  for (const warn of doc.warnings) {
+    const pos = warn.pos?.[0];
+    if (pos !== undefined) {
+      const { line, col } = offsetToLineCol(source, pos);
+      errors.push({ line, col, message: warn.message });
+    } else {
+      errors.push({ line: 0, col: 0, message: warn.message });
+    }
+  }
+
+  return errors;
+}
+
+interface TemplateInfo {
+  templateName: string;
+  templateIndex: number;
+  /** Number of items this template expands into (>1 for broadcast). */
+  expandedCount: number;
+}
+
+/**
+ * Check if a plain JS object is a template context (has a `template` string property).
+ */
+function isTemplateContext(obj: unknown): obj is { template: string } {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "template" in obj &&
+    typeof (obj as Record<string, unknown>).template === "string"
+  );
+}
+
+/**
+ * Count how many items a template context expands into.
+ * Without broadcast: 1. With broadcast: product of all dimension lengths.
+ */
+function countExpandedItems(context: Record<string, unknown>): number {
+  const broadcast = context.broadcast;
+  if (!broadcast || typeof broadcast !== "object" || Array.isArray(broadcast)) {
+    return 1;
+  }
+  let count = 1;
+  for (const dim of Object.values(broadcast as Record<string, unknown>)) {
+    if (Array.isArray(dim)) {
+      count *= dim.length;
+    }
+  }
+  return Math.max(count, 1);
+}
+
+/**
+ * Given a Zod error path (relative to the expanded/validated object),
+ * remap it to point to the original YAML source location.
+ *
+ * If the path goes through an expanded template context, the returned
+ * path points into the template definition instead (e.g.
+ * `["templates", 0, "templateContent", "elements", 0, "file"]`).
+ *
+ * If no remapping is needed, returns the original path unchanged.
+ */
+export function remapErrorPath(
+  errorPath: (string | number)[],
+  originalObj: Record<string, unknown>,
+  templates: { templateName: string }[],
+): (string | number)[] {
+  const path = [...errorPath];
+  let current: unknown = originalObj;
+  const consumed: (string | number)[] = [];
+
+  for (let i = 0; i < path.length; i++) {
+    const segment = path[i];
+
+    if (Array.isArray(current) && typeof segment === "number") {
+      // Walk the original array, accounting for template expansions
+      // that may have shifted indices.
+      let expandedIndex = 0;
+      for (let origIdx = 0; origIdx < current.length; origIdx++) {
+        const item = current[origIdx];
+
+        if (isTemplateContext(item)) {
+          const info = resolveTemplate(item, templates);
+          if (!info) {
+            // Template not found — can't remap, treat as opaque
+            expandedIndex += 1;
+            if (expandedIndex > segment) {
+              break;
+            }
+            continue;
+          }
+
+          const expandedCount = countExpandedItems(
+            item as Record<string, unknown>,
+          );
+
+          if (
+            segment >= expandedIndex &&
+            segment < expandedIndex + expandedCount
+          ) {
+            // This expanded index came from this template
+            const remaining = path.slice(i + 1);
+            return [
+              "templates",
+              info.templateIndex,
+              "templateContent",
+              ...remaining,
+            ];
+          }
+
+          expandedIndex += expandedCount;
+        } else {
+          if (expandedIndex === segment) {
+            // Found the matching non-template item
+            current = item;
+            consumed.push(segment);
+            break;
+          }
+          expandedIndex += 1;
+        }
+      }
+
+      if (consumed[consumed.length - 1] !== segment) {
+        // We didn't find a match — return original path
+        return errorPath;
+      }
+    } else if (
+      typeof current === "object" &&
+      current !== null &&
+      !Array.isArray(current) &&
+      typeof segment === "string"
+    ) {
+      current = (current as Record<string, unknown>)[segment];
+      consumed.push(segment);
+    } else {
+      // Can't walk further — return original path
+      return errorPath;
+    }
+  }
+
+  return errorPath;
+}
+
+function resolveTemplate(
+  context: { template: string },
+  templates: { templateName: string }[],
+): TemplateInfo | null {
+  const idx = templates.findIndex((t) => t.templateName === context.template);
+  if (idx === -1) return null;
+  return {
+    templateName: context.template,
+    templateIndex: idx,
+    expandedCount: countExpandedItems(
+      context as unknown as Record<string, unknown>,
+    ),
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,12 +302,11 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^4.1.1",
         "stagebook": "*",
+        "yaml": "^2.8.3",
         "zod": "^3.23.0"
       },
       "devDependencies": {
-        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
         "@types/vscode": "1.115.0",
         "@vscode/vsce": "^3.0.0",
@@ -13609,7 +13608,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"


### PR DESCRIPTION
## Summary
- `pathToRange()` — maps a Zod issue path to a line/column range in YAML source by walking the `yaml` package's AST
- `extractYamlErrors()` — extracts YAML syntax errors and duplicate key warnings with source positions
- `remapErrorPath()` — redirects Zod error paths through template-expanded content back to the template definition, handling broadcast expansion and mixed arrays
- Uses only the `yaml` package (single parse, AST + `.toJSON()`) — drops `js-yaml` as a direct extension dependency

Refs #74

## Test plan
- [x] 22 unit tests covering:
  - Scalar, nested object, and array path resolution
  - Missing/out-of-bounds paths return null
  - Deep nesting (6+ levels)
  - YAML syntax errors and duplicate key detection
  - Template remapping: simple, broadcast, mixed arrays, missing templates
- [x] Extension still builds
- [x] All monorepo tests pass (529 existing + 22 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)