### PR TITLE
Add treatment preview webview panel

### DIFF
--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "license": "MIT",
   "type": "module",
+  "exports": {
+    "./preview": "./src/preview.ts"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build && cp dist/index.html dist/404.html",

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -40,8 +40,10 @@ export function Viewer({
   const [position, setPosition] = useState(0);
   const [store] = useState(() => new ViewerStateStore());
 
-  // Subscribe to store changes so the UI re-renders
-  useSyncExternalStore(
+  // Subscribe to store changes so the UI re-renders.
+  // The version is included in ctx memo deps below so that
+  // StagebookProvider gets a new context value on store changes.
+  const storeVersion = useSyncExternalStore(
     useCallback((cb: () => void) => store.onChange(cb), [store]),
     useCallback(() => store.getVersion(), [store]),
   );
@@ -76,8 +78,10 @@ export function Viewer({
         getAssetURL,
         renderers: createSkeletonRenderers(),
       }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       store,
+      storeVersion,
       position,
       stageIndex,
       treatment.playerCount,

--- a/apps/viewer/src/preview.ts
+++ b/apps/viewer/src/preview.ts
@@ -1,0 +1,26 @@
+// Preview infrastructure — reusable by any app that wants to preview
+// stagebook treatment content (VS Code extension, standalone viewer, etc.)
+
+// Lib utilities
+export { ViewerStateStore } from "./lib/store";
+export type { PositionKey, StoreEntry, StoreRecord } from "./lib/store";
+export { createViewerContext } from "./lib/context";
+export type { ViewerContextOptions } from "./lib/context";
+export { flattenSteps } from "./lib/steps";
+export type { ViewerStep, Phase } from "./lib/steps";
+export { extractStageReferences } from "./lib/references";
+export { extractTimeBreakpoints } from "./lib/timeBreakpoints";
+export { createUrlContentFns } from "./lib/contentFns";
+
+// React components
+export { Viewer } from "./components/Viewer";
+export type { ViewerProps } from "./components/Viewer";
+export { StageNav } from "./components/StageNav";
+export { StateInspector } from "./components/StateInspector";
+export { TimeScrubber } from "./components/TimeScrubber";
+export {
+  SkeletonPlaceholder,
+  createSkeletonRenderers,
+} from "./components/SkeletonPlaceholder";
+export { TreatmentPicker } from "./components/TreatmentPicker";
+export { FieldForm } from "./components/FieldForm";

--- a/apps/vscode/.vscodeignore
+++ b/apps/vscode/.vscodeignore
@@ -1,5 +1,6 @@
 **
 !dist/extension.js
+!dist/webview.js
 !package.json
 !language-configuration.json
 !syntaxes/**

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -98,8 +98,10 @@
     "build": "npm run build:extension && npm run build:webview",
     "build:extension": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
     "build:webview": "esbuild src/webview/index.tsx --bundle --outfile=dist/webview.js --format=iife --platform=browser --sourcemap --loader:.css=text --define:process.env.NODE_ENV='\"production\"'",
-    "build:watch": "npm run build -- --watch",
-    "vscode:prepublish": "npm run build",
+    "build:production": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify && esbuild src/webview/index.tsx --bundle --outfile=dist/webview.js --format=iife --platform=browser --minify --loader:.css=text --define:process.env.NODE_ENV='\"production\"'",
+    "build:watch:extension": "npm run build:extension -- --watch",
+    "build:watch:webview": "npm run build:webview -- --watch",
+    "vscode:prepublish": "npm run build:production",
     "package": "vsce package --no-dependencies",
     "lint": "echo 'no linter configured yet'",
     "test": "vitest run"

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -27,7 +27,7 @@
       },
       {
         "command": "stagebook.previewStage",
-        "title": "Stagebook: Preview Stage"
+        "title": "Stagebook: Preview Treatment"
       }
     ],
     "menus": {

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -24,12 +24,21 @@
       {
         "command": "stagebook.previewExpandedTemplates",
         "title": "Stagebook: Preview Expanded Templates"
+      },
+      {
+        "command": "stagebook.previewStage",
+        "title": "Stagebook: Preview Stage"
       }
     ],
     "menus": {
       "editor/context": [
         {
           "command": "stagebook.previewExpandedTemplates",
+          "when": "resourceLangId == treatmentsYaml",
+          "group": "navigation"
+        },
+        {
+          "command": "stagebook.previewStage",
           "when": "resourceLangId == treatmentsYaml",
           "group": "navigation"
         }
@@ -86,7 +95,9 @@
     }
   },
   "scripts": {
-    "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
+    "build": "npm run build:extension && npm run build:webview",
+    "build:extension": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
+    "build:webview": "esbuild src/webview/index.tsx --bundle --outfile=dist/webview.js --format=iife --platform=browser --sourcemap --loader:.css=text --define:process.env.NODE_ENV='\"production\"'",
     "build:watch": "npm run build -- --watch",
     "vscode:prepublish": "npm run build",
     "package": "vsce package --no-dependencies",
@@ -94,11 +105,16 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
     "stagebook": "*",
+    "stagebook-viewer": "*",
     "yaml": "^2.8.3",
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@types/node": "^22.0.0",
     "@types/vscode": "1.115.0",
     "@vscode/vsce": "^3.0.0",

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -470,8 +470,79 @@ function getWebviewContent(
   <style>
     :root {
       --viewer-sidebar-width: 280px;
+      --stagebook-primary: #3b82f6;
+      --stagebook-primary-hover: #2563eb;
+      --stagebook-text: #1f2937;
+      --stagebook-text-secondary: #374151;
+      --stagebook-text-muted: #6b7280;
+      --stagebook-text-faint: #9ca3af;
+      --stagebook-border: #d1d5db;
+      --stagebook-bg-muted: #f9fafb;
+      --stagebook-bg-track: #e5e7eb;
+      --stagebook-prompt-max-width: 36rem;
+      --stagebook-prompt-text-size: 1rem;
+      --stagebook-prompt-line-height: 1.5;
+      --stagebook-prompt-h1-size: 1.875rem;
+      --stagebook-prompt-h2-size: 1.5rem;
+      --stagebook-prompt-h3-size: 1.25rem;
+      --stagebook-prompt-h1-weight: 700;
+      --stagebook-prompt-h2-weight: 600;
+      --stagebook-prompt-h3-weight: 600;
+      --stagebook-link: #2563eb;
+      --stagebook-code-bg: rgba(0, 0, 0, 0.06);
+      --stagebook-code-font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      --stagebook-blockquote-border: #d1d5db;
+      --stagebook-blockquote-bg: #f9fafb;
     }
-    body { margin: 0; padding: 0; }
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: #ffffff;
+      color: var(--stagebook-text);
+      font-family: ui-sans-serif, system-ui, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+    /* Reset VS Code webview defaults */
+    code, pre {
+      font-family: var(--stagebook-code-font);
+      background-color: var(--stagebook-code-bg);
+      color: var(--stagebook-text);
+    }
+    pre {
+      padding: 0.75rem 1rem;
+      border-radius: 0.375rem;
+      overflow-x: auto;
+    }
+    code {
+      padding: 0.125rem 0.25rem;
+      border-radius: 0.25rem;
+      font-size: 0.875em;
+    }
+    /* Form resets */
+    input[type="checkbox"], input[type="radio"] {
+      appearance: none;
+      width: 1rem; height: 1rem;
+      border: 1px solid var(--stagebook-border);
+      border-radius: 0.125rem;
+      background-color: #fff;
+      vertical-align: middle;
+      cursor: pointer;
+    }
+    input[type="radio"] { border-radius: 9999px; }
+    input[type="checkbox"]:checked, input[type="radio"]:checked {
+      background-color: var(--stagebook-primary);
+      border-color: var(--stagebook-primary);
+      background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+      background-size: 100% 100%; background-position: center; background-repeat: no-repeat;
+    }
+    input[type="radio"]:checked {
+      background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e");
+    }
+    table { border-collapse: collapse; margin: 1rem 0; width: 100%; max-width: var(--stagebook-prompt-max-width); }
+    th, td { border: 1px solid var(--stagebook-border); padding: 0.5rem 0.75rem; text-align: left; font-size: 0.875rem; }
+    th { background-color: var(--stagebook-bg-muted); font-weight: 500; }
   </style>
 </head>
 <body>
@@ -641,7 +712,21 @@ export function activate(context: vscode.ExtensionContext): void {
 
         // Handle messages from the webview
         previewPanel.webview.onDidReceiveMessage(async (msg) => {
-          if (msg.type === "readFile" && workspaceFolder) {
+          if (msg.type === "ready") {
+            // Webview JS loaded — send treatment data now
+            const baseUri = workspaceFolder
+              ? previewPanel!.webview
+                  .asWebviewUri(workspaceFolder.uri)
+                  .toString()
+              : "";
+            previewPanel?.webview.postMessage({
+              type: "treatment",
+              treatmentFile,
+              introIndex: 0,
+              treatmentIndex: 0,
+              webviewBaseUri: baseUri,
+            });
+          } else if (msg.type === "readFile" && workspaceFolder) {
             try {
               const fileUri = vscode.Uri.joinPath(
                 workspaceFolder.uri,
@@ -668,18 +753,6 @@ export function activate(context: vscode.ExtensionContext): void {
         previewPanel.webview,
         context.extensionUri,
       );
-
-      const webviewBaseUri = workspaceFolder
-        ? previewPanel.webview.asWebviewUri(workspaceFolder.uri).toString()
-        : "";
-
-      previewPanel.webview.postMessage({
-        type: "treatment",
-        treatmentFile,
-        introIndex: 0,
-        treatmentIndex: 0,
-        webviewBaseUri,
-      });
     }),
   );
 

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -563,7 +563,12 @@ function getNonce(): string {
 }
 
 function parseTreatmentForPreview(source: string) {
-  const obj = parseYaml(source);
+  let obj: unknown;
+  try {
+    obj = parseYaml(source);
+  } catch {
+    return null;
+  }
   if (typeof obj !== "object" || obj === null) return null;
   const record = obj as Record<string, unknown>;
   const templates = (record.templates ?? []) as unknown[];
@@ -669,6 +674,9 @@ export function activate(context: vscode.ExtensionContext): void {
 
   // Register stage preview webview command
   let previewPanel: vscode.WebviewPanel | undefined;
+  // Mutable state updated on each command invocation — avoids stale closures
+  let currentTreatment: ReturnType<typeof parseTreatmentForPreview> = null;
+  let currentWorkspaceFolder: vscode.WorkspaceFolder | undefined;
 
   context.subscriptions.push(
     vscode.commands.registerCommand("stagebook.previewStage", () => {
@@ -679,17 +687,24 @@ export function activate(context: vscode.ExtensionContext): void {
       }
 
       const source = editor.document.getText();
-      const treatmentFile = parseTreatmentForPreview(source);
-      if (!treatmentFile) {
+      currentTreatment = parseTreatmentForPreview(source);
+      if (!currentTreatment) {
         vscode.window.showErrorMessage(
           "Could not parse treatment file for preview.",
         );
         return;
       }
 
-      const workspaceFolder =
+      currentWorkspaceFolder =
         vscode.workspace.getWorkspaceFolder(editor.document.uri) ??
         vscode.workspace.workspaceFolders?.[0];
+
+      if (!currentWorkspaceFolder) {
+        vscode.window.showErrorMessage(
+          "No workspace folder found. Open a folder first.",
+        );
+        return;
+      }
 
       if (previewPanel) {
         previewPanel.reveal(vscode.ViewColumn.Beside);
@@ -702,7 +717,7 @@ export function activate(context: vscode.ExtensionContext): void {
             enableScripts: true,
             localResourceRoots: [
               vscode.Uri.joinPath(context.extensionUri, "dist"),
-              ...(workspaceFolder ? [workspaceFolder.uri] : []),
+              ...(vscode.workspace.workspaceFolders?.map((f) => f.uri) ?? []),
             ],
           },
         );
@@ -712,25 +727,36 @@ export function activate(context: vscode.ExtensionContext): void {
 
         // Handle messages from the webview
         previewPanel.webview.onDidReceiveMessage(async (msg) => {
-          if (msg.type === "ready") {
-            // Webview JS loaded — send treatment data now
-            const baseUri = workspaceFolder
-              ? previewPanel!.webview
-                  .asWebviewUri(workspaceFolder.uri)
-                  .toString()
-              : "";
+          if (
+            msg.type === "ready" &&
+            currentTreatment &&
+            currentWorkspaceFolder
+          ) {
+            const baseUri = previewPanel!.webview
+              .asWebviewUri(currentWorkspaceFolder.uri)
+              .toString();
             previewPanel?.webview.postMessage({
               type: "treatment",
-              treatmentFile,
+              treatmentFile: currentTreatment,
               introIndex: 0,
               treatmentIndex: 0,
               webviewBaseUri: baseUri,
             });
-          } else if (msg.type === "readFile" && workspaceFolder) {
+          } else if (msg.type === "readFile" && currentWorkspaceFolder) {
+            // Guard against path traversal
+            const filePath = String(msg.path);
+            if (filePath.includes("..") || path.isAbsolute(filePath)) {
+              previewPanel?.webview.postMessage({
+                type: "fileContent",
+                requestId: msg.requestId,
+                error: `Invalid path: ${filePath}`,
+              });
+              return;
+            }
             try {
               const fileUri = vscode.Uri.joinPath(
-                workspaceFolder.uri,
-                msg.path,
+                currentWorkspaceFolder.uri,
+                filePath,
               );
               const content = await vscode.workspace.fs.readFile(fileUri);
               previewPanel?.webview.postMessage({
@@ -742,7 +768,7 @@ export function activate(context: vscode.ExtensionContext): void {
               previewPanel?.webview.postMessage({
                 type: "fileContent",
                 requestId: msg.requestId,
-                error: `Failed to read: ${msg.path}`,
+                error: `Failed to read: ${filePath}`,
               });
             }
           }

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -12,6 +12,8 @@ import {
 } from "./lib/semanticTokens";
 import { expandTreatmentSource } from "./lib/expandTreatment";
 import { findClosestMatch } from "./lib/levenshtein";
+import { fillTemplates, treatmentFileSchema } from "stagebook";
+import { parse as parseYaml } from "yaml";
 
 const diagnosticCollection =
   vscode.languages.createDiagnosticCollection("stagebook");
@@ -448,6 +450,72 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
   }
 }
 
+// --- Stage Preview Webview ---
+
+function getWebviewContent(
+  webview: vscode.Webview,
+  extensionUri: vscode.Uri,
+): string {
+  const scriptUri = webview.asWebviewUri(
+    vscode.Uri.joinPath(extensionUri, "dist", "webview.js"),
+  );
+  const nonce = getNonce();
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline'; img-src ${webview.cspSource} data:; font-src ${webview.cspSource};">
+  <style>
+    :root {
+      --viewer-sidebar-width: 280px;
+    }
+    body { margin: 0; padding: 0; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+}
+
+function getNonce(): string {
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let nonce = "";
+  for (let i = 0; i < 32; i++) {
+    nonce += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return nonce;
+}
+
+function parseTreatmentForPreview(source: string) {
+  const obj = parseYaml(source);
+  if (typeof obj !== "object" || obj === null) return null;
+  const record = obj as Record<string, unknown>;
+  const templates = (record.templates ?? []) as unknown[];
+
+  let expanded = record;
+  if (templates.length > 0) {
+    try {
+      const { result } = fillTemplates({
+        obj: record,
+        templates,
+        allowUnresolved: true,
+      });
+      expanded = result as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+
+  const parsed = treatmentFileSchema.safeParse(expanded);
+  if (!parsed.success) return null;
+  return parsed.data;
+}
+
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(diagnosticCollection);
 
@@ -525,6 +593,93 @@ export function activate(context: vscode.ExtensionContext): void {
       if (isTreatmentsYaml(e.document)) {
         expandedProvider.refreshForSource(e.document.uri);
       }
+    }),
+  );
+
+  // Register stage preview webview command
+  let previewPanel: vscode.WebviewPanel | undefined;
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("stagebook.previewStage", () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor || !isTreatmentsYaml(editor.document)) {
+        vscode.window.showWarningMessage("Open a .treatments.yaml file first.");
+        return;
+      }
+
+      const source = editor.document.getText();
+      const treatmentFile = parseTreatmentForPreview(source);
+      if (!treatmentFile) {
+        vscode.window.showErrorMessage(
+          "Could not parse treatment file for preview.",
+        );
+        return;
+      }
+
+      const workspaceFolder =
+        vscode.workspace.getWorkspaceFolder(editor.document.uri) ??
+        vscode.workspace.workspaceFolders?.[0];
+
+      if (previewPanel) {
+        previewPanel.reveal(vscode.ViewColumn.Beside);
+      } else {
+        previewPanel = vscode.window.createWebviewPanel(
+          "stagebook.stagePreview",
+          "Stage Preview",
+          vscode.ViewColumn.Beside,
+          {
+            enableScripts: true,
+            localResourceRoots: [
+              vscode.Uri.joinPath(context.extensionUri, "dist"),
+              ...(workspaceFolder ? [workspaceFolder.uri] : []),
+            ],
+          },
+        );
+        previewPanel.onDidDispose(() => {
+          previewPanel = undefined;
+        });
+
+        // Handle messages from the webview
+        previewPanel.webview.onDidReceiveMessage(async (msg) => {
+          if (msg.type === "readFile" && workspaceFolder) {
+            try {
+              const fileUri = vscode.Uri.joinPath(
+                workspaceFolder.uri,
+                msg.path,
+              );
+              const content = await vscode.workspace.fs.readFile(fileUri);
+              previewPanel?.webview.postMessage({
+                type: "fileContent",
+                requestId: msg.requestId,
+                content: new TextDecoder().decode(content),
+              });
+            } catch {
+              previewPanel?.webview.postMessage({
+                type: "fileContent",
+                requestId: msg.requestId,
+                error: `Failed to read: ${msg.path}`,
+              });
+            }
+          }
+        });
+      }
+
+      previewPanel.webview.html = getWebviewContent(
+        previewPanel.webview,
+        context.extensionUri,
+      );
+
+      const webviewBaseUri = workspaceFolder
+        ? previewPanel.webview.asWebviewUri(workspaceFolder.uri).toString()
+        : "";
+
+      previewPanel.webview.postMessage({
+        type: "treatment",
+        treatmentFile,
+        introIndex: 0,
+        treatmentIndex: 0,
+        webviewBaseUri,
+      });
     }),
   );
 

--- a/apps/vscode/src/webview/index.tsx
+++ b/apps/vscode/src/webview/index.tsx
@@ -1,0 +1,140 @@
+import React, { useState, useEffect, useMemo } from "react";
+import { createRoot } from "react-dom/client";
+import type { TreatmentFileType } from "stagebook";
+import { Viewer } from "stagebook-viewer/preview";
+
+// Declare the VS Code API injected by the webview
+declare function acquireVsCodeApi(): {
+  postMessage(message: unknown): void;
+  getState(): unknown;
+  setState(state: unknown): void;
+};
+
+const vscode = acquireVsCodeApi();
+
+// --- Content functions via postMessage bridge ---
+
+let requestId = 0;
+const pendingRequests = new Map<
+  number,
+  { resolve: (value: string) => void; reject: (err: Error) => void }
+>();
+
+// Listen for responses from the extension host
+window.addEventListener("message", (event) => {
+  const msg = event.data;
+  if (msg.type === "treatment") {
+    // Treatment data from extension host — handled by App state
+    return;
+  }
+  if (msg.type === "fileContent") {
+    const pending = pendingRequests.get(msg.requestId);
+    if (pending) {
+      pendingRequests.delete(msg.requestId);
+      if (msg.error) {
+        pending.reject(new Error(msg.error));
+      } else {
+        pending.resolve(msg.content);
+      }
+    }
+  }
+});
+
+function createWebviewContentFns(webviewBaseUri: string) {
+  const cache = new Map<string, Promise<string>>();
+
+  return {
+    getTextContent(path: string): Promise<string> {
+      const cached = cache.get(path);
+      if (cached) return cached;
+
+      const id = requestId++;
+      const promise = new Promise<string>((resolve, reject) => {
+        pendingRequests.set(id, { resolve, reject });
+        vscode.postMessage({ type: "readFile", requestId: id, path });
+      });
+
+      cache.set(path, promise);
+      return promise;
+    },
+
+    getAssetURL(path: string): string {
+      return webviewBaseUri + "/" + path;
+    },
+  };
+}
+
+// --- App ---
+
+function App() {
+  const [treatmentFile, setTreatmentFile] = useState<TreatmentFileType | null>(
+    null,
+  );
+  const [introIndex, setIntroIndex] = useState(0);
+  const [treatmentIndex, setTreatmentIndex] = useState(0);
+  const [webviewBaseUri, setWebviewBaseUri] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      const msg = event.data;
+      if (msg.type === "treatment") {
+        setTreatmentFile(msg.treatmentFile);
+        setIntroIndex(msg.introIndex ?? 0);
+        setTreatmentIndex(msg.treatmentIndex ?? 0);
+        setWebviewBaseUri(msg.webviewBaseUri ?? "");
+        setError(null);
+      } else if (msg.type === "error") {
+        setError(msg.message);
+        setTreatmentFile(null);
+      }
+    };
+    window.addEventListener("message", handler);
+
+    // Tell the extension host we're ready
+    vscode.postMessage({ type: "ready" });
+
+    return () => window.removeEventListener("message", handler);
+  }, []);
+
+  const contentFns = useMemo(
+    () => createWebviewContentFns(webviewBaseUri),
+    [webviewBaseUri],
+  );
+
+  if (error) {
+    return (
+      <div style={{ padding: "2rem", color: "#ef4444" }}>
+        <h2>Preview Error</h2>
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  if (!treatmentFile) {
+    return (
+      <div style={{ padding: "2rem", color: "#6b7280" }}>
+        <p>Loading treatment preview...</p>
+      </div>
+    );
+  }
+
+  return (
+    <Viewer
+      treatmentFile={treatmentFile}
+      getTextContent={contentFns.getTextContent}
+      getAssetURL={contentFns.getAssetURL}
+      selectedIntroIndex={introIndex}
+      selectedTreatmentIndex={treatmentIndex}
+      onBack={() => {
+        /* no-op in extension webview */
+      }}
+    />
+  );
+}
+
+// Mount
+const root = document.getElementById("root");
+if (root) {
+  createRoot(root).render(<App />);
+}

--- a/apps/vscode/src/webview/index.tsx
+++ b/apps/vscode/src/webview/index.tsx
@@ -52,14 +52,20 @@ function createWebviewContentFns(webviewBaseUri: string) {
       const promise = new Promise<string>((resolve, reject) => {
         pendingRequests.set(id, { resolve, reject });
         vscode.postMessage({ type: "readFile", requestId: id, path });
-      });
+      }).catch((err) => {
+        cache.delete(path);
+        throw err;
+      }) as Promise<string>;
 
       cache.set(path, promise);
       return promise;
     },
 
-    getAssetURL(path: string): string {
-      return webviewBaseUri + "/" + path;
+    getAssetURL(assetPath: string): string {
+      const base = webviewBaseUri.endsWith("/")
+        ? webviewBaseUri
+        : webviewBaseUri + "/";
+      return base + assetPath.replace(/^\/+/, "");
     },
   };
 }

--- a/apps/vscode/tsconfig.json
+++ b/apps/vscode/tsconfig.json
@@ -8,6 +8,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "jsx": "react-jsx",
     "outDir": "dist",
     "rootDir": "src",
     "sourceMap": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -300,12 +300,17 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
         "stagebook": "*",
+        "stagebook-viewer": "*",
         "yaml": "^2.8.3",
         "zod": "^3.23.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "@types/vscode": "1.115.0",
         "@vscode/vsce": "^3.0.0",
         "esbuild": "^0.25.0",


### PR DESCRIPTION
## Summary

Renders stagebook treatment stages in a VS Code webview panel, reusing the Viewer component from the standalone viewer app.

- **Command:** "Stagebook: Preview Treatment" (command palette + right-click context menu)
- **Rendering:** Full Viewer with stage navigation, time scrubber, state inspector, position switching
- **File loading:** postMessage bridge — webview requests file content, extension host reads from workspace
- **Styling:** Stagebook CSS variables, form resets, code/table styles injected into webview HTML

### Also in this PR
- Viewer package exports (`stagebook-viewer/preview`)
- Viewer refactored to accept pluggable `getTextContent`/`getAssetURL` (was hardcoded to `rawBaseUrl`)
- ViewingPhase wrapper with `useMemo` for stable content function refs
- Fix: `storeVersion` in ctx memo deps so state inspector changes propagate to Display elements
- Tailwind CSS removed from stagebook and viewer (inline styles + plain CSS)

Refs #79

## Test plan
- [x] Extension + webview both build
- [x] All 120 vscode tests pass
- [x] All 60 viewer tests pass
- [x] Manual testing: previewed treatment files with prompts, display elements, navigation

## Known limitations
- Webview bundle is 1.7MB unminified (can add `--minify` to esbuild)
- No live-update when source YAML changes (could add in follow-up)
- State inspector sets values for current position only (see #117)

🤖 Generated with [Claude Code](https://claude.com/claude-code)