### PR TITLE
Improve diagnostics for missing fields

### DIFF
--- a/apps/vscode/src/lib/validateTreatment.test.ts
+++ b/apps/vscode/src/lib/validateTreatment.test.ts
@@ -253,7 +253,7 @@ treatments:
       );
     });
 
-    it("includes the field path in missing-field messages", () => {
+    it("includes the formatted field path in missing-field messages", () => {
       // A survey element is missing its required surveyName field.
       const src = `introSequences:
   - name: intro1
@@ -270,14 +270,18 @@ treatments:
         elements:
           - type: survey`;
       const result = validateTreatmentSource(src);
-      // The path should be mentioned so the user knows which field is missing
+      // The diagnostic message should include the full formatted path
+      // (dotted segments + bracketed array indices) so the user can locate
+      // the missing field in the schema hierarchy.
       const pathedError = result.diagnostics.find((d) =>
-        d.message.includes("surveyName"),
+        d.message.includes(
+          "treatments[0].gameStages[0].elements[0].surveyName",
+        ),
       );
       expect(pathedError).toBeDefined();
     });
 
-    it("places missing-field errors on the nearest existing ancestor, not (0,0)", () => {
+    it("places missing-field errors on the missing-field's parent element, not (0,0)", () => {
       const src = `introSequences:
   - name: intro1
     introSteps:
@@ -292,14 +296,16 @@ treatments:
         duration: 300
         elements:
           - type: prompt`;
-      // The prompt element is missing required "file" field.
-      // The error should land on the element itself (line 13 area),
-      // not at position (0, 0).
+      // The prompt element is missing its required "file" field.
+      // The diagnostic for that specific missing field should be attached
+      // to the prompt element (the nearest existing ancestor), not (0,0).
       const result = validateTreatmentSource(src);
-      const errors = result.diagnostics.filter((d) => d.severity === "error");
-      expect(errors.length).toBeGreaterThan(0);
-      // At least one error should have a non-zero line
-      expect(errors.some((d) => d.range && d.range.startLine > 0)).toBe(true);
+      const fileError = result.diagnostics.find((d) =>
+        d.message.includes("treatments[0].gameStages[0].elements[0].file"),
+      );
+      expect(fileError).toBeDefined();
+      expect(fileError!.range).not.toBeNull();
+      expect(fileError!.range!.startLine).toBeGreaterThan(0);
     });
 
     it("classifies duplicate key diagnostics as warnings", () => {

--- a/apps/vscode/src/lib/validateTreatment.test.ts
+++ b/apps/vscode/src/lib/validateTreatment.test.ts
@@ -253,6 +253,55 @@ treatments:
       );
     });
 
+    it("includes the field path in missing-field messages", () => {
+      // A survey element is missing its required surveyName field.
+      const src = `introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: survey`;
+      const result = validateTreatmentSource(src);
+      // The path should be mentioned so the user knows which field is missing
+      const pathedError = result.diagnostics.find((d) =>
+        d.message.includes("surveyName"),
+      );
+      expect(pathedError).toBeDefined();
+    });
+
+    it("places missing-field errors on the nearest existing ancestor, not (0,0)", () => {
+      const src = `introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: prompt`;
+      // The prompt element is missing required "file" field.
+      // The error should land on the element itself (line 13 area),
+      // not at position (0, 0).
+      const result = validateTreatmentSource(src);
+      const errors = result.diagnostics.filter((d) => d.severity === "error");
+      expect(errors.length).toBeGreaterThan(0);
+      // At least one error should have a non-zero line
+      expect(errors.some((d) => d.range && d.range.startLine > 0)).toBe(true);
+    });
+
     it("classifies duplicate key diagnostics as warnings", () => {
       const src = `introSequences:
   - name: intro1

--- a/apps/vscode/src/lib/validateTreatment.ts
+++ b/apps/vscode/src/lib/validateTreatment.ts
@@ -59,8 +59,11 @@ export function validateTreatmentSource(source: string): ValidationResult {
         range = mapper.resolve(ancestorPath);
       }
 
-      // Augment terse Zod messages (like "Required") with the path so the
-      // user knows which field the error refers to.
+      // Append the field path to every diagnostic so the user always knows
+      // which field the error refers to. Zod messages often omit the field
+      // name (e.g., "Required", "Expected number, received string"), and
+      // even when they include it, the full path gives hierarchical context.
+      // Skipped only when the path is already present verbatim in the message.
       const pathStr = formatPath(issue.path);
       const message =
         pathStr && !issue.message.toLowerCase().includes(pathStr.toLowerCase())

--- a/apps/vscode/src/lib/validateTreatment.ts
+++ b/apps/vscode/src/lib/validateTreatment.ts
@@ -49,10 +49,26 @@ export function validateTreatmentSource(source: string): ValidationResult {
 
   if (!result.success) {
     for (const issue of result.error.issues) {
-      const range = mapper.resolve(issue.path);
+      // Try to resolve the exact path; if it doesn't exist in the source
+      // (e.g., "Required" errors on missing fields), walk up to the nearest
+      // ancestor that does exist so the squiggly lands somewhere meaningful.
+      let range = mapper.resolve(issue.path);
+      let ancestorPath = issue.path;
+      while (!range && ancestorPath.length > 0) {
+        ancestorPath = ancestorPath.slice(0, -1);
+        range = mapper.resolve(ancestorPath);
+      }
+
+      // Augment terse Zod messages (like "Required") with the path so the
+      // user knows which field the error refers to.
+      const pathStr = formatPath(issue.path);
+      const message =
+        pathStr && !issue.message.toLowerCase().includes(pathStr.toLowerCase())
+          ? `${issue.message} (${pathStr})`
+          : issue.message;
 
       diagnostics.push({
-        message: issue.message,
+        message,
         severity: "error",
         range,
       });
@@ -60,4 +76,21 @@ export function validateTreatmentSource(source: string): ValidationResult {
   }
 
   return { diagnostics, parsedObj };
+}
+
+/**
+ * Format a Zod issue path as a readable dotted string.
+ * Array indices are shown in brackets: ["treatments", 0, "gameStages", 1] → "treatments[0].gameStages[1]"
+ */
+function formatPath(path: (string | number)[]): string {
+  if (path.length === 0) return "";
+  let result = "";
+  for (const segment of path) {
+    if (typeof segment === "number") {
+      result += `[${segment}]`;
+    } else {
+      result += result ? `.${segment}` : segment;
+    }
+  }
+  return result;
 }


### PR DESCRIPTION
## Summary

Found during manual testing on a real treatment file: a survey element was missing its `surveyName` field, and the diagnostic showed up as a bare "Required" squiggly on `introSequences` at line 0 — unhelpful.

Two fixes:
1. **Path fallback**: when a Zod error path doesn't resolve in the YAML (because the field is missing), walk up to the nearest ancestor that does exist. Keeps the squiggly on something meaningful.
2. **Message augmentation**: append the field path to the diagnostic message. "Required" becomes "Required (treatments[0].exitSequence[0].elements[0].surveyName)".

## Test plan
- [x] 136 unit tests pass (2 new)
- [x] Manual: validated against a real treatment file with missing fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)