### PR TITLE
Add expanded templates preview command

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -20,6 +20,21 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "commands": [
+      {
+        "command": "stagebook.previewExpandedTemplates",
+        "title": "Stagebook: Preview Expanded Templates"
+      }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "stagebook.previewExpandedTemplates",
+          "when": "resourceLangId == treatmentsYaml",
+          "group": "navigation"
+        }
+      ]
+    },
     "languages": [
       {
         "id": "treatmentsYaml",

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -284,8 +284,7 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
   readonly onDidChange = this._onDidChange.event;
 
   provideTextDocumentContent(uri: vscode.Uri): string {
-    // The source document URI is encoded in the query parameter
-    const sourceUri = vscode.Uri.parse(uri.query);
+    const sourceUri = vscode.Uri.parse(decodeURIComponent(uri.query));
     const sourceDoc = vscode.workspace.textDocuments.find(
       (d) => d.uri.toString() === sourceUri.toString(),
     );
@@ -295,14 +294,18 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
 
     const result = expandTreatmentSource(sourceDoc.getText());
     if (result.error) {
-      return `# Template expansion error:\n# ${result.error}`;
+      const commentedError = result.error
+        .split(/\r?\n/)
+        .map((line) => `# ${line}`)
+        .join("\n");
+      return `# Template expansion error:\n${commentedError}`;
     }
     return result.yaml;
   }
 
   refreshForSource(sourceUri: vscode.Uri): void {
     const expandedUri = vscode.Uri.parse(
-      `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${sourceUri.toString()}`,
+      `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${encodeURIComponent(sourceUri.toString())}`,
     );
     this._onDidChange.fire(expandedUri);
   }
@@ -344,7 +347,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
         const sourceUri = editor.document.uri;
         const expandedUri = vscode.Uri.parse(
-          `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${sourceUri.toString()}`,
+          `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${encodeURIComponent(sourceUri.toString())}`,
         );
 
         const doc = await vscode.workspace.openTextDocument(expandedUri);

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -10,6 +10,7 @@ import {
   computeSemanticTokens,
   type SemanticTokenType,
 } from "./lib/semanticTokens";
+import { expandTreatmentSource } from "./lib/expandTreatment";
 
 const diagnosticCollection =
   vscode.languages.createDiagnosticCollection("stagebook");
@@ -274,6 +275,39 @@ class TreatmentSemanticTokenProvider
   }
 }
 
+// --- Expanded Templates Preview ---
+
+const EXPANDED_SCHEME = "stagebook-expanded";
+
+class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
+  private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+  readonly onDidChange = this._onDidChange.event;
+
+  provideTextDocumentContent(uri: vscode.Uri): string {
+    // The source document URI is encoded in the query parameter
+    const sourceUri = vscode.Uri.parse(uri.query);
+    const sourceDoc = vscode.workspace.textDocuments.find(
+      (d) => d.uri.toString() === sourceUri.toString(),
+    );
+    if (!sourceDoc) {
+      return "# Source document not found. Please reopen the preview.";
+    }
+
+    const result = expandTreatmentSource(sourceDoc.getText());
+    if (result.error) {
+      return `# Template expansion error:\n# ${result.error}`;
+    }
+    return result.yaml;
+  }
+
+  refreshForSource(sourceUri: vscode.Uri): void {
+    const expandedUri = vscode.Uri.parse(
+      `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${sourceUri.toString()}`,
+    );
+    this._onDidChange.fire(expandedUri);
+  }
+}
+
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(diagnosticCollection);
 
@@ -284,6 +318,54 @@ export function activate(context: vscode.ExtensionContext): void {
       new TreatmentSemanticTokenProvider(),
       tokenLegend,
     ),
+  );
+
+  // Register expanded templates content provider
+  const expandedProvider = new ExpandedTemplatesProvider();
+  context.subscriptions.push(
+    vscode.workspace.registerTextDocumentContentProvider(
+      EXPANDED_SCHEME,
+      expandedProvider,
+    ),
+  );
+
+  // Register the expand command
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "stagebook.previewExpandedTemplates",
+      async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor || !isTreatmentsYaml(editor.document)) {
+          vscode.window.showWarningMessage(
+            "Open a .treatments.yaml file first.",
+          );
+          return;
+        }
+
+        const sourceUri = editor.document.uri;
+        const expandedUri = vscode.Uri.parse(
+          `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${sourceUri.toString()}`,
+        );
+
+        const doc = await vscode.workspace.openTextDocument(expandedUri);
+        await vscode.window.showTextDocument(doc, {
+          viewColumn: vscode.ViewColumn.Beside,
+          preview: true,
+          preserveFocus: true,
+        });
+        // Set language for syntax highlighting
+        await vscode.languages.setTextDocumentLanguage(doc, "yaml");
+      },
+    ),
+  );
+
+  // Auto-refresh the expanded preview when the source changes
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeTextDocument((e) => {
+      if (isTreatmentsYaml(e.document)) {
+        expandedProvider.refreshForSource(e.document.uri);
+      }
+    }),
   );
 
   // Validate the active document on activation (no debounce)

--- a/apps/vscode/src/lib/expandTreatment.test.ts
+++ b/apps/vscode/src/lib/expandTreatment.test.ts
@@ -109,19 +109,13 @@ treatments:
       expect(result.error).not.toBeNull();
     });
 
-    it("returns an error when template expansion fails", () => {
-      const src = `templates:
-  - templateName: myStage
-    templateContent:
-      name: \${missing}_stage
+    it("returns an error when templates key is not an array", () => {
+      const src = `templates: notAnArray
 treatments:
-  - name: study1
-    playerCount: 1
-    gameStages:
-      - template: myStage`;
+  - name: study1`;
       const result = expandTreatmentSource(src);
-      // Should either expand with unresolved fields or report an error
-      expect(result.yaml.length > 0 || result.error !== null).toBe(true);
+      expect(result.error).toContain("must be an array");
+      expect(result.yaml).toBe("");
     });
   });
 

--- a/apps/vscode/src/lib/expandTreatment.test.ts
+++ b/apps/vscode/src/lib/expandTreatment.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect } from "vitest";
+import { expandTreatmentSource } from "./expandTreatment";
+
+describe("expandTreatmentSource", () => {
+  describe("no templates", () => {
+    it("returns the YAML unchanged when there are no templates", () => {
+      const src = `treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: submitButton`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("name: study1");
+      expect(result.yaml).toContain("type: submitButton");
+      expect(result.truncated).toBe(false);
+    });
+  });
+
+  describe("simple template expansion", () => {
+    it("expands a template context into concrete content", () => {
+      const src = `templates:
+  - templateName: myStage
+    templateContent:
+      name: stage1
+      duration: 300
+      elements:
+        - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: myStage`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("name: stage1");
+      expect(result.yaml).toContain("duration: 300");
+      expect(result.yaml).toContain("type: submitButton");
+      // Templates key should be removed from output
+      expect(result.yaml).not.toMatch(/^templates:/m);
+    });
+  });
+
+  describe("field substitution", () => {
+    it("substitutes field values into template content", () => {
+      const src = `templates:
+  - templateName: topicStage
+    templateContent:
+      name: \${topic}_stage
+      duration: 300
+      elements:
+        - type: prompt
+          file: prompts/\${topic}.prompt.md
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: topicStage
+        fields:
+          topic: climate`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("name: climate_stage");
+      expect(result.yaml).toContain("file: prompts/climate.prompt.md");
+    });
+  });
+
+  describe("broadcast expansion", () => {
+    it("expands broadcast dimensions into multiple items", () => {
+      const src = `templates:
+  - templateName: topicStage
+    templateContent:
+      name: \${topic}_stage
+      duration: 300
+      elements:
+        - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: topicStage
+        broadcast:
+          d0:
+            - topic: climate
+            - topic: guns
+            - topic: immigration`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("climate_stage");
+      expect(result.yaml).toContain("guns_stage");
+      expect(result.yaml).toContain("immigration_stage");
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns an error for invalid YAML", () => {
+      const src = `[[[invalid`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).not.toBeNull();
+      expect(result.yaml).toBe("");
+    });
+
+    it("returns an error for non-object YAML", () => {
+      const src = `just a string`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).not.toBeNull();
+    });
+
+    it("returns an error when template expansion fails", () => {
+      const src = `templates:
+  - templateName: myStage
+    templateContent:
+      name: \${missing}_stage
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: myStage`;
+      const result = expandTreatmentSource(src);
+      // Should either expand with unresolved fields or report an error
+      expect(result.yaml.length > 0 || result.error !== null).toBe(true);
+    });
+  });
+
+  describe("output size limit", () => {
+    it("truncates output that exceeds the line limit", () => {
+      // Generate a treatment with a large broadcast
+      const topics = Array.from({ length: 200 }, (_, i) => `topic${i}`);
+      const broadcastItems = topics
+        .map((t) => `            - topic: ${t}`)
+        .join("\n");
+      const src = `templates:
+  - templateName: bigStage
+    templateContent:
+      name: \${topic}_stage
+      duration: 300
+      elements:
+        - type: prompt
+          file: prompts/\${topic}.prompt.md
+        - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: bigStage
+        broadcast:
+          d0:
+${broadcastItems}`;
+      const result = expandTreatmentSource(src, { maxLines: 100 });
+      expect(result.truncated).toBe(true);
+      const lines = result.yaml.split("\n");
+      // Should be at or under the limit (plus truncation notice)
+      expect(lines.length).toBeLessThanOrEqual(105);
+      expect(result.yaml).toContain("# --- Output truncated at 100 lines");
+    });
+  });
+
+  describe("nested templates", () => {
+    it("expands templates that reference other templates", () => {
+      const src = `templates:
+  - templateName: innerElem
+    templateContent:
+      type: submitButton
+  - templateName: outerStage
+    templateContent:
+      name: stage1
+      duration: 300
+      elements:
+        - template: innerElem
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: outerStage`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("type: submitButton");
+      expect(result.yaml).toContain("name: stage1");
+    });
+  });
+
+  describe("nonexistent template reference", () => {
+    it("returns an error when a template reference does not exist", () => {
+      const src = `templates:
+  - templateName: myStage
+    templateContent:
+      name: stage1
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: nonexistentStage`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toContain("not found");
+      expect(result.yaml).toBe("");
+    });
+  });
+
+  describe("unresolved placeholders", () => {
+    it("preserves unresolved placeholders in the output", () => {
+      const src = `templates:
+  - templateName: myStage
+    templateContent:
+      name: \${missing}_stage
+      duration: 300
+      elements:
+        - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: myStage`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("${missing}_stage");
+    });
+  });
+
+  describe("multi-dimension broadcast", () => {
+    it("expands broadcast with multiple dimensions into cartesian product", () => {
+      const src = `templates:
+  - templateName: topicStage
+    templateContent:
+      name: \${topic}_\${condition}_stage
+      duration: 300
+      elements:
+        - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: topicStage
+        broadcast:
+          d0:
+            - topic: climate
+            - topic: guns
+          d1:
+            - condition: control
+            - condition: treatment`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("climate_control_stage");
+      expect(result.yaml).toContain("climate_treatment_stage");
+      expect(result.yaml).toContain("guns_control_stage");
+      expect(result.yaml).toContain("guns_treatment_stage");
+    });
+  });
+
+  describe("broadcast size guard", () => {
+    it("rejects broadcasts that would produce too many items", () => {
+      const topics = Array.from({ length: 200 }, (_, i) => `topic${i}`);
+      const broadcastItems = topics
+        .map((t) => `            - topic: ${t}`)
+        .join("\n");
+      const src = `templates:
+  - templateName: bigStage
+    templateContent:
+      name: \${topic}_stage
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: bigStage
+        broadcast:
+          d0:
+${broadcastItems}`;
+      const result = expandTreatmentSource(src, { maxBroadcastProduct: 100 });
+      expect(result.error).toContain("Broadcast expansion would produce");
+      expect(result.yaml).toBe("");
+    });
+  });
+
+  describe("templates key removal", () => {
+    it("removes the templates key from expanded output", () => {
+      const src = `templates:
+  - templateName: myStage
+    templateContent:
+      name: stage1
+      duration: 300
+      elements:
+        - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: myStage`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).not.toMatch(/templateName:/);
+      expect(result.yaml).not.toMatch(/templateContent:/);
+    });
+  });
+});

--- a/apps/vscode/src/lib/expandTreatment.ts
+++ b/apps/vscode/src/lib/expandTreatment.ts
@@ -1,0 +1,153 @@
+import { fillTemplates } from "stagebook";
+import { parse, stringify } from "yaml";
+
+const DEFAULT_MAX_LINES = 5000;
+const DEFAULT_MAX_BROADCAST = 10000;
+
+export interface ExpandResult {
+  /** The expanded YAML string, or "" on error. */
+  yaml: string;
+  /** Error message if expansion failed, null on success. */
+  error: string | null;
+  /** Whether the output was truncated due to line limit. */
+  truncated: boolean;
+}
+
+export interface ExpandOptions {
+  maxLines?: number;
+  maxBroadcastProduct?: number;
+}
+
+/**
+ * Walk the parsed object looking for broadcast dimensions and estimate
+ * the total Cartesian product size. Returns an error message if it
+ * exceeds the limit, or null if it's within bounds.
+ */
+function checkBroadcastSize(obj: unknown, limit: number): string | null {
+  let totalProduct = 0;
+
+  function walk(node: unknown): void {
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+    if (typeof node !== "object" || node === null) return;
+    const record = node as Record<string, unknown>;
+
+    if (record.broadcast && typeof record.broadcast === "object") {
+      const dims = record.broadcast as Record<string, unknown>;
+      let product = 1;
+      for (const dim of Object.values(dims)) {
+        if (Array.isArray(dim)) product *= dim.length;
+      }
+      totalProduct += product;
+    }
+
+    for (const value of Object.values(record)) {
+      walk(value);
+    }
+  }
+
+  walk(obj);
+
+  if (totalProduct > limit) {
+    return `Broadcast expansion would produce ~${totalProduct} items (limit: ${limit}). Reduce broadcast dimensions or increase the limit.`;
+  }
+  return null;
+}
+
+/**
+ * Expand all templates in a treatment YAML source string.
+ *
+ * Returns the fully expanded YAML with the `templates` key removed.
+ * This is a pure function — no VS Code dependency.
+ */
+export function expandTreatmentSource(
+  source: string,
+  options?: ExpandOptions,
+): ExpandResult {
+  const maxLines = options?.maxLines ?? DEFAULT_MAX_LINES;
+
+  // Parse YAML
+  let obj: unknown;
+  try {
+    obj = parse(source);
+  } catch (e) {
+    return {
+      yaml: "",
+      error: `YAML parse error: ${e instanceof Error ? e.message : String(e)}`,
+      truncated: false,
+    };
+  }
+
+  if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+    return {
+      yaml: "",
+      error:
+        "Treatment file must be a YAML mapping (object), not a scalar or array.",
+      truncated: false,
+    };
+  }
+
+  const record = obj as Record<string, unknown>;
+  const templates = (record.templates ?? []) as unknown[];
+
+  // Guard against combinatorial explosion from large broadcast dimensions.
+  // Estimate the total product size before expanding.
+  const broadcastLimit = options?.maxBroadcastProduct ?? DEFAULT_MAX_BROADCAST;
+  const sizeError = checkBroadcastSize(record, broadcastLimit);
+  if (sizeError) {
+    return { yaml: "", error: sizeError, truncated: false };
+  }
+
+  // Expand templates
+  let expanded: Record<string, unknown>;
+  try {
+    if (templates.length > 0) {
+      const { result } = fillTemplates({
+        obj: record,
+        templates,
+        allowUnresolved: true,
+      });
+      expanded = result as Record<string, unknown>;
+    } else {
+      expanded = { ...record };
+    }
+  } catch (e) {
+    return {
+      yaml: "",
+      error: `Template expansion failed: ${e instanceof Error ? e.message : String(e)}`,
+      truncated: false,
+    };
+  }
+
+  // Remove templates key from output
+  delete expanded.templates;
+
+  // Serialize back to YAML
+  let yaml: string;
+  try {
+    yaml = stringify(expanded, { indent: 2, lineWidth: 0 });
+  } catch (e) {
+    return {
+      yaml: "",
+      error: `YAML serialization failed: ${e instanceof Error ? e.message : String(e)}`,
+      truncated: false,
+    };
+  }
+
+  // Truncate if over the line limit
+  const lines = yaml.split("\n");
+  if (lines.length > maxLines) {
+    const truncatedYaml = lines.slice(0, maxLines).join("\n");
+    return {
+      yaml:
+        truncatedYaml +
+        `\n\n# --- Output truncated at ${maxLines} lines (${lines.length} total) ---`,
+      error: null,
+      truncated: true,
+    };
+  }
+
+  return { yaml, error: null, truncated: false };
+}

--- a/apps/vscode/src/lib/expandTreatment.ts
+++ b/apps/vscode/src/lib/expandTreatment.ts
@@ -34,7 +34,11 @@ function checkBroadcastSize(obj: unknown, limit: number): string | null {
     if (typeof node !== "object" || node === null) return;
     const record = node as Record<string, unknown>;
 
-    if (record.broadcast && typeof record.broadcast === "object") {
+    if (
+      typeof record.template === "string" &&
+      record.broadcast &&
+      typeof record.broadcast === "object"
+    ) {
       const dims = record.broadcast as Record<string, unknown>;
       let product = 1;
       for (const dim of Object.values(dims)) {
@@ -90,6 +94,15 @@ export function expandTreatmentSource(
   }
 
   const record = obj as Record<string, unknown>;
+
+  if (record.templates !== undefined && !Array.isArray(record.templates)) {
+    return {
+      yaml: "",
+      error: "The 'templates' key must be an array.",
+      truncated: false,
+    };
+  }
+
   const templates = (record.templates ?? []) as unknown[];
 
   // Guard against combinatorial explosion from large broadcast dimensions.


### PR DESCRIPTION
## Summary
- **Command:** "Stagebook: Preview Expanded Templates" — command palette + right-click context menu on `.treatments.yaml` files
- **Output:** Read-only virtual document showing fully expanded YAML with templates key removed
- **Live update:** Re-renders when the source document changes
- **Truncation:** Caps at 5,000 lines with a notice showing total count
- **Broadcast guard:** Rejects expansions that would produce >10,000 items before attempting expansion (prevents memory/CPU explosion)
- **Error handling:** Structured errors for invalid YAML, non-object input, expansion failures, broadcast overflow

Uses stagebook's `fillTemplates()` with `allowUnresolved: true` so unresolved `${field}` placeholders are preserved in the output.

Refs #80

## Test plan
- [x] 14 new tests: passthrough, expansion, fields, broadcast (1D + 2D), nested templates, nonexistent ref, unresolved placeholders, truncation with notice, broadcast guard, templates key removal, 3 error paths
- [x] 87 existing tests still pass (101 total)
- [x] Extension builds
- [x] All monorepo tests pass
- [x] Local security/test/spec reviews completed before commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)