### PR TITLE
Unify template variable highlighting via semantic tokens

### DIFF
--- a/apps/vscode/src/lib/semanticTokens.test.ts
+++ b/apps/vscode/src/lib/semanticTokens.test.ts
@@ -64,11 +64,44 @@ describe("computeSemanticTokens", () => {
       });
     });
 
-    it("highlights file paths containing template variables", () => {
+    it("splits file paths around template variables", () => {
       const src = `file: projects/${"\${topic}"}/q1.prompt.md`;
       const tokens = computeSemanticTokens(src);
       const fileTokens = tokens.filter((t) => t.tokenType === "string");
+      const varTokens = tokens.filter((t) => t.tokenType === "variable");
+      // "projects/" and "/q1.prompt.md" as string, "${topic}" as variable
+      expect(fileTokens).toHaveLength(2);
+      expect(fileTokens[0]).toMatchObject({ text: "projects/" });
+      expect(fileTokens[1]).toMatchObject({ text: "/q1.prompt.md" });
+      expect(varTokens).toHaveLength(1);
+      expect(varTokens[0]).toMatchObject({ text: "${topic}" });
+    });
+
+    it("highlights simple file paths as a single string token", () => {
+      const src = `file: prompts/q1.prompt.md`;
+      const tokens = computeSemanticTokens(src);
+      const fileTokens = tokens.filter((t) => t.tokenType === "string");
       expect(fileTokens).toHaveLength(1);
+      expect(fileTokens[0]).toMatchObject({ text: "prompts/q1.prompt.md" });
+    });
+  });
+
+  describe("template variables in values", () => {
+    it("highlights ${...} placeholders in non-file values", () => {
+      const src = `name: \${topicName}_presurvey`;
+      const tokens = computeSemanticTokens(src);
+      const varTokens = tokens.filter((t) => t.tokenType === "variable");
+      expect(varTokens).toHaveLength(1);
+      expect(varTokens[0]).toMatchObject({ text: "${topicName}" });
+    });
+
+    it("highlights multiple placeholders in one value", () => {
+      const src = `name: \${topic}_\${condition}_stage`;
+      const tokens = computeSemanticTokens(src);
+      const varTokens = tokens.filter((t) => t.tokenType === "variable");
+      expect(varTokens).toHaveLength(2);
+      expect(varTokens[0]).toMatchObject({ text: "${topic}" });
+      expect(varTokens[1]).toMatchObject({ text: "${condition}" });
     });
   });
 

--- a/apps/vscode/src/lib/semanticTokens.ts
+++ b/apps/vscode/src/lib/semanticTokens.ts
@@ -247,7 +247,8 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
             isScalar(value) &&
             typeof value.value === "string" &&
             value.range &&
-            TEMPLATE_VAR_RE.test(value.value) &&
+            ((TEMPLATE_VAR_RE.lastIndex = 0),
+            TEMPLATE_VAR_RE.test(value.value)) &&
             k !== "file" // file paths already handled above
           ) {
             emitTemplateVarTokens(value.range[0], value.value);

--- a/apps/vscode/src/lib/semanticTokens.ts
+++ b/apps/vscode/src/lib/semanticTokens.ts
@@ -119,6 +119,46 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
     });
   }
 
+  const TEMPLATE_VAR_RE = /\$\{[a-zA-Z0-9_]+\}/g;
+
+  /**
+   * Emit variable tokens for ${...} placeholders within a string.
+   * Only emits tokens for the placeholders, not the surrounding text.
+   */
+  function emitTemplateVarTokens(startOffset: number, text: string): void {
+    TEMPLATE_VAR_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = TEMPLATE_VAR_RE.exec(text)) !== null) {
+      addToken(startOffset + match.index, match[0], "variable");
+    }
+  }
+
+  /**
+   * Emit tokens for a file path, splitting around ${...} placeholders.
+   * Path segments get "string", placeholders get "variable".
+   */
+  function addFilePathTokens(startOffset: number, text: string): void {
+    let lastIndex = 0;
+    TEMPLATE_VAR_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = TEMPLATE_VAR_RE.exec(text)) !== null) {
+      if (match.index > lastIndex) {
+        addToken(
+          startOffset + lastIndex,
+          text.slice(lastIndex, match.index),
+          "string",
+        );
+      }
+      addToken(startOffset + match.index, match[0], "variable");
+      lastIndex = match.index + match[0].length;
+    }
+
+    if (lastIndex < text.length) {
+      addToken(startOffset + lastIndex, text.slice(lastIndex), "string");
+    }
+  }
+
   function walkNode(node: unknown, keyName?: string): void {
     if (isMap(node)) {
       for (const pair of node.items) {
@@ -173,7 +213,7 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
             typeof value.value === "string" &&
             value.range
           ) {
-            addToken(value.range[0], value.value, "string");
+            addFilePathTokens(value.range[0], value.value);
           } else if (
             k === "contentType" &&
             isScalar(value) &&
@@ -198,6 +238,19 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
             enumValues.has(value.value)
           ) {
             addToken(value.range[0], value.value, "keyword");
+          }
+
+          // For any other scalar value containing ${...} placeholders,
+          // emit variable tokens so template fields are highlighted
+          // consistently everywhere they appear.
+          if (
+            isScalar(value) &&
+            typeof value.value === "string" &&
+            value.range &&
+            TEMPLATE_VAR_RE.test(value.value) &&
+            k !== "file" // file paths already handled above
+          ) {
+            emitTemplateVarTokens(value.range[0], value.value);
           }
 
           // Recurse into the value

--- a/apps/vscode/syntaxes/treatmentsYaml.tmLanguage.json
+++ b/apps/vscode/syntaxes/treatmentsYaml.tmLanguage.json
@@ -2,14 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Treatments YAML",
   "scopeName": "source.treatments-yaml",
+  "comment": "Inherits base YAML. Domain-specific highlighting is handled by the semantic token provider.",
   "patterns": [
-    { "include": "#template-variable" },
     { "include": "source.yaml" }
-  ],
-  "repository": {
-    "template-variable": {
-      "match": "\\$\\{[a-zA-Z0-9_]+\\}",
-      "name": "variable.other.constant.treatments-yaml"
-    }
-  }
+  ]
 }


### PR DESCRIPTION
## Summary
- Move all `${...}` placeholder highlighting from TextMate grammar to semantic token provider
- Template variables now look consistent everywhere — file paths, names, any string value
- File paths split into `string` segments + `variable` placeholders
- Remove TextMate `template-variable` pattern (was causing mixed yellow/blue colors)

## Test plan
- [x] 4 new tests: template vars in non-file values, multiple placeholders, simple/split file paths
- [x] 104 total tests pass
- [x] Manual testing: `${topicName}` is solid blue in both `name:` and `file:` values

🤖 Generated with [Claude Code](https://claude.com/claude-code)