### PR TITLE
Add file path quick-fix and autocomplete

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -11,6 +11,7 @@ import {
   type SemanticTokenType,
 } from "./lib/semanticTokens";
 import { expandTreatmentSource } from "./lib/expandTreatment";
+import { findClosestMatch } from "./lib/levenshtein";
 
 const diagnosticCollection =
   vscode.languages.createDiagnosticCollection("stagebook");
@@ -275,6 +276,130 @@ class TreatmentSemanticTokenProvider
   }
 }
 
+// --- File Path Quick-Fix ---
+
+class FilePathQuickFixProvider implements vscode.CodeActionProvider {
+  static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix];
+
+  // Cache workspace file paths to avoid re-globbing on every cursor move
+  private cachedPaths: string[] = [];
+  private cacheTimestamp = 0;
+  private static readonly CACHE_TTL_MS = 5000;
+
+  async provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range,
+  ): Promise<vscode.CodeAction[]> {
+    const diagnostics = vscode.languages
+      .getDiagnostics(document.uri)
+      .filter(
+        (d) =>
+          d.source === "stagebook" &&
+          d.message.startsWith("File not found:") &&
+          d.range.intersection(range),
+      );
+
+    if (diagnostics.length === 0 || !vscode.workspace.workspaceFolders?.length)
+      return [];
+
+    const actions: vscode.CodeAction[] = [];
+    const workspaceFolder =
+      vscode.workspace.getWorkspaceFolder(document.uri) ??
+      vscode.workspace.workspaceFolders[0];
+
+    // Refresh the cached file list if stale
+    const now = Date.now();
+    if (now - this.cacheTimestamp > FilePathQuickFixProvider.CACHE_TTL_MS) {
+      const allFiles = await vscode.workspace.findFiles(
+        "**/*.{prompt.md,md,yaml,jpg,jpeg,png,mp3,mp4}",
+        "**/node_modules/**",
+        5000,
+      );
+      this.cachedPaths = allFiles.map((f) =>
+        path.relative(workspaceFolder.uri.fsPath, f.fsPath),
+      );
+      this.cacheTimestamp = now;
+    }
+
+    for (const diagnostic of diagnostics) {
+      const badPath = diagnostic.message.replace("File not found: ", "");
+      const suggestion = findClosestMatch(badPath, this.cachedPaths);
+      if (!suggestion) continue;
+
+      const action = new vscode.CodeAction(
+        `Did you mean: ${suggestion}?`,
+        vscode.CodeActionKind.QuickFix,
+      );
+      action.edit = new vscode.WorkspaceEdit();
+      action.edit.replace(document.uri, diagnostic.range, suggestion);
+      action.isPreferred = true;
+      action.diagnostics = [diagnostic];
+      actions.push(action);
+    }
+
+    return actions;
+  }
+}
+
+// --- File Path Autocomplete ---
+
+class FilePathCompletionProvider implements vscode.CompletionItemProvider {
+  async provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ): Promise<vscode.CompletionItem[] | undefined> {
+    const line = document.lineAt(position).text;
+    const prefix = line.substring(0, position.character);
+
+    // Only trigger after "file:" with optional whitespace
+    if (!/^\s*file:\s/.test(prefix)) return undefined;
+
+    if (!vscode.workspace.workspaceFolders?.length) return undefined;
+
+    const workspaceFolder =
+      vscode.workspace.getWorkspaceFolder(document.uri) ??
+      vscode.workspace.workspaceFolders[0];
+
+    // Get the partial path the user has typed so far
+    const fileValueMatch = prefix.match(/file:\s+(.*)/);
+    const partial = fileValueMatch?.[1] ?? "";
+
+    // Sanitize glob metacharacters in user input
+    const sanitized = partial.replace(/[*?[\]{}]/g, "\\$&");
+    const globPattern = sanitized
+      ? `**/${sanitized}*`
+      : "**/*.{prompt.md,md,yaml}";
+    const files = await vscode.workspace.findFiles(
+      globPattern,
+      "**/node_modules/**",
+      50,
+    );
+
+    return files.map((fileUri) => {
+      const relativePath = path.relative(
+        workspaceFolder.uri.fsPath,
+        fileUri.fsPath,
+      );
+      const item = new vscode.CompletionItem(
+        relativePath,
+        vscode.CompletionItemKind.File,
+      );
+      item.insertText = relativePath;
+      // Replace the entire value after "file: "
+      const valueStart = prefix.indexOf("file:") + "file:".length;
+      const whitespaceAfterColon =
+        prefix.substring(valueStart).match(/^\s*/)?.[0] ?? " ";
+      item.range = new vscode.Range(
+        position.line,
+        valueStart + whitespaceAfterColon.length,
+        position.line,
+        line.length,
+      );
+      return item;
+    });
+  }
+}
+
 // --- Expanded Templates Preview ---
 
 const EXPANDED_SCHEME = "stagebook-expanded";
@@ -320,6 +445,26 @@ export function activate(context: vscode.ExtensionContext): void {
       { language: "treatmentsYaml" },
       new TreatmentSemanticTokenProvider(),
       tokenLegend,
+    ),
+  );
+
+  // Register file path quick-fix provider
+  context.subscriptions.push(
+    vscode.languages.registerCodeActionsProvider(
+      "treatmentsYaml",
+      new FilePathQuickFixProvider(),
+      {
+        providedCodeActionKinds:
+          FilePathQuickFixProvider.providedCodeActionKinds,
+      },
+    ),
+  );
+
+  // Register file path autocomplete provider
+  context.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(
+      "treatmentsYaml",
+      new FilePathCompletionProvider(),
     ),
   );
 

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -311,12 +311,18 @@ class FilePathQuickFixProvider implements vscode.CodeActionProvider {
     const now = Date.now();
     if (now - this.cacheTimestamp > FilePathQuickFixProvider.CACHE_TTL_MS) {
       const allFiles = await vscode.workspace.findFiles(
-        "**/*.{prompt.md,md,yaml,jpg,jpeg,png,mp3,mp4}",
+        new vscode.RelativePattern(
+          workspaceFolder,
+          "**/*.{prompt.md,md,yaml,jpg,jpeg,png,mp3,mp4}",
+        ),
         "**/node_modules/**",
         5000,
       );
       this.cachedPaths = allFiles.map((f) =>
-        path.relative(workspaceFolder.uri.fsPath, f.fsPath),
+        path
+          .relative(workspaceFolder.uri.fsPath, f.fsPath)
+          .split(path.sep)
+          .join("/"),
       );
       this.cacheTimestamp = now;
     }
@@ -351,8 +357,8 @@ class FilePathCompletionProvider implements vscode.CompletionItemProvider {
     const line = document.lineAt(position).text;
     const prefix = line.substring(0, position.character);
 
-    // Only trigger after "file:" with optional whitespace
-    if (!/^\s*file:\s/.test(prefix)) return undefined;
+    // Trigger after "file:" anywhere in the line (handles "- file:", indented, etc.)
+    if (!/\bfile:\s/.test(prefix)) return undefined;
 
     if (!vscode.workspace.workspaceFolders?.length) return undefined;
 
@@ -361,7 +367,7 @@ class FilePathCompletionProvider implements vscode.CompletionItemProvider {
       vscode.workspace.workspaceFolders[0];
 
     // Get the partial path the user has typed so far
-    const fileValueMatch = prefix.match(/file:\s+(.*)/);
+    const fileValueMatch = prefix.match(/\bfile:\s+(.*)/);
     const partial = fileValueMatch?.[1] ?? "";
 
     // Sanitize glob metacharacters in user input
@@ -370,30 +376,36 @@ class FilePathCompletionProvider implements vscode.CompletionItemProvider {
       ? `**/${sanitized}*`
       : "**/*.{prompt.md,md,yaml}";
     const files = await vscode.workspace.findFiles(
-      globPattern,
+      new vscode.RelativePattern(workspaceFolder, globPattern),
       "**/node_modules/**",
       50,
     );
 
+    // Find the end of the value (stop at comment or end of line)
+    const valueEndMatch = line.substring(position.character).match(/\s+#/);
+    const valueEnd = valueEndMatch
+      ? position.character + valueEndMatch.index!
+      : line.length;
+
     return files.map((fileUri) => {
-      const relativePath = path.relative(
-        workspaceFolder.uri.fsPath,
-        fileUri.fsPath,
-      );
+      const relativePath = path
+        .relative(workspaceFolder.uri.fsPath, fileUri.fsPath)
+        .split(path.sep)
+        .join("/");
       const item = new vscode.CompletionItem(
         relativePath,
         vscode.CompletionItemKind.File,
       );
       item.insertText = relativePath;
-      // Replace the entire value after "file: "
-      const valueStart = prefix.indexOf("file:") + "file:".length;
+      // Replace only the value portion (not trailing comments)
+      const valueStart = prefix.lastIndexOf("file:") + "file:".length;
       const whitespaceAfterColon =
         prefix.substring(valueStart).match(/^\s*/)?.[0] ?? " ";
       item.range = new vscode.Range(
         position.line,
         valueStart + whitespaceAfterColon.length,
         position.line,
-        line.length,
+        valueEnd,
       );
       return item;
     });

--- a/apps/vscode/src/lib/levenshtein.test.ts
+++ b/apps/vscode/src/lib/levenshtein.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { levenshtein, findClosestMatch } from "./levenshtein";
+
+describe("levenshtein", () => {
+  it("returns 0 for identical strings", () => {
+    expect(levenshtein("abc", "abc")).toBe(0);
+  });
+
+  it("returns the length of the other string when one is empty", () => {
+    expect(levenshtein("", "abc")).toBe(3);
+    expect(levenshtein("abc", "")).toBe(3);
+  });
+
+  it("returns 1 for a single substitution", () => {
+    expect(levenshtein("cat", "car")).toBe(1);
+  });
+
+  it("returns 1 for a single insertion", () => {
+    expect(levenshtein("cat", "cats")).toBe(1);
+  });
+
+  it("returns 1 for a single deletion", () => {
+    expect(levenshtein("cats", "cat")).toBe(1);
+  });
+
+  it("returns 0 for both empty strings", () => {
+    expect(levenshtein("", "")).toBe(0);
+  });
+
+  it("is symmetric", () => {
+    expect(levenshtein("kitten", "sitting")).toBe(
+      levenshtein("sitting", "kitten"),
+    );
+  });
+
+  it("handles multi-operation edits", () => {
+    expect(levenshtein("kitten", "sitting")).toBe(3);
+  });
+
+  it("handles a realistic file path typo", () => {
+    expect(
+      levenshtein(
+        "prompts/icebreaker.prompt.md",
+        "prompts/ice_breaker.prompt.md",
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("findClosestMatch", () => {
+  const candidates = [
+    "prompts/ice_breaker.prompt.md",
+    "prompts/consent.prompt.md",
+    "prompts/debrief.prompt.md",
+    "projects/config.yaml",
+  ];
+
+  it("finds the closest match within the distance threshold", () => {
+    const result = findClosestMatch("prompts/icebreaker.prompt.md", candidates);
+    expect(result).toBe("prompts/ice_breaker.prompt.md");
+  });
+
+  it("returns null when no match is within the threshold", () => {
+    const result = findClosestMatch("totally/different/path.md", candidates);
+    expect(result).toBeNull();
+  });
+
+  it("returns the closest when multiple are within threshold", () => {
+    const result = findClosestMatch("prompts/consnt.prompt.md", candidates);
+    expect(result).toBe("prompts/consent.prompt.md");
+  });
+
+  it("returns null for an empty candidates list", () => {
+    const result = findClosestMatch("anything", []);
+    expect(result).toBeNull();
+  });
+
+  it("returns exact match (distance 0)", () => {
+    const result = findClosestMatch("prompts/consent.prompt.md", candidates);
+    expect(result).toBe("prompts/consent.prompt.md");
+  });
+
+  it("rejects match at exactly the threshold (distance < maxDistance)", () => {
+    // "abcde" vs "fghij" has distance 5 — should be rejected with maxDistance=5
+    const result = findClosestMatch("abcde", ["fghij"], 5);
+    expect(result).toBeNull();
+  });
+
+  it("accepts match just under the threshold", () => {
+    // "abcd" vs "abce" has distance 1 — should be accepted with maxDistance=2
+    const result = findClosestMatch("abcd", ["abce"], 2);
+    expect(result).toBe("abce");
+  });
+});

--- a/apps/vscode/src/lib/levenshtein.ts
+++ b/apps/vscode/src/lib/levenshtein.ts
@@ -31,7 +31,7 @@ export function levenshtein(a: string, b: string): number {
 
 /**
  * Find the closest matching string from a list of candidates.
- * Returns null if no candidate is within the distance threshold.
+ * Returns null if no candidate has distance strictly less than maxDistance.
  */
 export function findClosestMatch(
   target: string,

--- a/apps/vscode/src/lib/levenshtein.ts
+++ b/apps/vscode/src/lib/levenshtein.ts
@@ -1,0 +1,53 @@
+const DEFAULT_MAX_DISTANCE = 5;
+
+/**
+ * Compute the Levenshtein edit distance between two strings.
+ */
+export function levenshtein(a: string, b: string): number {
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  // Use a single-row DP approach for O(min(m,n)) space
+  const shorter = a.length <= b.length ? a : b;
+  const longer = a.length <= b.length ? b : a;
+
+  let prev = Array.from({ length: shorter.length + 1 }, (_, i) => i);
+
+  for (let i = 1; i <= longer.length; i++) {
+    const curr = [i];
+    for (let j = 1; j <= shorter.length; j++) {
+      const cost = longer[i - 1] === shorter[j - 1] ? 0 : 1;
+      curr[j] = Math.min(
+        curr[j - 1] + 1, // insertion
+        prev[j] + 1, // deletion
+        prev[j - 1] + cost, // substitution
+      );
+    }
+    prev = curr;
+  }
+
+  return prev[shorter.length];
+}
+
+/**
+ * Find the closest matching string from a list of candidates.
+ * Returns null if no candidate is within the distance threshold.
+ */
+export function findClosestMatch(
+  target: string,
+  candidates: string[],
+  maxDistance: number = DEFAULT_MAX_DISTANCE,
+): string | null {
+  let bestMatch: string | null = null;
+  let bestDistance = maxDistance + 1;
+
+  for (const candidate of candidates) {
+    const distance = levenshtein(target, candidate);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestMatch = candidate;
+    }
+  }
+
+  return bestDistance < maxDistance ? bestMatch : null;
+}


### PR DESCRIPTION
## Summary
- **Quick-fix:** When a `file:` reference shows "File not found", suggests the closest matching workspace file (Levenshtein distance < 5) as a one-click fix
- **Autocomplete:** When typing after `file:`, suggests matching workspace files as completion items
- **Levenshtein utility:** Pure function with `findClosestMatch` helper, fully tested

### Security fixes from pre-commit review
- Cached file list with 5s TTL (avoids re-globbing on every cursor move)
- Glob metacharacter sanitization in autocomplete input
- File search scoped to relevant extensions (.prompt.md, .md, .yaml, etc.)

Refs #81

## Test plan
- [x] 16 new tests for levenshtein + findClosestMatch (edge cases: both empty, symmetry, multi-op, boundary threshold, exact match)
- [x] 120 total tests pass
- [x] Local security + spec reviews completed before commit
- [x] CI should pass (no VS Code API in test paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)