### PR TITLE
Add PreviewHost with field resolution and refresh affordance

### DIFF
--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -2,15 +2,13 @@ import { useState, useMemo, useCallback, useEffect } from "react";
 import type { TreatmentFileType } from "stagebook";
 import { loadTreatmentFromUrl } from "./lib/loader";
 import {
-  expandTreatmentFile,
   TreatmentValidationError,
   type ValidationIssue,
 } from "./lib/treatment";
 import { createUrlContentFns } from "./lib/contentFns";
 import { LandingPage } from "./components/LandingPage";
 import { TreatmentPicker } from "./components/TreatmentPicker";
-import { FieldForm } from "./components/FieldForm";
-import { Viewer } from "./components/Viewer";
+import { PreviewHost } from "./components/PreviewHost";
 
 type AppState =
   | { phase: "landing" }
@@ -19,15 +17,6 @@ type AppState =
       phase: "selecting";
       treatmentFile: TreatmentFileType;
       rawBaseUrl: string;
-      unresolvedFields: string[];
-    }
-  | {
-      phase: "fields";
-      treatmentFile: TreatmentFileType;
-      rawBaseUrl: string;
-      unresolvedFields: string[];
-      selectedIntroIndex: number;
-      selectedTreatmentIndex: number;
     }
   | {
       phase: "viewing";
@@ -49,29 +38,14 @@ export function App() {
   const handleLoad = useCallback(async (url: string) => {
     setState({ phase: "loading", url });
     try {
-      const { treatmentFile, unresolvedFields, rawBaseUrl } =
-        await loadTreatmentFromUrl(url);
+      const { treatmentFile, rawBaseUrl } = await loadTreatmentFromUrl(url);
 
       const needsPicker =
         treatmentFile.introSequences.length > 1 ||
         treatmentFile.treatments.length > 1;
 
       if (needsPicker) {
-        setState({
-          phase: "selecting",
-          treatmentFile,
-          rawBaseUrl,
-          unresolvedFields,
-        });
-      } else if (unresolvedFields.length > 0) {
-        setState({
-          phase: "fields",
-          treatmentFile,
-          rawBaseUrl,
-          unresolvedFields,
-          selectedIntroIndex: 0,
-          selectedTreatmentIndex: 0,
-        });
+        setState({ phase: "selecting", treatmentFile, rawBaseUrl });
       } else {
         setState({
           phase: "viewing",
@@ -120,53 +94,17 @@ export function App() {
       );
 
     case "selecting": {
-      const { treatmentFile, rawBaseUrl, unresolvedFields } = state;
+      const { treatmentFile, rawBaseUrl } = state;
       return (
         <TreatmentPicker
           treatmentFile={treatmentFile}
           onSelect={(introIndex, treatmentIndex) => {
-            if (unresolvedFields.length > 0) {
-              setState({
-                phase: "fields",
-                treatmentFile,
-                rawBaseUrl,
-                unresolvedFields,
-                selectedIntroIndex: introIndex,
-                selectedTreatmentIndex: treatmentIndex,
-              });
-            } else {
-              setState({
-                phase: "viewing",
-                treatmentFile,
-                rawBaseUrl,
-                selectedIntroIndex: introIndex,
-                selectedTreatmentIndex: treatmentIndex,
-              });
-            }
-          }}
-        />
-      );
-    }
-
-    case "fields": {
-      const {
-        treatmentFile,
-        rawBaseUrl,
-        unresolvedFields,
-        selectedIntroIndex,
-        selectedTreatmentIndex,
-      } = state;
-      return (
-        <FieldForm
-          unresolvedFields={unresolvedFields}
-          onSubmit={(values) => {
-            const { result } = expandTreatmentFile(treatmentFile, values);
             setState({
               phase: "viewing",
-              treatmentFile: result,
+              treatmentFile,
               rawBaseUrl,
-              selectedIntroIndex,
-              selectedTreatmentIndex,
+              selectedIntroIndex: introIndex,
+              selectedTreatmentIndex: treatmentIndex,
             });
           }}
         />
@@ -209,7 +147,7 @@ function ViewingPhase({
   );
 
   return (
-    <Viewer
+    <PreviewHost
       treatmentFile={treatmentFile}
       getTextContent={contentFns.getTextContent}
       getAssetURL={contentFns.getAssetURL}

--- a/apps/viewer/src/components/PreviewHost.tsx
+++ b/apps/viewer/src/components/PreviewHost.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
-import { fillTemplates, type TreatmentFileType } from "stagebook";
+import type { TreatmentFileType } from "stagebook";
+import { expandTreatmentFile } from "../lib/expandTreatmentFile";
 import { FieldForm } from "./FieldForm";
 import { Viewer } from "./Viewer";
 
@@ -57,19 +58,11 @@ export function PreviewHost({
       ...(additionalFields ?? {}),
       ...(userValues ?? {}),
     };
-    // Strip template definitions before expansion — their bodies contain
-    // placeholder syntax that would otherwise be flagged as unresolved.
-    const { templates, ...withoutTemplates } = treatmentFile;
-    const { result, unresolvedFields } = fillTemplates({
-      obj: withoutTemplates,
-      templates: templates ?? [],
-      additionalFields: Object.keys(merged).length > 0 ? merged : undefined,
-      allowUnresolved: true,
-    });
-    return {
-      resolved: result as TreatmentFileType,
-      unresolvedFields,
-    };
+    const { result, unresolvedFields } = expandTreatmentFile(
+      treatmentFile,
+      Object.keys(merged).length > 0 ? merged : undefined,
+    );
+    return { resolved: result, unresolvedFields };
   }, [treatmentFile, additionalFields, userValues]);
 
   if (unresolvedFields.length > 0) {

--- a/apps/viewer/src/components/PreviewHost.tsx
+++ b/apps/viewer/src/components/PreviewHost.tsx
@@ -1,0 +1,98 @@
+import { useMemo, useState } from "react";
+import { fillTemplates, type TreatmentFileType } from "stagebook";
+import { FieldForm } from "./FieldForm";
+import { Viewer } from "./Viewer";
+
+export interface PreviewHostProps {
+  treatmentFile: TreatmentFileType;
+  /**
+   * Pre-supplied values for `${field}` placeholders (e.g. from a sidecar
+   * file). Any placeholders not covered here will surface as a FieldForm.
+   */
+  additionalFields?: Record<string, unknown>;
+  selectedIntroIndex: number;
+  selectedTreatmentIndex: number;
+  /** Must be referentially stable (memoized) to avoid re-fetch loops. */
+  getTextContent: (path: string) => Promise<string>;
+  /** Must be referentially stable (memoized) to avoid re-fetch loops. */
+  getAssetURL: (path: string) => string;
+  /** Optional — hidden in the header when omitted. */
+  onBack?: () => void;
+  /**
+   * Called with the values the user entered into FieldForm, letting a host
+   * persist them (e.g. write to a sidecar file). Not called when placeholders
+   * are resolved purely from `additionalFields`.
+   */
+  onFieldsResolved?: (values: Record<string, string>) => void;
+  /** Optional refresh affordance passed through to the Viewer header. */
+  onRefresh?: () => void;
+}
+
+/**
+ * Resolves `${field}` placeholders before rendering the Viewer.
+ *
+ * Stagebook components expect concrete values, but treatment files may
+ * reference study/player-context variables that aren't available in a
+ * preview environment. This host bridges the gap: it runs fillTemplates,
+ * prompts the user for any remaining unresolved fields via FieldForm, and
+ * only hands a fully-resolved treatment to the Viewer.
+ */
+export function PreviewHost({
+  treatmentFile,
+  additionalFields,
+  selectedIntroIndex,
+  selectedTreatmentIndex,
+  getTextContent,
+  getAssetURL,
+  onBack,
+  onFieldsResolved,
+  onRefresh,
+}: PreviewHostProps) {
+  const [userValues, setUserValues] = useState<Record<string, string> | null>(
+    null,
+  );
+
+  const { resolved, unresolvedFields } = useMemo(() => {
+    const merged = {
+      ...(additionalFields ?? {}),
+      ...(userValues ?? {}),
+    };
+    // Strip template definitions before expansion — their bodies contain
+    // placeholder syntax that would otherwise be flagged as unresolved.
+    const { templates, ...withoutTemplates } = treatmentFile;
+    const { result, unresolvedFields } = fillTemplates({
+      obj: withoutTemplates,
+      templates: templates ?? [],
+      additionalFields: Object.keys(merged).length > 0 ? merged : undefined,
+      allowUnresolved: true,
+    });
+    return {
+      resolved: result as TreatmentFileType,
+      unresolvedFields,
+    };
+  }, [treatmentFile, additionalFields, userValues]);
+
+  if (unresolvedFields.length > 0) {
+    return (
+      <FieldForm
+        unresolvedFields={unresolvedFields}
+        onSubmit={(values) => {
+          setUserValues(values);
+          onFieldsResolved?.(values);
+        }}
+      />
+    );
+  }
+
+  return (
+    <Viewer
+      treatmentFile={resolved}
+      getTextContent={getTextContent}
+      getAssetURL={getAssetURL}
+      selectedIntroIndex={selectedIntroIndex}
+      selectedTreatmentIndex={selectedTreatmentIndex}
+      onBack={onBack}
+      onRefresh={onRefresh}
+    />
+  );
+}

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -1,4 +1,10 @@
-import { useState, useMemo, useCallback, useSyncExternalStore } from "react";
+import {
+  useEffect,
+  useState,
+  useMemo,
+  useCallback,
+  useSyncExternalStore,
+} from "react";
 import type { TreatmentFileType } from "stagebook";
 import { StagebookProvider, Stage } from "stagebook/components";
 import { flattenSteps } from "../lib/steps";
@@ -17,7 +23,20 @@ export interface ViewerProps {
   getAssetURL: (path: string) => string;
   selectedIntroIndex: number;
   selectedTreatmentIndex: number;
-  onBack: () => void;
+  /**
+   * Optional back affordance. When provided, the header shows a back arrow
+   * that invokes this callback. Omit to hide the arrow (e.g. in an embedded
+   * preview where there is no prior screen to return to).
+   */
+  onBack?: () => void;
+  /**
+   * Optional refresh affordance. When provided, the header shows a reload
+   * icon that invokes this callback. The Viewer itself doesn't re-fetch —
+   * hosts are expected to supply an updated `treatmentFile` prop in response.
+   * Viewer state (stageIndex, position, saved responses) persists across the
+   * prop update since React doesn't unmount the component.
+   */
+  onRefresh?: () => void;
 }
 
 export function Viewer({
@@ -27,6 +46,7 @@ export function Viewer({
   selectedIntroIndex,
   selectedTreatmentIndex,
   onBack,
+  onRefresh,
 }: ViewerProps) {
   const treatment = treatmentFile.treatments[selectedTreatmentIndex];
   const introSequence = treatmentFile.introSequences[selectedIntroIndex];
@@ -39,6 +59,15 @@ export function Viewer({
   const [stageIndex, setStageIndex] = useState(0);
   const [position, setPosition] = useState(0);
   const [store] = useState(() => new ViewerStateStore());
+
+  // Clamp stageIndex if the treatment was edited to have fewer stages
+  // (e.g. researcher deleted a stage while the preview was open). Without
+  // this, steps[stageIndex] returns undefined and the viewer blanks.
+  useEffect(() => {
+    if (steps.length > 0 && stageIndex >= steps.length) {
+      setStageIndex(steps.length - 1);
+    }
+  }, [steps.length, stageIndex]);
 
   // Subscribe to store changes so the UI re-renders.
   // The version is included in ctx memo deps below so that
@@ -104,9 +133,21 @@ export function Viewer({
       {/* Header */}
       <header style={headerStyle}>
         <div style={headerLeftStyle}>
-          <button aria-label="Back" onClick={onBack} style={backButtonStyle}>
-            &larr;
-          </button>
+          {onBack && (
+            <button aria-label="Back" onClick={onBack} style={backButtonStyle}>
+              &larr;
+            </button>
+          )}
+          {onRefresh && (
+            <button
+              aria-label="Refresh preview"
+              title="Refresh preview"
+              onClick={onRefresh}
+              style={refreshButtonStyle}
+            >
+              &#x21bb;
+            </button>
+          )}
           <span style={treatmentNameStyle}>{treatment.name}</span>
         </div>
         <StageNav
@@ -209,6 +250,16 @@ const backButtonStyle: React.CSSProperties = {
   fontSize: "1.25rem",
   color: "#6b7280",
   padding: "0.25rem",
+};
+
+const refreshButtonStyle: React.CSSProperties = {
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  fontSize: "1.1rem",
+  color: "#6b7280",
+  padding: "0.25rem",
+  lineHeight: 1,
 };
 
 const treatmentNameStyle: React.CSSProperties = {

--- a/apps/viewer/src/lib/expandTreatmentFile.ts
+++ b/apps/viewer/src/lib/expandTreatmentFile.ts
@@ -1,0 +1,24 @@
+import { fillTemplates, type TreatmentFileType } from "stagebook";
+
+/**
+ * Expand templates in a parsed treatment file and detect unresolved fields.
+ * Optionally provide additionalFields to resolve remaining placeholders.
+ *
+ * Lives in its own module (not `treatment.ts`) so it can be imported by
+ * the webview entry point without pulling in js-yaml transitively.
+ */
+export function expandTreatmentFile(
+  treatmentFile: TreatmentFileType,
+  additionalFields?: Record<string, unknown>,
+): { result: TreatmentFileType; unresolvedFields: string[] } {
+  // Strip template definitions before expansion — they contain
+  // placeholder syntax that would be falsely flagged as unresolved.
+  const { templates, ...withoutTemplates } = treatmentFile;
+  const { result, unresolvedFields } = fillTemplates({
+    obj: withoutTemplates,
+    templates: templates ?? [],
+    additionalFields,
+    allowUnresolved: true,
+  });
+  return { result: result as TreatmentFileType, unresolvedFields };
+}

--- a/apps/viewer/src/lib/treatment.ts
+++ b/apps/viewer/src/lib/treatment.ts
@@ -1,9 +1,7 @@
 import { load as loadYaml } from "js-yaml";
-import {
-  fillTemplates,
-  treatmentFileSchema,
-  type TreatmentFileType,
-} from "stagebook";
+import { treatmentFileSchema, type TreatmentFileType } from "stagebook";
+
+export { expandTreatmentFile } from "./expandTreatmentFile";
 
 export interface ValidationIssue {
   path: string;
@@ -36,24 +34,4 @@ export function parseTreatmentYaml(yaml: string): TreatmentFileType {
     throw new TreatmentValidationError(issues);
   }
   return result.data;
-}
-
-/**
- * Expand templates in a parsed treatment file and detect unresolved fields.
- * Optionally provide additionalFields to resolve remaining placeholders.
- */
-export function expandTreatmentFile(
-  treatmentFile: TreatmentFileType,
-  additionalFields?: Record<string, unknown>,
-): { result: TreatmentFileType; unresolvedFields: string[] } {
-  // Strip template definitions before expansion — they contain
-  // placeholder syntax that would be falsely flagged as unresolved.
-  const { templates, ...withoutTemplates } = treatmentFile;
-  const { result, unresolvedFields } = fillTemplates({
-    obj: withoutTemplates,
-    templates: templates ?? [],
-    additionalFields,
-    allowUnresolved: true,
-  });
-  return { result: result as TreatmentFileType, unresolvedFields };
 }

--- a/apps/viewer/src/preview.ts
+++ b/apps/viewer/src/preview.ts
@@ -15,6 +15,8 @@ export { createUrlContentFns } from "./lib/contentFns";
 // React components
 export { Viewer } from "./components/Viewer";
 export type { ViewerProps } from "./components/Viewer";
+export { PreviewHost } from "./components/PreviewHost";
+export type { PreviewHostProps } from "./components/PreviewHost";
 export { StageNav } from "./components/StageNav";
 export { StateInspector } from "./components/StateInspector";
 export { TimeScrubber } from "./components/TimeScrubber";

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -678,6 +678,7 @@ export function activate(context: vscode.ExtensionContext): void {
   let previewPanel: vscode.WebviewPanel | undefined;
   // Mutable state updated on each command invocation — avoids stale closures
   let currentTreatment: ReturnType<typeof parseTreatmentForPreview> = null;
+  let currentTreatmentUri: vscode.Uri | undefined;
   let currentTreatmentDir: vscode.Uri | undefined;
   let currentWorkspaceRootFsPath: string | undefined;
 
@@ -709,6 +710,7 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
       }
 
+      currentTreatmentUri = editor.document.uri;
       currentTreatmentDir = vscode.Uri.joinPath(editor.document.uri, "..");
       currentWorkspaceRootFsPath = workspaceFolder.uri.fsPath;
 
@@ -744,6 +746,38 @@ export function activate(context: vscode.ExtensionContext): void {
               treatmentIndex: 0,
               webviewBaseUri: baseUri,
             });
+          } else if (msg.type === "refresh") {
+            // Re-read the source file, re-parse, and push the updated
+            // treatment. Viewer state (stageIndex, position, saved responses,
+            // filled-in fields) persists across this prop update because the
+            // webview's React tree doesn't unmount.
+            if (!currentTreatmentUri || !currentTreatmentDir) return;
+            try {
+              const doc =
+                await vscode.workspace.openTextDocument(currentTreatmentUri);
+              const parsed = parseTreatmentForPreview(doc.getText());
+              if (!parsed) {
+                vscode.window.showErrorMessage(
+                  "Refresh failed: could not parse treatment file.",
+                );
+                return;
+              }
+              currentTreatment = parsed;
+              const baseUri = previewPanel!.webview
+                .asWebviewUri(currentTreatmentDir)
+                .toString();
+              previewPanel?.webview.postMessage({
+                type: "treatment",
+                treatmentFile: parsed,
+                introIndex: 0,
+                treatmentIndex: 0,
+                webviewBaseUri: baseUri,
+              });
+            } catch (err) {
+              vscode.window.showErrorMessage(
+                `Refresh failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
           } else if (msg.type === "readFile" && currentTreatmentDir) {
             // Guard against path traversal
             const filePath = String(msg.path);

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -752,6 +752,12 @@ export function activate(context: vscode.ExtensionContext): void {
             // filled-in fields) persists across this prop update because the
             // webview's React tree doesn't unmount.
             if (!currentTreatmentUri || !currentTreatmentDir) return;
+            // Capture the panel before any awaits. If the user closes the
+            // preview mid-refresh, onDidDispose clears `previewPanel` and
+            // a non-null assertion on the outer ref would throw.
+            const panel = previewPanel;
+            const treatmentDir = currentTreatmentDir;
+            if (!panel) return;
             try {
               const doc =
                 await vscode.workspace.openTextDocument(currentTreatmentUri);
@@ -763,10 +769,12 @@ export function activate(context: vscode.ExtensionContext): void {
                 return;
               }
               currentTreatment = parsed;
-              const baseUri = previewPanel!.webview
-                .asWebviewUri(currentTreatmentDir)
+              // Panel may have been disposed while we were awaiting above.
+              if (!previewPanel) return;
+              const baseUri = panel.webview
+                .asWebviewUri(treatmentDir)
                 .toString();
-              previewPanel?.webview.postMessage({
+              panel.webview.postMessage({
                 type: "treatment",
                 treatmentFile: parsed,
                 introIndex: 0,

--- a/apps/vscode/src/webview/index.tsx
+++ b/apps/vscode/src/webview/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { createRoot } from "react-dom/client";
 import type { TreatmentFileType } from "stagebook";
-import { Viewer } from "stagebook-viewer/preview";
+import { PreviewHost } from "stagebook-viewer/preview";
 
 // Declare the VS Code API injected by the webview
 declare function acquireVsCodeApi(): {
@@ -80,6 +80,9 @@ function App() {
   const [treatmentIndex, setTreatmentIndex] = useState(0);
   const [webviewBaseUri, setWebviewBaseUri] = useState("");
   const [error, setError] = useState<string | null>(null);
+  // Bumped on each treatment message so that `contentFns` is recreated
+  // with a fresh cache, forcing prompt files to re-fetch from disk.
+  const [contentVersion, setContentVersion] = useState(0);
 
   useEffect(() => {
     const handler = (event: MessageEvent) => {
@@ -89,6 +92,7 @@ function App() {
         setIntroIndex(msg.introIndex ?? 0);
         setTreatmentIndex(msg.treatmentIndex ?? 0);
         setWebviewBaseUri(msg.webviewBaseUri ?? "");
+        setContentVersion((v) => v + 1);
         setError(null);
       } else if (msg.type === "error") {
         setError(msg.message);
@@ -105,7 +109,9 @@ function App() {
 
   const contentFns = useMemo(
     () => createWebviewContentFns(webviewBaseUri),
-    [webviewBaseUri],
+    // contentVersion is part of the deps so a refresh creates a fresh cache
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [webviewBaseUri, contentVersion],
   );
 
   if (error) {
@@ -126,15 +132,13 @@ function App() {
   }
 
   return (
-    <Viewer
+    <PreviewHost
       treatmentFile={treatmentFile}
       getTextContent={contentFns.getTextContent}
       getAssetURL={contentFns.getAssetURL}
       selectedIntroIndex={introIndex}
       selectedTreatmentIndex={treatmentIndex}
-      onBack={() => {
-        /* no-op in extension webview */
-      }}
+      onRefresh={() => vscode.postMessage({ type: "refresh" })}
     />
   );
 }

--- a/apps/vscode/src/webview/index.tsx
+++ b/apps/vscode/src/webview/index.tsx
@@ -107,10 +107,10 @@ function App() {
     return () => window.removeEventListener("message", handler);
   }, []);
 
+  // `contentVersion` is deliberately part of the deps so a refresh creates
+  // a fresh cache — forcing prompt files to re-fetch from disk.
   const contentFns = useMemo(
     () => createWebviewContentFns(webviewBaseUri),
-    // contentVersion is part of the deps so a refresh creates a fresh cache
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [webviewBaseUri, contentVersion],
   );
 


### PR DESCRIPTION
## Summary
- Introduces `PreviewHost`, a field-resolving wrapper around `Viewer`. When a treatment file contains unresolved `\${field}` placeholders after template expansion, it renders `FieldForm` so the user supplies values, then re-expands and hands a fully-resolved tree to `Viewer`. Stagebook components keep their strict contract — no placeholder handling leaks into them.
- Refresh affordance in the preview header (reload icon) that lets the researcher re-read the treatment without resetting Viewer state. Stage-index clamp on stage deletion. Prompt-file cache busting on refresh.

## Details

Architecture:
- **Boundary:** stagebook components expect resolved values (unchanged contract). Schema accepts `\${...}` for authoring-time validation (from #124). Preview layer owns resolution.
- **Viewer SPA** collapses its `phase: "fields"` state machine entry — `PreviewHost` now owns that flow, so `App.tsx` just picks treatment/intro indices and hands off.
- **Extension webview** mounts `PreviewHost` instead of `Viewer`. Closes the crash where unresolved placeholders flowed through as strings (e.g. `MediaPlayer.currentTime = "\${story1StartAt}"` → non-finite `TypeError`).

Refresh flow:
- New `onRefresh?: () => void` prop on `Viewer` + `PreviewHost`. When provided, the header renders a reload icon.
- Extension webview sends `{ type: "refresh" }` → extension re-reads the source document, re-parses, posts the updated treatment.
- Viewer state (stageIndex, position, store, userValues) persists across the prop update because React doesn't unmount.
- `stageIndex` is clamped when the stage count shrinks (prevents blanking when a stage is deleted).
- `onBack` made optional — hidden in the extension webview where there's no prior screen.
- Webview bumps a `contentVersion` on each treatment message, recreating the prompt-file cache so `.prompt.md` edits are picked up on refresh.

Fixes #125
Closes #120 (file path resolution already fixed via #121)

## Test plan
- [x] `npm test` passes (485 stagebook + 59 viewer + 136 vscode = 680 tests)
- [x] `npm run lint` clean
- [x] Rebuild + install VSIX; manually verified:
  - Treatment with `\${story1Url}`/`\${story1StartAt}` etc. surfaces FieldForm instead of crashing MediaPlayer
  - Refresh button re-reads treatment file; Viewer state preserved
  - `.prompt.md` edits appear after clicking refresh (once the file is saved)
  - Deleting a stage in the treatment and refreshing no longer blanks the preview
- [ ] Component tests for `PreviewHost` (deferred — viewer workspace has no DOM test infrastructure; logic is covered by `expandTreatmentFile` unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)