### PR TITLE
Move DSL resolution into StagebookProvider, simplify platform contract

### DIFF
--- a/apps/viewer/src/components/StateInspector.tsx
+++ b/apps/viewer/src/components/StateInspector.tsx
@@ -93,7 +93,25 @@ function ReferenceEditor({
   position: number;
   stageIndex: number;
 }) {
-  const { referenceKey, path } = getReferenceKeyAndPath(reference);
+  let referenceKey: string;
+  let path: string[];
+  try {
+    ({ referenceKey, path } = getReferenceKeyAndPath(reference));
+  } catch {
+    return (
+      <div style={refGroupStyle}>
+        <label style={refLabelStyle}>{reference}</label>
+        <input
+          type="text"
+          value=""
+          disabled
+          placeholder="(invalid reference)"
+          style={{ ...refInputStyle, opacity: 0.5 }}
+        />
+      </div>
+    );
+  }
+
   const rawValues = store.lookup(referenceKey, position);
   const values = rawValues
     .map((v) => getNestedValueByPath(v, path))
@@ -101,8 +119,6 @@ function ReferenceEditor({
   const currentValue = values[0] !== undefined ? String(values[0]) : "";
 
   const handleChange = (newValue: string) => {
-    const { referenceKey, path } = getReferenceKeyAndPath(reference);
-
     if (path.length === 0) {
       // No nested path — store the value directly
       store.set(position, referenceKey, newValue, stageIndex);

--- a/apps/viewer/src/components/StateInspector.tsx
+++ b/apps/viewer/src/components/StateInspector.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { getReferenceKeyAndPath } from "stagebook";
+import { getReferenceKeyAndPath, getNestedValueByPath } from "stagebook";
 import { ViewerStateStore } from "../lib/store";
 import { extractStageReferences } from "../lib/references";
 import type { ViewerStep } from "../lib/steps";
@@ -93,7 +93,11 @@ function ReferenceEditor({
   position: number;
   stageIndex: number;
 }) {
-  const values = store.resolve(reference, position);
+  const { referenceKey, path } = getReferenceKeyAndPath(reference);
+  const rawValues = store.lookup(referenceKey, position);
+  const values = rawValues
+    .map((v) => getNestedValueByPath(v, path))
+    .filter((v) => v !== undefined);
   const currentValue = values[0] !== undefined ? String(values[0]) : "";
 
   const handleChange = (newValue: string) => {

--- a/apps/viewer/src/lib/context.test.ts
+++ b/apps/viewer/src/lib/context.test.ts
@@ -25,12 +25,12 @@ function makeContext(overrides?: {
 }
 
 describe("createViewerContext", () => {
-  describe("save and resolve", () => {
-    it("save writes to store and resolve reads back", () => {
+  describe("save and get", () => {
+    it("save writes to store and get reads back raw values", () => {
       const { ctx } = makeContext();
       ctx.save("prompt_q1", { value: "yes" });
-      const values = ctx.resolve("prompt.q1", "player");
-      expect(values).toEqual(["yes"]);
+      const values = ctx.get("prompt_q1", "player");
+      expect(values).toEqual([{ value: "yes" }]);
     });
 
     it("defaults to player scope", () => {
@@ -47,27 +47,27 @@ describe("createViewerContext", () => {
       expect(store.get("shared", "prompt_q1")).toBeDefined();
     });
 
-    it("resolve with numeric string position reads that position", () => {
+    it("get with numeric string scope reads that position", () => {
       const { store, ctx } = makeContext({ position: 0 });
       store.save("prompt_q1", { value: "from-pos-1" }, "player", 1, 0);
-      const values = ctx.resolve("prompt.q1", "1");
-      expect(values).toEqual(["from-pos-1"]);
+      const values = ctx.get("prompt_q1", "1");
+      expect(values).toEqual([{ value: "from-pos-1" }]);
     });
 
-    it("resolve with 'all' returns values from all positions", () => {
+    it("get with 'all' returns raw values from all positions", () => {
       const { store, ctx } = makeContext();
       store.save("prompt_q1", { value: "a" }, "player", 0, 0);
       store.save("prompt_q1", { value: "b" }, "player", 1, 0);
-      const values = ctx.resolve("prompt.q1", "all");
-      expect(values).toEqual(["a", "b"]);
+      const values = ctx.get("prompt_q1", "all");
+      expect(values).toEqual([{ value: "a" }, { value: "b" }]);
     });
 
-    it("resolve with 'any' returns values from all positions", () => {
+    it("get with 'any' returns raw values from all positions", () => {
       const { store, ctx } = makeContext();
       store.save("prompt_q1", { value: "a" }, "player", 0, 0);
       store.save("prompt_q1", { value: "b" }, "player", 1, 0);
-      const values = ctx.resolve("prompt.q1", "any");
-      expect(values).toEqual(["a", "b"]);
+      const values = ctx.get("prompt_q1", "any");
+      expect(values).toEqual([{ value: "a" }, { value: "b" }]);
     });
   });
 

--- a/apps/viewer/src/lib/context.ts
+++ b/apps/viewer/src/lib/context.ts
@@ -41,13 +41,13 @@ export function createViewerContext(
   } = options;
 
   return {
-    resolve(reference: string, positionArg?: string): unknown[] {
-      const mapped = mapPosition(positionArg, position);
+    get(key: string, scope?: string): unknown[] {
+      const mapped = mapPosition(scope, position);
       if (typeof mapped === "number" || mapped === "shared") {
-        return store.resolve(reference, mapped);
+        return store.lookup(key, mapped);
       }
       // "all", "any", "percentAgreement" → return from all player positions
-      return store.resolve(reference);
+      return store.lookup(key);
     },
 
     save(key: string, value: unknown, scope?: "player" | "shared"): void {

--- a/apps/viewer/src/lib/store.test.ts
+++ b/apps/viewer/src/lib/store.test.ts
@@ -47,40 +47,33 @@ describe("ViewerStateStore", () => {
     });
   });
 
-  describe("resolve", () => {
-    it("resolves a prompt reference for a specific position", () => {
+  describe("lookup", () => {
+    it("looks up a value for a specific position", () => {
       const store = new ViewerStateStore();
       store.save("prompt_q1", { value: "yes" }, "player", 0, 0);
-      const values = store.resolve("prompt.q1", 0);
-      expect(values).toEqual(["yes"]);
+      const values = store.lookup("prompt_q1", 0);
+      expect(values).toEqual([{ value: "yes" }]);
     });
 
-    it("resolves a prompt reference across all positions", () => {
+    it("looks up values across all positions", () => {
       const store = new ViewerStateStore();
       store.save("prompt_q1", { value: "yes" }, "player", 0, 0);
       store.save("prompt_q1", { value: "no" }, "player", 1, 0);
-      const values = store.resolve("prompt.q1");
-      expect(values).toEqual(["yes", "no"]);
+      const values = store.lookup("prompt_q1");
+      expect(values).toEqual([{ value: "yes" }, { value: "no" }]);
     });
 
-    it("resolves a shared reference", () => {
+    it("looks up a shared value", () => {
       const store = new ViewerStateStore();
       store.save("prompt_q1", { value: "shared-val" }, "shared", 0, 0);
-      const values = store.resolve("prompt.q1", "shared");
-      expect(values).toEqual(["shared-val"]);
+      const values = store.lookup("prompt_q1", "shared");
+      expect(values).toEqual([{ value: "shared-val" }]);
     });
 
-    it("returns empty array for missing references", () => {
+    it("returns empty array for missing keys", () => {
       const store = new ViewerStateStore();
-      const values = store.resolve("prompt.missing", 0);
+      const values = store.lookup("prompt_missing", 0);
       expect(values).toEqual([]);
-    });
-
-    it("navigates nested paths for non-prompt types", () => {
-      const store = new ViewerStateStore();
-      store.save("survey_TIPI", { result: { score: 4.5 } }, "player", 0, 0);
-      const values = store.resolve("survey.TIPI.result.score", 0);
-      expect(values).toEqual([4.5]);
     });
   });
 

--- a/apps/viewer/src/lib/store.ts
+++ b/apps/viewer/src/lib/store.ts
@@ -1,5 +1,3 @@
-import { getReferenceKeyAndPath, getNestedValueByPath } from "stagebook";
-
 export type PositionKey = number | "shared";
 
 export interface StoreEntry {
@@ -67,46 +65,35 @@ export class ViewerStateStore {
   }
 
   /**
-   * Resolve a DSL reference (e.g. "prompt.q1") against the store.
+   * Look up raw stored values by storage key.
    * If position is a number, returns that position's value.
    * If position is "shared", returns the shared value.
    * If position is undefined, returns values from all player positions.
    */
-  resolve(reference: string, position?: number | "shared"): unknown[] {
-    const { referenceKey, path } = getReferenceKeyAndPath(reference);
-
+  lookup(key: string, position?: number | "shared"): unknown[] {
     if (position === "shared") {
-      return this.resolveOne("shared", referenceKey, path);
+      return this.lookupOne("shared", key);
     }
 
     if (position !== undefined) {
-      return this.resolveOne(position, referenceKey, path);
+      return this.lookupOne(position, key);
     }
 
     // No position specified — collect from all player positions
     const values: unknown[] = [];
     for (const [posKey, bucket] of this.data) {
       if (posKey === "shared") continue;
-      const entry = bucket.get(referenceKey);
+      const entry = bucket.get(key);
       if (entry !== undefined) {
-        const resolved = getNestedValueByPath(entry.value, path);
-        if (resolved !== undefined) {
-          values.push(resolved);
-        }
+        values.push(entry.value);
       }
     }
     return values;
   }
 
-  private resolveOne(
-    posKey: PositionKey,
-    referenceKey: string,
-    path: string[],
-  ): unknown[] {
-    const entry = this.data.get(posKey)?.get(referenceKey);
-    if (entry === undefined) return [];
-    const resolved = getNestedValueByPath(entry.value, path);
-    return resolved !== undefined ? [resolved] : [];
+  private lookupOne(posKey: PositionKey, key: string): unknown[] {
+    const entry = this.data.get(posKey)?.get(key);
+    return entry !== undefined ? [entry.value] : [];
   }
 
   // --- Submitted ---

--- a/docs/engineer/api-reference.md
+++ b/docs/engineer/api-reference.md
@@ -70,7 +70,7 @@ compare("hello", "matches", "\\d+");    // false
 
 ### `getReferenceKeyAndPath(reference)`
 
-Parse a DSL reference string into a storage key and nested path.
+Parse a DSL reference string into a storage key and nested path. The `StagebookProvider` uses this internally to convert DSL references into flat key lookups — **platforms don't need to call this for basic integration**. It remains exported for advanced tooling (e.g., state inspectors, debugging tools).
 
 ```typescript
 import { getReferenceKeyAndPath } from "stagebook";

--- a/docs/engineer/architecture.md
+++ b/docs/engineer/architecture.md
@@ -6,8 +6,10 @@ Stagebook display components need to do four things: read experiment state, writ
 
 ```typescript
 interface StagebookContext {
-  // Read state via DSL reference strings
-  resolve(reference: string, position?: string): unknown[];
+  // Look up raw stored values by storage key.
+  // scope: "player" (default), "shared", "all", "any", "percentAgreement",
+  // or a numeric string for a specific position.
+  get(key: string, scope?: string): unknown[];
 
   // Write state under a DSL-derived key
   save(key: string, value: unknown, scope?: "player" | "shared"): void;
@@ -54,7 +56,9 @@ The platform provides the StagebookProvider context. Stagebook handles everythin
 
 ## How reading works
 
-Every element that reads experiment state does so through a **reference string** — a DSL concept like `prompt.myQuestion`, `survey.bigFive.result.score`, or `urlParams.condition`. The `resolve()` function returns an array because some references resolve across multiple participants (e.g., `position: "all"` returns one value per player). In a solo intro step the array has one element; in a group game stage it may have several. The component doesn't need to know which case it's in.
+Every element that reads experiment state does so through a **reference string** — a DSL concept like `prompt.myQuestion`, `survey.bigFive.result.score`, or `urlParams.condition`. Internally, the `StagebookProvider` converts these reference strings into flat storage keys and navigated paths (e.g., `prompt.myQuestion` → key `prompt_myQuestion`, path `["value"]`), calls the platform's `get()` to fetch raw stored values, then extracts the requested path from each result. The result is an array because some scopes (`"all"`, `"any"`) return one value per participant. Components don't need to know the details — they call `resolve()` (via `useResolve`) and get extracted values back.
+
+The platform's `get()` is a simple key-value lookup — it doesn't need to understand the DSL reference syntax or the internal record structure. It returns exactly what was passed to `save()`.
 
 ## How writing works
 

--- a/docs/engineer/integration-guide.md
+++ b/docs/engineer/integration-guide.md
@@ -118,11 +118,12 @@ To render Stagebook elements, your platform must implement the `StagebookContext
 import type { StagebookContext } from "stagebook/components";
 
 const context: StagebookContext = {
-  // Read experiment state by DSL reference string.
-  // Returns an array because some references resolve across multiple participants.
-  resolve(reference: string, position?: string): unknown[] {
-    // Parse the reference, look up the value in your state store.
-    // "position" controls whose data to return: "player", "shared", "all", "any", or index.
+  // Look up raw stored values by storage key.
+  // Returns an array of values — exactly what was passed to save().
+  // "scope" controls whose data to return: "player", "shared", "all", "any", or index.
+  // Stagebook handles DSL reference parsing internally — platforms don't need to.
+  get(key: string, scope?: string): unknown[] {
+    // Look up `key` in your state store for the given scope.
   },
 
   // Write participant data under a DSL-derived key.
@@ -185,7 +186,7 @@ function GameStage({ stageConfig, onSubmit }) {
   const context = useYourPlatformContext(); // your platform's hooks
 
   const scoreContext: StagebookContext = {
-    resolve: (ref, pos) => yourResolve(ref, pos, context),
+    get: (key, scope) => yourLookup(key, scope, context),
     save: (key, val, scope) => yourSave(key, val, scope, context),
     getElapsedTime: () => context.timer.elapsed,
     submit: onSubmit,
@@ -223,7 +224,7 @@ The same `StagebookContext` interface works across all three experiment phases. 
 |---|---|---|---|
 | `position` | `undefined` | `0`, `1`, `2`, ... | same as game |
 | `playerCount` | `undefined` | group size | group size |
-| `resolve` | single-player values only | multi-player values | multi-player values |
+| `get` | single-player values only | multi-player values | multi-player values |
 | `save(..., "shared")` | not available | writes to group state | writes to group state |
 | `getElapsedTime` | client-side `Date.now()` | server-synced timer | client-side `Date.now()` |
 | `submit` | advance to next step | signal readiness | advance to next step |

--- a/docs/engineer/platform-requirements.md
+++ b/docs/engineer/platform-requirements.md
@@ -8,7 +8,7 @@ Not every platform needs every capability. A VS Code preview tool only needs con
 
 ## 1. State Management (required)
 
-Stagebook components read and write experiment state through the `resolve()` and `save()` methods on the StagebookProvider. The platform must implement a state store that supports these operations.
+Stagebook components read and write experiment state through the `get()` and `save()` methods on the StagebookProvider. The platform must implement a state store that supports these operations.
 
 ### State Scopes
 
@@ -31,20 +31,20 @@ Stagebook components write state under predictable keys:
 
 ### Read Patterns
 
-`resolve(reference, position)` must:
+`get(key, scope)` must:
 
-1. Parse the reference string (use `getReferenceKeyAndPath()` from Stagebook)
-2. Look up the key in the appropriate state scope
-3. Navigate the nested path to the requested value
-4. Return an **array** of values, because some positions (`"all"`, `"any"`) return one value per participant
+1. Look up the key in the appropriate state scope
+2. Return an **array** of raw stored values (exactly what was passed to `save()`)
 
-The `position` parameter determines whose state to read:
+Stagebook handles DSL reference parsing and nested path extraction internally — the platform does not need to import `getReferenceKeyAndPath()` or understand the reference syntax. The platform's `get()` is a flat key-value lookup.
 
-| Position | Behavior |
-|----------|----------|
+The `scope` parameter determines whose state to read:
+
+| Scope | Behavior |
+|-------|----------|
 | `"player"` or omitted | Current participant's player state |
 | `"shared"` | Shared/game state |
-| `0`, `1`, `2`, ... | Specific participant by position index |
+| `"0"`, `"1"`, `"2"`, ... | Specific participant by position index (as string) |
 | `"all"` | Array with one value per participant |
 | `"any"` | Array with one value per participant (conditions check if any satisfy) |
 | `"percentAgreement"` | Array with one value per participant (conditions compute consensus %) |
@@ -71,7 +71,7 @@ Some reference namespaces require the platform to collect and store data that St
 - `connectionInfo.timezone` — IP-based timezone
 - `connectionInfo.isKnownVpn` — whether the IP is on a known VPN list
 
-The platform stores this under the key `connectionInfo` in player state. Stagebook's `resolve("connectionInfo.country")` looks up `connectionInfo` and traverses `.country`.
+The platform stores this under the key `connectionInfo` in player state. Internally, Stagebook's `resolve("connectionInfo.country")` calls `get("connectionInfo")` and traverses `.country`.
 
 **`browserInfo.*`** — Client-side browser information:
 - `browserInfo.screenWidth`, `browserInfo.screenHeight` — screen resolution
@@ -395,4 +395,4 @@ For pre-registered studies, the platform should:
 | Data export | Simple JSON | N/A | JSONL + GitHub push |
 | Pre-registration | N/A | N/A | Recommended |
 
-A minimal Stagebook integration (solo, no video, local content) requires only: React state for `resolve`/`save`, step sequencing for `submit`, `Date.now()` for `getElapsedTime`, and local file reading for `getTextContent`. Everything else is additive.
+A minimal Stagebook integration (solo, no video, local content) requires only: React state for `get`/`save`, step sequencing for `submit`, `Date.now()` for `getElapsedTime`, and local file reading for `getTextContent`. Everything else is additive.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9263,7 +9263,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/src/components/StagebookProvider.test.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.test.tsx
@@ -6,6 +6,7 @@ import { createRoot, type Root } from "react-dom/client";
 import {
   type StagebookContext,
   StagebookProvider,
+  useResolve,
   useTextContent,
   type TextContentResult,
 } from "./StagebookProvider.js";
@@ -17,7 +18,7 @@ function createMockContext(
   overrides?: Partial<StagebookContext>,
 ): StagebookContext {
   return {
-    resolve: vi.fn(() => []),
+    get: vi.fn(() => []),
     save: vi.fn(),
     getElapsedTime: vi.fn(() => 0),
     submit: vi.fn(),
@@ -43,12 +44,12 @@ describe("StagebookContext interface", () => {
     expect(ctx.isSubmitted).toBe(false);
   });
 
-  test("resolve returns array", () => {
-    const resolve = vi.fn(() => ["value1", "value2"]);
-    const ctx = createMockContext({ resolve });
+  test("get returns array", () => {
+    const get = vi.fn(() => ["value1", "value2"]);
+    const ctx = createMockContext({ get });
 
-    const result = ctx.resolve("prompt.myPrompt", "all");
-    expect(resolve).toHaveBeenCalledWith("prompt.myPrompt", "all");
+    const result = ctx.get("prompt_myPrompt", "all");
+    expect(get).toHaveBeenCalledWith("prompt_myPrompt", "all");
     expect(result).toEqual(["value1", "value2"]);
   });
 
@@ -118,6 +119,102 @@ describe("StagebookProvider + useStagebookContext", () => {
       // Outside React entirely, it throws a different React error
       useStagebookContext();
     }).toThrow();
+  });
+});
+
+// Helper to render useResolve inside a StagebookProvider
+function renderUseResolve(
+  reference: string,
+  ctx: StagebookContext,
+  position?: string,
+): {
+  result: { current: unknown[] };
+  unmount: () => void;
+} {
+  const result = { current: [] as unknown[] };
+  const container = document.createElement("div");
+  let root: Root;
+
+  function Harness(): ReactNode {
+    result.current = useResolve(reference, position);
+    return null;
+  }
+
+  act(() => {
+    root = createRoot(container);
+    root.render(
+      <StagebookProvider value={ctx}>
+        <Harness />
+      </StagebookProvider>,
+    );
+  });
+
+  return {
+    result,
+    unmount: () => act(() => root.unmount()),
+  };
+}
+
+describe("Provider-level resolve (get → resolve pipeline)", () => {
+  test("extracts .value path for prompt references", () => {
+    const get = vi.fn(() => [
+      { type: "multipleChoice", value: "yes", step: "s0" },
+    ]);
+    const ctx = createMockContext({ get });
+
+    const { result, unmount } = renderUseResolve("prompt.q1", ctx);
+
+    expect(get).toHaveBeenCalledWith("prompt_q1", undefined);
+    expect(result.current).toEqual(["yes"]);
+    unmount();
+  });
+
+  test("navigates nested paths for survey references", () => {
+    const get = vi.fn(() => [{ result: { score: 4.5 } }]);
+    const ctx = createMockContext({ get });
+
+    const { result, unmount } = renderUseResolve(
+      "survey.TIPI.result.score",
+      ctx,
+    );
+
+    expect(get).toHaveBeenCalledWith("survey_TIPI", undefined);
+    expect(result.current).toEqual([4.5]);
+    unmount();
+  });
+
+  test("passes scope through to get", () => {
+    const get = vi.fn(() => []);
+    const ctx = createMockContext({ get });
+
+    const { unmount } = renderUseResolve("prompt.q1", ctx, "all");
+
+    expect(get).toHaveBeenCalledWith("prompt_q1", "all");
+    unmount();
+  });
+
+  test("filters out undefined path results", () => {
+    // Record exists but doesn't have the nested .value path
+    const get = vi.fn(() => [{ name: "q1" }]);
+    const ctx = createMockContext({ get });
+
+    const { result, unmount } = renderUseResolve("prompt.q1", ctx);
+
+    expect(result.current).toEqual([]);
+    unmount();
+  });
+
+  test("resolves across multiple raw values", () => {
+    const get = vi.fn(() => [
+      { value: "a", step: "s0" },
+      { value: "b", step: "s1" },
+    ]);
+    const ctx = createMockContext({ get });
+
+    const { result, unmount } = renderUseResolve("prompt.q1", ctx, "all");
+
+    expect(result.current).toEqual(["a", "b"]);
+    unmount();
   });
 });
 

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -1,12 +1,18 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import React, { createContext, useContext, useState, useEffect } from "react";
 import type { DiscussionType } from "../schemas/treatment.js";
+import {
+  getReferenceKeyAndPath,
+  getNestedValueByPath,
+} from "../utils/reference.js";
 
 // --------------- StagebookContext Interface ---------------
 
 export interface StagebookContext {
-  // Read state via DSL reference strings
-  resolve(reference: string, position?: string): unknown[];
+  // Look up raw stored values by storage key.
+  // scope: "player" (default), "shared", "all", "any", "percentAgreement",
+  // or a numeric string for a specific position.
+  get(key: string, scope?: string): unknown[];
 
   // Write state under a DSL-derived key
   save(key: string, value: unknown, scope?: "player" | "shared"): void;
@@ -43,9 +49,15 @@ export interface StagebookContext {
   }) => React.ReactNode;
 }
 
-// --------------- Context ---------------
+// --------------- Internal context ---------------
 
-const StagebookReactContext = createContext<StagebookContext | null>(null);
+interface InternalStagebookContext extends StagebookContext {
+  resolve(reference: string, position?: string): unknown[];
+}
+
+const StagebookReactContext = createContext<InternalStagebookContext | null>(
+  null,
+);
 
 // --------------- Provider ---------------
 
@@ -56,8 +68,24 @@ export function StagebookProvider({
   value: StagebookContext;
   children: React.ReactNode;
 }) {
+  const resolve = React.useCallback(
+    (reference: string, position?: string): unknown[] => {
+      const { referenceKey, path } = getReferenceKeyAndPath(reference);
+      const rawValues = value.get(referenceKey, position);
+      return rawValues
+        .map((v) => getNestedValueByPath(v, path))
+        .filter((v) => v !== undefined);
+    },
+    [value],
+  );
+
+  const internal: InternalStagebookContext = React.useMemo(
+    () => ({ ...value, resolve }),
+    [value, resolve],
+  );
+
   return (
-    <StagebookReactContext.Provider value={value}>
+    <StagebookReactContext.Provider value={internal}>
       {children}
     </StagebookReactContext.Provider>
   );
@@ -65,7 +93,7 @@ export function StagebookProvider({
 
 // --------------- Hooks ---------------
 
-export function useStagebookContext(): StagebookContext {
+export function useStagebookContext(): InternalStagebookContext {
   const ctx = useContext(StagebookReactContext);
   if (!ctx) {
     throw new Error(

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -70,7 +70,14 @@ export function StagebookProvider({
 }) {
   const resolve = React.useCallback(
     (reference: string, position?: string): unknown[] => {
-      const { referenceKey, path } = getReferenceKeyAndPath(reference);
+      let referenceKey: string;
+      let path: string[];
+      try {
+        ({ referenceKey, path } = getReferenceKeyAndPath(reference));
+      } catch {
+        console.error(`Invalid reference: "${reference}"`);
+        return [];
+      }
       const rawValues = value.get(referenceKey, position);
       return rawValues
         .map((v) => getNestedValueByPath(v, path))

--- a/packages/stagebook/src/components/testing/MockSaveTracker.tsx
+++ b/packages/stagebook/src/components/testing/MockSaveTracker.tsx
@@ -27,7 +27,7 @@ export function MockSaveTracker({
   const [saves, setSaves] = useState<SaveEntry[]>([]);
 
   const mockContext: StagebookContext = {
-    resolve: () => [],
+    get: () => [],
     save: (key: string, value: unknown, scope?: "player" | "shared") => {
       setSaves((prev) => [...prev, { key, value, scope }]);
     },

--- a/packages/stagebook/src/components/testing/MockStageRenderer.tsx
+++ b/packages/stagebook/src/components/testing/MockStageRenderer.tsx
@@ -23,27 +23,44 @@ export interface MockStageRendererProps {
   stateValues?: Record<string, unknown>;
 }
 
-/** Wrap a value at a nested path, e.g. wrapAtPath("yes", ["value"]) → { value: "yes" } */
-function wrapAtPath(value: unknown, path: string[]): unknown {
-  if (path.length === 0) return value;
-  const result: Record<string, unknown> = {};
-  let cursor = result;
+/** Set a value at a nested path within an object, mutating in place. */
+function setAtPath(
+  obj: Record<string, unknown>,
+  path: string[],
+  value: unknown,
+): void {
+  let cursor = obj;
   for (let i = 0; i < path.length - 1; i++) {
-    cursor[path[i]] = {};
-    cursor = cursor[path[i]] as Record<string, unknown>;
+    const seg = path[i];
+    if (typeof cursor[seg] !== "object" || cursor[seg] === null) {
+      cursor[seg] = {};
+    }
+    cursor = cursor[seg] as Record<string, unknown>;
   }
   cursor[path[path.length - 1]] = value;
-  return result;
 }
 
-/** Convert DSL-reference-keyed stateValues to flat-key → raw-record map */
+/**
+ * Convert DSL-reference-keyed stateValues to flat-key → raw-record map.
+ * Multiple references sharing a storage key (e.g., "survey.TIPI.result.score"
+ * and "survey.TIPI.result.other") are deep-merged into a single record.
+ */
 function buildFlatValues(
   stateValues: Record<string, unknown>,
 ): Map<string, unknown> {
   const flat = new Map<string, unknown>();
   for (const [ref, val] of Object.entries(stateValues)) {
     const { referenceKey, path } = getReferenceKeyAndPath(ref);
-    flat.set(referenceKey, wrapAtPath(val, path));
+    if (path.length === 0) {
+      flat.set(referenceKey, val);
+    } else {
+      let record = flat.get(referenceKey);
+      if (typeof record !== "object" || record === null) {
+        record = {};
+        flat.set(referenceKey, record);
+      }
+      setAtPath(record as Record<string, unknown>, path, val);
+    }
   }
   return flat;
 }

--- a/packages/stagebook/src/components/testing/MockStageRenderer.tsx
+++ b/packages/stagebook/src/components/testing/MockStageRenderer.tsx
@@ -11,6 +11,7 @@ import {
   type StagebookContext,
 } from "../StagebookProvider.js";
 import { Stage, type StageConfig } from "../Stage.js";
+import { getReferenceKeyAndPath } from "../../utils/reference.js";
 
 export interface MockStageRendererProps {
   stage: StageConfig;
@@ -18,8 +19,33 @@ export interface MockStageRendererProps {
   playerCount?: number;
   isSubmitted?: boolean;
   elapsedTime?: number;
-  /** Key-value map of reference string → value for resolve() */
+  /** Key-value map of DSL reference string → extracted value (e.g., "prompt.answer" → "yes") */
   stateValues?: Record<string, unknown>;
+}
+
+/** Wrap a value at a nested path, e.g. wrapAtPath("yes", ["value"]) → { value: "yes" } */
+function wrapAtPath(value: unknown, path: string[]): unknown {
+  if (path.length === 0) return value;
+  const result: Record<string, unknown> = {};
+  let cursor = result;
+  for (let i = 0; i < path.length - 1; i++) {
+    cursor[path[i]] = {};
+    cursor = cursor[path[i]] as Record<string, unknown>;
+  }
+  cursor[path[path.length - 1]] = value;
+  return result;
+}
+
+/** Convert DSL-reference-keyed stateValues to flat-key → raw-record map */
+function buildFlatValues(
+  stateValues: Record<string, unknown>,
+): Map<string, unknown> {
+  const flat = new Map<string, unknown>();
+  for (const [ref, val] of Object.entries(stateValues)) {
+    const { referenceKey, path } = getReferenceKeyAndPath(ref);
+    flat.set(referenceKey, wrapAtPath(val, path));
+  }
+  return flat;
 }
 
 export function MockStageRenderer({
@@ -30,9 +56,11 @@ export function MockStageRenderer({
   elapsedTime = 0,
   stateValues = {},
 }: MockStageRendererProps) {
+  const flatValues = buildFlatValues(stateValues);
+
   const mockContext: StagebookContext = {
-    resolve: (reference: string) => {
-      const val = stateValues[reference];
+    get: (key: string) => {
+      const val = flatValues.get(key);
       return val !== undefined ? [val] : [];
     },
     save: () => {},

--- a/packages/stagebook/src/components/testing/MockStageRenderer.tsx
+++ b/packages/stagebook/src/components/testing/MockStageRenderer.tsx
@@ -23,44 +23,27 @@ export interface MockStageRendererProps {
   stateValues?: Record<string, unknown>;
 }
 
-/** Set a value at a nested path within an object, mutating in place. */
-function setAtPath(
-  obj: Record<string, unknown>,
-  path: string[],
-  value: unknown,
-): void {
-  let cursor = obj;
+/** Wrap a value at a nested path, e.g. wrapAtPath("yes", ["value"]) → { value: "yes" } */
+function wrapAtPath(value: unknown, path: string[]): unknown {
+  if (path.length === 0) return value;
+  const result: Record<string, unknown> = {};
+  let cursor = result;
   for (let i = 0; i < path.length - 1; i++) {
-    const seg = path[i];
-    if (typeof cursor[seg] !== "object" || cursor[seg] === null) {
-      cursor[seg] = {};
-    }
-    cursor = cursor[seg] as Record<string, unknown>;
+    cursor[path[i]] = {};
+    cursor = cursor[path[i]] as Record<string, unknown>;
   }
   cursor[path[path.length - 1]] = value;
+  return result;
 }
 
-/**
- * Convert DSL-reference-keyed stateValues to flat-key → raw-record map.
- * Multiple references sharing a storage key (e.g., "survey.TIPI.result.score"
- * and "survey.TIPI.result.other") are deep-merged into a single record.
- */
+/** Convert DSL-reference-keyed stateValues to flat-key → raw-record map. */
 function buildFlatValues(
   stateValues: Record<string, unknown>,
 ): Map<string, unknown> {
   const flat = new Map<string, unknown>();
   for (const [ref, val] of Object.entries(stateValues)) {
     const { referenceKey, path } = getReferenceKeyAndPath(ref);
-    if (path.length === 0) {
-      flat.set(referenceKey, val);
-    } else {
-      let record = flat.get(referenceKey);
-      if (typeof record !== "object" || record === null) {
-        record = {};
-        flat.set(referenceKey, record);
-      }
-      setAtPath(record as Record<string, unknown>, path, val);
-    }
+    flat.set(referenceKey, wrapAtPath(val, path));
   }
   return flat;
 }

--- a/packages/stagebook/src/components/testing/MockSurveyStage.tsx
+++ b/packages/stagebook/src/components/testing/MockSurveyStage.tsx
@@ -31,7 +31,7 @@ export function MockSurveyStage() {
   };
 
   const mockContext: StagebookContext = {
-    resolve: () => [],
+    get: () => [],
     save: (key: string, value: unknown) => {
       setSavedEntries((prev) => [...prev, { key, value }]);
     },

--- a/packages/stagebook/src/utils/reference.test.ts
+++ b/packages/stagebook/src/utils/reference.test.ts
@@ -58,6 +58,12 @@ describe("getReferenceKeyAndPath", () => {
     expect(result.path).toEqual(["value"]);
   });
 
+  test("timeline reference", () => {
+    const result = getReferenceKeyAndPath("timeline.myAnnotations");
+    expect(result.referenceKey).toBe("timeline_myAnnotations");
+    expect(result.path).toEqual([]);
+  });
+
   test("discussion reference", () => {
     const result = getReferenceKeyAndPath("discussion.main.messageCount");
     expect(result.referenceKey).toBe("main");

--- a/packages/stagebook/src/utils/reference.ts
+++ b/packages/stagebook/src/utils/reference.ts
@@ -23,7 +23,7 @@ export function getReferenceKeyAndPath(reference: string): ReferenceKeyAndPath {
   let path: string[] = [];
   let referenceKey: string | undefined;
 
-  if (["survey", "submitButton", "qualtrics"].includes(type)) {
+  if (["survey", "submitButton", "qualtrics", "timeline"].includes(type)) {
     [name, ...path] = rest;
     referenceKey = `${type}_${name}`;
   } else if (type === "prompt") {
@@ -50,6 +50,7 @@ export function getReferenceKeyAndPath(reference: string): ReferenceKeyAndPath {
         "survey",
         "submitButton",
         "qualtrics",
+        "timeline",
         "prompt",
         "trackedLink",
         "participantInfo",


### PR DESCRIPTION
## Summary

- Replace `resolve(reference, position?)` with `get(key, scope?)` on the `StagebookContext` interface — platforms now provide a simple flat key-value lookup instead of parsing DSL references and extracting nested paths
- The `StagebookProvider` builds `resolve` internally using `getReferenceKeyAndPath` + `getNestedValueByPath`, so all internal components work unchanged
- Add `timeline` case to `getReferenceKeyAndPath` (pre-existing bug — any stage with a Timeline element would throw)
- Update mock testing helpers to use the new interface; fix `MockStageRenderer`'s `stateValues` to convert DSL references through the new pipeline
- Wrap the provider's `resolve` in try/catch so malformed references log an error and return `[]` instead of crashing the component tree

## Motivation

The old interface required every platform to replicate stagebook's DSL reference parsing and record structure extraction. The annotator platform hit exactly this bug — it returned the full enriched record to `RadioGroup` instead of extracting `.value`, causing selected options to appear unselected (#97).

## Files changed

| File | Change |
|------|--------|
| `StagebookProvider.tsx` | Replace `resolve` with `get` in interface; build `resolve` in provider with try/catch |
| `StagebookProvider.test.tsx` | Update mock context; add 5 provider-level resolution tests |
| `reference.ts` | Add `timeline` case |
| `reference.test.ts` | Add timeline reference test |
| `MockSaveTracker.tsx`, `MockStageRenderer.tsx`, `MockSurveyStage.tsx` | Replace `resolve` with `get` |
| `store.ts` | Replace `resolve`/`resolveOne` with `lookup`/`lookupOne` |
| `store.test.ts` | Update tests for `lookup` with flat keys and raw records |
| `context.ts` | Replace `resolve` with `get` |
| `context.test.ts` | Update tests for `get` with flat keys and raw records |
| `StateInspector.tsx` | Use `store.lookup` + manual path extraction |
| `architecture.md`, `integration-guide.md`, `platform-requirements.md`, `api-reference.md` | Update docs |

## Test plan

- [x] All 534 tests pass (475 library + 59 viewer)
- [x] Lint clean
- [x] Pre-commit and pre-push hooks pass
- [ ] Verify Playwright CT tests still pass (mock helpers updated)
- [ ] Verify viewer renders correctly with the dev server

Closes #97

https://claude.ai/code/session_013zg5VYnrLrAzGM1v8M4ZQ9