### PR TITLE
Bump stagebook to 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9263,7 +9263,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- Bump stagebook package version from 0.2.0 to 0.3.0

## Why 0.3.0

Breaking change to the public `StagebookContext` interface: `resolve(reference, position?)` was replaced with `get(key, scope?)` in #100 (closes #97). Platforms must update their context implementations.

## Test plan

- [x] Version-only change — no code changes
- [ ] CI passes

https://claude.ai/code/session_013zg5VYnrLrAzGM1v8M4ZQ9