### PR TITLE
Return false for empty referenceValues in evaluateCondition

### DIFF
--- a/packages/stagebook/src/utils/evaluateConditions.test.ts
+++ b/packages/stagebook/src/utils/evaluateConditions.test.ts
@@ -32,13 +32,17 @@ describe("evaluateCondition", () => {
       ).toBe(true);
     });
 
-    test("empty values array satisfies (vacuous truth)", () => {
+    test("empty values array fails for value comparators", () => {
+      // Empty array means no data to compare against — the condition
+      // cannot be satisfied. (Previously returned true via vacuous truth
+      // of [].every(), which caused conditional submit buttons gated on
+      // "exists" to appear before any prompt was answered.)
       expect(
         evaluateCondition(
           { reference: "prompt.q1", comparator: "equals", value: "yes" },
           [],
         ),
-      ).toBe(true);
+      ).toBe(false);
     });
 
     test("exists comparator", () => {
@@ -55,6 +59,21 @@ describe("evaluateCondition", () => {
           undefined,
         ]),
       ).toBe(false);
+    });
+
+    test("exists fails for empty array (nothing exists)", () => {
+      expect(
+        evaluateCondition({ reference: "prompt.q1", comparator: "exists" }, []),
+      ).toBe(false);
+    });
+
+    test("doesNotExist passes for empty array", () => {
+      expect(
+        evaluateCondition(
+          { reference: "prompt.q1", comparator: "doesNotExist" },
+          [],
+        ),
+      ).toBe(true);
     });
   });
 
@@ -99,6 +118,20 @@ describe("evaluateCondition", () => {
           [10, 20, 75],
         ),
       ).toBe(true);
+    });
+
+    test("fails on empty array (no value to satisfy)", () => {
+      expect(
+        evaluateCondition(
+          {
+            reference: "prompt.q1",
+            position: "any",
+            comparator: "equals",
+            value: "yes",
+          },
+          [],
+        ),
+      ).toBe(false);
     });
   });
 
@@ -283,11 +316,32 @@ describe("evaluateConditions", () => {
     ).toBe(false);
   });
 
-  test("condition with missing reference resolves to empty array", () => {
-    // Empty array → every() returns true (vacuous truth)
+  test("condition with missing reference (empty array) fails", () => {
+    // Missing references resolve to [] — the condition cannot be satisfied
+    // without data. (Regression test: previously returned true via the
+    // vacuous truth of [].every(), which caused conditional submit buttons
+    // gated on "exists" to appear before any prompt was answered.)
     expect(
       evaluateConditions(
         [{ reference: "prompt.missing", comparator: "equals", value: "yes" }],
+        mockResolve({}),
+      ),
+    ).toBe(false);
+  });
+
+  test("exists on missing reference fails", () => {
+    expect(
+      evaluateConditions(
+        [{ reference: "prompt.missing", comparator: "exists" }],
+        mockResolve({}),
+      ),
+    ).toBe(false);
+  });
+
+  test("doesNotExist on missing reference passes", () => {
+    expect(
+      evaluateConditions(
+        [{ reference: "prompt.missing", comparator: "doesNotExist" }],
         mockResolve({}),
       ),
     ).toBe(true);

--- a/packages/stagebook/src/utils/evaluateConditions.ts
+++ b/packages/stagebook/src/utils/evaluateConditions.ts
@@ -17,6 +17,15 @@ export function evaluateCondition(
 ): boolean {
   const { position, comparator, value } = condition;
 
+  // No data to compare against — the condition cannot be satisfied
+  // except for doesNotExist, which explicitly asserts absence.
+  // Without this guard, [].every() returns true vacuously and conditional
+  // gates (e.g. submit buttons with `comparator: exists`) appear before
+  // any data has been saved.
+  if (referenceValues.length === 0) {
+    return comparator === "doesNotExist";
+  }
+
   if (position === "percentAgreement") {
     const counts: Record<string, number> = {};
     const definedValues = referenceValues.filter((val) => val !== undefined);


### PR DESCRIPTION
## Summary
- Conditional gates (e.g. submit buttons with `comparator: exists`) were evaluating to true before any data had been saved, because `[].every()` returns true vacuously.
- Fix: short-circuit the empty-array case at the top of `evaluateCondition` — no data means the condition cannot be satisfied, except for `doesNotExist` which explicitly asserts absence.
- Updates two existing tests that codified the bug as "vacuous truth" and adds five new tests covering `exists` / `doesNotExist` / `equals` on empty arrays across the default (`all`) and `any` position modes.

Fixes #126

## Test plan
- [x] `npm test` passes (485 stagebook + 59 viewer + 136 vscode = 680 tests)
- [x] `npm run lint` clean
- [ ] Manual verification via vscode-extension branch (merge main in, package VSIX, open a treatment with a conditional submit button gated on `exists` — button should stay hidden until the referenced prompts are answered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)