### PR TITLE
Allow field placeholders in mediaPlayer startAt/stopAt/stepDuration

### DIFF
--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -460,6 +460,29 @@ test("mediaPlayer: full config with all fields", () => {
   expect(result.success).toBe(true);
 });
 
+test("mediaPlayer: startAt/stopAt/stepDuration accept ${field} placeholders", () => {
+  const result = mediaPlayerSchema.safeParse({
+    type: "mediaPlayer",
+    url: "shared/interview.mp4",
+    startAt: "${clipStart}",
+    stopAt: "${clipEnd}",
+    stepDuration: "${stepSize}",
+  });
+  expect(result.success).toBe(true);
+});
+
+test("mediaPlayer: stopAt <= startAt check skipped when either is a placeholder", () => {
+  // With concrete numbers, stopAt <= startAt would fail. With a placeholder,
+  // the cross-field check should be skipped.
+  const result = mediaPlayerSchema.safeParse({
+    type: "mediaPlayer",
+    url: "shared/interview.mp4",
+    startAt: 100,
+    stopAt: "${clipEnd}",
+  });
+  expect(result.success).toBe(true);
+});
+
 test("mediaPlayer: missing url is invalid", () => {
   const result = mediaPlayerSchema.safeParse({
     type: "mediaPlayer",

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -474,13 +474,32 @@ test("mediaPlayer: startAt/stopAt/stepDuration accept ${field} placeholders", ()
 test("mediaPlayer: stopAt <= startAt check skipped when either is a placeholder", () => {
   // With concrete numbers, stopAt <= startAt would fail. With a placeholder,
   // the cross-field check should be skipped.
-  const result = mediaPlayerSchema.safeParse({
+  // This check lives in elementSchema.superRefine (not mediaPlayerSchema),
+  // so we must parse through elementSchema to exercise it.
+  const result = elementSchema.safeParse({
     type: "mediaPlayer",
     url: "shared/interview.mp4",
     startAt: 100,
     stopAt: "${clipEnd}",
   });
   expect(result.success).toBe(true);
+});
+
+test("mediaPlayer: stopAt <= startAt IS rejected when both are concrete numbers", () => {
+  // Sanity check: the cross-field check still fires when both values are numbers.
+  const result = elementSchema.safeParse({
+    type: "mediaPlayer",
+    url: "shared/interview.mp4",
+    startAt: 100,
+    stopAt: 50,
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find((i) =>
+      i.message.includes("stopAt must be greater than startAt"),
+    );
+    expect(issue).toBeDefined();
+  }
 });
 
 test("mediaPlayer: missing url is invalid", () => {

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -814,10 +814,10 @@ export const mediaPlayerSchema = elementBaseSchema
     playVideo: z.boolean().optional(),
     playAudio: z.boolean().optional(),
     captionsFile: z.string().optional(),
-    startAt: z.number().nonnegative().optional(),
-    stopAt: z.number().positive().optional(),
+    startAt: z.number().nonnegative().or(fieldPlaceholderSchema).optional(),
+    stopAt: z.number().positive().or(fieldPlaceholderSchema).optional(),
     allowScrubOutsideBounds: z.boolean().optional(),
-    stepDuration: z.number().positive().optional(),
+    stepDuration: z.number().positive().or(fieldPlaceholderSchema).optional(),
     syncToStageTime: z.boolean().optional(),
     submitOnComplete: z.boolean().optional(),
     playback: z.enum(["once", "manual"]).optional(),
@@ -978,10 +978,15 @@ export const elementSchema = altTemplateContext(
       (data as { type?: unknown }).type === "mediaPlayer" &&
       result.success
     ) {
-      const mp = data as { startAt?: number; stopAt?: number };
+      const mp = data as {
+        startAt?: number | string;
+        stopAt?: number | string;
+      };
+      // Only compare when both are concrete numbers — skip when either is
+      // an unresolved ${field} placeholder
       if (
-        mp.startAt !== undefined &&
-        mp.stopAt !== undefined &&
+        typeof mp.startAt === "number" &&
+        typeof mp.stopAt === "number" &&
         mp.stopAt <= mp.startAt
       ) {
         ctx.addIssue({


### PR DESCRIPTION
## Summary

The mediaPlayer schema required numeric values for `startAt`, `stopAt`, and `stepDuration`, which broke when researchers set these via template field placeholders like `\${clipStart}`. Other numeric fields in the schema (`duration`, `displayTime`) already allowed placeholders via `.or(fieldPlaceholderSchema)` — mediaPlayer's numeric fields were inconsistently strict.

Also updates the `stopAt > startAt` cross-field check to skip when either value is a placeholder string (can't compare string to number).

Found during VS Code extension manual testing on a real treatment file.

## Test plan
- [x] 2 new tests covering placeholder acceptance and skip behavior
- [x] All 471 stagebook tests pass
- [x] Verified the extension now validates treatment files with `startAt: \${...}` without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)