### PR TITLE
Add prompt file validation with diagnostics

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -4,6 +4,7 @@ import {
   validateTreatmentSource,
   type Diagnostic,
 } from "./lib/validateTreatment";
+import { validatePromptSource } from "./lib/validatePrompt";
 import { pathToRange } from "./lib/yamlPositionMap";
 
 const diagnosticCollection =
@@ -215,8 +216,21 @@ function makeFileDiagnostic(
   return diag;
 }
 
-function validatePromptFile(_document: vscode.TextDocument): void {
-  // TODO (#76): validate with stagebook's promptFileSchema
+function validatePromptFile(document: vscode.TextDocument): void {
+  const source = document.getText();
+  const result = validatePromptSource(source);
+
+  const vscodeDiagnostics = result.diagnostics.map((d) => {
+    const diag = new vscode.Diagnostic(
+      toVscodeRange(d.range),
+      d.message,
+      toSeverity(d.severity),
+    );
+    diag.source = "stagebook";
+    return diag;
+  });
+
+  diagnosticCollection.set(document.uri, vscodeDiagnostics);
 }
 
 export function activate(context: vscode.ExtensionContext): void {

--- a/apps/vscode/src/lib/types.ts
+++ b/apps/vscode/src/lib/types.ts
@@ -1,0 +1,7 @@
+import type { SourceRange } from "./yamlPositionMap";
+
+export interface Diagnostic {
+  message: string;
+  severity: "error" | "warning";
+  range: SourceRange | null;
+}

--- a/apps/vscode/src/lib/validatePrompt.test.ts
+++ b/apps/vscode/src/lib/validatePrompt.test.ts
@@ -180,8 +180,112 @@ then a horizontal rule
       const warnings = result.diagnostics.filter(
         (d) => d.severity === "warning",
       );
-      expect(warnings.length).toBeGreaterThan(0);
+      expect(warnings).toHaveLength(1);
       expect(warnings[0].message).toMatch(/horizontal rule|\*\*\*|___/i);
+      expect(warnings[0].range).toEqual({
+        startLine: 7,
+        startCol: 0,
+        endLine: 7,
+        endCol: 3,
+      });
+    });
+  });
+
+  describe("slider type", () => {
+    it("returns no diagnostics for a valid slider prompt", () => {
+      const src = `---
+name: test/slider.prompt.md
+type: slider
+min: 0
+max: 100
+interval: 10
+---
+Rate your agreement.
+---
+> Low
+> High`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("reports errors when slider is missing required fields", () => {
+      const src = `---
+name: test/slider.prompt.md
+type: slider
+---
+Rate something.
+---
+> Low`;
+      const result = validatePromptSource(src);
+      const messages = result.diagnostics.map((d) => d.message);
+      expect(messages).toContain("min is required for slider type");
+      expect(messages).toContain("max is required for slider type");
+      expect(messages).toContain("interval is required for slider type");
+    });
+  });
+
+  describe("listSorter type", () => {
+    it("returns no diagnostics for a valid listSorter prompt", () => {
+      const src = `---
+name: test/sort.prompt.md
+type: listSorter
+---
+Rank these items.
+---
+> Item A
+> Item B
+> Item C`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+
+  describe("metadata YAML parse failure", () => {
+    it("reports error for malformed YAML in metadata", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: [unclosed bracket
+---
+Body text
+---
+`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toContainEqual(
+        expect.objectContaining({
+          message: expect.stringContaining("parse metadata YAML"),
+          severity: "error",
+        }),
+      );
+    });
+  });
+
+  describe("CRLF line endings", () => {
+    it("handles CRLF line endings correctly", () => {
+      const src =
+        "---\r\nname: test/prompt.prompt.md\r\ntype: multipleChoice\r\n---\r\nPick one\r\n---\r\n- A\r\n- B";
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+
+  describe("metadata field position mapping", () => {
+    it("maps metadata field error to the specific YAML key line", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: multipleChoice
+rows: 3
+---
+Pick one
+---
+- A
+- B`;
+      const result = validatePromptSource(src);
+      const rowsError = result.diagnostics.find((d) =>
+        d.message.includes("rows"),
+      );
+      expect(rowsError).toBeDefined();
+      // "rows:" is on line 3 (0-indexed)
+      expect(rowsError!.range!.startLine).toBe(3);
     });
   });
 });

--- a/apps/vscode/src/lib/validatePrompt.test.ts
+++ b/apps/vscode/src/lib/validatePrompt.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import { validatePromptSource } from "./validatePrompt";
+
+describe("validatePromptSource", () => {
+  describe("valid prompt files", () => {
+    it("returns no diagnostics for a valid multipleChoice prompt", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: multipleChoice
+---
+What is your favorite color?
+---
+- Red
+- Blue
+- Green`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("returns no diagnostics for a valid noResponse prompt", () => {
+      const src = `---
+name: test/info.prompt.md
+type: noResponse
+---
+Please read the following instructions carefully.
+---
+`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("returns no diagnostics for a valid openResponse prompt", () => {
+      const src = `---
+name: test/open.prompt.md
+type: openResponse
+---
+Please describe your experience.
+---
+> Your response here`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+
+  describe("structural errors", () => {
+    it("reports error for missing --- delimiters", () => {
+      const src = `Just some text without delimiters`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics[0].severity).toBe("error");
+      expect(result.diagnostics[0].message).toMatch(/section|delimiter/i);
+    });
+
+    it("reports error for only two delimiters", () => {
+      const src = `---
+name: test.prompt.md
+type: noResponse
+---
+Body text but no third delimiter`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics[0].message).toMatch(/section|delimiter/i);
+    });
+
+    it("reports error for empty file", () => {
+      const result = validatePromptSource("");
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("metadata errors", () => {
+    it("reports error for missing type field", () => {
+      const src = `---
+name: test/prompt.prompt.md
+---
+Body text
+---
+`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics[0].severity).toBe("error");
+    });
+
+    it("reports error for invalid type value", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: invalidType
+---
+Body text
+---
+`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics[0].severity).toBe("error");
+    });
+
+    it("reports error for rows on non-openResponse type", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: multipleChoice
+rows: 3
+---
+Pick one
+---
+- A
+- B`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toContainEqual(
+        expect.objectContaining({
+          message: expect.stringContaining("rows"),
+        }),
+      );
+    });
+  });
+
+  describe("response errors", () => {
+    it("reports error for invalid response line format", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: multipleChoice
+---
+Pick one
+---
+Red
+Blue`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toContainEqual(
+        expect.objectContaining({
+          message: expect.stringMatching(/response line|must start with/i),
+        }),
+      );
+    });
+  });
+
+  describe("error position mapping", () => {
+    it("maps metadata errors to the metadata section", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: invalidType
+---
+Body text
+---
+`;
+      const result = validatePromptSource(src);
+      const metadataErrors = result.diagnostics.filter(
+        (d) =>
+          d.range !== null && d.range.startLine >= 1 && d.range.startLine <= 3,
+      );
+      expect(metadataErrors.length).toBeGreaterThan(0);
+    });
+
+    it("maps response errors to the response section", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: multipleChoice
+---
+Pick one
+---
+bad line`;
+      const result = validatePromptSource(src);
+      const responseErrors = result.diagnostics.filter(
+        (d) => d.range !== null && d.range.startLine >= 6,
+      );
+      expect(responseErrors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("extra delimiter warning", () => {
+    it("warns when more than 3 --- delimiters exist", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: noResponse
+---
+Some text
+---
+then a horizontal rule
+---
+`;
+      const result = validatePromptSource(src);
+      const warnings = result.diagnostics.filter(
+        (d) => d.severity === "warning",
+      );
+      expect(warnings.length).toBeGreaterThan(0);
+      expect(warnings[0].message).toMatch(/horizontal rule|\*\*\*|___/i);
+    });
+  });
+});

--- a/apps/vscode/src/lib/validatePrompt.ts
+++ b/apps/vscode/src/lib/validatePrompt.ts
@@ -1,11 +1,6 @@
 import { promptFileSchema } from "stagebook";
 import type { SourceRange } from "./yamlPositionMap";
-
-export interface Diagnostic {
-  message: string;
-  severity: "error" | "warning";
-  range: SourceRange | null;
-}
+import type { Diagnostic } from "./types";
 
 export interface PromptValidationResult {
   diagnostics: Diagnostic[];
@@ -18,7 +13,7 @@ function findDelimiterLines(source: string): number[] {
   const lines = source.split(/\r?\n/);
   const result: number[] = [];
   for (let i = 0; i < lines.length; i++) {
-    if (/^-{3,}$/.test(lines[i].trim())) {
+    if (/^-{3,}$/.test(lines[i])) {
       result.push(i);
     }
   }

--- a/apps/vscode/src/lib/validatePrompt.ts
+++ b/apps/vscode/src/lib/validatePrompt.ts
@@ -64,21 +64,24 @@ function mapPromptErrorToRange(
         }
       }
     }
-    // Fall back to the metadata section start
+    // Fall back to the metadata section start (clamp for empty sections)
+    const metaFallbackLine = Math.min(metaStart + 1, metaEnd);
     return {
-      startLine: metaStart + 1,
+      startLine: metaFallbackLine,
       startCol: 0,
-      endLine: metaEnd - 1,
-      endCol: 0,
+      endLine: metaFallbackLine,
+      endCol: 1,
     };
   }
 
   if (section === "body") {
+    // Clamp for empty body (adjacent delimiters)
+    const bodyLine = Math.min(metaEnd + 1, responseStart);
     return {
-      startLine: metaEnd + 1,
+      startLine: bodyLine,
       startCol: 0,
-      endLine: responseStart - 1,
-      endCol: 0,
+      endLine: bodyLine,
+      endCol: 1,
     };
   }
 

--- a/apps/vscode/src/lib/validatePrompt.ts
+++ b/apps/vscode/src/lib/validatePrompt.ts
@@ -1,0 +1,145 @@
+import { promptFileSchema } from "stagebook";
+import type { SourceRange } from "./yamlPositionMap";
+
+export interface Diagnostic {
+  message: string;
+  severity: "error" | "warning";
+  range: SourceRange | null;
+}
+
+export interface PromptValidationResult {
+  diagnostics: Diagnostic[];
+}
+
+/**
+ * Find the 0-based line numbers of all `---` delimiters in the source.
+ */
+function findDelimiterLines(source: string): number[] {
+  const lines = source.split(/\r?\n/);
+  const result: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (/^-{3,}$/.test(lines[i].trim())) {
+      result.push(i);
+    }
+  }
+  return result;
+}
+
+/**
+ * Map a Zod issue path from promptFileSchema to a source line range.
+ *
+ * promptFileSchema produces paths like:
+ * - [] — structural errors (missing delimiters)
+ * - ["metadata", "type"] — metadata field errors
+ * - ["body"] — body section errors
+ * - ["responses"] — response format errors
+ */
+function mapPromptErrorToRange(
+  source: string,
+  path: (string | number)[],
+  delimiters: number[],
+): SourceRange | null {
+  if (delimiters.length < 3) {
+    // Can't map without delimiters — fall back to line 0
+    return { startLine: 0, startCol: 0, endLine: 0, endCol: 1 };
+  }
+
+  const [metaStart, metaEnd, responseStart] = delimiters;
+
+  if (path.length === 0) {
+    return { startLine: 0, startCol: 0, endLine: 0, endCol: 1 };
+  }
+
+  const section = path[0];
+
+  if (section === "metadata") {
+    // Map to the metadata section (between first and second ---)
+    // If we have a specific field name, try to find it
+    if (path.length >= 2 && typeof path[1] === "string") {
+      const fieldName = path[1];
+      const lines = source.split(/\r?\n/);
+      for (let i = metaStart + 1; i < metaEnd; i++) {
+        if (lines[i] && lines[i].trimStart().startsWith(fieldName + ":")) {
+          return {
+            startLine: i,
+            startCol: 0,
+            endLine: i,
+            endCol: lines[i].length,
+          };
+        }
+      }
+    }
+    // Fall back to the metadata section start
+    return {
+      startLine: metaStart + 1,
+      startCol: 0,
+      endLine: metaEnd - 1,
+      endCol: 0,
+    };
+  }
+
+  if (section === "body") {
+    return {
+      startLine: metaEnd + 1,
+      startCol: 0,
+      endLine: responseStart - 1,
+      endCol: 0,
+    };
+  }
+
+  if (section === "responses") {
+    // Map to the response section (after the third ---)
+    return {
+      startLine: responseStart + 1,
+      startCol: 0,
+      endLine: responseStart + 1,
+      endCol: 1,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Validate a prompt markdown source string.
+ *
+ * Returns diagnostics with source positions.
+ * This is a pure function — no VS Code dependency.
+ */
+export function validatePromptSource(source: string): PromptValidationResult {
+  const diagnostics: Diagnostic[] = [];
+  const delimiters = findDelimiterLines(source);
+
+  // Warn about extra delimiters (likely horizontal rule attempts)
+  if (delimiters.length > 3) {
+    for (let i = 3; i < delimiters.length; i++) {
+      diagnostics.push({
+        message:
+          "Extra --- delimiter found. If you want a horizontal rule, use *** or ___ instead — three dashes are used to separate prompt sections.",
+        severity: "warning",
+        range: {
+          startLine: delimiters[i],
+          startCol: 0,
+          endLine: delimiters[i],
+          endCol: 3,
+        },
+      });
+    }
+  }
+
+  // Validate with stagebook's promptFileSchema
+  const result = promptFileSchema.safeParse(source);
+
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      const range = mapPromptErrorToRange(source, issue.path, delimiters);
+      diagnostics.push({
+        message: issue.message,
+        severity: "error",
+        range,
+      });
+    }
+  }
+
+  return { diagnostics };
+}

--- a/apps/vscode/src/lib/validateTreatment.ts
+++ b/apps/vscode/src/lib/validateTreatment.ts
@@ -1,15 +1,8 @@
 import { treatmentFileSchema } from "stagebook";
-import {
-  createPositionMapper,
-  extractYamlErrors,
-  type SourceRange,
-} from "./yamlPositionMap";
+import { createPositionMapper, extractYamlErrors } from "./yamlPositionMap";
+import type { Diagnostic } from "./types";
 
-export interface Diagnostic {
-  message: string;
-  severity: "error" | "warning";
-  range: SourceRange | null;
-}
+export type { Diagnostic };
 
 export interface ValidationResult {
   diagnostics: Diagnostic[];


### PR DESCRIPTION
## Summary
- Pure `validatePromptSource()` function validates `*.prompt.md` files against stagebook's `promptFileSchema`
- Maps errors to source positions within the three-section format (metadata → YAML field line, body → body section, responses → response section)
- Warns about extra `---` delimiters (suggests `***` or `___` for horizontal rules)
- Wires `validatePromptFile` in extension.ts (was a TODO stub)

Refs #76

## Test plan
- [x] 13 new tests: valid files (3 types), structural errors, metadata errors, response format errors, position mapping, extra delimiter warnings
- [x] 48 existing tests still pass (32 position mapping + 16 treatment validation)
- [x] Extension builds (531KB)
- [x] All monorepo tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)