### PR TITLE
Release v0.4.0: VS Code extension + viewer refactor + schema/condition fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, vscode-extension]
   push:
-    branches: [main]
+    branches: [main, vscode-extension]
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This repository provides supporting infrastructure for translating stagebook man
 
 Stagebook is platform-agnostic. Define your study protocol once, then run it on any compatible platform.
 
+**[Try the Viewer](https://deliberation-lab.github.io/stagebook/viewer/)** — walk through any study from the participant's perspective. Paste a GitHub URL to a treatment file, or explore the built-in examples.
+
 ## Installation
 
 From GitHub (builds automatically on install):

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -18,12 +18,10 @@
     "stagebook": "*"
   },
   "devDependencies": {
-    "@tailwindcss/vite": "^4.2.2",
     "@types/js-yaml": "^4.0.9",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.5.2",
-    "tailwindcss": "^4.2.2",
     "typescript": "^5.5.0",
     "vite": "^6.3.3",
     "vitest": "^4.1.4"

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "license": "MIT",
   "type": "module",
+  "exports": {
+    "./preview": "./src/preview.ts"
+  },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build && cp dist/index.html dist/404.html",

--- a/apps/viewer/package.json
+++ b/apps/viewer/package.json
@@ -12,18 +12,18 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@tailwindcss/vite": "^4.2.2",
     "js-yaml": "^4.1.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "stagebook": "*",
-    "tailwindcss": "^4.2.2"
+    "stagebook": "*"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.2.2",
     "@types/js-yaml": "^4.0.9",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.5.2",
+    "tailwindcss": "^4.2.2",
     "typescript": "^5.5.0",
     "vite": "^6.3.3",
     "vitest": "^4.1.4"

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import type { TreatmentFileType } from "stagebook";
 import { loadTreatmentFromUrl } from "./lib/loader";
 import {
@@ -6,6 +6,7 @@ import {
   TreatmentValidationError,
   type ValidationIssue,
 } from "./lib/treatment";
+import { createUrlContentFns } from "./lib/contentFns";
 import { LandingPage } from "./components/LandingPage";
 import { TreatmentPicker } from "./components/TreatmentPicker";
 import { FieldForm } from "./components/FieldForm";
@@ -172,16 +173,19 @@ export function App() {
       );
     }
 
-    case "viewing":
+    case "viewing": {
+      const contentFns = createUrlContentFns(state.rawBaseUrl);
       return (
         <Viewer
           treatmentFile={state.treatmentFile}
-          rawBaseUrl={state.rawBaseUrl}
+          getTextContent={contentFns.getTextContent}
+          getAssetURL={contentFns.getAssetURL}
           selectedIntroIndex={state.selectedIntroIndex}
           selectedTreatmentIndex={state.selectedTreatmentIndex}
           onBack={() => setState({ phase: "landing" })}
         />
       );
+    }
   }
 }
 

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -2,15 +2,13 @@ import { useState, useMemo, useCallback, useEffect } from "react";
 import type { TreatmentFileType } from "stagebook";
 import { loadTreatmentFromUrl } from "./lib/loader";
 import {
-  expandTreatmentFile,
   TreatmentValidationError,
   type ValidationIssue,
 } from "./lib/treatment";
 import { createUrlContentFns } from "./lib/contentFns";
 import { LandingPage } from "./components/LandingPage";
 import { TreatmentPicker } from "./components/TreatmentPicker";
-import { FieldForm } from "./components/FieldForm";
-import { Viewer } from "./components/Viewer";
+import { PreviewHost } from "./components/PreviewHost";
 
 type AppState =
   | { phase: "landing" }
@@ -19,15 +17,6 @@ type AppState =
       phase: "selecting";
       treatmentFile: TreatmentFileType;
       rawBaseUrl: string;
-      unresolvedFields: string[];
-    }
-  | {
-      phase: "fields";
-      treatmentFile: TreatmentFileType;
-      rawBaseUrl: string;
-      unresolvedFields: string[];
-      selectedIntroIndex: number;
-      selectedTreatmentIndex: number;
     }
   | {
       phase: "viewing";
@@ -49,29 +38,14 @@ export function App() {
   const handleLoad = useCallback(async (url: string) => {
     setState({ phase: "loading", url });
     try {
-      const { treatmentFile, unresolvedFields, rawBaseUrl } =
-        await loadTreatmentFromUrl(url);
+      const { treatmentFile, rawBaseUrl } = await loadTreatmentFromUrl(url);
 
       const needsPicker =
         treatmentFile.introSequences.length > 1 ||
         treatmentFile.treatments.length > 1;
 
       if (needsPicker) {
-        setState({
-          phase: "selecting",
-          treatmentFile,
-          rawBaseUrl,
-          unresolvedFields,
-        });
-      } else if (unresolvedFields.length > 0) {
-        setState({
-          phase: "fields",
-          treatmentFile,
-          rawBaseUrl,
-          unresolvedFields,
-          selectedIntroIndex: 0,
-          selectedTreatmentIndex: 0,
-        });
+        setState({ phase: "selecting", treatmentFile, rawBaseUrl });
       } else {
         setState({
           phase: "viewing",
@@ -120,53 +94,17 @@ export function App() {
       );
 
     case "selecting": {
-      const { treatmentFile, rawBaseUrl, unresolvedFields } = state;
+      const { treatmentFile, rawBaseUrl } = state;
       return (
         <TreatmentPicker
           treatmentFile={treatmentFile}
           onSelect={(introIndex, treatmentIndex) => {
-            if (unresolvedFields.length > 0) {
-              setState({
-                phase: "fields",
-                treatmentFile,
-                rawBaseUrl,
-                unresolvedFields,
-                selectedIntroIndex: introIndex,
-                selectedTreatmentIndex: treatmentIndex,
-              });
-            } else {
-              setState({
-                phase: "viewing",
-                treatmentFile,
-                rawBaseUrl,
-                selectedIntroIndex: introIndex,
-                selectedTreatmentIndex: treatmentIndex,
-              });
-            }
-          }}
-        />
-      );
-    }
-
-    case "fields": {
-      const {
-        treatmentFile,
-        rawBaseUrl,
-        unresolvedFields,
-        selectedIntroIndex,
-        selectedTreatmentIndex,
-      } = state;
-      return (
-        <FieldForm
-          unresolvedFields={unresolvedFields}
-          onSubmit={(values) => {
-            const { result } = expandTreatmentFile(treatmentFile, values);
             setState({
               phase: "viewing",
-              treatmentFile: result,
+              treatmentFile,
               rawBaseUrl,
-              selectedIntroIndex,
-              selectedTreatmentIndex,
+              selectedIntroIndex: introIndex,
+              selectedTreatmentIndex: treatmentIndex,
             });
           }}
         />
@@ -209,7 +147,7 @@ function ViewingPhase({
   );
 
   return (
-    <Viewer
+    <PreviewHost
       treatmentFile={treatmentFile}
       getTextContent={contentFns.getTextContent}
       getAssetURL={contentFns.getAssetURL}

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -173,20 +173,51 @@ export function App() {
       );
     }
 
-    case "viewing": {
-      const contentFns = createUrlContentFns(state.rawBaseUrl);
+    case "viewing":
       return (
-        <Viewer
+        <ViewingPhase
           treatmentFile={state.treatmentFile}
-          getTextContent={contentFns.getTextContent}
-          getAssetURL={contentFns.getAssetURL}
+          rawBaseUrl={state.rawBaseUrl}
           selectedIntroIndex={state.selectedIntroIndex}
           selectedTreatmentIndex={state.selectedTreatmentIndex}
           onBack={() => setState({ phase: "landing" })}
         />
       );
-    }
   }
+}
+
+/**
+ * Wrapper component for the viewing phase — enables useMemo for
+ * stable content function references (can't use hooks in switch cases).
+ */
+function ViewingPhase({
+  treatmentFile,
+  rawBaseUrl,
+  selectedIntroIndex,
+  selectedTreatmentIndex,
+  onBack,
+}: {
+  treatmentFile: TreatmentFileType;
+  rawBaseUrl: string;
+  selectedIntroIndex: number;
+  selectedTreatmentIndex: number;
+  onBack: () => void;
+}) {
+  const contentFns = useMemo(
+    () => createUrlContentFns(rawBaseUrl),
+    [rawBaseUrl],
+  );
+
+  return (
+    <Viewer
+      treatmentFile={treatmentFile}
+      getTextContent={contentFns.getTextContent}
+      getAssetURL={contentFns.getAssetURL}
+      selectedIntroIndex={selectedIntroIndex}
+      selectedTreatmentIndex={selectedTreatmentIndex}
+      onBack={onBack}
+    />
+  );
 }
 
 function LoadingScreen({ url }: { url: string }) {

--- a/apps/viewer/src/components/PreviewHost.tsx
+++ b/apps/viewer/src/components/PreviewHost.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
-import { fillTemplates, type TreatmentFileType } from "stagebook";
+import type { TreatmentFileType } from "stagebook";
+import { expandTreatmentFile } from "../lib/expandTreatmentFile";
 import { FieldForm } from "./FieldForm";
 import { Viewer } from "./Viewer";
 
@@ -57,19 +58,11 @@ export function PreviewHost({
       ...(additionalFields ?? {}),
       ...(userValues ?? {}),
     };
-    // Strip template definitions before expansion — their bodies contain
-    // placeholder syntax that would otherwise be flagged as unresolved.
-    const { templates, ...withoutTemplates } = treatmentFile;
-    const { result, unresolvedFields } = fillTemplates({
-      obj: withoutTemplates,
-      templates: templates ?? [],
-      additionalFields: Object.keys(merged).length > 0 ? merged : undefined,
-      allowUnresolved: true,
-    });
-    return {
-      resolved: result as TreatmentFileType,
-      unresolvedFields,
-    };
+    const { result, unresolvedFields } = expandTreatmentFile(
+      treatmentFile,
+      Object.keys(merged).length > 0 ? merged : undefined,
+    );
+    return { resolved: result, unresolvedFields };
   }, [treatmentFile, additionalFields, userValues]);
 
   if (unresolvedFields.length > 0) {

--- a/apps/viewer/src/components/PreviewHost.tsx
+++ b/apps/viewer/src/components/PreviewHost.tsx
@@ -1,0 +1,98 @@
+import { useMemo, useState } from "react";
+import { fillTemplates, type TreatmentFileType } from "stagebook";
+import { FieldForm } from "./FieldForm";
+import { Viewer } from "./Viewer";
+
+export interface PreviewHostProps {
+  treatmentFile: TreatmentFileType;
+  /**
+   * Pre-supplied values for `${field}` placeholders (e.g. from a sidecar
+   * file). Any placeholders not covered here will surface as a FieldForm.
+   */
+  additionalFields?: Record<string, unknown>;
+  selectedIntroIndex: number;
+  selectedTreatmentIndex: number;
+  /** Must be referentially stable (memoized) to avoid re-fetch loops. */
+  getTextContent: (path: string) => Promise<string>;
+  /** Must be referentially stable (memoized) to avoid re-fetch loops. */
+  getAssetURL: (path: string) => string;
+  /** Optional — hidden in the header when omitted. */
+  onBack?: () => void;
+  /**
+   * Called with the values the user entered into FieldForm, letting a host
+   * persist them (e.g. write to a sidecar file). Not called when placeholders
+   * are resolved purely from `additionalFields`.
+   */
+  onFieldsResolved?: (values: Record<string, string>) => void;
+  /** Optional refresh affordance passed through to the Viewer header. */
+  onRefresh?: () => void;
+}
+
+/**
+ * Resolves `${field}` placeholders before rendering the Viewer.
+ *
+ * Stagebook components expect concrete values, but treatment files may
+ * reference study/player-context variables that aren't available in a
+ * preview environment. This host bridges the gap: it runs fillTemplates,
+ * prompts the user for any remaining unresolved fields via FieldForm, and
+ * only hands a fully-resolved treatment to the Viewer.
+ */
+export function PreviewHost({
+  treatmentFile,
+  additionalFields,
+  selectedIntroIndex,
+  selectedTreatmentIndex,
+  getTextContent,
+  getAssetURL,
+  onBack,
+  onFieldsResolved,
+  onRefresh,
+}: PreviewHostProps) {
+  const [userValues, setUserValues] = useState<Record<string, string> | null>(
+    null,
+  );
+
+  const { resolved, unresolvedFields } = useMemo(() => {
+    const merged = {
+      ...(additionalFields ?? {}),
+      ...(userValues ?? {}),
+    };
+    // Strip template definitions before expansion — their bodies contain
+    // placeholder syntax that would otherwise be flagged as unresolved.
+    const { templates, ...withoutTemplates } = treatmentFile;
+    const { result, unresolvedFields } = fillTemplates({
+      obj: withoutTemplates,
+      templates: templates ?? [],
+      additionalFields: Object.keys(merged).length > 0 ? merged : undefined,
+      allowUnresolved: true,
+    });
+    return {
+      resolved: result as TreatmentFileType,
+      unresolvedFields,
+    };
+  }, [treatmentFile, additionalFields, userValues]);
+
+  if (unresolvedFields.length > 0) {
+    return (
+      <FieldForm
+        unresolvedFields={unresolvedFields}
+        onSubmit={(values) => {
+          setUserValues(values);
+          onFieldsResolved?.(values);
+        }}
+      />
+    );
+  }
+
+  return (
+    <Viewer
+      treatmentFile={resolved}
+      getTextContent={getTextContent}
+      getAssetURL={getAssetURL}
+      selectedIntroIndex={selectedIntroIndex}
+      selectedTreatmentIndex={selectedTreatmentIndex}
+      onBack={onBack}
+      onRefresh={onRefresh}
+    />
+  );
+}

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -1,4 +1,10 @@
-import { useState, useMemo, useCallback, useSyncExternalStore } from "react";
+import {
+  useEffect,
+  useState,
+  useMemo,
+  useCallback,
+  useSyncExternalStore,
+} from "react";
 import type { TreatmentFileType } from "stagebook";
 import { StagebookProvider, Stage } from "stagebook/components";
 import { flattenSteps } from "../lib/steps";
@@ -17,7 +23,20 @@ export interface ViewerProps {
   getAssetURL: (path: string) => string;
   selectedIntroIndex: number;
   selectedTreatmentIndex: number;
-  onBack: () => void;
+  /**
+   * Optional back affordance. When provided, the header shows a back arrow
+   * that invokes this callback. Omit to hide the arrow (e.g. in an embedded
+   * preview where there is no prior screen to return to).
+   */
+  onBack?: () => void;
+  /**
+   * Optional refresh affordance. When provided, the header shows a reload
+   * icon that invokes this callback. The Viewer itself doesn't re-fetch —
+   * hosts are expected to supply an updated `treatmentFile` prop in response.
+   * Viewer state (stageIndex, position, saved responses) persists across the
+   * prop update since React doesn't unmount the component.
+   */
+  onRefresh?: () => void;
 }
 
 export function Viewer({
@@ -27,6 +46,7 @@ export function Viewer({
   selectedIntroIndex,
   selectedTreatmentIndex,
   onBack,
+  onRefresh,
 }: ViewerProps) {
   const treatment = treatmentFile.treatments[selectedTreatmentIndex];
   const introSequence = treatmentFile.introSequences[selectedIntroIndex];
@@ -39,6 +59,15 @@ export function Viewer({
   const [stageIndex, setStageIndex] = useState(0);
   const [position, setPosition] = useState(0);
   const [store] = useState(() => new ViewerStateStore());
+
+  // Clamp stageIndex if the treatment was edited to have fewer stages
+  // (e.g. researcher deleted a stage while the preview was open). Without
+  // this, steps[stageIndex] returns undefined and the viewer blanks.
+  useEffect(() => {
+    if (steps.length > 0 && stageIndex >= steps.length) {
+      setStageIndex(steps.length - 1);
+    }
+  }, [steps.length, stageIndex]);
 
   // Subscribe to store changes so the UI re-renders.
   // The version is included in ctx memo deps below so that
@@ -104,9 +133,21 @@ export function Viewer({
       {/* Header */}
       <header style={headerStyle}>
         <div style={headerLeftStyle}>
-          <button aria-label="Back" onClick={onBack} style={backButtonStyle}>
-            &larr;
-          </button>
+          {onBack && (
+            <button aria-label="Back" onClick={onBack} style={backButtonStyle}>
+              &larr;
+            </button>
+          )}
+          {onRefresh && (
+            <button
+              aria-label="Refresh preview"
+              title="Refresh preview"
+              onClick={onRefresh}
+              style={refreshButtonStyle}
+            >
+              &#x21bb;
+            </button>
+          )}
           <span style={treatmentNameStyle}>{treatment.name}</span>
         </div>
         <StageNav
@@ -209,6 +250,16 @@ const backButtonStyle: React.CSSProperties = {
   fontSize: "1.25rem",
   color: "#6b7280",
   padding: "0.25rem",
+};
+
+const refreshButtonStyle: React.CSSProperties = {
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  fontSize: "1.1rem",
+  color: "#6b7280",
+  padding: "0.25rem",
+  lineHeight: 1,
 };
 
 const treatmentNameStyle: React.CSSProperties = {

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -9,9 +9,10 @@ import { StateInspector } from "./StateInspector";
 import { TimeScrubber } from "./TimeScrubber";
 import { createSkeletonRenderers } from "./SkeletonPlaceholder";
 
-interface ViewerProps {
+export interface ViewerProps {
   treatmentFile: TreatmentFileType;
-  rawBaseUrl: string;
+  getTextContent: (path: string) => Promise<string>;
+  getAssetURL: (path: string) => string;
   selectedIntroIndex: number;
   selectedTreatmentIndex: number;
   onBack: () => void;
@@ -19,7 +20,8 @@ interface ViewerProps {
 
 export function Viewer({
   treatmentFile,
-  rawBaseUrl,
+  getTextContent,
+  getAssetURL,
   selectedIntroIndex,
   selectedTreatmentIndex,
   onBack,
@@ -60,35 +62,6 @@ export function Viewer({
     [store, stageIndex],
   );
 
-  // getTextContent and getAssetURL only depend on rawBaseUrl, so keep
-  // them stable across stage/position changes to avoid re-fetch loops
-  // in useTextContent (which has getTextContent as an effect dependency).
-  const stableContentFns = useMemo(() => {
-    const cache = new Map<string, Promise<string>>();
-    return {
-      getTextContent(path: string): Promise<string> {
-        const cached = cache.get(path);
-        if (cached) return cached;
-        const promise = fetch(rawBaseUrl + path)
-          .then((res) => {
-            if (!res.ok) {
-              throw new Error(`Failed to fetch ${path} (HTTP ${res.status})`);
-            }
-            return res.text();
-          })
-          .catch((err) => {
-            cache.delete(path);
-            throw err;
-          });
-        cache.set(path, promise);
-        return promise;
-      },
-      getAssetURL(path: string): string {
-        return rawBaseUrl + path;
-      },
-    };
-  }, [rawBaseUrl]);
-
   const ctx = useMemo(
     () =>
       createViewerContext({
@@ -97,7 +70,8 @@ export function Viewer({
         stageIndex,
         playerCount: treatment.playerCount,
         onSubmit: handleSubmit,
-        ...stableContentFns,
+        getTextContent,
+        getAssetURL,
         renderers: createSkeletonRenderers(),
       }),
     [
@@ -106,7 +80,8 @@ export function Viewer({
       stageIndex,
       treatment.playerCount,
       handleSubmit,
-      stableContentFns,
+      getTextContent,
+      getAssetURL,
     ],
   );
 

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -11,7 +11,9 @@ import { createSkeletonRenderers } from "./SkeletonPlaceholder";
 
 export interface ViewerProps {
   treatmentFile: TreatmentFileType;
+  /** Must be referentially stable (memoized) to avoid re-fetch loops. */
   getTextContent: (path: string) => Promise<string>;
+  /** Must be referentially stable (memoized) to avoid re-fetch loops. */
   getAssetURL: (path: string) => string;
   selectedIntroIndex: number;
   selectedTreatmentIndex: number;

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -40,8 +40,10 @@ export function Viewer({
   const [position, setPosition] = useState(0);
   const [store] = useState(() => new ViewerStateStore());
 
-  // Subscribe to store changes so the UI re-renders
-  useSyncExternalStore(
+  // Subscribe to store changes so the UI re-renders.
+  // The version is included in ctx memo deps below so that
+  // StagebookProvider gets a new context value on store changes.
+  const storeVersion = useSyncExternalStore(
     useCallback((cb: () => void) => store.onChange(cb), [store]),
     useCallback(() => store.getVersion(), [store]),
   );
@@ -76,8 +78,10 @@ export function Viewer({
         getAssetURL,
         renderers: createSkeletonRenderers(),
       }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       store,
+      storeVersion,
       position,
       stageIndex,
       treatment.playerCount,

--- a/apps/viewer/src/lib/contentFns.ts
+++ b/apps/viewer/src/lib/contentFns.ts
@@ -1,0 +1,33 @@
+/**
+ * Create getTextContent and getAssetURL functions backed by HTTP fetch
+ * from a base URL (e.g., raw.githubusercontent.com).
+ *
+ * Results are cached so repeated calls for the same path don't re-fetch.
+ */
+export function createUrlContentFns(rawBaseUrl: string) {
+  const cache = new Map<string, Promise<string>>();
+
+  return {
+    getTextContent(path: string): Promise<string> {
+      const cached = cache.get(path);
+      if (cached) return cached;
+      const promise = fetch(rawBaseUrl + path)
+        .then((res) => {
+          if (!res.ok) {
+            throw new Error(`Failed to fetch ${path} (HTTP ${res.status})`);
+          }
+          return res.text();
+        })
+        .catch((err) => {
+          cache.delete(path);
+          throw err;
+        });
+      cache.set(path, promise);
+      return promise;
+    },
+
+    getAssetURL(path: string): string {
+      return rawBaseUrl + path;
+    },
+  };
+}

--- a/apps/viewer/src/lib/expandTreatmentFile.ts
+++ b/apps/viewer/src/lib/expandTreatmentFile.ts
@@ -1,0 +1,24 @@
+import { fillTemplates, type TreatmentFileType } from "stagebook";
+
+/**
+ * Expand templates in a parsed treatment file and detect unresolved fields.
+ * Optionally provide additionalFields to resolve remaining placeholders.
+ *
+ * Lives in its own module (not `treatment.ts`) so it can be imported by
+ * the webview entry point without pulling in js-yaml transitively.
+ */
+export function expandTreatmentFile(
+  treatmentFile: TreatmentFileType,
+  additionalFields?: Record<string, unknown>,
+): { result: TreatmentFileType; unresolvedFields: string[] } {
+  // Strip template definitions before expansion — they contain
+  // placeholder syntax that would be falsely flagged as unresolved.
+  const { templates, ...withoutTemplates } = treatmentFile;
+  const { result, unresolvedFields } = fillTemplates({
+    obj: withoutTemplates,
+    templates: templates ?? [],
+    additionalFields,
+    allowUnresolved: true,
+  });
+  return { result: result as TreatmentFileType, unresolvedFields };
+}

--- a/apps/viewer/src/lib/treatment.ts
+++ b/apps/viewer/src/lib/treatment.ts
@@ -1,9 +1,7 @@
 import { load as loadYaml } from "js-yaml";
-import {
-  fillTemplates,
-  treatmentFileSchema,
-  type TreatmentFileType,
-} from "stagebook";
+import { treatmentFileSchema, type TreatmentFileType } from "stagebook";
+
+export { expandTreatmentFile } from "./expandTreatmentFile";
 
 export interface ValidationIssue {
   path: string;
@@ -36,24 +34,4 @@ export function parseTreatmentYaml(yaml: string): TreatmentFileType {
     throw new TreatmentValidationError(issues);
   }
   return result.data;
-}
-
-/**
- * Expand templates in a parsed treatment file and detect unresolved fields.
- * Optionally provide additionalFields to resolve remaining placeholders.
- */
-export function expandTreatmentFile(
-  treatmentFile: TreatmentFileType,
-  additionalFields?: Record<string, unknown>,
-): { result: TreatmentFileType; unresolvedFields: string[] } {
-  // Strip template definitions before expansion — they contain
-  // placeholder syntax that would be falsely flagged as unresolved.
-  const { templates, ...withoutTemplates } = treatmentFile;
-  const { result, unresolvedFields } = fillTemplates({
-    obj: withoutTemplates,
-    templates: templates ?? [],
-    additionalFields,
-    allowUnresolved: true,
-  });
-  return { result: result as TreatmentFileType, unresolvedFields };
 }

--- a/apps/viewer/src/preview.ts
+++ b/apps/viewer/src/preview.ts
@@ -1,0 +1,26 @@
+// Preview infrastructure — reusable by any app that wants to preview
+// stagebook treatment content (VS Code extension, standalone viewer, etc.)
+
+// Lib utilities
+export { ViewerStateStore } from "./lib/store";
+export type { PositionKey, StoreEntry, StoreRecord } from "./lib/store";
+export { createViewerContext } from "./lib/context";
+export type { ViewerContextOptions } from "./lib/context";
+export { flattenSteps } from "./lib/steps";
+export type { ViewerStep, Phase } from "./lib/steps";
+export { extractStageReferences } from "./lib/references";
+export { extractTimeBreakpoints } from "./lib/timeBreakpoints";
+export { createUrlContentFns } from "./lib/contentFns";
+
+// React components
+export { Viewer } from "./components/Viewer";
+export type { ViewerProps } from "./components/Viewer";
+export { StageNav } from "./components/StageNav";
+export { StateInspector } from "./components/StateInspector";
+export { TimeScrubber } from "./components/TimeScrubber";
+export {
+  SkeletonPlaceholder,
+  createSkeletonRenderers,
+} from "./components/SkeletonPlaceholder";
+export { TreatmentPicker } from "./components/TreatmentPicker";
+export { FieldForm } from "./components/FieldForm";

--- a/apps/viewer/src/preview.ts
+++ b/apps/viewer/src/preview.ts
@@ -15,6 +15,8 @@ export { createUrlContentFns } from "./lib/contentFns";
 // React components
 export { Viewer } from "./components/Viewer";
 export type { ViewerProps } from "./components/Viewer";
+export { PreviewHost } from "./components/PreviewHost";
+export type { PreviewHostProps } from "./components/PreviewHost";
 export { StageNav } from "./components/StageNav";
 export { StateInspector } from "./components/StateInspector";
 export { TimeScrubber } from "./components/TimeScrubber";

--- a/apps/viewer/vite.config.ts
+++ b/apps/viewer/vite.config.ts
@@ -1,8 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
-import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react()],
   base: "/stagebook/viewer/",
 });

--- a/apps/vscode/.vscode/launch.json
+++ b/apps/vscode/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+      "preLaunchTask": "npm: build - stagebook-vscode"
+    }
+  ]
+}

--- a/apps/vscode/.vscodeignore
+++ b/apps/vscode/.vscodeignore
@@ -1,5 +1,6 @@
 **
 !dist/extension.js
+!dist/webview.js
 !package.json
 !language-configuration.json
 !syntaxes/**

--- a/apps/vscode/.vscodeignore
+++ b/apps/vscode/.vscodeignore
@@ -2,6 +2,6 @@ src/**
 node_modules/**
 tsconfig.json
 .vscode/**
-**/*.map
 **/*.ts
 !dist/**
+dist/**/*.map

--- a/apps/vscode/.vscodeignore
+++ b/apps/vscode/.vscodeignore
@@ -1,0 +1,7 @@
+src/**
+node_modules/**
+tsconfig.json
+.vscode/**
+**/*.map
+**/*.ts
+!dist/**

--- a/apps/vscode/.vscodeignore
+++ b/apps/vscode/.vscodeignore
@@ -1,7 +1,6 @@
-src/**
-node_modules/**
-tsconfig.json
-.vscode/**
-**/*.ts
-!dist/**
-dist/**/*.map
+**
+!dist/extension.js
+!package.json
+!language-configuration.json
+!syntaxes/**
+!LICENSE

--- a/apps/vscode/.vscodeignore
+++ b/apps/vscode/.vscodeignore
@@ -3,4 +3,4 @@
 !package.json
 !language-configuration.json
 !syntaxes/**
-!LICENSE
+

--- a/apps/vscode/language-configuration.json
+++ b/apps/vscode/language-configuration.json
@@ -1,0 +1,35 @@
+{
+  "comments": {
+    "lineComment": "#"
+  },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "\"", "close": "\"" },
+    { "open": "'", "close": "'" }
+  ],
+  "surroundingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "\"", "close": "\"" },
+    { "open": "'", "close": "'" }
+  ],
+  "indentationRules": {
+    "increaseIndentPattern": "^\\s*.*:\\s*$",
+    "decreaseIndentPattern": "^\\s*\\}"
+  },
+  "onEnterRules": [
+    {
+      "beforeText": "^\\s*- .*$",
+      "action": { "indent": "keep", "appendText": "- " }
+    },
+    {
+      "beforeText": "^\\s*-$",
+      "action": { "indent": "keep", "appendText": "- " }
+    }
+  ]
+}

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -39,6 +39,11 @@
         "language": "treatmentsYaml",
         "scopeName": "source.treatments-yaml",
         "path": "./syntaxes/treatmentsYaml.tmLanguage.json"
+      },
+      {
+        "language": "stagebookPrompt",
+        "scopeName": "text.html.markdown.prompt",
+        "path": "./syntaxes/stagebookPrompt.tmLanguage.json"
       }
     ],
     "configurationDefaults": {
@@ -53,7 +58,7 @@
     "build:watch": "npm run build -- --watch",
     "package": "vsce package",
     "lint": "echo 'no linter configured yet'",
-    "test": "echo 'no tests configured yet'"
+    "test": "vitest run"
   },
   "dependencies": {
     "js-yaml": "^4.1.1",
@@ -61,10 +66,12 @@
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@vscode/vsce": "^3.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "@types/vscode": "^1.96.0",
     "esbuild": "^0.25.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "vitest": "^4.1.4"
   }
 }

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -98,8 +98,10 @@
     "build": "npm run build:extension && npm run build:webview",
     "build:extension": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
     "build:webview": "esbuild src/webview/index.tsx --bundle --outfile=dist/webview.js --format=iife --platform=browser --sourcemap --loader:.css=text --define:process.env.NODE_ENV='\"production\"'",
-    "build:watch": "npm run build -- --watch",
-    "vscode:prepublish": "npm run build",
+    "build:production": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify && esbuild src/webview/index.tsx --bundle --outfile=dist/webview.js --format=iife --platform=browser --minify --loader:.css=text --define:process.env.NODE_ENV='\"production\"'",
+    "build:watch:extension": "npm run build:extension -- --watch",
+    "build:watch:webview": "npm run build:webview -- --watch",
+    "vscode:prepublish": "npm run build:production",
     "package": "vsce package --no-dependencies",
     "lint": "echo 'no linter configured yet'",
     "test": "vitest run"

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -27,7 +27,7 @@
       },
       {
         "command": "stagebook.previewStage",
-        "title": "Stagebook: Preview Stage"
+        "title": "Stagebook: Preview Treatment"
       }
     ],
     "menus": {

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -12,7 +12,7 @@
     "directory": "apps/vscode"
   },
   "engines": {
-    "vscode": "^1.96.0"
+    "vscode": "^1.115.0"
   },
   "categories": ["Programming Languages", "Linters"],
   "main": "./dist/extension.js",
@@ -69,7 +69,7 @@
     "@vscode/vsce": "^3.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
-    "@types/vscode": "1.96.0",
+    "@types/vscode": "1.115.0",
     "esbuild": "^0.25.0",
     "typescript": "^5.5.0",
     "vitest": "^4.1.4"

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -69,7 +69,7 @@
     "@vscode/vsce": "^3.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
-    "@types/vscode": "^1.96.0",
+    "@types/vscode": "1.96.0",
     "esbuild": "^0.25.0",
     "typescript": "^5.5.0",
     "vitest": "^4.1.4"

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -14,7 +14,10 @@
   "engines": {
     "vscode": "^1.115.0"
   },
-  "categories": ["Programming Languages", "Linters"],
+  "categories": [
+    "Programming Languages",
+    "Linters"
+  ],
   "main": "./dist/extension.js",
   "activationEvents": [
     "onLanguage:treatmentsYaml",
@@ -24,14 +27,22 @@
     "languages": [
       {
         "id": "treatmentsYaml",
-        "aliases": ["Treatments YAML"],
-        "extensions": [".treatments.yaml"],
+        "aliases": [
+          "Treatments YAML"
+        ],
+        "extensions": [
+          ".treatments.yaml"
+        ],
         "configuration": "./language-configuration.json"
       },
       {
         "id": "stagebookPrompt",
-        "aliases": ["Stagebook Prompt"],
-        "extensions": [".prompt.md"]
+        "aliases": [
+          "Stagebook Prompt"
+        ],
+        "extensions": [
+          ".prompt.md"
+        ]
       }
     ],
     "grammars": [
@@ -61,15 +72,14 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "js-yaml": "^4.1.1",
     "stagebook": "*",
+    "yaml": "^2.8.3",
     "zod": "^3.23.0"
   },
   "devDependencies": {
-    "@vscode/vsce": "^3.0.0",
-    "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
     "@types/vscode": "1.115.0",
+    "@vscode/vsce": "^3.0.0",
     "esbuild": "^0.25.0",
     "typescript": "^5.5.0",
     "vitest": "^4.1.4"

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -20,6 +20,21 @@
   ],
   "main": "./dist/extension.js",
   "contributes": {
+    "commands": [
+      {
+        "command": "stagebook.previewExpandedTemplates",
+        "title": "Stagebook: Preview Expanded Templates"
+      }
+    ],
+    "menus": {
+      "editor/context": [
+        {
+          "command": "stagebook.previewExpandedTemplates",
+          "when": "resourceLangId == treatmentsYaml",
+          "group": "navigation"
+        }
+      ]
+    },
     "languages": [
       {
         "id": "treatmentsYaml",

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -67,7 +67,7 @@
   "scripts": {
     "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
     "build:watch": "npm run build -- --watch",
-    "package": "vsce package",
+    "package": "vsce package --no-dependencies",
     "lint": "echo 'no linter configured yet'",
     "test": "vitest run"
   },

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -1,0 +1,70 @@
+{
+  "name": "stagebook-vscode",
+  "displayName": "Stagebook",
+  "description": "Validation, syntax highlighting, and preview for Stagebook treatment and prompt files",
+  "version": "0.1.0",
+  "publisher": "deliberation-lab",
+  "private": true,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/deliberation-lab/stagebook.git",
+    "directory": "apps/vscode"
+  },
+  "engines": {
+    "vscode": "^1.96.0"
+  },
+  "categories": ["Programming Languages", "Linters"],
+  "main": "./dist/extension.js",
+  "activationEvents": [
+    "onLanguage:treatmentsYaml",
+    "onLanguage:stagebookPrompt"
+  ],
+  "contributes": {
+    "languages": [
+      {
+        "id": "treatmentsYaml",
+        "aliases": ["Treatments YAML"],
+        "extensions": [".treatments.yaml"],
+        "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "stagebookPrompt",
+        "aliases": ["Stagebook Prompt"],
+        "extensions": [".prompt.md"]
+      }
+    ],
+    "grammars": [
+      {
+        "language": "treatmentsYaml",
+        "scopeName": "source.treatments-yaml",
+        "path": "./syntaxes/treatmentsYaml.tmLanguage.json"
+      }
+    ],
+    "configurationDefaults": {
+      "[treatmentsYaml]": {
+        "editor.tabSize": 2,
+        "editor.insertSpaces": true
+      }
+    }
+  },
+  "scripts": {
+    "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
+    "build:watch": "npm run build -- --watch",
+    "package": "vsce package",
+    "lint": "echo 'no linter configured yet'",
+    "test": "echo 'no tests configured yet'"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.1",
+    "stagebook": "*",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^22.0.0",
+    "@types/vscode": "^1.96.0",
+    "esbuild": "^0.25.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -67,6 +67,7 @@
   "scripts": {
     "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
     "build:watch": "npm run build -- --watch",
+    "vscode:prepublish": "npm run build",
     "package": "vsce package --no-dependencies",
     "lint": "echo 'no linter configured yet'",
     "test": "vitest run"

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -19,10 +19,6 @@
     "Linters"
   ],
   "main": "./dist/extension.js",
-  "activationEvents": [
-    "onLanguage:treatmentsYaml",
-    "onLanguage:stagebookPrompt"
-  ],
   "contributes": {
     "languages": [
       {
@@ -60,7 +56,17 @@
     "configurationDefaults": {
       "[treatmentsYaml]": {
         "editor.tabSize": 2,
-        "editor.insertSpaces": true
+        "editor.insertSpaces": true,
+        "editor.semanticHighlighting.enabled": true
+      },
+      "editor.semanticTokenColorCustomizations": {
+        "rules": {
+          "type:treatmentsYaml": "#4EC9B0",
+          "keyword:treatmentsYaml": "#C586C0",
+          "variable:treatmentsYaml": "#9CDCFE",
+          "string:treatmentsYaml": "#DCDCAA",
+          "property:treatmentsYaml": "#569CD6"
+        }
       }
     }
   },
@@ -83,6 +89,7 @@
     "@vscode/vsce": "^3.0.0",
     "esbuild": "^0.25.0",
     "typescript": "^5.5.0",
-    "vitest": "^4.1.4"
+    "vitest": "^4.1.4",
+    "vscode-tmgrammar-test": "^0.1.3"
   }
 }

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -24,12 +24,21 @@
       {
         "command": "stagebook.previewExpandedTemplates",
         "title": "Stagebook: Preview Expanded Templates"
+      },
+      {
+        "command": "stagebook.previewStage",
+        "title": "Stagebook: Preview Stage"
       }
     ],
     "menus": {
       "editor/context": [
         {
           "command": "stagebook.previewExpandedTemplates",
+          "when": "resourceLangId == treatmentsYaml",
+          "group": "navigation"
+        },
+        {
+          "command": "stagebook.previewStage",
           "when": "resourceLangId == treatmentsYaml",
           "group": "navigation"
         }
@@ -86,7 +95,9 @@
     }
   },
   "scripts": {
-    "build": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
+    "build": "npm run build:extension && npm run build:webview",
+    "build:extension": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --sourcemap",
+    "build:webview": "esbuild src/webview/index.tsx --bundle --outfile=dist/webview.js --format=iife --platform=browser --sourcemap --loader:.css=text --define:process.env.NODE_ENV='\"production\"'",
     "build:watch": "npm run build -- --watch",
     "vscode:prepublish": "npm run build",
     "package": "vsce package --no-dependencies",
@@ -94,11 +105,16 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
     "stagebook": "*",
+    "stagebook-viewer": "*",
     "yaml": "^2.8.3",
     "zod": "^3.23.0"
   },
   "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@types/node": "^22.0.0",
     "@types/vscode": "1.115.0",
     "@vscode/vsce": "^3.0.0",

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -11,6 +11,7 @@ import {
   type SemanticTokenType,
 } from "./lib/semanticTokens";
 import { expandTreatmentSource } from "./lib/expandTreatment";
+import { findClosestMatch } from "./lib/levenshtein";
 
 const diagnosticCollection =
   vscode.languages.createDiagnosticCollection("stagebook");
@@ -275,6 +276,130 @@ class TreatmentSemanticTokenProvider
   }
 }
 
+// --- File Path Quick-Fix ---
+
+class FilePathQuickFixProvider implements vscode.CodeActionProvider {
+  static readonly providedCodeActionKinds = [vscode.CodeActionKind.QuickFix];
+
+  // Cache workspace file paths to avoid re-globbing on every cursor move
+  private cachedPaths: string[] = [];
+  private cacheTimestamp = 0;
+  private static readonly CACHE_TTL_MS = 5000;
+
+  async provideCodeActions(
+    document: vscode.TextDocument,
+    range: vscode.Range,
+  ): Promise<vscode.CodeAction[]> {
+    const diagnostics = vscode.languages
+      .getDiagnostics(document.uri)
+      .filter(
+        (d) =>
+          d.source === "stagebook" &&
+          d.message.startsWith("File not found:") &&
+          d.range.intersection(range),
+      );
+
+    if (diagnostics.length === 0 || !vscode.workspace.workspaceFolders?.length)
+      return [];
+
+    const actions: vscode.CodeAction[] = [];
+    const workspaceFolder =
+      vscode.workspace.getWorkspaceFolder(document.uri) ??
+      vscode.workspace.workspaceFolders[0];
+
+    // Refresh the cached file list if stale
+    const now = Date.now();
+    if (now - this.cacheTimestamp > FilePathQuickFixProvider.CACHE_TTL_MS) {
+      const allFiles = await vscode.workspace.findFiles(
+        "**/*.{prompt.md,md,yaml,jpg,jpeg,png,mp3,mp4}",
+        "**/node_modules/**",
+        5000,
+      );
+      this.cachedPaths = allFiles.map((f) =>
+        path.relative(workspaceFolder.uri.fsPath, f.fsPath),
+      );
+      this.cacheTimestamp = now;
+    }
+
+    for (const diagnostic of diagnostics) {
+      const badPath = diagnostic.message.replace("File not found: ", "");
+      const suggestion = findClosestMatch(badPath, this.cachedPaths);
+      if (!suggestion) continue;
+
+      const action = new vscode.CodeAction(
+        `Did you mean: ${suggestion}?`,
+        vscode.CodeActionKind.QuickFix,
+      );
+      action.edit = new vscode.WorkspaceEdit();
+      action.edit.replace(document.uri, diagnostic.range, suggestion);
+      action.isPreferred = true;
+      action.diagnostics = [diagnostic];
+      actions.push(action);
+    }
+
+    return actions;
+  }
+}
+
+// --- File Path Autocomplete ---
+
+class FilePathCompletionProvider implements vscode.CompletionItemProvider {
+  async provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+  ): Promise<vscode.CompletionItem[] | undefined> {
+    const line = document.lineAt(position).text;
+    const prefix = line.substring(0, position.character);
+
+    // Only trigger after "file:" with optional whitespace
+    if (!/^\s*file:\s/.test(prefix)) return undefined;
+
+    if (!vscode.workspace.workspaceFolders?.length) return undefined;
+
+    const workspaceFolder =
+      vscode.workspace.getWorkspaceFolder(document.uri) ??
+      vscode.workspace.workspaceFolders[0];
+
+    // Get the partial path the user has typed so far
+    const fileValueMatch = prefix.match(/file:\s+(.*)/);
+    const partial = fileValueMatch?.[1] ?? "";
+
+    // Sanitize glob metacharacters in user input
+    const sanitized = partial.replace(/[*?[\]{}]/g, "\\$&");
+    const globPattern = sanitized
+      ? `**/${sanitized}*`
+      : "**/*.{prompt.md,md,yaml}";
+    const files = await vscode.workspace.findFiles(
+      globPattern,
+      "**/node_modules/**",
+      50,
+    );
+
+    return files.map((fileUri) => {
+      const relativePath = path.relative(
+        workspaceFolder.uri.fsPath,
+        fileUri.fsPath,
+      );
+      const item = new vscode.CompletionItem(
+        relativePath,
+        vscode.CompletionItemKind.File,
+      );
+      item.insertText = relativePath;
+      // Replace the entire value after "file: "
+      const valueStart = prefix.indexOf("file:") + "file:".length;
+      const whitespaceAfterColon =
+        prefix.substring(valueStart).match(/^\s*/)?.[0] ?? " ";
+      item.range = new vscode.Range(
+        position.line,
+        valueStart + whitespaceAfterColon.length,
+        position.line,
+        line.length,
+      );
+      return item;
+    });
+  }
+}
+
 // --- Expanded Templates Preview ---
 
 const EXPANDED_SCHEME = "stagebook-expanded";
@@ -320,6 +445,26 @@ export function activate(context: vscode.ExtensionContext): void {
       { language: "treatmentsYaml" },
       new TreatmentSemanticTokenProvider(),
       tokenLegend,
+    ),
+  );
+
+  // Register file path quick-fix provider
+  context.subscriptions.push(
+    vscode.languages.registerCodeActionsProvider(
+      "treatmentsYaml",
+      new FilePathQuickFixProvider(),
+      {
+        providedCodeActionKinds:
+          FilePathQuickFixProvider.providedCodeActionKinds,
+      },
+    ),
+  );
+
+  // Register file path autocomplete provider
+  context.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(
+      "treatmentsYaml",
+      new FilePathCompletionProvider(),
     ),
   );
 

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -470,8 +470,79 @@ function getWebviewContent(
   <style>
     :root {
       --viewer-sidebar-width: 280px;
+      --stagebook-primary: #3b82f6;
+      --stagebook-primary-hover: #2563eb;
+      --stagebook-text: #1f2937;
+      --stagebook-text-secondary: #374151;
+      --stagebook-text-muted: #6b7280;
+      --stagebook-text-faint: #9ca3af;
+      --stagebook-border: #d1d5db;
+      --stagebook-bg-muted: #f9fafb;
+      --stagebook-bg-track: #e5e7eb;
+      --stagebook-prompt-max-width: 36rem;
+      --stagebook-prompt-text-size: 1rem;
+      --stagebook-prompt-line-height: 1.5;
+      --stagebook-prompt-h1-size: 1.875rem;
+      --stagebook-prompt-h2-size: 1.5rem;
+      --stagebook-prompt-h3-size: 1.25rem;
+      --stagebook-prompt-h1-weight: 700;
+      --stagebook-prompt-h2-weight: 600;
+      --stagebook-prompt-h3-weight: 600;
+      --stagebook-link: #2563eb;
+      --stagebook-code-bg: rgba(0, 0, 0, 0.06);
+      --stagebook-code-font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      --stagebook-blockquote-border: #d1d5db;
+      --stagebook-blockquote-bg: #f9fafb;
     }
-    body { margin: 0; padding: 0; }
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: #ffffff;
+      color: var(--stagebook-text);
+      font-family: ui-sans-serif, system-ui, sans-serif;
+      -webkit-font-smoothing: antialiased;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+    /* Reset VS Code webview defaults */
+    code, pre {
+      font-family: var(--stagebook-code-font);
+      background-color: var(--stagebook-code-bg);
+      color: var(--stagebook-text);
+    }
+    pre {
+      padding: 0.75rem 1rem;
+      border-radius: 0.375rem;
+      overflow-x: auto;
+    }
+    code {
+      padding: 0.125rem 0.25rem;
+      border-radius: 0.25rem;
+      font-size: 0.875em;
+    }
+    /* Form resets */
+    input[type="checkbox"], input[type="radio"] {
+      appearance: none;
+      width: 1rem; height: 1rem;
+      border: 1px solid var(--stagebook-border);
+      border-radius: 0.125rem;
+      background-color: #fff;
+      vertical-align: middle;
+      cursor: pointer;
+    }
+    input[type="radio"] { border-radius: 9999px; }
+    input[type="checkbox"]:checked, input[type="radio"]:checked {
+      background-color: var(--stagebook-primary);
+      border-color: var(--stagebook-primary);
+      background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+      background-size: 100% 100%; background-position: center; background-repeat: no-repeat;
+    }
+    input[type="radio"]:checked {
+      background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e");
+    }
+    table { border-collapse: collapse; margin: 1rem 0; width: 100%; max-width: var(--stagebook-prompt-max-width); }
+    th, td { border: 1px solid var(--stagebook-border); padding: 0.5rem 0.75rem; text-align: left; font-size: 0.875rem; }
+    th { background-color: var(--stagebook-bg-muted); font-weight: 500; }
   </style>
 </head>
 <body>
@@ -641,7 +712,21 @@ export function activate(context: vscode.ExtensionContext): void {
 
         // Handle messages from the webview
         previewPanel.webview.onDidReceiveMessage(async (msg) => {
-          if (msg.type === "readFile" && workspaceFolder) {
+          if (msg.type === "ready") {
+            // Webview JS loaded — send treatment data now
+            const baseUri = workspaceFolder
+              ? previewPanel!.webview
+                  .asWebviewUri(workspaceFolder.uri)
+                  .toString()
+              : "";
+            previewPanel?.webview.postMessage({
+              type: "treatment",
+              treatmentFile,
+              introIndex: 0,
+              treatmentIndex: 0,
+              webviewBaseUri: baseUri,
+            });
+          } else if (msg.type === "readFile" && workspaceFolder) {
             try {
               const fileUri = vscode.Uri.joinPath(
                 workspaceFolder.uri,
@@ -668,18 +753,6 @@ export function activate(context: vscode.ExtensionContext): void {
         previewPanel.webview,
         context.extensionUri,
       );
-
-      const webviewBaseUri = workspaceFolder
-        ? previewPanel.webview.asWebviewUri(workspaceFolder.uri).toString()
-        : "";
-
-      previewPanel.webview.postMessage({
-        type: "treatment",
-        treatmentFile,
-        introIndex: 0,
-        treatmentIndex: 0,
-        webviewBaseUri,
-      });
     }),
   );
 

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -761,7 +761,10 @@ export function activate(context: vscode.ExtensionContext): void {
                 filePath,
               );
               // Post-resolution workspace boundary check (defense in depth
-              // against symlinks and edge cases the substring check misses)
+              // against path traversal and shared-prefix edge cases that the
+              // substring check on `..` doesn't catch). Does not resolve
+              // symlinks — a symlink inside the workspace pointing out will
+              // still be followed by fs.readFile.
               if (
                 currentWorkspaceRootFsPath &&
                 !isWithinWorkspace(fileUri.fsPath, currentWorkspaceRootFsPath)

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -1,7 +1,15 @@
 import * as vscode from "vscode";
+import {
+  validateTreatmentSource,
+  type Diagnostic,
+} from "./lib/validateTreatment";
+import { pathToRange } from "./lib/yamlPositionMap";
 
 const diagnosticCollection =
   vscode.languages.createDiagnosticCollection("stagebook");
+
+const DEBOUNCE_MS = 300;
+const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 function isTreatmentsYaml(document: vscode.TextDocument): boolean {
   return (
@@ -27,9 +35,165 @@ function validateDocument(document: vscode.TextDocument): void {
   }
 }
 
-function validateTreatmentFile(_document: vscode.TextDocument): void {
-  // TODO (#75): validate with stagebook's treatmentFileSchema
-  // TODO (#74): map Zod error paths to YAML source positions
+function validateDocumentDebounced(document: vscode.TextDocument): void {
+  const key = document.uri.toString();
+  const existing = debounceTimers.get(key);
+  if (existing) clearTimeout(existing);
+
+  debounceTimers.set(
+    key,
+    setTimeout(() => {
+      debounceTimers.delete(key);
+      validateDocument(document);
+    }, DEBOUNCE_MS),
+  );
+}
+
+function toSeverity(
+  severity: Diagnostic["severity"],
+): vscode.DiagnosticSeverity {
+  return severity === "warning"
+    ? vscode.DiagnosticSeverity.Warning
+    : vscode.DiagnosticSeverity.Error;
+}
+
+function toVscodeRange(range: Diagnostic["range"]): vscode.Range {
+  if (!range) {
+    return new vscode.Range(0, 0, 0, 0);
+  }
+  return new vscode.Range(
+    range.startLine,
+    range.startCol,
+    range.endLine,
+    range.endCol,
+  );
+}
+
+function validateTreatmentFile(document: vscode.TextDocument): void {
+  const source = document.getText();
+  const result = validateTreatmentSource(source);
+
+  const vscodeDiagnostics = result.diagnostics.map((d) => {
+    const diag = new vscode.Diagnostic(
+      toVscodeRange(d.range),
+      d.message,
+      toSeverity(d.severity),
+    );
+    diag.source = "stagebook";
+    return diag;
+  });
+
+  diagnosticCollection.set(document.uri, vscodeDiagnostics);
+
+  // File existence checking (async — updates diagnostics after stat)
+  if (
+    result.parsedObj &&
+    typeof result.parsedObj === "object" &&
+    vscode.workspace.workspaceFolders?.length
+  ) {
+    checkFileReferences(document, result.parsedObj, source, vscodeDiagnostics);
+  }
+}
+
+/**
+ * Walk the parsed treatment object looking for `file:` fields.
+ * Check that referenced files exist and have the right extension.
+ */
+function checkFileReferences(
+  document: vscode.TextDocument,
+  obj: unknown,
+  source: string,
+  diagnostics: vscode.Diagnostic[],
+  path: (string | number)[] = [],
+): void {
+  if (Array.isArray(obj)) {
+    obj.forEach((item, i) =>
+      checkFileReferences(document, item, source, diagnostics, [...path, i]),
+    );
+    return;
+  }
+
+  if (typeof obj !== "object" || obj === null) return;
+
+  const record = obj as Record<string, unknown>;
+
+  if (typeof record.file === "string" && record.file.length > 0) {
+    const filePath = record.file;
+
+    // Skip if the path contains template placeholders
+    if (/\$\{[a-zA-Z0-9_]+\}/.test(filePath)) return;
+
+    const workspaceFolder = vscode.workspace.workspaceFolders![0];
+    const fileUri = vscode.Uri.joinPath(workspaceFolder.uri, filePath);
+
+    // Guard against path traversal
+    if (!fileUri.fsPath.startsWith(workspaceFolder.uri.fsPath)) {
+      diagnostics.push(
+        makeFileDiagnostic(
+          source,
+          [...path, "file"],
+          `File path escapes workspace: ${filePath}`,
+          vscode.DiagnosticSeverity.Error,
+        ),
+      );
+      diagnosticCollection.set(document.uri, diagnostics);
+      return;
+    }
+
+    vscode.workspace.fs.stat(fileUri).then(
+      () => {
+        // File exists — check extension for prompt elements
+        if (record.type === "prompt" && !filePath.endsWith(".prompt.md")) {
+          diagnostics.push(
+            makeFileDiagnostic(
+              source,
+              [...path, "file"],
+              `Prompt file should have .prompt.md extension: ${filePath}`,
+              vscode.DiagnosticSeverity.Warning,
+            ),
+          );
+          diagnosticCollection.set(document.uri, diagnostics);
+        }
+      },
+      () => {
+        diagnostics.push(
+          makeFileDiagnostic(
+            source,
+            [...path, "file"],
+            `File not found: ${filePath}`,
+            vscode.DiagnosticSeverity.Error,
+          ),
+        );
+        diagnosticCollection.set(document.uri, diagnostics);
+      },
+    );
+  }
+
+  for (const [key, value] of Object.entries(record)) {
+    if (key === "file") continue;
+    checkFileReferences(document, value, source, diagnostics, [...path, key]);
+  }
+}
+
+function makeFileDiagnostic(
+  source: string,
+  path: (string | number)[],
+  message: string,
+  severity: vscode.DiagnosticSeverity,
+): vscode.Diagnostic {
+  const range = pathToRange(source, path);
+  const vscodeRange = range
+    ? new vscode.Range(
+        range.startLine,
+        range.startCol,
+        range.endLine,
+        range.endCol,
+      )
+    : new vscode.Range(0, 0, 0, 0);
+
+  const diag = new vscode.Diagnostic(vscodeRange, message, severity);
+  diag.source = "stagebook";
+  return diag;
 }
 
 function validatePromptFile(_document: vscode.TextDocument): void {
@@ -39,26 +203,26 @@ function validatePromptFile(_document: vscode.TextDocument): void {
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(diagnosticCollection);
 
-  // Validate the active document on activation
+  // Validate the active document on activation (no debounce)
   if (vscode.window.activeTextEditor) {
     validateDocument(vscode.window.activeTextEditor.document);
   }
 
-  // Validate on open
+  // Validate on open (no debounce)
   context.subscriptions.push(
     vscode.workspace.onDidOpenTextDocument((document) => {
       validateDocument(document);
     }),
   );
 
-  // Validate on edit
+  // Validate on edit (debounced)
   context.subscriptions.push(
     vscode.workspace.onDidChangeTextDocument((event) => {
-      validateDocument(event.document);
+      validateDocumentDebounced(event.document);
     }),
   );
 
-  // Validate on editor focus change
+  // Validate on editor focus change (no debounce)
   context.subscriptions.push(
     vscode.window.onDidChangeActiveTextEditor((editor) => {
       if (editor) {

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -1,0 +1,73 @@
+import * as vscode from "vscode";
+
+const diagnosticCollection =
+  vscode.languages.createDiagnosticCollection("stagebook");
+
+function isTreatmentsYaml(document: vscode.TextDocument): boolean {
+  return (
+    document.languageId === "treatmentsYaml" ||
+    document.fileName.endsWith(".treatments.yaml")
+  );
+}
+
+function isStagebookPrompt(document: vscode.TextDocument): boolean {
+  return (
+    document.languageId === "stagebookPrompt" ||
+    document.fileName.endsWith(".prompt.md")
+  );
+}
+
+function validateDocument(document: vscode.TextDocument): void {
+  if (isTreatmentsYaml(document)) {
+    validateTreatmentFile(document);
+  } else if (isStagebookPrompt(document)) {
+    validatePromptFile(document);
+  } else {
+    diagnosticCollection.delete(document.uri);
+  }
+}
+
+function validateTreatmentFile(_document: vscode.TextDocument): void {
+  // TODO (#75): validate with stagebook's treatmentFileSchema
+  // TODO (#74): map Zod error paths to YAML source positions
+}
+
+function validatePromptFile(_document: vscode.TextDocument): void {
+  // TODO (#76): validate with stagebook's promptFileSchema
+}
+
+export function activate(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(diagnosticCollection);
+
+  // Validate the active document on activation
+  if (vscode.window.activeTextEditor) {
+    validateDocument(vscode.window.activeTextEditor.document);
+  }
+
+  // Validate on open
+  context.subscriptions.push(
+    vscode.workspace.onDidOpenTextDocument((document) => {
+      validateDocument(document);
+    }),
+  );
+
+  // Validate on edit
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeTextDocument((event) => {
+      validateDocument(event.document);
+    }),
+  );
+
+  // Validate on editor focus change
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      if (editor) {
+        validateDocument(editor.document);
+      }
+    }),
+  );
+}
+
+export function deactivate(): void {
+  diagnosticCollection.dispose();
+}

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -678,6 +678,7 @@ export function activate(context: vscode.ExtensionContext): void {
   let previewPanel: vscode.WebviewPanel | undefined;
   // Mutable state updated on each command invocation — avoids stale closures
   let currentTreatment: ReturnType<typeof parseTreatmentForPreview> = null;
+  let currentTreatmentUri: vscode.Uri | undefined;
   let currentTreatmentDir: vscode.Uri | undefined;
   let currentWorkspaceRootFsPath: string | undefined;
 
@@ -709,6 +710,7 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
       }
 
+      currentTreatmentUri = editor.document.uri;
       currentTreatmentDir = vscode.Uri.joinPath(editor.document.uri, "..");
       currentWorkspaceRootFsPath = workspaceFolder.uri.fsPath;
 
@@ -744,6 +746,38 @@ export function activate(context: vscode.ExtensionContext): void {
               treatmentIndex: 0,
               webviewBaseUri: baseUri,
             });
+          } else if (msg.type === "refresh") {
+            // Re-read the source file, re-parse, and push the updated
+            // treatment. Viewer state (stageIndex, position, saved responses,
+            // filled-in fields) persists across this prop update because the
+            // webview's React tree doesn't unmount.
+            if (!currentTreatmentUri || !currentTreatmentDir) return;
+            try {
+              const doc =
+                await vscode.workspace.openTextDocument(currentTreatmentUri);
+              const parsed = parseTreatmentForPreview(doc.getText());
+              if (!parsed) {
+                vscode.window.showErrorMessage(
+                  "Refresh failed: could not parse treatment file.",
+                );
+                return;
+              }
+              currentTreatment = parsed;
+              const baseUri = previewPanel!.webview
+                .asWebviewUri(currentTreatmentDir)
+                .toString();
+              previewPanel?.webview.postMessage({
+                type: "treatment",
+                treatmentFile: parsed,
+                introIndex: 0,
+                treatmentIndex: 0,
+                webviewBaseUri: baseUri,
+              });
+            } catch (err) {
+              vscode.window.showErrorMessage(
+                `Refresh failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
           } else if (msg.type === "readFile" && currentTreatmentDir) {
             // Guard against path traversal
             const filePath = String(msg.path);

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -563,7 +563,12 @@ function getNonce(): string {
 }
 
 function parseTreatmentForPreview(source: string) {
-  const obj = parseYaml(source);
+  let obj: unknown;
+  try {
+    obj = parseYaml(source);
+  } catch {
+    return null;
+  }
   if (typeof obj !== "object" || obj === null) return null;
   const record = obj as Record<string, unknown>;
   const templates = (record.templates ?? []) as unknown[];
@@ -669,6 +674,9 @@ export function activate(context: vscode.ExtensionContext): void {
 
   // Register stage preview webview command
   let previewPanel: vscode.WebviewPanel | undefined;
+  // Mutable state updated on each command invocation — avoids stale closures
+  let currentTreatment: ReturnType<typeof parseTreatmentForPreview> = null;
+  let currentWorkspaceFolder: vscode.WorkspaceFolder | undefined;
 
   context.subscriptions.push(
     vscode.commands.registerCommand("stagebook.previewStage", () => {
@@ -679,17 +687,24 @@ export function activate(context: vscode.ExtensionContext): void {
       }
 
       const source = editor.document.getText();
-      const treatmentFile = parseTreatmentForPreview(source);
-      if (!treatmentFile) {
+      currentTreatment = parseTreatmentForPreview(source);
+      if (!currentTreatment) {
         vscode.window.showErrorMessage(
           "Could not parse treatment file for preview.",
         );
         return;
       }
 
-      const workspaceFolder =
+      currentWorkspaceFolder =
         vscode.workspace.getWorkspaceFolder(editor.document.uri) ??
         vscode.workspace.workspaceFolders?.[0];
+
+      if (!currentWorkspaceFolder) {
+        vscode.window.showErrorMessage(
+          "No workspace folder found. Open a folder first.",
+        );
+        return;
+      }
 
       if (previewPanel) {
         previewPanel.reveal(vscode.ViewColumn.Beside);
@@ -702,7 +717,7 @@ export function activate(context: vscode.ExtensionContext): void {
             enableScripts: true,
             localResourceRoots: [
               vscode.Uri.joinPath(context.extensionUri, "dist"),
-              ...(workspaceFolder ? [workspaceFolder.uri] : []),
+              ...(vscode.workspace.workspaceFolders?.map((f) => f.uri) ?? []),
             ],
           },
         );
@@ -712,25 +727,36 @@ export function activate(context: vscode.ExtensionContext): void {
 
         // Handle messages from the webview
         previewPanel.webview.onDidReceiveMessage(async (msg) => {
-          if (msg.type === "ready") {
-            // Webview JS loaded — send treatment data now
-            const baseUri = workspaceFolder
-              ? previewPanel!.webview
-                  .asWebviewUri(workspaceFolder.uri)
-                  .toString()
-              : "";
+          if (
+            msg.type === "ready" &&
+            currentTreatment &&
+            currentWorkspaceFolder
+          ) {
+            const baseUri = previewPanel!.webview
+              .asWebviewUri(currentWorkspaceFolder.uri)
+              .toString();
             previewPanel?.webview.postMessage({
               type: "treatment",
-              treatmentFile,
+              treatmentFile: currentTreatment,
               introIndex: 0,
               treatmentIndex: 0,
               webviewBaseUri: baseUri,
             });
-          } else if (msg.type === "readFile" && workspaceFolder) {
+          } else if (msg.type === "readFile" && currentWorkspaceFolder) {
+            // Guard against path traversal
+            const filePath = String(msg.path);
+            if (filePath.includes("..") || path.isAbsolute(filePath)) {
+              previewPanel?.webview.postMessage({
+                type: "fileContent",
+                requestId: msg.requestId,
+                error: `Invalid path: ${filePath}`,
+              });
+              return;
+            }
             try {
               const fileUri = vscode.Uri.joinPath(
-                workspaceFolder.uri,
-                msg.path,
+                currentWorkspaceFolder.uri,
+                filePath,
               );
               const content = await vscode.workspace.fs.readFile(fileUri);
               previewPanel?.webview.postMessage({
@@ -742,7 +768,7 @@ export function activate(context: vscode.ExtensionContext): void {
               previewPanel?.webview.postMessage({
                 type: "fileContent",
                 requestId: msg.requestId,
-                error: `Failed to read: ${msg.path}`,
+                error: `Failed to read: ${filePath}`,
               });
             }
           }

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -137,7 +137,9 @@ function checkFileReferences(
 
   if (typeof record.file === "string" && record.file.length > 0) {
     const filePath = record.file;
-    const workspaceFolder = vscode.workspace.workspaceFolders![0];
+    const workspaceFolder =
+      vscode.workspace.getWorkspaceFolder(document.uri) ??
+      vscode.workspace.workspaceFolders![0];
     const fileUri = vscode.Uri.joinPath(workspaceFolder.uri, filePath);
 
     // Guard against path traversal (check before template placeholder skip)
@@ -164,20 +166,8 @@ function checkFileReferences(
     const uriKey = document.uri.toString();
     vscode.workspace.fs.stat(fileUri).then(
       () => {
-        // Discard if a newer validation has started
-        if (validationVersions.get(uriKey) !== version) return;
-
-        if (record.type === "prompt" && !filePath.endsWith(".prompt.md")) {
-          diagnostics.push(
-            makeFileDiagnostic(
-              source,
-              [...objPath, "file"],
-              `Prompt file should have .prompt.md extension: ${filePath}`,
-              vscode.DiagnosticSeverity.Warning,
-            ),
-          );
-          diagnosticCollection.set(document.uri, diagnostics);
-        }
+        // File exists — .prompt.md extension is enforced by the schema
+        // (promptFilePathSchema), so no redundant check needed here.
       },
       () => {
         if (validationVersions.get(uriKey) !== version) return;

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -284,8 +284,7 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
   readonly onDidChange = this._onDidChange.event;
 
   provideTextDocumentContent(uri: vscode.Uri): string {
-    // The source document URI is encoded in the query parameter
-    const sourceUri = vscode.Uri.parse(uri.query);
+    const sourceUri = vscode.Uri.parse(decodeURIComponent(uri.query));
     const sourceDoc = vscode.workspace.textDocuments.find(
       (d) => d.uri.toString() === sourceUri.toString(),
     );
@@ -295,14 +294,18 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
 
     const result = expandTreatmentSource(sourceDoc.getText());
     if (result.error) {
-      return `# Template expansion error:\n# ${result.error}`;
+      const commentedError = result.error
+        .split(/\r?\n/)
+        .map((line) => `# ${line}`)
+        .join("\n");
+      return `# Template expansion error:\n${commentedError}`;
     }
     return result.yaml;
   }
 
   refreshForSource(sourceUri: vscode.Uri): void {
     const expandedUri = vscode.Uri.parse(
-      `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${sourceUri.toString()}`,
+      `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${encodeURIComponent(sourceUri.toString())}`,
     );
     this._onDidChange.fire(expandedUri);
   }
@@ -344,7 +347,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
         const sourceUri = editor.document.uri;
         const expandedUri = vscode.Uri.parse(
-          `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${sourceUri.toString()}`,
+          `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${encodeURIComponent(sourceUri.toString())}`,
         );
 
         const doc = await vscode.workspace.openTextDocument(expandedUri);

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -468,7 +468,7 @@ function getWebviewContent(
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="Content-Security-Policy"
-    content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline'; img-src ${webview.cspSource} data:; font-src ${webview.cspSource};">
+    content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline'; img-src ${webview.cspSource} data:; font-src ${webview.cspSource}; media-src ${webview.cspSource} data:;">
   <style>
     :root {
       --viewer-sidebar-width: 280px;
@@ -618,11 +618,18 @@ export function activate(context: vscode.ExtensionContext): void {
     ),
   );
 
-  // Register file path autocomplete provider
+  // Register file path autocomplete provider. Trigger characters limit
+  // VS Code to invoking the provider only at likely path-completion
+  // points rather than on every keystroke — meaningful because the
+  // provider can hit `workspace.findFiles`.
   context.subscriptions.push(
     vscode.languages.registerCompletionItemProvider(
       "treatmentsYaml",
       new FilePathCompletionProvider(),
+      ":",
+      "/",
+      ".",
+      " ",
     ),
   );
 

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -146,12 +146,14 @@ function checkFileReferences(
 
   if (typeof record.file === "string" && record.file.length > 0) {
     const filePath = record.file;
+    // Resolve relative to the treatment file's directory, not workspace root
+    const treatmentDir = vscode.Uri.joinPath(document.uri, "..");
+    const fileUri = vscode.Uri.joinPath(treatmentDir, filePath);
+
+    // Guard against path traversal (check before template placeholder skip)
     const workspaceFolder =
       vscode.workspace.getWorkspaceFolder(document.uri) ??
       vscode.workspace.workspaceFolders![0];
-    const fileUri = vscode.Uri.joinPath(workspaceFolder.uri, filePath);
-
-    // Guard against path traversal (check before template placeholder skip)
     const base = workspaceFolder.uri.fsPath + path.sep;
     if (
       fileUri.fsPath !== workspaceFolder.uri.fsPath &&
@@ -308,6 +310,8 @@ class FilePathQuickFixProvider implements vscode.CodeActionProvider {
     const workspaceFolder =
       vscode.workspace.getWorkspaceFolder(document.uri) ??
       vscode.workspace.workspaceFolders[0];
+    // Suggestions should be relative to the treatment file's directory
+    const treatmentDirFsPath = vscode.Uri.joinPath(document.uri, "..").fsPath;
 
     // Refresh the cached file list if stale
     const now = Date.now();
@@ -321,10 +325,7 @@ class FilePathQuickFixProvider implements vscode.CodeActionProvider {
         5000,
       );
       this.cachedPaths = allFiles.map((f) =>
-        path
-          .relative(workspaceFolder.uri.fsPath, f.fsPath)
-          .split(path.sep)
-          .join("/"),
+        path.relative(treatmentDirFsPath, f.fsPath).split(path.sep).join("/"),
       );
       this.cacheTimestamp = now;
     }
@@ -367,6 +368,8 @@ class FilePathCompletionProvider implements vscode.CompletionItemProvider {
     const workspaceFolder =
       vscode.workspace.getWorkspaceFolder(document.uri) ??
       vscode.workspace.workspaceFolders[0];
+    // Completions should be relative to the treatment file's directory
+    const treatmentDirFsPath = vscode.Uri.joinPath(document.uri, "..").fsPath;
 
     // Get the partial path the user has typed so far
     const fileValueMatch = prefix.match(/\bfile:\s+(.*)/);
@@ -391,7 +394,7 @@ class FilePathCompletionProvider implements vscode.CompletionItemProvider {
 
     return files.map((fileUri) => {
       const relativePath = path
-        .relative(workspaceFolder.uri.fsPath, fileUri.fsPath)
+        .relative(treatmentDirFsPath, fileUri.fsPath)
         .split(path.sep)
         .join("/");
       const item = new vscode.CompletionItem(
@@ -677,6 +680,7 @@ export function activate(context: vscode.ExtensionContext): void {
   // Mutable state updated on each command invocation — avoids stale closures
   let currentTreatment: ReturnType<typeof parseTreatmentForPreview> = null;
   let currentWorkspaceFolder: vscode.WorkspaceFolder | undefined;
+  let currentTreatmentDir: vscode.Uri | undefined;
 
   context.subscriptions.push(
     vscode.commands.registerCommand("stagebook.previewStage", () => {
@@ -698,6 +702,7 @@ export function activate(context: vscode.ExtensionContext): void {
       currentWorkspaceFolder =
         vscode.workspace.getWorkspaceFolder(editor.document.uri) ??
         vscode.workspace.workspaceFolders?.[0];
+      currentTreatmentDir = vscode.Uri.joinPath(editor.document.uri, "..");
 
       if (!currentWorkspaceFolder) {
         vscode.window.showErrorMessage(
@@ -727,13 +732,9 @@ export function activate(context: vscode.ExtensionContext): void {
 
         // Handle messages from the webview
         previewPanel.webview.onDidReceiveMessage(async (msg) => {
-          if (
-            msg.type === "ready" &&
-            currentTreatment &&
-            currentWorkspaceFolder
-          ) {
+          if (msg.type === "ready" && currentTreatment && currentTreatmentDir) {
             const baseUri = previewPanel!.webview
-              .asWebviewUri(currentWorkspaceFolder.uri)
+              .asWebviewUri(currentTreatmentDir)
               .toString();
             previewPanel?.webview.postMessage({
               type: "treatment",
@@ -742,7 +743,7 @@ export function activate(context: vscode.ExtensionContext): void {
               treatmentIndex: 0,
               webviewBaseUri: baseUri,
             });
-          } else if (msg.type === "readFile" && currentWorkspaceFolder) {
+          } else if (msg.type === "readFile" && currentTreatmentDir) {
             // Guard against path traversal
             const filePath = String(msg.path);
             if (filePath.includes("..") || path.isAbsolute(filePath)) {
@@ -755,7 +756,7 @@ export function activate(context: vscode.ExtensionContext): void {
             }
             try {
               const fileUri = vscode.Uri.joinPath(
-                currentWorkspaceFolder.uri,
+                currentTreatmentDir,
                 filePath,
               );
               const content = await vscode.workspace.fs.readFile(fileUri);

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -10,6 +10,7 @@ import {
   computeSemanticTokens,
   type SemanticTokenType,
 } from "./lib/semanticTokens";
+import { expandTreatmentSource } from "./lib/expandTreatment";
 
 const diagnosticCollection =
   vscode.languages.createDiagnosticCollection("stagebook");
@@ -274,6 +275,39 @@ class TreatmentSemanticTokenProvider
   }
 }
 
+// --- Expanded Templates Preview ---
+
+const EXPANDED_SCHEME = "stagebook-expanded";
+
+class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
+  private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
+  readonly onDidChange = this._onDidChange.event;
+
+  provideTextDocumentContent(uri: vscode.Uri): string {
+    // The source document URI is encoded in the query parameter
+    const sourceUri = vscode.Uri.parse(uri.query);
+    const sourceDoc = vscode.workspace.textDocuments.find(
+      (d) => d.uri.toString() === sourceUri.toString(),
+    );
+    if (!sourceDoc) {
+      return "# Source document not found. Please reopen the preview.";
+    }
+
+    const result = expandTreatmentSource(sourceDoc.getText());
+    if (result.error) {
+      return `# Template expansion error:\n# ${result.error}`;
+    }
+    return result.yaml;
+  }
+
+  refreshForSource(sourceUri: vscode.Uri): void {
+    const expandedUri = vscode.Uri.parse(
+      `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${sourceUri.toString()}`,
+    );
+    this._onDidChange.fire(expandedUri);
+  }
+}
+
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(diagnosticCollection);
 
@@ -284,6 +318,54 @@ export function activate(context: vscode.ExtensionContext): void {
       new TreatmentSemanticTokenProvider(),
       tokenLegend,
     ),
+  );
+
+  // Register expanded templates content provider
+  const expandedProvider = new ExpandedTemplatesProvider();
+  context.subscriptions.push(
+    vscode.workspace.registerTextDocumentContentProvider(
+      EXPANDED_SCHEME,
+      expandedProvider,
+    ),
+  );
+
+  // Register the expand command
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "stagebook.previewExpandedTemplates",
+      async () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor || !isTreatmentsYaml(editor.document)) {
+          vscode.window.showWarningMessage(
+            "Open a .treatments.yaml file first.",
+          );
+          return;
+        }
+
+        const sourceUri = editor.document.uri;
+        const expandedUri = vscode.Uri.parse(
+          `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${sourceUri.toString()}`,
+        );
+
+        const doc = await vscode.workspace.openTextDocument(expandedUri);
+        await vscode.window.showTextDocument(doc, {
+          viewColumn: vscode.ViewColumn.Beside,
+          preview: true,
+          preserveFocus: true,
+        });
+        // Set language for syntax highlighting
+        await vscode.languages.setTextDocumentLanguage(doc, "yaml");
+      },
+    ),
+  );
+
+  // Auto-refresh the expanded preview when the source changes
+  context.subscriptions.push(
+    vscode.workspace.onDidChangeTextDocument((e) => {
+      if (isTreatmentsYaml(e.document)) {
+        expandedProvider.refreshForSource(e.document.uri);
+      }
+    }),
   );
 
   // Validate the active document on activation (no debounce)

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -68,6 +68,4 @@ export function activate(context: vscode.ExtensionContext): void {
   );
 }
 
-export function deactivate(): void {
-  diagnosticCollection.dispose();
-}
+export function deactivate(): void {}

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -12,6 +12,8 @@ import {
 } from "./lib/semanticTokens";
 import { expandTreatmentSource } from "./lib/expandTreatment";
 import { findClosestMatch } from "./lib/levenshtein";
+import { fillTemplates, treatmentFileSchema } from "stagebook";
+import { parse as parseYaml } from "yaml";
 
 const diagnosticCollection =
   vscode.languages.createDiagnosticCollection("stagebook");
@@ -448,6 +450,72 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
   }
 }
 
+// --- Stage Preview Webview ---
+
+function getWebviewContent(
+  webview: vscode.Webview,
+  extensionUri: vscode.Uri,
+): string {
+  const scriptUri = webview.asWebviewUri(
+    vscode.Uri.joinPath(extensionUri, "dist", "webview.js"),
+  );
+  const nonce = getNonce();
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'none'; script-src 'nonce-${nonce}'; style-src 'unsafe-inline'; img-src ${webview.cspSource} data:; font-src ${webview.cspSource};">
+  <style>
+    :root {
+      --viewer-sidebar-width: 280px;
+    }
+    body { margin: 0; padding: 0; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script nonce="${nonce}" src="${scriptUri}"></script>
+</body>
+</html>`;
+}
+
+function getNonce(): string {
+  const chars =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let nonce = "";
+  for (let i = 0; i < 32; i++) {
+    nonce += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return nonce;
+}
+
+function parseTreatmentForPreview(source: string) {
+  const obj = parseYaml(source);
+  if (typeof obj !== "object" || obj === null) return null;
+  const record = obj as Record<string, unknown>;
+  const templates = (record.templates ?? []) as unknown[];
+
+  let expanded = record;
+  if (templates.length > 0) {
+    try {
+      const { result } = fillTemplates({
+        obj: record,
+        templates,
+        allowUnresolved: true,
+      });
+      expanded = result as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  }
+
+  const parsed = treatmentFileSchema.safeParse(expanded);
+  if (!parsed.success) return null;
+  return parsed.data;
+}
+
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(diagnosticCollection);
 
@@ -525,6 +593,93 @@ export function activate(context: vscode.ExtensionContext): void {
       if (isTreatmentsYaml(e.document)) {
         expandedProvider.refreshForSource(e.document.uri);
       }
+    }),
+  );
+
+  // Register stage preview webview command
+  let previewPanel: vscode.WebviewPanel | undefined;
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("stagebook.previewStage", () => {
+      const editor = vscode.window.activeTextEditor;
+      if (!editor || !isTreatmentsYaml(editor.document)) {
+        vscode.window.showWarningMessage("Open a .treatments.yaml file first.");
+        return;
+      }
+
+      const source = editor.document.getText();
+      const treatmentFile = parseTreatmentForPreview(source);
+      if (!treatmentFile) {
+        vscode.window.showErrorMessage(
+          "Could not parse treatment file for preview.",
+        );
+        return;
+      }
+
+      const workspaceFolder =
+        vscode.workspace.getWorkspaceFolder(editor.document.uri) ??
+        vscode.workspace.workspaceFolders?.[0];
+
+      if (previewPanel) {
+        previewPanel.reveal(vscode.ViewColumn.Beside);
+      } else {
+        previewPanel = vscode.window.createWebviewPanel(
+          "stagebook.stagePreview",
+          "Stage Preview",
+          vscode.ViewColumn.Beside,
+          {
+            enableScripts: true,
+            localResourceRoots: [
+              vscode.Uri.joinPath(context.extensionUri, "dist"),
+              ...(workspaceFolder ? [workspaceFolder.uri] : []),
+            ],
+          },
+        );
+        previewPanel.onDidDispose(() => {
+          previewPanel = undefined;
+        });
+
+        // Handle messages from the webview
+        previewPanel.webview.onDidReceiveMessage(async (msg) => {
+          if (msg.type === "readFile" && workspaceFolder) {
+            try {
+              const fileUri = vscode.Uri.joinPath(
+                workspaceFolder.uri,
+                msg.path,
+              );
+              const content = await vscode.workspace.fs.readFile(fileUri);
+              previewPanel?.webview.postMessage({
+                type: "fileContent",
+                requestId: msg.requestId,
+                content: new TextDecoder().decode(content),
+              });
+            } catch {
+              previewPanel?.webview.postMessage({
+                type: "fileContent",
+                requestId: msg.requestId,
+                error: `Failed to read: ${msg.path}`,
+              });
+            }
+          }
+        });
+      }
+
+      previewPanel.webview.html = getWebviewContent(
+        previewPanel.webview,
+        context.extensionUri,
+      );
+
+      const webviewBaseUri = workspaceFolder
+        ? previewPanel.webview.asWebviewUri(workspaceFolder.uri).toString()
+        : "";
+
+      previewPanel.webview.postMessage({
+        type: "treatment",
+        treatmentFile,
+        introIndex: 0,
+        treatmentIndex: 0,
+        webviewBaseUri,
+      });
     }),
   );
 

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -1,3 +1,4 @@
+import * as path from "path";
 import * as vscode from "vscode";
 import {
   validateTreatmentSource,
@@ -10,6 +11,9 @@ const diagnosticCollection =
 
 const DEBOUNCE_MS = 300;
 const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+/** Version counter per document URI — used to discard stale async results. */
+const validationVersions = new Map<string, number>();
 
 function isTreatmentsYaml(document: vscode.TextDocument): boolean {
   return (
@@ -70,6 +74,10 @@ function toVscodeRange(range: Diagnostic["range"]): vscode.Range {
 }
 
 function validateTreatmentFile(document: vscode.TextDocument): void {
+  const uriKey = document.uri.toString();
+  const version = (validationVersions.get(uriKey) ?? 0) + 1;
+  validationVersions.set(uriKey, version);
+
   const source = document.getText();
   const result = validateTreatmentSource(source);
 
@@ -91,7 +99,13 @@ function validateTreatmentFile(document: vscode.TextDocument): void {
     typeof result.parsedObj === "object" &&
     vscode.workspace.workspaceFolders?.length
   ) {
-    checkFileReferences(document, result.parsedObj, source, vscodeDiagnostics);
+    checkFileReferences(
+      document,
+      result.parsedObj,
+      source,
+      vscodeDiagnostics,
+      version,
+    );
   }
 }
 
@@ -104,11 +118,15 @@ function checkFileReferences(
   obj: unknown,
   source: string,
   diagnostics: vscode.Diagnostic[],
-  path: (string | number)[] = [],
+  version: number,
+  objPath: (string | number)[] = [],
 ): void {
   if (Array.isArray(obj)) {
     obj.forEach((item, i) =>
-      checkFileReferences(document, item, source, diagnostics, [...path, i]),
+      checkFileReferences(document, item, source, diagnostics, version, [
+        ...objPath,
+        i,
+      ]),
     );
     return;
   }
@@ -119,19 +137,19 @@ function checkFileReferences(
 
   if (typeof record.file === "string" && record.file.length > 0) {
     const filePath = record.file;
-
-    // Skip if the path contains template placeholders
-    if (/\$\{[a-zA-Z0-9_]+\}/.test(filePath)) return;
-
     const workspaceFolder = vscode.workspace.workspaceFolders![0];
     const fileUri = vscode.Uri.joinPath(workspaceFolder.uri, filePath);
 
-    // Guard against path traversal
-    if (!fileUri.fsPath.startsWith(workspaceFolder.uri.fsPath)) {
+    // Guard against path traversal (check before template placeholder skip)
+    const base = workspaceFolder.uri.fsPath + path.sep;
+    if (
+      fileUri.fsPath !== workspaceFolder.uri.fsPath &&
+      !fileUri.fsPath.startsWith(base)
+    ) {
       diagnostics.push(
         makeFileDiagnostic(
           source,
-          [...path, "file"],
+          [...objPath, "file"],
           `File path escapes workspace: ${filePath}`,
           vscode.DiagnosticSeverity.Error,
         ),
@@ -140,14 +158,20 @@ function checkFileReferences(
       return;
     }
 
+    // Skip file existence check if the path contains template placeholders
+    if (/\$\{[a-zA-Z0-9_]+\}/.test(filePath)) return;
+
+    const uriKey = document.uri.toString();
     vscode.workspace.fs.stat(fileUri).then(
       () => {
-        // File exists — check extension for prompt elements
+        // Discard if a newer validation has started
+        if (validationVersions.get(uriKey) !== version) return;
+
         if (record.type === "prompt" && !filePath.endsWith(".prompt.md")) {
           diagnostics.push(
             makeFileDiagnostic(
               source,
-              [...path, "file"],
+              [...objPath, "file"],
               `Prompt file should have .prompt.md extension: ${filePath}`,
               vscode.DiagnosticSeverity.Warning,
             ),
@@ -156,10 +180,12 @@ function checkFileReferences(
         }
       },
       () => {
+        if (validationVersions.get(uriKey) !== version) return;
+
         diagnostics.push(
           makeFileDiagnostic(
             source,
-            [...path, "file"],
+            [...objPath, "file"],
             `File not found: ${filePath}`,
             vscode.DiagnosticSeverity.Error,
           ),
@@ -171,17 +197,20 @@ function checkFileReferences(
 
   for (const [key, value] of Object.entries(record)) {
     if (key === "file") continue;
-    checkFileReferences(document, value, source, diagnostics, [...path, key]);
+    checkFileReferences(document, value, source, diagnostics, version, [
+      ...objPath,
+      key,
+    ]);
   }
 }
 
 function makeFileDiagnostic(
   source: string,
-  path: (string | number)[],
+  objPath: (string | number)[],
   message: string,
   severity: vscode.DiagnosticSeverity,
 ): vscode.Diagnostic {
-  const range = pathToRange(source, path);
+  const range = pathToRange(source, objPath);
   const vscodeRange = range
     ? new vscode.Range(
         range.startLine,
@@ -228,6 +257,18 @@ export function activate(context: vscode.ExtensionContext): void {
       if (editor) {
         validateDocument(editor.document);
       }
+    }),
+  );
+
+  // Clean up timers and diagnostics when documents close
+  context.subscriptions.push(
+    vscode.workspace.onDidCloseTextDocument((document) => {
+      const key = document.uri.toString();
+      const timer = debounceTimers.get(key);
+      if (timer) clearTimeout(timer);
+      debounceTimers.delete(key);
+      validationVersions.delete(key);
+      diagnosticCollection.delete(document.uri);
     }),
   );
 }

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -4,6 +4,7 @@ import {
   validateTreatmentSource,
   type Diagnostic,
 } from "./lib/validateTreatment";
+import { validatePromptSource } from "./lib/validatePrompt";
 import { pathToRange } from "./lib/yamlPositionMap";
 
 const diagnosticCollection =
@@ -215,8 +216,21 @@ function makeFileDiagnostic(
   return diag;
 }
 
-function validatePromptFile(_document: vscode.TextDocument): void {
-  // TODO (#76): validate with stagebook's promptFileSchema
+function validatePromptFile(document: vscode.TextDocument): void {
+  const source = document.getText();
+  const result = validatePromptSource(source);
+
+  const vscodeDiagnostics = result.diagnostics.map((d) => {
+    const diag = new vscode.Diagnostic(
+      toVscodeRange(d.range),
+      d.message,
+      toSeverity(d.severity),
+    );
+    diag.source = "stagebook";
+    return diag;
+  });
+
+  diagnosticCollection.set(document.uri, vscodeDiagnostics);
 }
 
 export function activate(context: vscode.ExtensionContext): void {

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -12,6 +12,7 @@ import {
 } from "./lib/semanticTokens";
 import { expandTreatmentSource } from "./lib/expandTreatment";
 import { findClosestMatch } from "./lib/levenshtein";
+import { isWithinWorkspace, relativizePath } from "./lib/filePaths";
 import { fillTemplates, treatmentFileSchema } from "stagebook";
 import { parse as parseYaml } from "yaml";
 
@@ -154,11 +155,7 @@ function checkFileReferences(
     const workspaceFolder =
       vscode.workspace.getWorkspaceFolder(document.uri) ??
       vscode.workspace.workspaceFolders![0];
-    const base = workspaceFolder.uri.fsPath + path.sep;
-    if (
-      fileUri.fsPath !== workspaceFolder.uri.fsPath &&
-      !fileUri.fsPath.startsWith(base)
-    ) {
+    if (!isWithinWorkspace(fileUri.fsPath, workspaceFolder.uri.fsPath)) {
       diagnostics.push(
         makeFileDiagnostic(
           source,
@@ -288,6 +285,7 @@ class FilePathQuickFixProvider implements vscode.CodeActionProvider {
   // Cache workspace file paths to avoid re-globbing on every cursor move
   private cachedPaths: string[] = [];
   private cacheTimestamp = 0;
+  private cachedTreatmentDir = "";
   private static readonly CACHE_TTL_MS = 5000;
 
   async provideCodeActions(
@@ -313,9 +311,12 @@ class FilePathQuickFixProvider implements vscode.CodeActionProvider {
     // Suggestions should be relative to the treatment file's directory
     const treatmentDirFsPath = vscode.Uri.joinPath(document.uri, "..").fsPath;
 
-    // Refresh the cached file list if stale
+    // Refresh the cached file list if stale or treatment dir changed
     const now = Date.now();
-    if (now - this.cacheTimestamp > FilePathQuickFixProvider.CACHE_TTL_MS) {
+    if (
+      now - this.cacheTimestamp > FilePathQuickFixProvider.CACHE_TTL_MS ||
+      this.cachedTreatmentDir !== treatmentDirFsPath
+    ) {
       const allFiles = await vscode.workspace.findFiles(
         new vscode.RelativePattern(
           workspaceFolder,
@@ -325,9 +326,10 @@ class FilePathQuickFixProvider implements vscode.CodeActionProvider {
         5000,
       );
       this.cachedPaths = allFiles.map((f) =>
-        path.relative(treatmentDirFsPath, f.fsPath).split(path.sep).join("/"),
+        relativizePath(treatmentDirFsPath, f.fsPath),
       );
       this.cacheTimestamp = now;
+      this.cachedTreatmentDir = treatmentDirFsPath;
     }
 
     for (const diagnostic of diagnostics) {
@@ -393,10 +395,7 @@ class FilePathCompletionProvider implements vscode.CompletionItemProvider {
       : line.length;
 
     return files.map((fileUri) => {
-      const relativePath = path
-        .relative(treatmentDirFsPath, fileUri.fsPath)
-        .split(path.sep)
-        .join("/");
+      const relativePath = relativizePath(treatmentDirFsPath, fileUri.fsPath);
       const item = new vscode.CompletionItem(
         relativePath,
         vscode.CompletionItemKind.File,
@@ -679,8 +678,8 @@ export function activate(context: vscode.ExtensionContext): void {
   let previewPanel: vscode.WebviewPanel | undefined;
   // Mutable state updated on each command invocation — avoids stale closures
   let currentTreatment: ReturnType<typeof parseTreatmentForPreview> = null;
-  let currentWorkspaceFolder: vscode.WorkspaceFolder | undefined;
   let currentTreatmentDir: vscode.Uri | undefined;
+  let currentWorkspaceRootFsPath: string | undefined;
 
   context.subscriptions.push(
     vscode.commands.registerCommand("stagebook.previewStage", () => {
@@ -699,17 +698,19 @@ export function activate(context: vscode.ExtensionContext): void {
         return;
       }
 
-      currentWorkspaceFolder =
+      const workspaceFolder =
         vscode.workspace.getWorkspaceFolder(editor.document.uri) ??
         vscode.workspace.workspaceFolders?.[0];
-      currentTreatmentDir = vscode.Uri.joinPath(editor.document.uri, "..");
 
-      if (!currentWorkspaceFolder) {
+      if (!workspaceFolder) {
         vscode.window.showErrorMessage(
           "No workspace folder found. Open a folder first.",
         );
         return;
       }
+
+      currentTreatmentDir = vscode.Uri.joinPath(editor.document.uri, "..");
+      currentWorkspaceRootFsPath = workspaceFolder.uri.fsPath;
 
       if (previewPanel) {
         previewPanel.reveal(vscode.ViewColumn.Beside);
@@ -759,6 +760,19 @@ export function activate(context: vscode.ExtensionContext): void {
                 currentTreatmentDir,
                 filePath,
               );
+              // Post-resolution workspace boundary check (defense in depth
+              // against symlinks and edge cases the substring check misses)
+              if (
+                currentWorkspaceRootFsPath &&
+                !isWithinWorkspace(fileUri.fsPath, currentWorkspaceRootFsPath)
+              ) {
+                previewPanel?.webview.postMessage({
+                  type: "fileContent",
+                  requestId: msg.requestId,
+                  error: `Path escapes workspace: ${filePath}`,
+                });
+                return;
+              }
               const content = await vscode.workspace.fs.readFile(fileUri);
               previewPanel?.webview.postMessage({
                 type: "fileContent",

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -752,6 +752,12 @@ export function activate(context: vscode.ExtensionContext): void {
             // filled-in fields) persists across this prop update because the
             // webview's React tree doesn't unmount.
             if (!currentTreatmentUri || !currentTreatmentDir) return;
+            // Capture the panel before any awaits. If the user closes the
+            // preview mid-refresh, onDidDispose clears `previewPanel` and
+            // a non-null assertion on the outer ref would throw.
+            const panel = previewPanel;
+            const treatmentDir = currentTreatmentDir;
+            if (!panel) return;
             try {
               const doc =
                 await vscode.workspace.openTextDocument(currentTreatmentUri);
@@ -763,10 +769,12 @@ export function activate(context: vscode.ExtensionContext): void {
                 return;
               }
               currentTreatment = parsed;
-              const baseUri = previewPanel!.webview
-                .asWebviewUri(currentTreatmentDir)
+              // Panel may have been disposed while we were awaiting above.
+              if (!previewPanel) return;
+              const baseUri = panel.webview
+                .asWebviewUri(treatmentDir)
                 .toString();
-              previewPanel?.webview.postMessage({
+              panel.webview.postMessage({
                 type: "treatment",
                 treatmentFile: parsed,
                 introIndex: 0,

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -6,6 +6,10 @@ import {
 } from "./lib/validateTreatment";
 import { validatePromptSource } from "./lib/validatePrompt";
 import { pathToRange } from "./lib/yamlPositionMap";
+import {
+  computeSemanticTokens,
+  type SemanticTokenType,
+} from "./lib/semanticTokens";
 
 const diagnosticCollection =
   vscode.languages.createDiagnosticCollection("stagebook");
@@ -233,8 +237,54 @@ function validatePromptFile(document: vscode.TextDocument): void {
   diagnosticCollection.set(document.uri, vscodeDiagnostics);
 }
 
+// Standard VS Code semantic token types — every theme colors these
+const semanticTokenTypes: SemanticTokenType[] = [
+  "type",
+  "keyword",
+  "variable",
+  "string",
+  "property",
+];
+
+const tokenLegend = new vscode.SemanticTokensLegend(semanticTokenTypes);
+
+class TreatmentSemanticTokenProvider
+  implements vscode.DocumentSemanticTokensProvider
+{
+  provideDocumentSemanticTokens(
+    document: vscode.TextDocument,
+  ): vscode.SemanticTokens {
+    const builder = new vscode.SemanticTokensBuilder(tokenLegend);
+    const source = document.getText();
+    const tokens = computeSemanticTokens(source);
+
+    for (const token of tokens) {
+      builder.push(
+        new vscode.Range(
+          token.line,
+          token.startCol,
+          token.line,
+          token.startCol + token.length,
+        ),
+        token.tokenType,
+      );
+    }
+
+    return builder.build();
+  }
+}
+
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(diagnosticCollection);
+
+  // Register semantic token provider for treatment files
+  context.subscriptions.push(
+    vscode.languages.registerDocumentSemanticTokensProvider(
+      { language: "treatmentsYaml" },
+      new TreatmentSemanticTokenProvider(),
+      tokenLegend,
+    ),
+  );
 
   // Validate the active document on activation (no debounce)
   if (vscode.window.activeTextEditor) {

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -311,12 +311,18 @@ class FilePathQuickFixProvider implements vscode.CodeActionProvider {
     const now = Date.now();
     if (now - this.cacheTimestamp > FilePathQuickFixProvider.CACHE_TTL_MS) {
       const allFiles = await vscode.workspace.findFiles(
-        "**/*.{prompt.md,md,yaml,jpg,jpeg,png,mp3,mp4}",
+        new vscode.RelativePattern(
+          workspaceFolder,
+          "**/*.{prompt.md,md,yaml,jpg,jpeg,png,mp3,mp4}",
+        ),
         "**/node_modules/**",
         5000,
       );
       this.cachedPaths = allFiles.map((f) =>
-        path.relative(workspaceFolder.uri.fsPath, f.fsPath),
+        path
+          .relative(workspaceFolder.uri.fsPath, f.fsPath)
+          .split(path.sep)
+          .join("/"),
       );
       this.cacheTimestamp = now;
     }
@@ -351,8 +357,8 @@ class FilePathCompletionProvider implements vscode.CompletionItemProvider {
     const line = document.lineAt(position).text;
     const prefix = line.substring(0, position.character);
 
-    // Only trigger after "file:" with optional whitespace
-    if (!/^\s*file:\s/.test(prefix)) return undefined;
+    // Trigger after "file:" anywhere in the line (handles "- file:", indented, etc.)
+    if (!/\bfile:\s/.test(prefix)) return undefined;
 
     if (!vscode.workspace.workspaceFolders?.length) return undefined;
 
@@ -361,7 +367,7 @@ class FilePathCompletionProvider implements vscode.CompletionItemProvider {
       vscode.workspace.workspaceFolders[0];
 
     // Get the partial path the user has typed so far
-    const fileValueMatch = prefix.match(/file:\s+(.*)/);
+    const fileValueMatch = prefix.match(/\bfile:\s+(.*)/);
     const partial = fileValueMatch?.[1] ?? "";
 
     // Sanitize glob metacharacters in user input
@@ -370,30 +376,36 @@ class FilePathCompletionProvider implements vscode.CompletionItemProvider {
       ? `**/${sanitized}*`
       : "**/*.{prompt.md,md,yaml}";
     const files = await vscode.workspace.findFiles(
-      globPattern,
+      new vscode.RelativePattern(workspaceFolder, globPattern),
       "**/node_modules/**",
       50,
     );
 
+    // Find the end of the value (stop at comment or end of line)
+    const valueEndMatch = line.substring(position.character).match(/\s+#/);
+    const valueEnd = valueEndMatch
+      ? position.character + valueEndMatch.index!
+      : line.length;
+
     return files.map((fileUri) => {
-      const relativePath = path.relative(
-        workspaceFolder.uri.fsPath,
-        fileUri.fsPath,
-      );
+      const relativePath = path
+        .relative(workspaceFolder.uri.fsPath, fileUri.fsPath)
+        .split(path.sep)
+        .join("/");
       const item = new vscode.CompletionItem(
         relativePath,
         vscode.CompletionItemKind.File,
       );
       item.insertText = relativePath;
-      // Replace the entire value after "file: "
-      const valueStart = prefix.indexOf("file:") + "file:".length;
+      // Replace only the value portion (not trailing comments)
+      const valueStart = prefix.lastIndexOf("file:") + "file:".length;
       const whitespaceAfterColon =
         prefix.substring(valueStart).match(/^\s*/)?.[0] ?? " ";
       item.range = new vscode.Range(
         position.line,
         valueStart + whitespaceAfterColon.length,
         position.line,
-        line.length,
+        valueEnd,
       );
       return item;
     });

--- a/apps/vscode/src/lib/expandTreatment.test.ts
+++ b/apps/vscode/src/lib/expandTreatment.test.ts
@@ -109,19 +109,13 @@ treatments:
       expect(result.error).not.toBeNull();
     });
 
-    it("returns an error when template expansion fails", () => {
-      const src = `templates:
-  - templateName: myStage
-    templateContent:
-      name: \${missing}_stage
+    it("returns an error when templates key is not an array", () => {
+      const src = `templates: notAnArray
 treatments:
-  - name: study1
-    playerCount: 1
-    gameStages:
-      - template: myStage`;
+  - name: study1`;
       const result = expandTreatmentSource(src);
-      // Should either expand with unresolved fields or report an error
-      expect(result.yaml.length > 0 || result.error !== null).toBe(true);
+      expect(result.error).toContain("must be an array");
+      expect(result.yaml).toBe("");
     });
   });
 

--- a/apps/vscode/src/lib/expandTreatment.test.ts
+++ b/apps/vscode/src/lib/expandTreatment.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect } from "vitest";
+import { expandTreatmentSource } from "./expandTreatment";
+
+describe("expandTreatmentSource", () => {
+  describe("no templates", () => {
+    it("returns the YAML unchanged when there are no templates", () => {
+      const src = `treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: submitButton`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("name: study1");
+      expect(result.yaml).toContain("type: submitButton");
+      expect(result.truncated).toBe(false);
+    });
+  });
+
+  describe("simple template expansion", () => {
+    it("expands a template context into concrete content", () => {
+      const src = `templates:
+  - templateName: myStage
+    templateContent:
+      name: stage1
+      duration: 300
+      elements:
+        - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: myStage`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("name: stage1");
+      expect(result.yaml).toContain("duration: 300");
+      expect(result.yaml).toContain("type: submitButton");
+      // Templates key should be removed from output
+      expect(result.yaml).not.toMatch(/^templates:/m);
+    });
+  });
+
+  describe("field substitution", () => {
+    it("substitutes field values into template content", () => {
+      const src = `templates:
+  - templateName: topicStage
+    templateContent:
+      name: \${topic}_stage
+      duration: 300
+      elements:
+        - type: prompt
+          file: prompts/\${topic}.prompt.md
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: topicStage
+        fields:
+          topic: climate`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("name: climate_stage");
+      expect(result.yaml).toContain("file: prompts/climate.prompt.md");
+    });
+  });
+
+  describe("broadcast expansion", () => {
+    it("expands broadcast dimensions into multiple items", () => {
+      const src = `templates:
+  - templateName: topicStage
+    templateContent:
+      name: \${topic}_stage
+      duration: 300
+      elements:
+        - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: topicStage
+        broadcast:
+          d0:
+            - topic: climate
+            - topic: guns
+            - topic: immigration`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("climate_stage");
+      expect(result.yaml).toContain("guns_stage");
+      expect(result.yaml).toContain("immigration_stage");
+    });
+  });
+
+  describe("error handling", () => {
+    it("returns an error for invalid YAML", () => {
+      const src = `[[[invalid`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).not.toBeNull();
+      expect(result.yaml).toBe("");
+    });
+
+    it("returns an error for non-object YAML", () => {
+      const src = `just a string`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).not.toBeNull();
+    });
+
+    it("returns an error when template expansion fails", () => {
+      const src = `templates:
+  - templateName: myStage
+    templateContent:
+      name: \${missing}_stage
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: myStage`;
+      const result = expandTreatmentSource(src);
+      // Should either expand with unresolved fields or report an error
+      expect(result.yaml.length > 0 || result.error !== null).toBe(true);
+    });
+  });
+
+  describe("output size limit", () => {
+    it("truncates output that exceeds the line limit", () => {
+      // Generate a treatment with a large broadcast
+      const topics = Array.from({ length: 200 }, (_, i) => `topic${i}`);
+      const broadcastItems = topics
+        .map((t) => `            - topic: ${t}`)
+        .join("\n");
+      const src = `templates:
+  - templateName: bigStage
+    templateContent:
+      name: \${topic}_stage
+      duration: 300
+      elements:
+        - type: prompt
+          file: prompts/\${topic}.prompt.md
+        - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: bigStage
+        broadcast:
+          d0:
+${broadcastItems}`;
+      const result = expandTreatmentSource(src, { maxLines: 100 });
+      expect(result.truncated).toBe(true);
+      const lines = result.yaml.split("\n");
+      // Should be at or under the limit (plus truncation notice)
+      expect(lines.length).toBeLessThanOrEqual(105);
+      expect(result.yaml).toContain("# --- Output truncated at 100 lines");
+    });
+  });
+
+  describe("nested templates", () => {
+    it("expands templates that reference other templates", () => {
+      const src = `templates:
+  - templateName: innerElem
+    templateContent:
+      type: submitButton
+  - templateName: outerStage
+    templateContent:
+      name: stage1
+      duration: 300
+      elements:
+        - template: innerElem
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: outerStage`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("type: submitButton");
+      expect(result.yaml).toContain("name: stage1");
+    });
+  });
+
+  describe("nonexistent template reference", () => {
+    it("returns an error when a template reference does not exist", () => {
+      const src = `templates:
+  - templateName: myStage
+    templateContent:
+      name: stage1
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: nonexistentStage`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toContain("not found");
+      expect(result.yaml).toBe("");
+    });
+  });
+
+  describe("unresolved placeholders", () => {
+    it("preserves unresolved placeholders in the output", () => {
+      const src = `templates:
+  - templateName: myStage
+    templateContent:
+      name: \${missing}_stage
+      duration: 300
+      elements:
+        - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: myStage`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("${missing}_stage");
+    });
+  });
+
+  describe("multi-dimension broadcast", () => {
+    it("expands broadcast with multiple dimensions into cartesian product", () => {
+      const src = `templates:
+  - templateName: topicStage
+    templateContent:
+      name: \${topic}_\${condition}_stage
+      duration: 300
+      elements:
+        - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: topicStage
+        broadcast:
+          d0:
+            - topic: climate
+            - topic: guns
+          d1:
+            - condition: control
+            - condition: treatment`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("climate_control_stage");
+      expect(result.yaml).toContain("climate_treatment_stage");
+      expect(result.yaml).toContain("guns_control_stage");
+      expect(result.yaml).toContain("guns_treatment_stage");
+    });
+  });
+
+  describe("broadcast size guard", () => {
+    it("rejects broadcasts that would produce too many items", () => {
+      const topics = Array.from({ length: 200 }, (_, i) => `topic${i}`);
+      const broadcastItems = topics
+        .map((t) => `            - topic: ${t}`)
+        .join("\n");
+      const src = `templates:
+  - templateName: bigStage
+    templateContent:
+      name: \${topic}_stage
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: bigStage
+        broadcast:
+          d0:
+${broadcastItems}`;
+      const result = expandTreatmentSource(src, { maxBroadcastProduct: 100 });
+      expect(result.error).toContain("Broadcast expansion would produce");
+      expect(result.yaml).toBe("");
+    });
+  });
+
+  describe("templates key removal", () => {
+    it("removes the templates key from expanded output", () => {
+      const src = `templates:
+  - templateName: myStage
+    templateContent:
+      name: stage1
+      duration: 300
+      elements:
+        - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: myStage`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toBeNull();
+      expect(result.yaml).not.toMatch(/templateName:/);
+      expect(result.yaml).not.toMatch(/templateContent:/);
+    });
+  });
+});

--- a/apps/vscode/src/lib/expandTreatment.ts
+++ b/apps/vscode/src/lib/expandTreatment.ts
@@ -1,0 +1,153 @@
+import { fillTemplates } from "stagebook";
+import { parse, stringify } from "yaml";
+
+const DEFAULT_MAX_LINES = 5000;
+const DEFAULT_MAX_BROADCAST = 10000;
+
+export interface ExpandResult {
+  /** The expanded YAML string, or "" on error. */
+  yaml: string;
+  /** Error message if expansion failed, null on success. */
+  error: string | null;
+  /** Whether the output was truncated due to line limit. */
+  truncated: boolean;
+}
+
+export interface ExpandOptions {
+  maxLines?: number;
+  maxBroadcastProduct?: number;
+}
+
+/**
+ * Walk the parsed object looking for broadcast dimensions and estimate
+ * the total Cartesian product size. Returns an error message if it
+ * exceeds the limit, or null if it's within bounds.
+ */
+function checkBroadcastSize(obj: unknown, limit: number): string | null {
+  let totalProduct = 0;
+
+  function walk(node: unknown): void {
+    if (Array.isArray(node)) {
+      for (const item of node) walk(item);
+      return;
+    }
+    if (typeof node !== "object" || node === null) return;
+    const record = node as Record<string, unknown>;
+
+    if (record.broadcast && typeof record.broadcast === "object") {
+      const dims = record.broadcast as Record<string, unknown>;
+      let product = 1;
+      for (const dim of Object.values(dims)) {
+        if (Array.isArray(dim)) product *= dim.length;
+      }
+      totalProduct += product;
+    }
+
+    for (const value of Object.values(record)) {
+      walk(value);
+    }
+  }
+
+  walk(obj);
+
+  if (totalProduct > limit) {
+    return `Broadcast expansion would produce ~${totalProduct} items (limit: ${limit}). Reduce broadcast dimensions or increase the limit.`;
+  }
+  return null;
+}
+
+/**
+ * Expand all templates in a treatment YAML source string.
+ *
+ * Returns the fully expanded YAML with the `templates` key removed.
+ * This is a pure function — no VS Code dependency.
+ */
+export function expandTreatmentSource(
+  source: string,
+  options?: ExpandOptions,
+): ExpandResult {
+  const maxLines = options?.maxLines ?? DEFAULT_MAX_LINES;
+
+  // Parse YAML
+  let obj: unknown;
+  try {
+    obj = parse(source);
+  } catch (e) {
+    return {
+      yaml: "",
+      error: `YAML parse error: ${e instanceof Error ? e.message : String(e)}`,
+      truncated: false,
+    };
+  }
+
+  if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
+    return {
+      yaml: "",
+      error:
+        "Treatment file must be a YAML mapping (object), not a scalar or array.",
+      truncated: false,
+    };
+  }
+
+  const record = obj as Record<string, unknown>;
+  const templates = (record.templates ?? []) as unknown[];
+
+  // Guard against combinatorial explosion from large broadcast dimensions.
+  // Estimate the total product size before expanding.
+  const broadcastLimit = options?.maxBroadcastProduct ?? DEFAULT_MAX_BROADCAST;
+  const sizeError = checkBroadcastSize(record, broadcastLimit);
+  if (sizeError) {
+    return { yaml: "", error: sizeError, truncated: false };
+  }
+
+  // Expand templates
+  let expanded: Record<string, unknown>;
+  try {
+    if (templates.length > 0) {
+      const { result } = fillTemplates({
+        obj: record,
+        templates,
+        allowUnresolved: true,
+      });
+      expanded = result as Record<string, unknown>;
+    } else {
+      expanded = { ...record };
+    }
+  } catch (e) {
+    return {
+      yaml: "",
+      error: `Template expansion failed: ${e instanceof Error ? e.message : String(e)}`,
+      truncated: false,
+    };
+  }
+
+  // Remove templates key from output
+  delete expanded.templates;
+
+  // Serialize back to YAML
+  let yaml: string;
+  try {
+    yaml = stringify(expanded, { indent: 2, lineWidth: 0 });
+  } catch (e) {
+    return {
+      yaml: "",
+      error: `YAML serialization failed: ${e instanceof Error ? e.message : String(e)}`,
+      truncated: false,
+    };
+  }
+
+  // Truncate if over the line limit
+  const lines = yaml.split("\n");
+  if (lines.length > maxLines) {
+    const truncatedYaml = lines.slice(0, maxLines).join("\n");
+    return {
+      yaml:
+        truncatedYaml +
+        `\n\n# --- Output truncated at ${maxLines} lines (${lines.length} total) ---`,
+      error: null,
+      truncated: true,
+    };
+  }
+
+  return { yaml, error: null, truncated: false };
+}

--- a/apps/vscode/src/lib/expandTreatment.ts
+++ b/apps/vscode/src/lib/expandTreatment.ts
@@ -34,7 +34,11 @@ function checkBroadcastSize(obj: unknown, limit: number): string | null {
     if (typeof node !== "object" || node === null) return;
     const record = node as Record<string, unknown>;
 
-    if (record.broadcast && typeof record.broadcast === "object") {
+    if (
+      typeof record.template === "string" &&
+      record.broadcast &&
+      typeof record.broadcast === "object"
+    ) {
       const dims = record.broadcast as Record<string, unknown>;
       let product = 1;
       for (const dim of Object.values(dims)) {
@@ -90,6 +94,15 @@ export function expandTreatmentSource(
   }
 
   const record = obj as Record<string, unknown>;
+
+  if (record.templates !== undefined && !Array.isArray(record.templates)) {
+    return {
+      yaml: "",
+      error: "The 'templates' key must be an array.",
+      truncated: false,
+    };
+  }
+
   const templates = (record.templates ?? []) as unknown[];
 
   // Guard against combinatorial explosion from large broadcast dimensions.

--- a/apps/vscode/src/lib/filePaths.test.ts
+++ b/apps/vscode/src/lib/filePaths.test.ts
@@ -2,82 +2,90 @@ import { describe, it, expect } from "vitest";
 import * as path from "path";
 import { isWithinWorkspace, relativizePath } from "./filePaths";
 
+// Construct paths using the platform's native separator so tests work on
+// both POSIX and Windows. The leading path.sep makes each a rooted path.
+const ROOT = path.join(path.sep, "workspace");
+
 describe("isWithinWorkspace", () => {
   it("returns true when resolved path equals workspace root", () => {
-    expect(isWithinWorkspace("/workspace", "/workspace")).toBe(true);
+    expect(isWithinWorkspace(ROOT, ROOT)).toBe(true);
   });
 
   it("returns true for a direct child", () => {
-    expect(
-      isWithinWorkspace(path.join("/workspace", "file.txt"), "/workspace"),
-    ).toBe(true);
+    expect(isWithinWorkspace(path.join(ROOT, "file.txt"), ROOT)).toBe(true);
   });
 
   it("returns true for a deeply nested path", () => {
     expect(
-      isWithinWorkspace(
-        path.join("/workspace", "a", "b", "c", "file.txt"),
-        "/workspace",
-      ),
+      isWithinWorkspace(path.join(ROOT, "a", "b", "c", "file.txt"), ROOT),
     ).toBe(true);
   });
 
   it("returns false when path escapes workspace via traversal", () => {
-    expect(isWithinWorkspace("/etc/passwd", "/workspace")).toBe(false);
+    const outside = path.join(path.sep, "etc", "passwd");
+    expect(isWithinWorkspace(outside, ROOT)).toBe(false);
   });
 
   it("returns false for a sibling directory with a shared prefix", () => {
     // "/workspace-other/file" should NOT match "/workspace"
-    expect(
-      isWithinWorkspace(
-        path.join("/workspace-other", "file.txt"),
-        "/workspace",
-      ),
-    ).toBe(false);
+    const sibling = path.join(path.sep, "workspace-other", "file.txt");
+    expect(isWithinWorkspace(sibling, ROOT)).toBe(false);
   });
 
   it("returns false for a parent directory", () => {
-    expect(isWithinWorkspace("/", "/workspace")).toBe(false);
+    expect(isWithinWorkspace(path.sep, ROOT)).toBe(false);
+  });
+
+  it("tolerates a trailing separator on the workspace root", () => {
+    expect(
+      isWithinWorkspace(path.join(ROOT, "file.txt"), ROOT + path.sep),
+    ).toBe(true);
+  });
+
+  it("handles the filesystem root as workspace root", () => {
+    const fsRoot = path.sep;
+    expect(isWithinWorkspace(path.join(fsRoot, "anything"), fsRoot)).toBe(true);
+    expect(isWithinWorkspace(fsRoot, fsRoot)).toBe(true);
+  });
+
+  it("normalizes unclean input paths", () => {
+    // path.resolve collapses "." and redundant separators
+    const messy = path.join(ROOT, ".", "a", "b", "..", "file.txt");
+    expect(isWithinWorkspace(messy, ROOT)).toBe(true);
   });
 });
 
 describe("relativizePath", () => {
   it("returns a simple filename when file is in the base dir", () => {
-    expect(
-      relativizePath(
-        "/workspace/study",
-        path.join("/workspace/study", "q.prompt.md"),
-      ),
-    ).toBe("q.prompt.md");
+    const base = path.join(ROOT, "study");
+    expect(relativizePath(base, path.join(base, "q.prompt.md"))).toBe(
+      "q.prompt.md",
+    );
   });
 
   it("returns a forward-slash path for a nested file", () => {
+    const base = path.join(ROOT, "study");
     expect(
-      relativizePath(
-        "/workspace/study",
-        path.join("/workspace/study", "prompts", "q.prompt.md"),
-      ),
+      relativizePath(base, path.join(base, "prompts", "q.prompt.md")),
     ).toBe("prompts/q.prompt.md");
   });
 
   it("returns ../ segments when file is in a sibling directory", () => {
     expect(
       relativizePath(
-        path.join("/workspace", "study"),
-        path.join("/workspace", "shared", "q.prompt.md"),
+        path.join(ROOT, "study"),
+        path.join(ROOT, "shared", "q.prompt.md"),
       ),
     ).toBe("../shared/q.prompt.md");
   });
 
-  it("returns the same result when base and file are the same directory", () => {
-    expect(relativizePath("/workspace", "/workspace")).toBe("");
+  it("returns an empty string when base and file are the same directory", () => {
+    expect(relativizePath(ROOT, ROOT)).toBe("");
   });
 
-  it("uses forward slashes even on the current platform", () => {
-    const result = relativizePath(
-      path.join("/workspace", "a"),
-      path.join("/workspace", "a", "b", "c.md"),
-    );
+  it("uses forward slashes even on platforms where path.sep is a backslash", () => {
+    const base = path.join(ROOT, "a");
+    const result = relativizePath(base, path.join(base, "b", "c.md"));
     expect(result).not.toContain("\\");
     expect(result).toBe("b/c.md");
   });

--- a/apps/vscode/src/lib/filePaths.test.ts
+++ b/apps/vscode/src/lib/filePaths.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import * as path from "path";
+import { isWithinWorkspace, relativizePath } from "./filePaths";
+
+describe("isWithinWorkspace", () => {
+  it("returns true when resolved path equals workspace root", () => {
+    expect(isWithinWorkspace("/workspace", "/workspace")).toBe(true);
+  });
+
+  it("returns true for a direct child", () => {
+    expect(
+      isWithinWorkspace(path.join("/workspace", "file.txt"), "/workspace"),
+    ).toBe(true);
+  });
+
+  it("returns true for a deeply nested path", () => {
+    expect(
+      isWithinWorkspace(
+        path.join("/workspace", "a", "b", "c", "file.txt"),
+        "/workspace",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns false when path escapes workspace via traversal", () => {
+    expect(isWithinWorkspace("/etc/passwd", "/workspace")).toBe(false);
+  });
+
+  it("returns false for a sibling directory with a shared prefix", () => {
+    // "/workspace-other/file" should NOT match "/workspace"
+    expect(
+      isWithinWorkspace(
+        path.join("/workspace-other", "file.txt"),
+        "/workspace",
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for a parent directory", () => {
+    expect(isWithinWorkspace("/", "/workspace")).toBe(false);
+  });
+});
+
+describe("relativizePath", () => {
+  it("returns a simple filename when file is in the base dir", () => {
+    expect(
+      relativizePath(
+        "/workspace/study",
+        path.join("/workspace/study", "q.prompt.md"),
+      ),
+    ).toBe("q.prompt.md");
+  });
+
+  it("returns a forward-slash path for a nested file", () => {
+    expect(
+      relativizePath(
+        "/workspace/study",
+        path.join("/workspace/study", "prompts", "q.prompt.md"),
+      ),
+    ).toBe("prompts/q.prompt.md");
+  });
+
+  it("returns ../ segments when file is in a sibling directory", () => {
+    expect(
+      relativizePath(
+        path.join("/workspace", "study"),
+        path.join("/workspace", "shared", "q.prompt.md"),
+      ),
+    ).toBe("../shared/q.prompt.md");
+  });
+
+  it("returns the same result when base and file are the same directory", () => {
+    expect(relativizePath("/workspace", "/workspace")).toBe("");
+  });
+
+  it("uses forward slashes even on the current platform", () => {
+    const result = relativizePath(
+      path.join("/workspace", "a"),
+      path.join("/workspace", "a", "b", "c.md"),
+    );
+    expect(result).not.toContain("\\");
+    expect(result).toBe("b/c.md");
+  });
+});

--- a/apps/vscode/src/lib/filePaths.ts
+++ b/apps/vscode/src/lib/filePaths.ts
@@ -1,0 +1,27 @@
+import * as path from "path";
+
+/**
+ * Check whether a resolved filesystem path stays within a workspace boundary.
+ *
+ * Returns true if `resolvedFsPath` is exactly equal to `workspaceRootFsPath`
+ * or is a descendant of it.
+ */
+export function isWithinWorkspace(
+  resolvedFsPath: string,
+  workspaceRootFsPath: string,
+): boolean {
+  if (resolvedFsPath === workspaceRootFsPath) return true;
+  return resolvedFsPath.startsWith(workspaceRootFsPath + path.sep);
+}
+
+/**
+ * Compute a forward-slash-separated relative path from a base directory
+ * to a file. Used to express file paths relative to a treatment file's
+ * directory for quick-fix suggestions and autocomplete completions.
+ */
+export function relativizePath(
+  baseDirFsPath: string,
+  fileFsPath: string,
+): string {
+  return path.relative(baseDirFsPath, fileFsPath).split(path.sep).join("/");
+}

--- a/apps/vscode/src/lib/filePaths.ts
+++ b/apps/vscode/src/lib/filePaths.ts
@@ -4,14 +4,21 @@ import * as path from "path";
  * Check whether a resolved filesystem path stays within a workspace boundary.
  *
  * Returns true if `resolvedFsPath` is exactly equal to `workspaceRootFsPath`
- * or is a descendant of it.
+ * or is a descendant of it. Both paths are normalized via `path.resolve` so
+ * trailing separators and unnormalized segments don't affect the result.
+ *
+ * Note: this is a string-level check; it does not resolve symlinks. A symlink
+ * inside the workspace pointing outside it will pass this check.
  */
 export function isWithinWorkspace(
   resolvedFsPath: string,
   workspaceRootFsPath: string,
 ): boolean {
-  if (resolvedFsPath === workspaceRootFsPath) return true;
-  return resolvedFsPath.startsWith(workspaceRootFsPath + path.sep);
+  const normalizedResolved = path.resolve(resolvedFsPath);
+  const normalizedRoot = path.resolve(workspaceRootFsPath);
+  if (normalizedResolved === normalizedRoot) return true;
+  const rel = path.relative(normalizedRoot, normalizedResolved);
+  return rel !== "" && !rel.startsWith("..") && !path.isAbsolute(rel);
 }
 
 /**

--- a/apps/vscode/src/lib/levenshtein.test.ts
+++ b/apps/vscode/src/lib/levenshtein.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { levenshtein, findClosestMatch } from "./levenshtein";
+
+describe("levenshtein", () => {
+  it("returns 0 for identical strings", () => {
+    expect(levenshtein("abc", "abc")).toBe(0);
+  });
+
+  it("returns the length of the other string when one is empty", () => {
+    expect(levenshtein("", "abc")).toBe(3);
+    expect(levenshtein("abc", "")).toBe(3);
+  });
+
+  it("returns 1 for a single substitution", () => {
+    expect(levenshtein("cat", "car")).toBe(1);
+  });
+
+  it("returns 1 for a single insertion", () => {
+    expect(levenshtein("cat", "cats")).toBe(1);
+  });
+
+  it("returns 1 for a single deletion", () => {
+    expect(levenshtein("cats", "cat")).toBe(1);
+  });
+
+  it("returns 0 for both empty strings", () => {
+    expect(levenshtein("", "")).toBe(0);
+  });
+
+  it("is symmetric", () => {
+    expect(levenshtein("kitten", "sitting")).toBe(
+      levenshtein("sitting", "kitten"),
+    );
+  });
+
+  it("handles multi-operation edits", () => {
+    expect(levenshtein("kitten", "sitting")).toBe(3);
+  });
+
+  it("handles a realistic file path typo", () => {
+    expect(
+      levenshtein(
+        "prompts/icebreaker.prompt.md",
+        "prompts/ice_breaker.prompt.md",
+      ),
+    ).toBe(1);
+  });
+});
+
+describe("findClosestMatch", () => {
+  const candidates = [
+    "prompts/ice_breaker.prompt.md",
+    "prompts/consent.prompt.md",
+    "prompts/debrief.prompt.md",
+    "projects/config.yaml",
+  ];
+
+  it("finds the closest match within the distance threshold", () => {
+    const result = findClosestMatch("prompts/icebreaker.prompt.md", candidates);
+    expect(result).toBe("prompts/ice_breaker.prompt.md");
+  });
+
+  it("returns null when no match is within the threshold", () => {
+    const result = findClosestMatch("totally/different/path.md", candidates);
+    expect(result).toBeNull();
+  });
+
+  it("returns the closest when multiple are within threshold", () => {
+    const result = findClosestMatch("prompts/consnt.prompt.md", candidates);
+    expect(result).toBe("prompts/consent.prompt.md");
+  });
+
+  it("returns null for an empty candidates list", () => {
+    const result = findClosestMatch("anything", []);
+    expect(result).toBeNull();
+  });
+
+  it("returns exact match (distance 0)", () => {
+    const result = findClosestMatch("prompts/consent.prompt.md", candidates);
+    expect(result).toBe("prompts/consent.prompt.md");
+  });
+
+  it("rejects match at exactly the threshold (distance < maxDistance)", () => {
+    // "abcde" vs "fghij" has distance 5 — should be rejected with maxDistance=5
+    const result = findClosestMatch("abcde", ["fghij"], 5);
+    expect(result).toBeNull();
+  });
+
+  it("accepts match just under the threshold", () => {
+    // "abcd" vs "abce" has distance 1 — should be accepted with maxDistance=2
+    const result = findClosestMatch("abcd", ["abce"], 2);
+    expect(result).toBe("abce");
+  });
+});

--- a/apps/vscode/src/lib/levenshtein.ts
+++ b/apps/vscode/src/lib/levenshtein.ts
@@ -31,7 +31,7 @@ export function levenshtein(a: string, b: string): number {
 
 /**
  * Find the closest matching string from a list of candidates.
- * Returns null if no candidate is within the distance threshold.
+ * Returns null if no candidate has distance strictly less than maxDistance.
  */
 export function findClosestMatch(
   target: string,

--- a/apps/vscode/src/lib/levenshtein.ts
+++ b/apps/vscode/src/lib/levenshtein.ts
@@ -1,0 +1,53 @@
+const DEFAULT_MAX_DISTANCE = 5;
+
+/**
+ * Compute the Levenshtein edit distance between two strings.
+ */
+export function levenshtein(a: string, b: string): number {
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+
+  // Use a single-row DP approach for O(min(m,n)) space
+  const shorter = a.length <= b.length ? a : b;
+  const longer = a.length <= b.length ? b : a;
+
+  let prev = Array.from({ length: shorter.length + 1 }, (_, i) => i);
+
+  for (let i = 1; i <= longer.length; i++) {
+    const curr = [i];
+    for (let j = 1; j <= shorter.length; j++) {
+      const cost = longer[i - 1] === shorter[j - 1] ? 0 : 1;
+      curr[j] = Math.min(
+        curr[j - 1] + 1, // insertion
+        prev[j] + 1, // deletion
+        prev[j - 1] + cost, // substitution
+      );
+    }
+    prev = curr;
+  }
+
+  return prev[shorter.length];
+}
+
+/**
+ * Find the closest matching string from a list of candidates.
+ * Returns null if no candidate is within the distance threshold.
+ */
+export function findClosestMatch(
+  target: string,
+  candidates: string[],
+  maxDistance: number = DEFAULT_MAX_DISTANCE,
+): string | null {
+  let bestMatch: string | null = null;
+  let bestDistance = maxDistance + 1;
+
+  for (const candidate of candidates) {
+    const distance = levenshtein(target, candidate);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestMatch = candidate;
+    }
+  }
+
+  return bestDistance < maxDistance ? bestMatch : null;
+}

--- a/apps/vscode/src/lib/semanticTokens.test.ts
+++ b/apps/vscode/src/lib/semanticTokens.test.ts
@@ -64,11 +64,44 @@ describe("computeSemanticTokens", () => {
       });
     });
 
-    it("highlights file paths containing template variables", () => {
+    it("splits file paths around template variables", () => {
       const src = `file: projects/${"\${topic}"}/q1.prompt.md`;
       const tokens = computeSemanticTokens(src);
       const fileTokens = tokens.filter((t) => t.tokenType === "string");
+      const varTokens = tokens.filter((t) => t.tokenType === "variable");
+      // "projects/" and "/q1.prompt.md" as string, "${topic}" as variable
+      expect(fileTokens).toHaveLength(2);
+      expect(fileTokens[0]).toMatchObject({ text: "projects/" });
+      expect(fileTokens[1]).toMatchObject({ text: "/q1.prompt.md" });
+      expect(varTokens).toHaveLength(1);
+      expect(varTokens[0]).toMatchObject({ text: "${topic}" });
+    });
+
+    it("highlights simple file paths as a single string token", () => {
+      const src = `file: prompts/q1.prompt.md`;
+      const tokens = computeSemanticTokens(src);
+      const fileTokens = tokens.filter((t) => t.tokenType === "string");
       expect(fileTokens).toHaveLength(1);
+      expect(fileTokens[0]).toMatchObject({ text: "prompts/q1.prompt.md" });
+    });
+  });
+
+  describe("template variables in values", () => {
+    it("highlights ${...} placeholders in non-file values", () => {
+      const src = `name: \${topicName}_presurvey`;
+      const tokens = computeSemanticTokens(src);
+      const varTokens = tokens.filter((t) => t.tokenType === "variable");
+      expect(varTokens).toHaveLength(1);
+      expect(varTokens[0]).toMatchObject({ text: "${topicName}" });
+    });
+
+    it("highlights multiple placeholders in one value", () => {
+      const src = `name: \${topic}_\${condition}_stage`;
+      const tokens = computeSemanticTokens(src);
+      const varTokens = tokens.filter((t) => t.tokenType === "variable");
+      expect(varTokens).toHaveLength(2);
+      expect(varTokens[0]).toMatchObject({ text: "${topic}" });
+      expect(varTokens[1]).toMatchObject({ text: "${condition}" });
     });
   });
 

--- a/apps/vscode/src/lib/semanticTokens.test.ts
+++ b/apps/vscode/src/lib/semanticTokens.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import { computeSemanticTokens } from "./semanticTokens";
+
+describe("computeSemanticTokens", () => {
+  describe("element types", () => {
+    it("highlights element type values after 'type:' key", () => {
+      const src = `elements:
+  - type: prompt
+    file: q1.prompt.md
+  - type: submitButton`;
+      const tokens = computeSemanticTokens(src);
+      const typeTokens = tokens.filter((t) => t.tokenType === "type");
+      expect(typeTokens).toHaveLength(2);
+      expect(typeTokens[0]).toMatchObject({ line: 1, text: "prompt" });
+      expect(typeTokens[1]).toMatchObject({ line: 3, text: "submitButton" });
+    });
+
+    it("does not highlight non-element-type values after 'type:' key", () => {
+      const src = `metadata:
+  type: openResponse`;
+      const tokens = computeSemanticTokens(src);
+      const typeTokens = tokens.filter((t) => t.tokenType === "type");
+      expect(typeTokens).toHaveLength(0);
+    });
+  });
+
+  describe("comparators", () => {
+    it("highlights comparator values after 'comparator:' key", () => {
+      const src = `conditions:
+  - comparator: equals
+    value: "yes"
+  - comparator: isAbove
+    value: 5`;
+      const tokens = computeSemanticTokens(src);
+      const compTokens = tokens.filter((t) => t.tokenType === "keyword");
+      expect(compTokens).toHaveLength(2);
+      expect(compTokens[0]).toMatchObject({ text: "equals" });
+      expect(compTokens[1]).toMatchObject({ text: "isAbove" });
+    });
+  });
+
+  describe("reference strings", () => {
+    it("highlights reference values after 'reference:' key", () => {
+      const src = `conditions:
+  - reference: prompt.q1
+    comparator: exists`;
+      const tokens = computeSemanticTokens(src);
+      const refTokens = tokens.filter((t) => t.tokenType === "variable");
+      expect(refTokens).toHaveLength(1);
+      expect(refTokens[0]).toMatchObject({ text: "prompt.q1" });
+    });
+  });
+
+  describe("file paths", () => {
+    it("highlights file values after 'file:' key", () => {
+      const src = `elements:
+  - type: prompt
+    file: prompts/q1.prompt.md`;
+      const tokens = computeSemanticTokens(src);
+      const fileTokens = tokens.filter((t) => t.tokenType === "string");
+      expect(fileTokens).toHaveLength(1);
+      expect(fileTokens[0]).toMatchObject({
+        text: "prompts/q1.prompt.md",
+      });
+    });
+
+    it("highlights file paths containing template variables", () => {
+      const src = `file: projects/${"\${topic}"}/q1.prompt.md`;
+      const tokens = computeSemanticTokens(src);
+      const fileTokens = tokens.filter((t) => t.tokenType === "string");
+      expect(fileTokens).toHaveLength(1);
+    });
+  });
+
+  describe("section keys", () => {
+    it("highlights structural section keys", () => {
+      const src = `templates:
+  - templateName: myStage
+    templateContent:
+      name: stage1
+treatments:
+  - name: study1
+    gameStages:
+      - name: s1
+        elements:
+          - type: submitButton`;
+      const tokens = computeSemanticTokens(src);
+      const sectionTokens = tokens.filter((t) => t.tokenType === "property");
+      const keys = sectionTokens.map((t) => t.text);
+      expect(keys).toContain("templates");
+      expect(keys).toContain("templateName");
+      expect(keys).toContain("templateContent");
+      expect(keys).toContain("treatments");
+      expect(keys).toContain("gameStages");
+      expect(keys).toContain("elements");
+    });
+
+    it("does not highlight regular keys like 'name' or 'duration'", () => {
+      const src = `name: study1
+duration: 300`;
+      const tokens = computeSemanticTokens(src);
+      const sectionTokens = tokens.filter((t) => t.tokenType === "property");
+      expect(sectionTokens).toHaveLength(0);
+    });
+  });
+
+  describe("conditions key as section key", () => {
+    it("highlights 'conditions' as a section key", () => {
+      const src = `conditions:
+  - comparator: equals
+    reference: prompt.q1
+    value: "yes"`;
+      const tokens = computeSemanticTokens(src);
+      const sectionTokens = tokens.filter((t) => t.tokenType === "property");
+      const keys = sectionTokens.map((t) => t.text);
+      expect(keys).toContain("conditions");
+    });
+
+    it("does not highlight comparator or reference as special keys", () => {
+      const src = `conditions:
+  - comparator: equals
+    reference: prompt.q1`;
+      const tokens = computeSemanticTokens(src);
+      const sectionKeys = tokens
+        .filter((t) => t.tokenType === "property")
+        .map((t) => t.text);
+      expect(sectionKeys).not.toContain("comparator");
+      expect(sectionKeys).not.toContain("reference");
+    });
+  });
+
+  describe("mixed content", () => {
+    it("handles a realistic treatment snippet", () => {
+      const src = `treatments:
+  - name: study1
+    playerCount: 3
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: prompt
+            file: prompts/q1.prompt.md
+            conditions:
+              - reference: prompt.consent
+                comparator: equals
+                value: "yes"
+          - type: submitButton`;
+      const tokens = computeSemanticTokens(src);
+      expect(tokens.length).toBeGreaterThan(0);
+
+      const types = new Set(tokens.map((t) => t.tokenType));
+      expect(types).toContain("property");
+      expect(types).toContain("type");
+      expect(types).toContain("string");
+      expect(types).toContain("variable");
+      expect(types).toContain("keyword");
+    });
+  });
+});

--- a/apps/vscode/src/lib/semanticTokens.test.ts
+++ b/apps/vscode/src/lib/semanticTokens.test.ts
@@ -129,6 +129,75 @@ duration: 300`;
     });
   });
 
+  describe("contentType values", () => {
+    it("highlights valid contentType values", () => {
+      const src = `contentType: elements`;
+      const tokens = computeSemanticTokens(src);
+      expect(tokens).toContainEqual(
+        expect.objectContaining({ text: "elements", tokenType: "type" }),
+      );
+    });
+
+    it("does not highlight invalid contentType values", () => {
+      const src = `contentType: banana`;
+      const tokens = computeSemanticTokens(src);
+      const typeTokens = tokens.filter((t) => t.tokenType === "type");
+      expect(typeTokens).toHaveLength(0);
+    });
+  });
+
+  describe("separator styles", () => {
+    it("highlights separator style values", () => {
+      const src = `style: thin`;
+      const tokens = computeSemanticTokens(src);
+      expect(tokens).toContainEqual(
+        expect.objectContaining({ text: "thin", tokenType: "keyword" }),
+      );
+    });
+  });
+
+  describe("enum values", () => {
+    it("highlights position enum values", () => {
+      const src = `position: shared`;
+      const tokens = computeSemanticTokens(src);
+      expect(tokens).toContainEqual(
+        expect.objectContaining({ text: "shared", tokenType: "keyword" }),
+      );
+    });
+
+    it("highlights chatType enum values", () => {
+      const src = `chatType: video`;
+      const tokens = computeSemanticTokens(src);
+      expect(tokens).toContainEqual(
+        expect.objectContaining({ text: "video", tokenType: "keyword" }),
+      );
+    });
+  });
+
+  describe("negative cases", () => {
+    it("does not highlight invalid comparator values", () => {
+      const src = `comparator: banana`;
+      const tokens = computeSemanticTokens(src);
+      expect(tokens.filter((t) => t.tokenType === "keyword")).toHaveLength(0);
+    });
+
+    it("does not highlight references with invalid type prefix", () => {
+      const src = `reference: invalidType.field`;
+      const tokens = computeSemanticTokens(src);
+      expect(tokens.filter((t) => t.tokenType === "variable")).toHaveLength(0);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns empty tokens for empty input", () => {
+      expect(computeSemanticTokens("")).toEqual([]);
+    });
+
+    it("returns empty tokens for comment-only YAML", () => {
+      expect(computeSemanticTokens("# just a comment")).toEqual([]);
+    });
+  });
+
   describe("mixed content", () => {
     it("handles a realistic treatment snippet", () => {
       const src = `treatments:

--- a/apps/vscode/src/lib/semanticTokens.ts
+++ b/apps/vscode/src/lib/semanticTokens.ts
@@ -1,0 +1,194 @@
+import { parseDocument, isMap, isSeq, isScalar, isPair } from "yaml";
+import {
+  validElementTypes,
+  validComparators,
+  validReferenceTypes,
+} from "stagebook";
+
+// Map domain concepts to VS Code's built-in semantic token types.
+// These are standard types that all themes already color distinctly.
+export type SemanticTokenType =
+  | "type" // element types (prompt, submitButton) → teal/green
+  | "keyword" // comparators (equals, isAbove) → purple
+  | "variable" // reference strings (prompt.q1) → light blue
+  | "string" // file paths → orange (distinct via modifier)
+  | "property" // section keys (elements, treatments) → blue
+  | "operator"; // unused but kept for type compatibility
+
+export interface SemanticToken {
+  line: number;
+  startCol: number;
+  length: number;
+  tokenType: SemanticTokenType;
+  /** The matched text, for testing */
+  text: string;
+}
+
+const elementTypeSet = new Set<string>(validElementTypes);
+const comparatorSet = new Set<string>(validComparators);
+const referenceTypeSet = new Set<string>(validReferenceTypes);
+const contentTypeSet = new Set([
+  "introSequence",
+  "introSequences",
+  "elements",
+  "element",
+  "stage",
+  "stages",
+  "treatment",
+  "treatments",
+  "reference",
+  "condition",
+  "player",
+  "introExitStep",
+  "exitSteps",
+]);
+
+const sectionKeys = new Set([
+  "introSequences",
+  "introSteps",
+  "gameStages",
+  "elements",
+  "treatments",
+  "templates",
+  "exitSequence",
+  "groupComposition",
+  "templateName",
+  "templateContent",
+  "contentType",
+  "broadcast",
+  "discussion",
+  "conditions",
+]);
+
+/**
+ * Convert a character offset to a 0-based line and column.
+ */
+function offsetToLineCol(
+  source: string,
+  offset: number,
+): { line: number; col: number } {
+  let line = 0;
+  let lastNewline = -1;
+  for (let i = 0; i < offset && i < source.length; i++) {
+    if (source[i] === "\n") {
+      line++;
+      lastNewline = i;
+    }
+  }
+  return { line, col: offset - lastNewline - 1 };
+}
+
+/**
+ * Compute semantic tokens for a treatment YAML source string.
+ *
+ * Walks the YAML AST and identifies domain-specific tokens based
+ * on key names and value content. Returns tokens sorted by position.
+ *
+ * This is a pure function — no VS Code dependency.
+ */
+export function computeSemanticTokens(source: string): SemanticToken[] {
+  const doc = parseDocument(source, { uniqueKeys: false });
+  if (!doc.contents) return [];
+
+  const tokens: SemanticToken[] = [];
+
+  function addToken(
+    offset: number,
+    text: string,
+    tokenType: SemanticTokenType,
+  ): void {
+    const { line, col } = offsetToLineCol(source, offset);
+    tokens.push({
+      line,
+      startCol: col,
+      length: text.length,
+      tokenType,
+      text,
+    });
+  }
+
+  function walkNode(node: unknown, keyName?: string): void {
+    if (isMap(node)) {
+      for (const pair of node.items) {
+        if (!isPair(pair)) continue;
+
+        const key = pair.key;
+        const value = pair.value;
+
+        // Highlight the key itself if it's a known section key
+        if (isScalar(key) && typeof key.value === "string" && key.range) {
+          const keyStr = key.value;
+          if (sectionKeys.has(keyStr)) {
+            addToken(key.range[0], keyStr, "property");
+          }
+        }
+
+        // Highlight the value based on the key name
+        if (isScalar(key) && typeof key.value === "string") {
+          const k = key.value;
+
+          if (
+            k === "type" &&
+            isScalar(value) &&
+            typeof value.value === "string" &&
+            value.range
+          ) {
+            if (elementTypeSet.has(value.value)) {
+              addToken(value.range[0], value.value, "type");
+            }
+          } else if (
+            k === "comparator" &&
+            isScalar(value) &&
+            typeof value.value === "string" &&
+            value.range
+          ) {
+            if (comparatorSet.has(value.value)) {
+              addToken(value.range[0], value.value, "keyword");
+            }
+          } else if (
+            k === "reference" &&
+            isScalar(value) &&
+            typeof value.value === "string" &&
+            value.range
+          ) {
+            const refType = value.value.split(".")[0];
+            if (referenceTypeSet.has(refType)) {
+              addToken(value.range[0], value.value, "variable");
+            }
+          } else if (
+            k === "file" &&
+            isScalar(value) &&
+            typeof value.value === "string" &&
+            value.range
+          ) {
+            addToken(value.range[0], value.value, "string");
+          } else if (
+            k === "contentType" &&
+            isScalar(value) &&
+            typeof value.value === "string" &&
+            value.range &&
+            contentTypeSet.has(value.value)
+          ) {
+            addToken(value.range[0], value.value, "type");
+          }
+
+          // Recurse into the value
+          walkNode(value, isScalar(key) ? String(key.value) : undefined);
+        } else {
+          walkNode(value);
+        }
+      }
+    } else if (isSeq(node)) {
+      for (const item of node.items) {
+        walkNode(item, keyName);
+      }
+    }
+  }
+
+  walkNode(doc.contents);
+
+  // Sort by position for consistent output
+  tokens.sort((a, b) => a.line - b.line || a.startCol - b.startCol);
+
+  return tokens;
+}

--- a/apps/vscode/src/lib/semanticTokens.ts
+++ b/apps/vscode/src/lib/semanticTokens.ts
@@ -247,7 +247,8 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
             isScalar(value) &&
             typeof value.value === "string" &&
             value.range &&
-            TEMPLATE_VAR_RE.test(value.value) &&
+            ((TEMPLATE_VAR_RE.lastIndex = 0),
+            TEMPLATE_VAR_RE.test(value.value)) &&
             k !== "file" // file paths already handled above
           ) {
             emitTemplateVarTokens(value.range[0], value.value);

--- a/apps/vscode/src/lib/semanticTokens.ts
+++ b/apps/vscode/src/lib/semanticTokens.ts
@@ -12,8 +12,7 @@ export type SemanticTokenType =
   | "keyword" // comparators (equals, isAbove) → purple
   | "variable" // reference strings (prompt.q1) → light blue
   | "string" // file paths → orange (distinct via modifier)
-  | "property" // section keys (elements, treatments) → blue
-  | "operator"; // unused but kept for type compatibility
+  | "property"; // section keys (elements, treatments) → blue
 
 export interface SemanticToken {
   line: number;
@@ -41,6 +40,19 @@ const contentTypeSet = new Set([
   "player",
   "introExitStep",
   "exitSteps",
+]);
+
+const separatorStyles = new Set(["thin", "thick", "regular"]);
+
+const enumValues = new Set([
+  "shared",
+  "player",
+  "all",
+  "any",
+  "percentAgreement",
+  "text",
+  "audio",
+  "video",
 ]);
 
 const sectionKeys = new Set([
@@ -170,6 +182,22 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
             contentTypeSet.has(value.value)
           ) {
             addToken(value.range[0], value.value, "type");
+          } else if (
+            k === "style" &&
+            isScalar(value) &&
+            typeof value.value === "string" &&
+            value.range &&
+            separatorStyles.has(value.value)
+          ) {
+            addToken(value.range[0], value.value, "keyword");
+          } else if (
+            (k === "position" || k === "chatType") &&
+            isScalar(value) &&
+            typeof value.value === "string" &&
+            value.range &&
+            enumValues.has(value.value)
+          ) {
+            addToken(value.range[0], value.value, "keyword");
           }
 
           // Recurse into the value

--- a/apps/vscode/src/lib/semanticTokens.ts
+++ b/apps/vscode/src/lib/semanticTokens.ts
@@ -119,6 +119,46 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
     });
   }
 
+  const TEMPLATE_VAR_RE = /\$\{[a-zA-Z0-9_]+\}/g;
+
+  /**
+   * Emit variable tokens for ${...} placeholders within a string.
+   * Only emits tokens for the placeholders, not the surrounding text.
+   */
+  function emitTemplateVarTokens(startOffset: number, text: string): void {
+    TEMPLATE_VAR_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = TEMPLATE_VAR_RE.exec(text)) !== null) {
+      addToken(startOffset + match.index, match[0], "variable");
+    }
+  }
+
+  /**
+   * Emit tokens for a file path, splitting around ${...} placeholders.
+   * Path segments get "string", placeholders get "variable".
+   */
+  function addFilePathTokens(startOffset: number, text: string): void {
+    let lastIndex = 0;
+    TEMPLATE_VAR_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+
+    while ((match = TEMPLATE_VAR_RE.exec(text)) !== null) {
+      if (match.index > lastIndex) {
+        addToken(
+          startOffset + lastIndex,
+          text.slice(lastIndex, match.index),
+          "string",
+        );
+      }
+      addToken(startOffset + match.index, match[0], "variable");
+      lastIndex = match.index + match[0].length;
+    }
+
+    if (lastIndex < text.length) {
+      addToken(startOffset + lastIndex, text.slice(lastIndex), "string");
+    }
+  }
+
   function walkNode(node: unknown, keyName?: string): void {
     if (isMap(node)) {
       for (const pair of node.items) {
@@ -173,7 +213,7 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
             typeof value.value === "string" &&
             value.range
           ) {
-            addToken(value.range[0], value.value, "string");
+            addFilePathTokens(value.range[0], value.value);
           } else if (
             k === "contentType" &&
             isScalar(value) &&
@@ -198,6 +238,19 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
             enumValues.has(value.value)
           ) {
             addToken(value.range[0], value.value, "keyword");
+          }
+
+          // For any other scalar value containing ${...} placeholders,
+          // emit variable tokens so template fields are highlighted
+          // consistently everywhere they appear.
+          if (
+            isScalar(value) &&
+            typeof value.value === "string" &&
+            value.range &&
+            TEMPLATE_VAR_RE.test(value.value) &&
+            k !== "file" // file paths already handled above
+          ) {
+            emitTemplateVarTokens(value.range[0], value.value);
           }
 
           // Recurse into the value

--- a/apps/vscode/src/lib/types.ts
+++ b/apps/vscode/src/lib/types.ts
@@ -1,0 +1,7 @@
+import type { SourceRange } from "./yamlPositionMap";
+
+export interface Diagnostic {
+  message: string;
+  severity: "error" | "warning";
+  range: SourceRange | null;
+}

--- a/apps/vscode/src/lib/validatePrompt.test.ts
+++ b/apps/vscode/src/lib/validatePrompt.test.ts
@@ -180,8 +180,112 @@ then a horizontal rule
       const warnings = result.diagnostics.filter(
         (d) => d.severity === "warning",
       );
-      expect(warnings.length).toBeGreaterThan(0);
+      expect(warnings).toHaveLength(1);
       expect(warnings[0].message).toMatch(/horizontal rule|\*\*\*|___/i);
+      expect(warnings[0].range).toEqual({
+        startLine: 7,
+        startCol: 0,
+        endLine: 7,
+        endCol: 3,
+      });
+    });
+  });
+
+  describe("slider type", () => {
+    it("returns no diagnostics for a valid slider prompt", () => {
+      const src = `---
+name: test/slider.prompt.md
+type: slider
+min: 0
+max: 100
+interval: 10
+---
+Rate your agreement.
+---
+> Low
+> High`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("reports errors when slider is missing required fields", () => {
+      const src = `---
+name: test/slider.prompt.md
+type: slider
+---
+Rate something.
+---
+> Low`;
+      const result = validatePromptSource(src);
+      const messages = result.diagnostics.map((d) => d.message);
+      expect(messages).toContain("min is required for slider type");
+      expect(messages).toContain("max is required for slider type");
+      expect(messages).toContain("interval is required for slider type");
+    });
+  });
+
+  describe("listSorter type", () => {
+    it("returns no diagnostics for a valid listSorter prompt", () => {
+      const src = `---
+name: test/sort.prompt.md
+type: listSorter
+---
+Rank these items.
+---
+> Item A
+> Item B
+> Item C`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+
+  describe("metadata YAML parse failure", () => {
+    it("reports error for malformed YAML in metadata", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: [unclosed bracket
+---
+Body text
+---
+`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toContainEqual(
+        expect.objectContaining({
+          message: expect.stringContaining("parse metadata YAML"),
+          severity: "error",
+        }),
+      );
+    });
+  });
+
+  describe("CRLF line endings", () => {
+    it("handles CRLF line endings correctly", () => {
+      const src =
+        "---\r\nname: test/prompt.prompt.md\r\ntype: multipleChoice\r\n---\r\nPick one\r\n---\r\n- A\r\n- B";
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+
+  describe("metadata field position mapping", () => {
+    it("maps metadata field error to the specific YAML key line", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: multipleChoice
+rows: 3
+---
+Pick one
+---
+- A
+- B`;
+      const result = validatePromptSource(src);
+      const rowsError = result.diagnostics.find((d) =>
+        d.message.includes("rows"),
+      );
+      expect(rowsError).toBeDefined();
+      // "rows:" is on line 3 (0-indexed)
+      expect(rowsError!.range!.startLine).toBe(3);
     });
   });
 });

--- a/apps/vscode/src/lib/validatePrompt.test.ts
+++ b/apps/vscode/src/lib/validatePrompt.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect } from "vitest";
+import { validatePromptSource } from "./validatePrompt";
+
+describe("validatePromptSource", () => {
+  describe("valid prompt files", () => {
+    it("returns no diagnostics for a valid multipleChoice prompt", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: multipleChoice
+---
+What is your favorite color?
+---
+- Red
+- Blue
+- Green`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("returns no diagnostics for a valid noResponse prompt", () => {
+      const src = `---
+name: test/info.prompt.md
+type: noResponse
+---
+Please read the following instructions carefully.
+---
+`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("returns no diagnostics for a valid openResponse prompt", () => {
+      const src = `---
+name: test/open.prompt.md
+type: openResponse
+---
+Please describe your experience.
+---
+> Your response here`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+
+  describe("structural errors", () => {
+    it("reports error for missing --- delimiters", () => {
+      const src = `Just some text without delimiters`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics[0].severity).toBe("error");
+      expect(result.diagnostics[0].message).toMatch(/section|delimiter/i);
+    });
+
+    it("reports error for only two delimiters", () => {
+      const src = `---
+name: test.prompt.md
+type: noResponse
+---
+Body text but no third delimiter`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics[0].message).toMatch(/section|delimiter/i);
+    });
+
+    it("reports error for empty file", () => {
+      const result = validatePromptSource("");
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("metadata errors", () => {
+    it("reports error for missing type field", () => {
+      const src = `---
+name: test/prompt.prompt.md
+---
+Body text
+---
+`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics[0].severity).toBe("error");
+    });
+
+    it("reports error for invalid type value", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: invalidType
+---
+Body text
+---
+`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics[0].severity).toBe("error");
+    });
+
+    it("reports error for rows on non-openResponse type", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: multipleChoice
+rows: 3
+---
+Pick one
+---
+- A
+- B`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toContainEqual(
+        expect.objectContaining({
+          message: expect.stringContaining("rows"),
+        }),
+      );
+    });
+  });
+
+  describe("response errors", () => {
+    it("reports error for invalid response line format", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: multipleChoice
+---
+Pick one
+---
+Red
+Blue`;
+      const result = validatePromptSource(src);
+      expect(result.diagnostics).toContainEqual(
+        expect.objectContaining({
+          message: expect.stringMatching(/response line|must start with/i),
+        }),
+      );
+    });
+  });
+
+  describe("error position mapping", () => {
+    it("maps metadata errors to the metadata section", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: invalidType
+---
+Body text
+---
+`;
+      const result = validatePromptSource(src);
+      const metadataErrors = result.diagnostics.filter(
+        (d) =>
+          d.range !== null && d.range.startLine >= 1 && d.range.startLine <= 3,
+      );
+      expect(metadataErrors.length).toBeGreaterThan(0);
+    });
+
+    it("maps response errors to the response section", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: multipleChoice
+---
+Pick one
+---
+bad line`;
+      const result = validatePromptSource(src);
+      const responseErrors = result.diagnostics.filter(
+        (d) => d.range !== null && d.range.startLine >= 6,
+      );
+      expect(responseErrors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("extra delimiter warning", () => {
+    it("warns when more than 3 --- delimiters exist", () => {
+      const src = `---
+name: test/prompt.prompt.md
+type: noResponse
+---
+Some text
+---
+then a horizontal rule
+---
+`;
+      const result = validatePromptSource(src);
+      const warnings = result.diagnostics.filter(
+        (d) => d.severity === "warning",
+      );
+      expect(warnings.length).toBeGreaterThan(0);
+      expect(warnings[0].message).toMatch(/horizontal rule|\*\*\*|___/i);
+    });
+  });
+});

--- a/apps/vscode/src/lib/validatePrompt.ts
+++ b/apps/vscode/src/lib/validatePrompt.ts
@@ -1,11 +1,6 @@
 import { promptFileSchema } from "stagebook";
 import type { SourceRange } from "./yamlPositionMap";
-
-export interface Diagnostic {
-  message: string;
-  severity: "error" | "warning";
-  range: SourceRange | null;
-}
+import type { Diagnostic } from "./types";
 
 export interface PromptValidationResult {
   diagnostics: Diagnostic[];
@@ -18,7 +13,7 @@ function findDelimiterLines(source: string): number[] {
   const lines = source.split(/\r?\n/);
   const result: number[] = [];
   for (let i = 0; i < lines.length; i++) {
-    if (/^-{3,}$/.test(lines[i].trim())) {
+    if (/^-{3,}$/.test(lines[i])) {
       result.push(i);
     }
   }

--- a/apps/vscode/src/lib/validatePrompt.ts
+++ b/apps/vscode/src/lib/validatePrompt.ts
@@ -64,21 +64,24 @@ function mapPromptErrorToRange(
         }
       }
     }
-    // Fall back to the metadata section start
+    // Fall back to the metadata section start (clamp for empty sections)
+    const metaFallbackLine = Math.min(metaStart + 1, metaEnd);
     return {
-      startLine: metaStart + 1,
+      startLine: metaFallbackLine,
       startCol: 0,
-      endLine: metaEnd - 1,
-      endCol: 0,
+      endLine: metaFallbackLine,
+      endCol: 1,
     };
   }
 
   if (section === "body") {
+    // Clamp for empty body (adjacent delimiters)
+    const bodyLine = Math.min(metaEnd + 1, responseStart);
     return {
-      startLine: metaEnd + 1,
+      startLine: bodyLine,
       startCol: 0,
-      endLine: responseStart - 1,
-      endCol: 0,
+      endLine: bodyLine,
+      endCol: 1,
     };
   }
 

--- a/apps/vscode/src/lib/validatePrompt.ts
+++ b/apps/vscode/src/lib/validatePrompt.ts
@@ -1,0 +1,145 @@
+import { promptFileSchema } from "stagebook";
+import type { SourceRange } from "./yamlPositionMap";
+
+export interface Diagnostic {
+  message: string;
+  severity: "error" | "warning";
+  range: SourceRange | null;
+}
+
+export interface PromptValidationResult {
+  diagnostics: Diagnostic[];
+}
+
+/**
+ * Find the 0-based line numbers of all `---` delimiters in the source.
+ */
+function findDelimiterLines(source: string): number[] {
+  const lines = source.split(/\r?\n/);
+  const result: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    if (/^-{3,}$/.test(lines[i].trim())) {
+      result.push(i);
+    }
+  }
+  return result;
+}
+
+/**
+ * Map a Zod issue path from promptFileSchema to a source line range.
+ *
+ * promptFileSchema produces paths like:
+ * - [] — structural errors (missing delimiters)
+ * - ["metadata", "type"] — metadata field errors
+ * - ["body"] — body section errors
+ * - ["responses"] — response format errors
+ */
+function mapPromptErrorToRange(
+  source: string,
+  path: (string | number)[],
+  delimiters: number[],
+): SourceRange | null {
+  if (delimiters.length < 3) {
+    // Can't map without delimiters — fall back to line 0
+    return { startLine: 0, startCol: 0, endLine: 0, endCol: 1 };
+  }
+
+  const [metaStart, metaEnd, responseStart] = delimiters;
+
+  if (path.length === 0) {
+    return { startLine: 0, startCol: 0, endLine: 0, endCol: 1 };
+  }
+
+  const section = path[0];
+
+  if (section === "metadata") {
+    // Map to the metadata section (between first and second ---)
+    // If we have a specific field name, try to find it
+    if (path.length >= 2 && typeof path[1] === "string") {
+      const fieldName = path[1];
+      const lines = source.split(/\r?\n/);
+      for (let i = metaStart + 1; i < metaEnd; i++) {
+        if (lines[i] && lines[i].trimStart().startsWith(fieldName + ":")) {
+          return {
+            startLine: i,
+            startCol: 0,
+            endLine: i,
+            endCol: lines[i].length,
+          };
+        }
+      }
+    }
+    // Fall back to the metadata section start
+    return {
+      startLine: metaStart + 1,
+      startCol: 0,
+      endLine: metaEnd - 1,
+      endCol: 0,
+    };
+  }
+
+  if (section === "body") {
+    return {
+      startLine: metaEnd + 1,
+      startCol: 0,
+      endLine: responseStart - 1,
+      endCol: 0,
+    };
+  }
+
+  if (section === "responses") {
+    // Map to the response section (after the third ---)
+    return {
+      startLine: responseStart + 1,
+      startCol: 0,
+      endLine: responseStart + 1,
+      endCol: 1,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Validate a prompt markdown source string.
+ *
+ * Returns diagnostics with source positions.
+ * This is a pure function — no VS Code dependency.
+ */
+export function validatePromptSource(source: string): PromptValidationResult {
+  const diagnostics: Diagnostic[] = [];
+  const delimiters = findDelimiterLines(source);
+
+  // Warn about extra delimiters (likely horizontal rule attempts)
+  if (delimiters.length > 3) {
+    for (let i = 3; i < delimiters.length; i++) {
+      diagnostics.push({
+        message:
+          "Extra --- delimiter found. If you want a horizontal rule, use *** or ___ instead — three dashes are used to separate prompt sections.",
+        severity: "warning",
+        range: {
+          startLine: delimiters[i],
+          startCol: 0,
+          endLine: delimiters[i],
+          endCol: 3,
+        },
+      });
+    }
+  }
+
+  // Validate with stagebook's promptFileSchema
+  const result = promptFileSchema.safeParse(source);
+
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      const range = mapPromptErrorToRange(source, issue.path, delimiters);
+      diagnostics.push({
+        message: issue.message,
+        severity: "error",
+        range,
+      });
+    }
+  }
+
+  return { diagnostics };
+}

--- a/apps/vscode/src/lib/validateTreatment.test.ts
+++ b/apps/vscode/src/lib/validateTreatment.test.ts
@@ -253,7 +253,7 @@ treatments:
       );
     });
 
-    it("includes the field path in missing-field messages", () => {
+    it("includes the formatted field path in missing-field messages", () => {
       // A survey element is missing its required surveyName field.
       const src = `introSequences:
   - name: intro1
@@ -270,14 +270,18 @@ treatments:
         elements:
           - type: survey`;
       const result = validateTreatmentSource(src);
-      // The path should be mentioned so the user knows which field is missing
+      // The diagnostic message should include the full formatted path
+      // (dotted segments + bracketed array indices) so the user can locate
+      // the missing field in the schema hierarchy.
       const pathedError = result.diagnostics.find((d) =>
-        d.message.includes("surveyName"),
+        d.message.includes(
+          "treatments[0].gameStages[0].elements[0].surveyName",
+        ),
       );
       expect(pathedError).toBeDefined();
     });
 
-    it("places missing-field errors on the nearest existing ancestor, not (0,0)", () => {
+    it("places missing-field errors on the missing-field's parent element, not (0,0)", () => {
       const src = `introSequences:
   - name: intro1
     introSteps:
@@ -292,14 +296,16 @@ treatments:
         duration: 300
         elements:
           - type: prompt`;
-      // The prompt element is missing required "file" field.
-      // The error should land on the element itself (line 13 area),
-      // not at position (0, 0).
+      // The prompt element is missing its required "file" field.
+      // The diagnostic for that specific missing field should be attached
+      // to the prompt element (the nearest existing ancestor), not (0,0).
       const result = validateTreatmentSource(src);
-      const errors = result.diagnostics.filter((d) => d.severity === "error");
-      expect(errors.length).toBeGreaterThan(0);
-      // At least one error should have a non-zero line
-      expect(errors.some((d) => d.range && d.range.startLine > 0)).toBe(true);
+      const fileError = result.diagnostics.find((d) =>
+        d.message.includes("treatments[0].gameStages[0].elements[0].file"),
+      );
+      expect(fileError).toBeDefined();
+      expect(fileError!.range).not.toBeNull();
+      expect(fileError!.range!.startLine).toBeGreaterThan(0);
     });
 
     it("classifies duplicate key diagnostics as warnings", () => {

--- a/apps/vscode/src/lib/validateTreatment.test.ts
+++ b/apps/vscode/src/lib/validateTreatment.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import { validateTreatmentSource } from "./validateTreatment";
+
+describe("validateTreatmentSource", () => {
+  describe("valid treatment files", () => {
+    it("returns no diagnostics for a minimal valid treatment", () => {
+      const src = `introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: submitButton`;
+      const result = validateTreatmentSource(src);
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+
+  describe("YAML syntax errors", () => {
+    it("reports YAML parse errors with positions", () => {
+      const src = `treatments:
+  - name: study1
+    playerCount: 3
+  bad indentation`;
+      const result = validateTreatmentSource(src);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics[0].severity).toBe("error");
+    });
+
+    it("reports duplicate YAML keys", () => {
+      const src = `introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    playerCount: 2
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: submitButton`;
+      const result = validateTreatmentSource(src);
+      const dupeWarnings = result.diagnostics.filter((d) =>
+        d.message.match(/unique|duplicate/i),
+      );
+      expect(dupeWarnings.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("schema validation errors", () => {
+    it("reports missing required fields", () => {
+      const src = `treatments:
+  - name: study1
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: submitButton`;
+      // Missing playerCount and introSequences
+      const result = validateTreatmentSource(src);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics[0].severity).toBe("error");
+    });
+
+    it("maps schema errors to source positions", () => {
+      const src = `introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: not_a_number
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: submitButton`;
+      // playerCount must be a number — error should have a source range
+      const result = validateTreatmentSource(src);
+      const rangedErrors = result.diagnostics.filter(
+        (d) => d.severity === "error" && d.range !== null,
+      );
+      expect(rangedErrors.length).toBeGreaterThan(0);
+    });
+
+    it("reports invalid element types", () => {
+      const src = `introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: notARealType`;
+      const result = validateTreatmentSource(src);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("template content validation", () => {
+    it("validates template content based on contentType", () => {
+      const src = `templates:
+  - templateName: myStage
+    contentType: stage
+    templateContent:
+      name: stage1
+      duration: -1
+      elements:
+        - type: submitButton
+introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: myStage`;
+      const result = validateTreatmentSource(src);
+      // duration: -1 is invalid in the template content
+      const templateErrors = result.diagnostics.filter(
+        (d) => d.severity === "error",
+      );
+      expect(templateErrors.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("returned JSON object", () => {
+    it("returns the parsed JS object for downstream use", () => {
+      const src = `introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: submitButton`;
+      const result = validateTreatmentSource(src);
+      expect(result.parsedObj).toBeDefined();
+      expect(
+        (result.parsedObj as Record<string, unknown>).treatments,
+      ).toBeDefined();
+    });
+
+    it("returns diagnostics for completely invalid YAML", () => {
+      const src = `[[[`;
+      const result = validateTreatmentSource(src);
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/vscode/src/lib/validateTreatment.test.ts
+++ b/apps/vscode/src/lib/validateTreatment.test.ts
@@ -253,6 +253,55 @@ treatments:
       );
     });
 
+    it("includes the field path in missing-field messages", () => {
+      // A survey element is missing its required surveyName field.
+      const src = `introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: survey`;
+      const result = validateTreatmentSource(src);
+      // The path should be mentioned so the user knows which field is missing
+      const pathedError = result.diagnostics.find((d) =>
+        d.message.includes("surveyName"),
+      );
+      expect(pathedError).toBeDefined();
+    });
+
+    it("places missing-field errors on the nearest existing ancestor, not (0,0)", () => {
+      const src = `introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: prompt`;
+      // The prompt element is missing required "file" field.
+      // The error should land on the element itself (line 13 area),
+      // not at position (0, 0).
+      const result = validateTreatmentSource(src);
+      const errors = result.diagnostics.filter((d) => d.severity === "error");
+      expect(errors.length).toBeGreaterThan(0);
+      // At least one error should have a non-zero line
+      expect(errors.some((d) => d.range && d.range.startLine > 0)).toBe(true);
+    });
+
     it("classifies duplicate key diagnostics as warnings", () => {
       const src = `introSequences:
   - name: intro1

--- a/apps/vscode/src/lib/validateTreatment.test.ts
+++ b/apps/vscode/src/lib/validateTreatment.test.ts
@@ -177,22 +177,17 @@ treatments:
   });
 
   describe("edge cases", () => {
-    it("reports error for empty YAML source", () => {
+    it("reports schema error for empty YAML source", () => {
       const result = validateTreatmentSource("");
-      expect(result.diagnostics).toContainEqual(
-        expect.objectContaining({
-          message: "Failed to parse YAML",
-          severity: "error",
-          range: null,
-        }),
-      );
-      expect(result.parsedObj).toBeNull();
+      // Empty YAML parses to null — Zod produces a schema error
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics[0].severity).toBe("error");
     });
 
-    it("reports error when YAML parses to a scalar", () => {
+    it("reports schema error when YAML parses to a scalar", () => {
       const result = validateTreatmentSource("hello world");
-      expect(result.parsedObj).toBeNull();
       expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics[0].severity).toBe("error");
     });
 
     it("reports schema errors when YAML parses to an array", () => {

--- a/apps/vscode/src/lib/validateTreatment.test.ts
+++ b/apps/vscode/src/lib/validateTreatment.test.ts
@@ -175,4 +175,111 @@ treatments:
       expect(result.diagnostics.length).toBeGreaterThan(0);
     });
   });
+
+  describe("edge cases", () => {
+    it("reports error for empty YAML source", () => {
+      const result = validateTreatmentSource("");
+      expect(result.diagnostics).toContainEqual(
+        expect.objectContaining({
+          message: "Failed to parse YAML",
+          severity: "error",
+          range: null,
+        }),
+      );
+      expect(result.parsedObj).toBeNull();
+    });
+
+    it("reports error when YAML parses to a scalar", () => {
+      const result = validateTreatmentSource("hello world");
+      expect(result.parsedObj).toBeNull();
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+
+    it("reports schema errors when YAML parses to an array", () => {
+      const result = validateTreatmentSource("- item1\n- item2");
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+      expect(result.diagnostics[0].severity).toBe("error");
+    });
+
+    it("accepts file with only templates (introSequences and treatments are optional)", () => {
+      const src = `templates:
+  - templateName: myStage
+    contentType: stage
+    templateContent:
+      name: stage1
+      duration: 300
+      elements:
+        - type: submitButton`;
+      const result = validateTreatmentSource(src);
+      const errors = result.diagnostics.filter((d) => d.severity === "error");
+      expect(errors).toEqual([]);
+    });
+
+    it("reports error for empty templates array", () => {
+      const src = `templates: []
+introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: submitButton`;
+      const result = validateTreatmentSource(src);
+      expect(result.diagnostics).toContainEqual(
+        expect.objectContaining({
+          message: expect.stringContaining("Templates cannot be empty"),
+        }),
+      );
+    });
+  });
+
+  describe("diagnostic quality", () => {
+    it("missing required fields produce messages mentioning 'required'", () => {
+      const src = `treatments:
+  - name: study1
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: submitButton`;
+      const result = validateTreatmentSource(src);
+      expect(result.diagnostics).toContainEqual(
+        expect.objectContaining({
+          severity: "error",
+          message: expect.stringMatching(/required/i),
+        }),
+      );
+    });
+
+    it("classifies duplicate key diagnostics as warnings", () => {
+      const src = `introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    playerCount: 2
+    gameStages:
+      - name: stage1
+        duration: 300
+        elements:
+          - type: submitButton`;
+      const result = validateTreatmentSource(src);
+      const dupeWarnings = result.diagnostics.filter((d) =>
+        d.message.match(/unique|duplicate/i),
+      );
+      expect(dupeWarnings.length).toBeGreaterThan(0);
+      expect(dupeWarnings.every((d) => d.severity === "warning")).toBe(true);
+    });
+  });
 });

--- a/apps/vscode/src/lib/validateTreatment.ts
+++ b/apps/vscode/src/lib/validateTreatment.ts
@@ -1,0 +1,85 @@
+import { treatmentFileSchema } from "stagebook";
+import {
+  createPositionMapper,
+  extractYamlErrors,
+  type SourceRange,
+} from "./yamlPositionMap";
+
+export interface Diagnostic {
+  message: string;
+  severity: "error" | "warning";
+  range: SourceRange | null;
+}
+
+export interface ValidationResult {
+  diagnostics: Diagnostic[];
+  /** The parsed JS object, or null if YAML parsing failed fatally. */
+  parsedObj: unknown;
+}
+
+/**
+ * Validate a treatment YAML source string.
+ *
+ * Returns diagnostics with source positions and the parsed object.
+ * This is a pure function — no VS Code dependency.
+ *
+ * The schema validates the original (unexpanded) object directly,
+ * since treatmentFileSchema uses altTemplateContext() and accepts
+ * both concrete objects and template contexts at every level.
+ */
+export function validateTreatmentSource(source: string): ValidationResult {
+  const diagnostics: Diagnostic[] = [];
+
+  // Step 1: Check for YAML syntax errors and duplicate keys
+  const yamlErrors = extractYamlErrors(source);
+  for (const err of yamlErrors) {
+    diagnostics.push({
+      message: err.message,
+      severity: err.message.match(/unique|duplicate/i) ? "warning" : "error",
+      range: {
+        startLine: err.line,
+        startCol: err.col,
+        endLine: err.line,
+        endCol: err.col + 1,
+      },
+    });
+  }
+
+  // Step 2: Parse into AST (for position mapping) and JS object (for Zod)
+  const mapper = createPositionMapper(source);
+  const parsedObj = mapper.toJSON();
+
+  if (
+    parsedObj === null ||
+    parsedObj === undefined ||
+    typeof parsedObj !== "object"
+  ) {
+    if (diagnostics.length === 0) {
+      diagnostics.push({
+        message: "Failed to parse YAML",
+        severity: "error",
+        range: null,
+      });
+    }
+    return { diagnostics, parsedObj: null };
+  }
+
+  // Step 3: Validate with stagebook's treatmentFileSchema
+  // The schema accepts template contexts natively (via altTemplateContext),
+  // so we validate the original object without expanding templates.
+  const result = treatmentFileSchema.safeParse(parsedObj);
+
+  if (!result.success) {
+    for (const issue of result.error.issues) {
+      const range = mapper.resolve(issue.path);
+
+      diagnostics.push({
+        message: issue.message,
+        severity: "error",
+        range,
+      });
+    }
+  }
+
+  return { diagnostics, parsedObj };
+}

--- a/apps/vscode/src/lib/validateTreatment.ts
+++ b/apps/vscode/src/lib/validateTreatment.ts
@@ -59,8 +59,11 @@ export function validateTreatmentSource(source: string): ValidationResult {
         range = mapper.resolve(ancestorPath);
       }
 
-      // Augment terse Zod messages (like "Required") with the path so the
-      // user knows which field the error refers to.
+      // Append the field path to every diagnostic so the user always knows
+      // which field the error refers to. Zod messages often omit the field
+      // name (e.g., "Required", "Expected number, received string"), and
+      // even when they include it, the full path gives hierarchical context.
+      // Skipped only when the path is already present verbatim in the message.
       const pathStr = formatPath(issue.path);
       const message =
         pathStr && !issue.message.toLowerCase().includes(pathStr.toLowerCase())

--- a/apps/vscode/src/lib/validateTreatment.ts
+++ b/apps/vscode/src/lib/validateTreatment.ts
@@ -1,15 +1,8 @@
 import { treatmentFileSchema } from "stagebook";
-import {
-  createPositionMapper,
-  extractYamlErrors,
-  type SourceRange,
-} from "./yamlPositionMap";
+import { createPositionMapper, extractYamlErrors } from "./yamlPositionMap";
+import type { Diagnostic } from "./types";
 
-export interface Diagnostic {
-  message: string;
-  severity: "error" | "warning";
-  range: SourceRange | null;
-}
+export type { Diagnostic };
 
 export interface ValidationResult {
   diagnostics: Diagnostic[];

--- a/apps/vscode/src/lib/validateTreatment.ts
+++ b/apps/vscode/src/lib/validateTreatment.ts
@@ -49,10 +49,26 @@ export function validateTreatmentSource(source: string): ValidationResult {
 
   if (!result.success) {
     for (const issue of result.error.issues) {
-      const range = mapper.resolve(issue.path);
+      // Try to resolve the exact path; if it doesn't exist in the source
+      // (e.g., "Required" errors on missing fields), walk up to the nearest
+      // ancestor that does exist so the squiggly lands somewhere meaningful.
+      let range = mapper.resolve(issue.path);
+      let ancestorPath = issue.path;
+      while (!range && ancestorPath.length > 0) {
+        ancestorPath = ancestorPath.slice(0, -1);
+        range = mapper.resolve(ancestorPath);
+      }
+
+      // Augment terse Zod messages (like "Required") with the path so the
+      // user knows which field the error refers to.
+      const pathStr = formatPath(issue.path);
+      const message =
+        pathStr && !issue.message.toLowerCase().includes(pathStr.toLowerCase())
+          ? `${issue.message} (${pathStr})`
+          : issue.message;
 
       diagnostics.push({
-        message: issue.message,
+        message,
         severity: "error",
         range,
       });
@@ -60,4 +76,21 @@ export function validateTreatmentSource(source: string): ValidationResult {
   }
 
   return { diagnostics, parsedObj };
+}
+
+/**
+ * Format a Zod issue path as a readable dotted string.
+ * Array indices are shown in brackets: ["treatments", 0, "gameStages", 1] → "treatments[0].gameStages[1]"
+ */
+function formatPath(path: (string | number)[]): string {
+  if (path.length === 0) return "";
+  let result = "";
+  for (const segment of path) {
+    if (typeof segment === "number") {
+      result += `[${segment}]`;
+    } else {
+      result += result ? `.${segment}` : segment;
+    }
+  }
+  return result;
 }

--- a/apps/vscode/src/lib/validateTreatment.ts
+++ b/apps/vscode/src/lib/validateTreatment.ts
@@ -49,24 +49,9 @@ export function validateTreatmentSource(source: string): ValidationResult {
   const mapper = createPositionMapper(source);
   const parsedObj = mapper.toJSON();
 
-  if (
-    parsedObj === null ||
-    parsedObj === undefined ||
-    typeof parsedObj !== "object"
-  ) {
-    if (diagnostics.length === 0) {
-      diagnostics.push({
-        message: "Failed to parse YAML",
-        severity: "error",
-        range: null,
-      });
-    }
-    return { diagnostics, parsedObj: null };
-  }
-
   // Step 3: Validate with stagebook's treatmentFileSchema
-  // The schema accepts template contexts natively (via altTemplateContext),
-  // so we validate the original object without expanding templates.
+  // Pass whatever was parsed (even null/scalar) — Zod produces clear
+  // "Expected object, received ..." messages for non-object input.
   const result = treatmentFileSchema.safeParse(parsedObj);
 
   if (!result.success) {

--- a/apps/vscode/src/lib/yamlPositionMap.test.ts
+++ b/apps/vscode/src/lib/yamlPositionMap.test.ts
@@ -448,6 +448,83 @@ describe("remapErrorPath", () => {
   });
 });
 
+describe("remapErrorPath — array templateContent", () => {
+  it("accounts for array templateContent expanding into multiple siblings", () => {
+    const arrayTemplates = [
+      {
+        templateName: "twoElements",
+        templateContent: [
+          { type: "prompt", file: "q1.prompt.md" },
+          { type: "separator" },
+        ],
+      },
+    ];
+    const original = {
+      templates: arrayTemplates,
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [
+            {
+              name: "s1",
+              elements: [{ template: "twoElements" }, { type: "submitButton" }],
+            },
+          ],
+        },
+      ],
+    };
+    // Template expands [0] into 2 items, so submitButton shifts to index 2
+    const result = remapErrorPath(
+      ["treatments", 0, "gameStages", 0, "elements", 2, "type"],
+      original,
+      arrayTemplates,
+    );
+    // Index 2 is the submitButton (non-template), not from the template
+    expect(result).toEqual([
+      "treatments",
+      0,
+      "gameStages",
+      0,
+      "elements",
+      2,
+      "type",
+    ]);
+  });
+
+  it("remaps errors within array-expanded template content", () => {
+    const arrayTemplates = [
+      {
+        templateName: "twoElements",
+        templateContent: [
+          { type: "prompt", file: "q1.prompt.md" },
+          { type: "separator" },
+        ],
+      },
+    ];
+    const original = {
+      templates: arrayTemplates,
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [
+            {
+              name: "s1",
+              elements: [{ template: "twoElements" }, { type: "submitButton" }],
+            },
+          ],
+        },
+      ],
+    };
+    // Error at expanded index 1 — second item from the array template
+    const result = remapErrorPath(
+      ["treatments", 0, "gameStages", 0, "elements", 1, "type"],
+      original,
+      arrayTemplates,
+    );
+    expect(result).toEqual(["templates", 0, "templateContent", "type"]);
+  });
+});
+
 describe("pathToRange — type mismatches", () => {
   it("returns null for a string segment on a sequence node", () => {
     const src = `items:

--- a/apps/vscode/src/lib/yamlPositionMap.test.ts
+++ b/apps/vscode/src/lib/yamlPositionMap.test.ts
@@ -1,0 +1,382 @@
+import { describe, it, expect } from "vitest";
+import {
+  pathToRange,
+  extractYamlErrors,
+  remapErrorPath,
+} from "./yamlPositionMap";
+
+describe("pathToRange", () => {
+  describe("scalar values", () => {
+    it("finds a top-level scalar", () => {
+      const src = `name: study1
+playerCount: 3`;
+      const range = pathToRange(src, ["name"]);
+      expect(range).toEqual({
+        startLine: 0,
+        startCol: 6,
+        endLine: 0,
+        endCol: 12,
+      });
+    });
+
+    it("finds a numeric value", () => {
+      const src = `name: study1
+playerCount: 3`;
+      const range = pathToRange(src, ["playerCount"]);
+      expect(range).toEqual({
+        startLine: 1,
+        startCol: 13,
+        endLine: 1,
+        endCol: 14,
+      });
+    });
+  });
+
+  describe("nested objects", () => {
+    it("finds a value nested one level deep", () => {
+      const src = `treatment:
+  name: study1
+  playerCount: 3`;
+      const range = pathToRange(src, ["treatment", "name"]);
+      expect(range).toEqual({
+        startLine: 1,
+        startCol: 8,
+        endLine: 1,
+        endCol: 14,
+      });
+    });
+
+    it("finds a value nested multiple levels deep", () => {
+      const src = `treatments:
+  - name: study1
+    gameStages:
+      - name: stage1
+        duration: 300`;
+      const range = pathToRange(src, [
+        "treatments",
+        0,
+        "gameStages",
+        0,
+        "duration",
+      ]);
+      expect(range).toEqual({
+        startLine: 4,
+        startCol: 18,
+        endLine: 4,
+        endCol: 21,
+      });
+    });
+  });
+
+  describe("array items", () => {
+    it("finds an array item by index", () => {
+      const src = `items:
+  - first
+  - second
+  - third`;
+      const range = pathToRange(src, ["items", 1]);
+      expect(range).toEqual({
+        startLine: 2,
+        startCol: 4,
+        endLine: 2,
+        endCol: 10,
+      });
+    });
+
+    it("finds a property inside an array item", () => {
+      const src = `elements:
+  - type: prompt
+    file: prompts/q1.prompt.md
+  - type: separator
+    style: thin`;
+      const range = pathToRange(src, ["elements", 1, "style"]);
+      expect(range).toEqual({
+        startLine: 4,
+        startCol: 11,
+        endLine: 4,
+        endCol: 15,
+      });
+    });
+  });
+
+  describe("missing paths", () => {
+    it("returns null for a path that does not exist", () => {
+      const src = `name: study1`;
+      const range = pathToRange(src, ["missing"]);
+      expect(range).toBeNull();
+    });
+
+    it("returns null for an out-of-bounds array index", () => {
+      const src = `items:
+  - first`;
+      const range = pathToRange(src, ["items", 5]);
+      expect(range).toBeNull();
+    });
+
+    it("returns null for an empty path on a document with no contents", () => {
+      const src = ``;
+      const range = pathToRange(src, ["anything"]);
+      expect(range).toBeNull();
+    });
+  });
+
+  describe("empty path", () => {
+    it("returns the range of the root node", () => {
+      const src = `name: study1`;
+      const range = pathToRange(src, []);
+      expect(range).not.toBeNull();
+      expect(range!.startLine).toBe(0);
+    });
+  });
+
+  describe("deeply nested paths", () => {
+    it("handles 6+ levels of nesting", () => {
+      const src = `treatments:
+  - name: t1
+    gameStages:
+      - name: s1
+        elements:
+          - type: prompt
+            conditions:
+              - comparator: equals
+                value: yes`;
+      const range = pathToRange(src, [
+        "treatments",
+        0,
+        "gameStages",
+        0,
+        "elements",
+        0,
+        "conditions",
+        0,
+        "value",
+      ]);
+      expect(range).toEqual({
+        startLine: 8,
+        startCol: 23,
+        endLine: 8,
+        endCol: 26,
+      });
+    });
+  });
+});
+
+describe("extractYamlErrors", () => {
+  it("returns no errors for valid YAML", () => {
+    const src = `name: study1
+playerCount: 3`;
+    const errors = extractYamlErrors(src);
+    expect(errors).toEqual([]);
+  });
+
+  it("returns an error for bad indentation", () => {
+    const src = `name: study1
+  bad indentation: here
+ worse: there`;
+    const errors = extractYamlErrors(src);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0]).toHaveProperty("line");
+    expect(errors[0]).toHaveProperty("message");
+  });
+
+  it("returns an error for a missing value after colon", () => {
+    const src = `name:
+  key1: value1
+  key2:
+  key3`;
+    const errors = extractYamlErrors(src);
+    // key3 without colon could be parsed as a scalar or cause an error
+    // depending on context — just verify we get structured output
+    expect(Array.isArray(errors)).toBe(true);
+  });
+
+  it("detects duplicate keys", () => {
+    const src = `name: first
+name: second
+playerCount: 3`;
+    const errors = extractYamlErrors(src);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].message).toMatch(/unique|duplicate/i);
+  });
+});
+
+describe("remapErrorPath", () => {
+  const templates = [
+    {
+      templateName: "myStage",
+      templateContent: {
+        name: "stage1",
+        duration: 300,
+        elements: [{ type: "prompt", file: "bad/path.md" }],
+      },
+    },
+  ];
+
+  describe("non-template paths", () => {
+    it("returns the original path when no templates are involved", () => {
+      const original = {
+        treatments: [{ name: "t1", playerCount: 3 }],
+      };
+      const result = remapErrorPath(
+        ["treatments", 0, "name"],
+        original,
+        templates,
+      );
+      expect(result).toEqual(["treatments", 0, "name"]);
+    });
+  });
+
+  describe("simple template expansion", () => {
+    it("remaps a path through a template context to the template definition", () => {
+      const original = {
+        templates,
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [{ template: "myStage" }],
+          },
+        ],
+      };
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 0, "elements", 0, "file"],
+        original,
+        templates,
+      );
+      expect(result).toEqual([
+        "templates",
+        0,
+        "templateContent",
+        "elements",
+        0,
+        "file",
+      ]);
+    });
+
+    it("remaps a top-level property of expanded template content", () => {
+      const original = {
+        templates,
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [{ template: "myStage" }],
+          },
+        ],
+      };
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 0, "duration"],
+        original,
+        templates,
+      );
+      expect(result).toEqual(["templates", 0, "templateContent", "duration"]);
+    });
+  });
+
+  describe("broadcast expansion", () => {
+    it("remaps paths through broadcast-expanded items to the template", () => {
+      // Broadcast expands one template context into multiple array items.
+      // Both expanded items [0] and [1] came from the same template at
+      // original index 0, so both should remap to that template's content.
+      const original = {
+        templates,
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [
+              {
+                template: "myStage",
+                broadcast: { d0: [{ topic: "a" }, { topic: "b" }] },
+              },
+            ],
+          },
+        ],
+      };
+      // Error in the second broadcast-expanded item
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 1, "elements", 0, "file"],
+        original,
+        templates,
+      );
+      expect(result).toEqual([
+        "templates",
+        0,
+        "templateContent",
+        "elements",
+        0,
+        "file",
+      ]);
+    });
+  });
+
+  describe("mixed arrays", () => {
+    it("remaps correctly when templates are mixed with non-template items", () => {
+      const original = {
+        templates,
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [
+              { name: "intro", duration: 60, elements: [] },
+              { template: "myStage" },
+            ],
+          },
+        ],
+      };
+      // Error at expanded index 1 — the template was at original index 1
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 1, "elements", 0, "file"],
+        original,
+        templates,
+      );
+      expect(result).toEqual([
+        "templates",
+        0,
+        "templateContent",
+        "elements",
+        0,
+        "file",
+      ]);
+    });
+
+    it("does not remap a non-template item after a template in the array", () => {
+      const original = {
+        templates,
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [
+              { template: "myStage" },
+              { name: "final", duration: 60, elements: [] },
+            ],
+          },
+        ],
+      };
+      // Error at expanded index 1 — this is the non-template item at original index 1
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 1, "name"],
+        original,
+        templates,
+      );
+      expect(result).toEqual(["treatments", 0, "gameStages", 1, "name"]);
+    });
+  });
+
+  describe("template not found", () => {
+    it("returns the original path if the referenced template does not exist", () => {
+      const original = {
+        templates: [],
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [{ template: "nonexistent" }],
+          },
+        ],
+      };
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 0, "duration"],
+        original,
+        [],
+      );
+      expect(result).toEqual(["treatments", 0, "gameStages", 0, "duration"]);
+    });
+  });
+});

--- a/apps/vscode/src/lib/yamlPositionMap.test.ts
+++ b/apps/vscode/src/lib/yamlPositionMap.test.ts
@@ -3,6 +3,7 @@ import {
   pathToRange,
   extractYamlErrors,
   remapErrorPath,
+  createPositionMapper,
 } from "./yamlPositionMap";
 
 describe("pathToRange", () => {
@@ -378,5 +379,146 @@ describe("remapErrorPath", () => {
       );
       expect(result).toEqual(["treatments", 0, "gameStages", 0, "duration"]);
     });
+  });
+
+  describe("multiple templates in one array", () => {
+    it("remaps to the correct template when multiple templates appear in sequence", () => {
+      const twoTemplates = [
+        {
+          templateName: "stageA",
+          templateContent: { name: "a", elements: [] },
+        },
+        {
+          templateName: "stageB",
+          templateContent: { name: "b", elements: [] },
+        },
+      ];
+      const original = {
+        templates: twoTemplates,
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [{ template: "stageA" }, { template: "stageB" }],
+          },
+        ],
+      };
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 1, "name"],
+        original,
+        twoTemplates,
+      );
+      expect(result).toEqual(["templates", 1, "templateContent", "name"]);
+    });
+  });
+
+  describe("multi-dimension broadcast", () => {
+    it("remaps paths through a multi-dimension broadcast expansion", () => {
+      const original = {
+        templates,
+        treatments: [
+          {
+            name: "t1",
+            gameStages: [
+              {
+                template: "myStage",
+                broadcast: {
+                  d0: [{ topic: "a" }, { topic: "b" }],
+                  d1: [{ group: "x" }, { group: "y" }],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      // 2 * 2 = 4 expanded items; index 3 is the last one
+      const result = remapErrorPath(
+        ["treatments", 0, "gameStages", 3, "elements", 0, "file"],
+        original,
+        templates,
+      );
+      expect(result).toEqual([
+        "templates",
+        0,
+        "templateContent",
+        "elements",
+        0,
+        "file",
+      ]);
+    });
+  });
+});
+
+describe("pathToRange — type mismatches", () => {
+  it("returns null for a string segment on a sequence node", () => {
+    const src = `items:
+  - first
+  - second`;
+    const range = pathToRange(src, ["items", "notANumber"]);
+    expect(range).toBeNull();
+  });
+
+  it("returns null for a numeric segment on a map node", () => {
+    const src = `name: study1`;
+    const range = pathToRange(src, [0]);
+    expect(range).toBeNull();
+  });
+});
+
+describe("pathToRange — multiline values", () => {
+  it("handles block scalar (pipe) spanning multiple lines", () => {
+    const src = `description: |
+  line one
+  line two
+name: next`;
+    const range = pathToRange(src, ["description"]);
+    expect(range).not.toBeNull();
+    expect(range!.endLine).toBeGreaterThan(range!.startLine);
+  });
+});
+
+describe("createPositionMapper", () => {
+  it("resolves multiple paths from a single parse", () => {
+    const src = `treatments:
+  - name: study1
+    playerCount: 3`;
+    const mapper = createPositionMapper(src);
+
+    const nameRange = mapper.resolve(["treatments", 0, "name"]);
+    const countRange = mapper.resolve(["treatments", 0, "playerCount"]);
+
+    expect(nameRange).toEqual({
+      startLine: 1,
+      startCol: 10,
+      endLine: 1,
+      endCol: 16,
+    });
+    expect(countRange).toEqual({
+      startLine: 2,
+      startCol: 17,
+      endLine: 2,
+      endCol: 18,
+    });
+  });
+
+  it("returns the same result as pathToRange", () => {
+    const src = `elements:
+  - type: prompt
+    file: prompts/q1.prompt.md`;
+    const mapper = createPositionMapper(src);
+
+    const fromMapper = mapper.resolve(["elements", 0, "file"]);
+    const fromDirect = pathToRange(src, ["elements", 0, "file"]);
+
+    expect(fromMapper).toEqual(fromDirect);
+  });
+
+  it("toJSON returns the parsed JS object", () => {
+    const src = `name: study1
+playerCount: 3`;
+    const mapper = createPositionMapper(src);
+    const obj = mapper.toJSON() as Record<string, unknown>;
+
+    expect(obj.name).toBe("study1");
+    expect(obj.playerCount).toBe(3);
   });
 });

--- a/apps/vscode/src/lib/yamlPositionMap.ts
+++ b/apps/vscode/src/lib/yamlPositionMap.ts
@@ -32,16 +32,15 @@ function offsetToLineCol(
 }
 
 /**
- * Given a YAML source string and a path (e.g. from a Zod issue),
- * return the source range of the value node at that path.
- *
- * Returns null if the path cannot be resolved.
+ * Resolve a path to a source range within a pre-parsed YAML document.
+ * This is the core AST-walking logic shared by pathToRange and
+ * createPositionMapper.
  */
-export function pathToRange(
+function resolvePathInDoc(
+  doc: ReturnType<typeof parseDocument>,
   source: string,
   path: (string | number)[],
 ): SourceRange | null {
-  const doc = parseDocument(source, { uniqueKeys: false });
   if (!doc.contents) return null;
 
   let node = doc.contents;
@@ -72,6 +71,49 @@ export function pathToRange(
     startCol: start.col,
     endLine: end.line,
     endCol: end.col,
+  };
+}
+
+/**
+ * Given a YAML source string and a path (e.g. from a Zod issue),
+ * return the source range of the value node at that path.
+ *
+ * Returns null if the path cannot be resolved.
+ *
+ * For resolving many paths against the same document, use
+ * createPositionMapper() instead to avoid re-parsing.
+ */
+export function pathToRange(
+  source: string,
+  path: (string | number)[],
+): SourceRange | null {
+  const doc = parseDocument(source, { uniqueKeys: false });
+  return resolvePathInDoc(doc, source, path);
+}
+
+export interface PositionMapper {
+  /** Resolve a path to a source range. Returns null if the path cannot be resolved. */
+  resolve(path: (string | number)[]): SourceRange | null;
+  /** Get the parsed JS object (for passing to Zod or remapErrorPath). */
+  toJSON(): unknown;
+}
+
+/**
+ * Parse a YAML source string once and return a mapper that can
+ * resolve many paths to source ranges without re-parsing.
+ *
+ * Use this in the validation pipeline where a single document
+ * may produce many Zod errors that each need position mapping.
+ */
+export function createPositionMapper(source: string): PositionMapper {
+  const doc = parseDocument(source, { uniqueKeys: false });
+  return {
+    resolve(path) {
+      return resolvePathInDoc(doc, source, path);
+    },
+    toJSON() {
+      return doc.toJSON();
+    },
   };
 }
 
@@ -121,7 +163,7 @@ function isTemplateContext(obj: unknown): obj is { template: string } {
   return (
     typeof obj === "object" &&
     obj !== null &&
-    "template" in obj &&
+    Object.hasOwn(obj, "template") &&
     typeof (obj as Record<string, unknown>).template === "string"
   );
 }
@@ -224,6 +266,7 @@ export function remapErrorPath(
       !Array.isArray(current) &&
       typeof segment === "string"
     ) {
+      if (!Object.hasOwn(current, segment)) return errorPath;
       current = (current as Record<string, unknown>)[segment];
       consumed.push(segment);
     } else {

--- a/apps/vscode/src/lib/yamlPositionMap.ts
+++ b/apps/vscode/src/lib/yamlPositionMap.ts
@@ -47,7 +47,8 @@ function resolvePathInDoc(
 
   for (const segment of path) {
     if (isMap(node) && typeof segment === "string") {
-      const pair = node.items.find(
+      // findLast: YAML keeps the last value for duplicate keys
+      const pair = node.items.findLast(
         (p) => isScalar(p.key) && p.key.value === segment,
       );
       if (!pair) return null;
@@ -170,20 +171,26 @@ function isTemplateContext(obj: unknown): obj is { template: string } {
 
 /**
  * Count how many items a template context expands into.
- * Without broadcast: 1. With broadcast: product of all dimension lengths.
+ * Base count is 1 for object templateContent, or templateContent.length
+ * for array templateContent. Multiplied by broadcast dimensions.
  */
-function countExpandedItems(context: Record<string, unknown>): number {
+function countExpandedItems(
+  context: Record<string, unknown>,
+  templateContent: unknown,
+): number {
+  const baseCount = Array.isArray(templateContent) ? templateContent.length : 1;
+
   const broadcast = context.broadcast;
   if (!broadcast || typeof broadcast !== "object" || Array.isArray(broadcast)) {
-    return 1;
+    return Math.max(baseCount, 1);
   }
-  let count = 1;
+  let broadcastMultiplier = 1;
   for (const dim of Object.values(broadcast as Record<string, unknown>)) {
     if (Array.isArray(dim)) {
-      count *= dim.length;
+      broadcastMultiplier *= dim.length;
     }
   }
-  return Math.max(count, 1);
+  return Math.max(baseCount * broadcastMultiplier, 1);
 }
 
 /**
@@ -199,7 +206,7 @@ function countExpandedItems(context: Record<string, unknown>): number {
 export function remapErrorPath(
   errorPath: (string | number)[],
   originalObj: Record<string, unknown>,
-  templates: { templateName: string }[],
+  templates: { templateName: string; templateContent?: unknown }[],
 ): (string | number)[] {
   const path = [...errorPath];
   let current: unknown = originalObj;
@@ -226,9 +233,7 @@ export function remapErrorPath(
             continue;
           }
 
-          const expandedCount = countExpandedItems(
-            item as Record<string, unknown>,
-          );
+          const expandedCount = info.expandedCount;
 
           if (
             segment >= expandedIndex &&
@@ -280,7 +285,7 @@ export function remapErrorPath(
 
 function resolveTemplate(
   context: { template: string },
-  templates: { templateName: string }[],
+  templates: { templateName: string; templateContent?: unknown }[],
 ): TemplateInfo | null {
   const idx = templates.findIndex((t) => t.templateName === context.template);
   if (idx === -1) return null;
@@ -289,6 +294,7 @@ function resolveTemplate(
     templateIndex: idx,
     expandedCount: countExpandedItems(
       context as unknown as Record<string, unknown>,
+      templates[idx].templateContent,
     ),
   };
 }

--- a/apps/vscode/src/lib/yamlPositionMap.ts
+++ b/apps/vscode/src/lib/yamlPositionMap.ts
@@ -1,0 +1,251 @@
+import { parseDocument, isMap, isSeq, isScalar } from "yaml";
+
+export interface SourceRange {
+  startLine: number;
+  startCol: number;
+  endLine: number;
+  endCol: number;
+}
+
+export interface YamlError {
+  line: number;
+  col: number;
+  message: string;
+}
+
+/**
+ * Convert a character offset to a 0-based line and column.
+ */
+function offsetToLineCol(
+  source: string,
+  offset: number,
+): { line: number; col: number } {
+  let line = 0;
+  let lastNewline = -1;
+  for (let i = 0; i < offset && i < source.length; i++) {
+    if (source[i] === "\n") {
+      line++;
+      lastNewline = i;
+    }
+  }
+  return { line, col: offset - lastNewline - 1 };
+}
+
+/**
+ * Given a YAML source string and a path (e.g. from a Zod issue),
+ * return the source range of the value node at that path.
+ *
+ * Returns null if the path cannot be resolved.
+ */
+export function pathToRange(
+  source: string,
+  path: (string | number)[],
+): SourceRange | null {
+  const doc = parseDocument(source, { uniqueKeys: false });
+  if (!doc.contents) return null;
+
+  let node = doc.contents;
+
+  for (const segment of path) {
+    if (isMap(node) && typeof segment === "string") {
+      const pair = node.items.find(
+        (p) => isScalar(p.key) && p.key.value === segment,
+      );
+      if (!pair) return null;
+      node = pair.value as typeof node;
+    } else if (isSeq(node) && typeof segment === "number") {
+      const item = node.items[segment];
+      if (!item) return null;
+      node = item as typeof node;
+    } else {
+      return null;
+    }
+  }
+
+  if (!node || !node.range) return null;
+
+  const [startOffset, endOffset] = node.range;
+  const start = offsetToLineCol(source, startOffset);
+  const end = offsetToLineCol(source, endOffset);
+  return {
+    startLine: start.line,
+    startCol: start.col,
+    endLine: end.line,
+    endCol: end.col,
+  };
+}
+
+/**
+ * Extract YAML syntax errors and duplicate key warnings from a source string.
+ *
+ * Returns structured errors with line positions and messages.
+ */
+export function extractYamlErrors(source: string): YamlError[] {
+  const doc = parseDocument(source, { uniqueKeys: true });
+  const errors: YamlError[] = [];
+
+  for (const err of doc.errors) {
+    const pos = err.pos?.[0];
+    if (pos !== undefined) {
+      const { line, col } = offsetToLineCol(source, pos);
+      errors.push({ line, col, message: err.message });
+    } else {
+      errors.push({ line: 0, col: 0, message: err.message });
+    }
+  }
+
+  for (const warn of doc.warnings) {
+    const pos = warn.pos?.[0];
+    if (pos !== undefined) {
+      const { line, col } = offsetToLineCol(source, pos);
+      errors.push({ line, col, message: warn.message });
+    } else {
+      errors.push({ line: 0, col: 0, message: warn.message });
+    }
+  }
+
+  return errors;
+}
+
+interface TemplateInfo {
+  templateName: string;
+  templateIndex: number;
+  /** Number of items this template expands into (>1 for broadcast). */
+  expandedCount: number;
+}
+
+/**
+ * Check if a plain JS object is a template context (has a `template` string property).
+ */
+function isTemplateContext(obj: unknown): obj is { template: string } {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "template" in obj &&
+    typeof (obj as Record<string, unknown>).template === "string"
+  );
+}
+
+/**
+ * Count how many items a template context expands into.
+ * Without broadcast: 1. With broadcast: product of all dimension lengths.
+ */
+function countExpandedItems(context: Record<string, unknown>): number {
+  const broadcast = context.broadcast;
+  if (!broadcast || typeof broadcast !== "object" || Array.isArray(broadcast)) {
+    return 1;
+  }
+  let count = 1;
+  for (const dim of Object.values(broadcast as Record<string, unknown>)) {
+    if (Array.isArray(dim)) {
+      count *= dim.length;
+    }
+  }
+  return Math.max(count, 1);
+}
+
+/**
+ * Given a Zod error path (relative to the expanded/validated object),
+ * remap it to point to the original YAML source location.
+ *
+ * If the path goes through an expanded template context, the returned
+ * path points into the template definition instead (e.g.
+ * `["templates", 0, "templateContent", "elements", 0, "file"]`).
+ *
+ * If no remapping is needed, returns the original path unchanged.
+ */
+export function remapErrorPath(
+  errorPath: (string | number)[],
+  originalObj: Record<string, unknown>,
+  templates: { templateName: string }[],
+): (string | number)[] {
+  const path = [...errorPath];
+  let current: unknown = originalObj;
+  const consumed: (string | number)[] = [];
+
+  for (let i = 0; i < path.length; i++) {
+    const segment = path[i];
+
+    if (Array.isArray(current) && typeof segment === "number") {
+      // Walk the original array, accounting for template expansions
+      // that may have shifted indices.
+      let expandedIndex = 0;
+      for (let origIdx = 0; origIdx < current.length; origIdx++) {
+        const item = current[origIdx];
+
+        if (isTemplateContext(item)) {
+          const info = resolveTemplate(item, templates);
+          if (!info) {
+            // Template not found — can't remap, treat as opaque
+            expandedIndex += 1;
+            if (expandedIndex > segment) {
+              break;
+            }
+            continue;
+          }
+
+          const expandedCount = countExpandedItems(
+            item as Record<string, unknown>,
+          );
+
+          if (
+            segment >= expandedIndex &&
+            segment < expandedIndex + expandedCount
+          ) {
+            // This expanded index came from this template
+            const remaining = path.slice(i + 1);
+            return [
+              "templates",
+              info.templateIndex,
+              "templateContent",
+              ...remaining,
+            ];
+          }
+
+          expandedIndex += expandedCount;
+        } else {
+          if (expandedIndex === segment) {
+            // Found the matching non-template item
+            current = item;
+            consumed.push(segment);
+            break;
+          }
+          expandedIndex += 1;
+        }
+      }
+
+      if (consumed[consumed.length - 1] !== segment) {
+        // We didn't find a match — return original path
+        return errorPath;
+      }
+    } else if (
+      typeof current === "object" &&
+      current !== null &&
+      !Array.isArray(current) &&
+      typeof segment === "string"
+    ) {
+      current = (current as Record<string, unknown>)[segment];
+      consumed.push(segment);
+    } else {
+      // Can't walk further — return original path
+      return errorPath;
+    }
+  }
+
+  return errorPath;
+}
+
+function resolveTemplate(
+  context: { template: string },
+  templates: { templateName: string }[],
+): TemplateInfo | null {
+  const idx = templates.findIndex((t) => t.templateName === context.template);
+  if (idx === -1) return null;
+  return {
+    templateName: context.template,
+    templateIndex: idx,
+    expandedCount: countExpandedItems(
+      context as unknown as Record<string, unknown>,
+    ),
+  };
+}

--- a/apps/vscode/src/webview/index.tsx
+++ b/apps/vscode/src/webview/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from "react";
 import { createRoot } from "react-dom/client";
 import type { TreatmentFileType } from "stagebook";
-import { Viewer } from "stagebook-viewer/preview";
+import { PreviewHost } from "stagebook-viewer/preview";
 
 // Declare the VS Code API injected by the webview
 declare function acquireVsCodeApi(): {
@@ -80,6 +80,9 @@ function App() {
   const [treatmentIndex, setTreatmentIndex] = useState(0);
   const [webviewBaseUri, setWebviewBaseUri] = useState("");
   const [error, setError] = useState<string | null>(null);
+  // Bumped on each treatment message so that `contentFns` is recreated
+  // with a fresh cache, forcing prompt files to re-fetch from disk.
+  const [contentVersion, setContentVersion] = useState(0);
 
   useEffect(() => {
     const handler = (event: MessageEvent) => {
@@ -89,6 +92,7 @@ function App() {
         setIntroIndex(msg.introIndex ?? 0);
         setTreatmentIndex(msg.treatmentIndex ?? 0);
         setWebviewBaseUri(msg.webviewBaseUri ?? "");
+        setContentVersion((v) => v + 1);
         setError(null);
       } else if (msg.type === "error") {
         setError(msg.message);
@@ -105,7 +109,9 @@ function App() {
 
   const contentFns = useMemo(
     () => createWebviewContentFns(webviewBaseUri),
-    [webviewBaseUri],
+    // contentVersion is part of the deps so a refresh creates a fresh cache
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [webviewBaseUri, contentVersion],
   );
 
   if (error) {
@@ -126,15 +132,13 @@ function App() {
   }
 
   return (
-    <Viewer
+    <PreviewHost
       treatmentFile={treatmentFile}
       getTextContent={contentFns.getTextContent}
       getAssetURL={contentFns.getAssetURL}
       selectedIntroIndex={introIndex}
       selectedTreatmentIndex={treatmentIndex}
-      onBack={() => {
-        /* no-op in extension webview */
-      }}
+      onRefresh={() => vscode.postMessage({ type: "refresh" })}
     />
   );
 }

--- a/apps/vscode/src/webview/index.tsx
+++ b/apps/vscode/src/webview/index.tsx
@@ -1,0 +1,140 @@
+import React, { useState, useEffect, useMemo } from "react";
+import { createRoot } from "react-dom/client";
+import type { TreatmentFileType } from "stagebook";
+import { Viewer } from "stagebook-viewer/preview";
+
+// Declare the VS Code API injected by the webview
+declare function acquireVsCodeApi(): {
+  postMessage(message: unknown): void;
+  getState(): unknown;
+  setState(state: unknown): void;
+};
+
+const vscode = acquireVsCodeApi();
+
+// --- Content functions via postMessage bridge ---
+
+let requestId = 0;
+const pendingRequests = new Map<
+  number,
+  { resolve: (value: string) => void; reject: (err: Error) => void }
+>();
+
+// Listen for responses from the extension host
+window.addEventListener("message", (event) => {
+  const msg = event.data;
+  if (msg.type === "treatment") {
+    // Treatment data from extension host — handled by App state
+    return;
+  }
+  if (msg.type === "fileContent") {
+    const pending = pendingRequests.get(msg.requestId);
+    if (pending) {
+      pendingRequests.delete(msg.requestId);
+      if (msg.error) {
+        pending.reject(new Error(msg.error));
+      } else {
+        pending.resolve(msg.content);
+      }
+    }
+  }
+});
+
+function createWebviewContentFns(webviewBaseUri: string) {
+  const cache = new Map<string, Promise<string>>();
+
+  return {
+    getTextContent(path: string): Promise<string> {
+      const cached = cache.get(path);
+      if (cached) return cached;
+
+      const id = requestId++;
+      const promise = new Promise<string>((resolve, reject) => {
+        pendingRequests.set(id, { resolve, reject });
+        vscode.postMessage({ type: "readFile", requestId: id, path });
+      });
+
+      cache.set(path, promise);
+      return promise;
+    },
+
+    getAssetURL(path: string): string {
+      return webviewBaseUri + "/" + path;
+    },
+  };
+}
+
+// --- App ---
+
+function App() {
+  const [treatmentFile, setTreatmentFile] = useState<TreatmentFileType | null>(
+    null,
+  );
+  const [introIndex, setIntroIndex] = useState(0);
+  const [treatmentIndex, setTreatmentIndex] = useState(0);
+  const [webviewBaseUri, setWebviewBaseUri] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      const msg = event.data;
+      if (msg.type === "treatment") {
+        setTreatmentFile(msg.treatmentFile);
+        setIntroIndex(msg.introIndex ?? 0);
+        setTreatmentIndex(msg.treatmentIndex ?? 0);
+        setWebviewBaseUri(msg.webviewBaseUri ?? "");
+        setError(null);
+      } else if (msg.type === "error") {
+        setError(msg.message);
+        setTreatmentFile(null);
+      }
+    };
+    window.addEventListener("message", handler);
+
+    // Tell the extension host we're ready
+    vscode.postMessage({ type: "ready" });
+
+    return () => window.removeEventListener("message", handler);
+  }, []);
+
+  const contentFns = useMemo(
+    () => createWebviewContentFns(webviewBaseUri),
+    [webviewBaseUri],
+  );
+
+  if (error) {
+    return (
+      <div style={{ padding: "2rem", color: "#ef4444" }}>
+        <h2>Preview Error</h2>
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  if (!treatmentFile) {
+    return (
+      <div style={{ padding: "2rem", color: "#6b7280" }}>
+        <p>Loading treatment preview...</p>
+      </div>
+    );
+  }
+
+  return (
+    <Viewer
+      treatmentFile={treatmentFile}
+      getTextContent={contentFns.getTextContent}
+      getAssetURL={contentFns.getAssetURL}
+      selectedIntroIndex={introIndex}
+      selectedTreatmentIndex={treatmentIndex}
+      onBack={() => {
+        /* no-op in extension webview */
+      }}
+    />
+  );
+}
+
+// Mount
+const root = document.getElementById("root");
+if (root) {
+  createRoot(root).render(<App />);
+}

--- a/apps/vscode/src/webview/index.tsx
+++ b/apps/vscode/src/webview/index.tsx
@@ -107,10 +107,10 @@ function App() {
     return () => window.removeEventListener("message", handler);
   }, []);
 
+  // `contentVersion` is deliberately part of the deps so a refresh creates
+  // a fresh cache — forcing prompt files to re-fetch from disk.
   const contentFns = useMemo(
     () => createWebviewContentFns(webviewBaseUri),
-    // contentVersion is part of the deps so a refresh creates a fresh cache
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [webviewBaseUri, contentVersion],
   );
 

--- a/apps/vscode/src/webview/index.tsx
+++ b/apps/vscode/src/webview/index.tsx
@@ -52,14 +52,20 @@ function createWebviewContentFns(webviewBaseUri: string) {
       const promise = new Promise<string>((resolve, reject) => {
         pendingRequests.set(id, { resolve, reject });
         vscode.postMessage({ type: "readFile", requestId: id, path });
-      });
+      }).catch((err) => {
+        cache.delete(path);
+        throw err;
+      }) as Promise<string>;
 
       cache.set(path, promise);
       return promise;
     },
 
-    getAssetURL(path: string): string {
-      return webviewBaseUri + "/" + path;
+    getAssetURL(assetPath: string): string {
+      const base = webviewBaseUri.endsWith("/")
+        ? webviewBaseUri
+        : webviewBaseUri + "/";
+      return base + assetPath.replace(/^\/+/, "");
     },
   };
 }

--- a/apps/vscode/syntaxes/stagebookPrompt.tmLanguage.json
+++ b/apps/vscode/syntaxes/stagebookPrompt.tmLanguage.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Stagebook Prompt",
+  "scopeName": "text.html.markdown.prompt",
+  "comment": "Extends standard markdown highlighting for *.prompt.md files.",
+  "patterns": [
+    { "include": "text.html.markdown" }
+  ]
+}

--- a/apps/vscode/syntaxes/treatmentsYaml.tmLanguage.json
+++ b/apps/vscode/syntaxes/treatmentsYaml.tmLanguage.json
@@ -2,14 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Treatments YAML",
   "scopeName": "source.treatments-yaml",
+  "comment": "Inherits base YAML. Domain-specific highlighting is handled by the semantic token provider.",
   "patterns": [
-    { "include": "#template-variable" },
     { "include": "source.yaml" }
-  ],
-  "repository": {
-    "template-variable": {
-      "match": "\\$\\{[a-zA-Z0-9_]+\\}",
-      "name": "variable.other.constant.treatments-yaml"
-    }
-  }
+  ]
 }

--- a/apps/vscode/syntaxes/treatmentsYaml.tmLanguage.json
+++ b/apps/vscode/syntaxes/treatmentsYaml.tmLanguage.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Treatments YAML",
+  "scopeName": "source.treatments-yaml",
+  "comment": "Stub grammar — inherits base YAML highlighting. Full domain-specific highlighting is tracked in issue #77.",
+  "patterns": [
+    { "include": "#template-variable" },
+    { "include": "source.yaml" }
+  ],
+  "repository": {
+    "template-variable": {
+      "match": "\\$\\{[a-zA-Z0-9_]+\\}",
+      "name": "variable.other.constant.treatments-yaml"
+    }
+  }
+}

--- a/apps/vscode/syntaxes/treatmentsYaml.tmLanguage.json
+++ b/apps/vscode/syntaxes/treatmentsYaml.tmLanguage.json
@@ -2,15 +2,66 @@
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Treatments YAML",
   "scopeName": "source.treatments-yaml",
-  "comment": "Stub grammar — inherits base YAML highlighting. Full domain-specific highlighting is tracked in issue #77.",
+  "comment": "Extends base YAML with domain-specific highlighting for stagebook treatment files.",
   "patterns": [
     { "include": "#template-variable" },
+    { "include": "#comparators" },
+    { "include": "#element-type-value" },
+    { "include": "#reference-prefix" },
+    { "include": "#top-level-section-key" },
+    { "include": "#condition-key" },
+    { "include": "#separator-style" },
+    { "include": "#domain-enum-value" },
     { "include": "source.yaml" }
   ],
   "repository": {
     "template-variable": {
       "match": "\\$\\{[a-zA-Z0-9_]+\\}",
       "name": "variable.other.constant.treatments-yaml"
+    },
+
+    "comparators": {
+      "comment": "Condition comparator values — all 16 from conditionSchema",
+      "match": "(?<=:\\s)\\b(exists|doesNotExist|equals|doesNotEqual|isAbove|isBelow|isAtLeast|isAtMost|hasLengthAtLeast|hasLengthAtMost|includes|doesNotInclude|matches|doesNotMatch|isOneOf|isNotOneOf)\\b",
+      "name": "keyword.control.comparator.treatments-yaml"
+    },
+
+    "element-type-value": {
+      "comment": "Element type values — matched after 'type:' to avoid highlighting these words in other contexts",
+      "match": "(?<=type:\\s)\\b(audio|image|display|prompt|separator|sharedNotepad|submitButton|survey|talkMeter|timer|mediaPlayer|timeline|qualtrics|trackedLink)\\b",
+      "name": "entity.name.type.element.treatments-yaml"
+    },
+
+    "top-level-section-key": {
+      "comment": "Structural section keys in treatment files",
+      "match": "(?<=^\\s*)\\b(introSequences|introSteps|gameStages|elements|treatments|templates|exitSequence|groupComposition|templateName|templateContent|contentType|broadcast)\\b(?=\\s*:)",
+      "name": "support.class.section.treatments-yaml"
+    },
+
+    "condition-key": {
+      "comment": "Keys within condition blocks",
+      "match": "(?<=^\\s*)\\b(conditions|comparator|reference|position)\\b(?=\\s*:)",
+      "name": "keyword.operator.condition.treatments-yaml"
+    },
+
+    "reference-prefix": {
+      "comment": "Reference namespace prefixes in reference strings (e.g. 'prompt.elementName')",
+      "match": "\\b(prompt|survey|discussion|participantInfo|urlParams|submitButton|qualtrics|trackedLink|connectionInfo|browserInfo)\\.",
+      "captures": {
+        "1": { "name": "support.function.reference.treatments-yaml" }
+      }
+    },
+
+    "separator-style": {
+      "comment": "Separator style enum values",
+      "match": "(?<=style:\\s)\\b(thin|thick|regular)\\b",
+      "name": "constant.other.separator-style.treatments-yaml"
+    },
+
+    "domain-enum-value": {
+      "comment": "Domain-specific enum values: position selectors and chat types",
+      "match": "(?<=:\\s)\\b(shared|player|all|any|percentAgreement|text|audio|video)\\b",
+      "name": "constant.language.enum.treatments-yaml"
     }
   }
 }

--- a/apps/vscode/syntaxes/treatmentsYaml.tmLanguage.json
+++ b/apps/vscode/syntaxes/treatmentsYaml.tmLanguage.json
@@ -2,66 +2,14 @@
   "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
   "name": "Treatments YAML",
   "scopeName": "source.treatments-yaml",
-  "comment": "Extends base YAML with domain-specific highlighting for stagebook treatment files.",
   "patterns": [
     { "include": "#template-variable" },
-    { "include": "#comparators" },
-    { "include": "#element-type-value" },
-    { "include": "#reference-prefix" },
-    { "include": "#top-level-section-key" },
-    { "include": "#condition-key" },
-    { "include": "#separator-style" },
-    { "include": "#domain-enum-value" },
     { "include": "source.yaml" }
   ],
   "repository": {
     "template-variable": {
       "match": "\\$\\{[a-zA-Z0-9_]+\\}",
       "name": "variable.other.constant.treatments-yaml"
-    },
-
-    "comparators": {
-      "comment": "Condition comparator values — all 16 from conditionSchema",
-      "match": "(?<=:\\s)\\b(exists|doesNotExist|equals|doesNotEqual|isAbove|isBelow|isAtLeast|isAtMost|hasLengthAtLeast|hasLengthAtMost|includes|doesNotInclude|matches|doesNotMatch|isOneOf|isNotOneOf)\\b",
-      "name": "keyword.control.comparator.treatments-yaml"
-    },
-
-    "element-type-value": {
-      "comment": "Element type values — matched after 'type:' to avoid highlighting these words in other contexts",
-      "match": "(?<=type:\\s)\\b(audio|image|display|prompt|separator|sharedNotepad|submitButton|survey|talkMeter|timer|mediaPlayer|timeline|qualtrics|trackedLink)\\b",
-      "name": "entity.name.type.element.treatments-yaml"
-    },
-
-    "top-level-section-key": {
-      "comment": "Structural section keys in treatment files",
-      "match": "(?<=^\\s*)\\b(introSequences|introSteps|gameStages|elements|treatments|templates|exitSequence|groupComposition|templateName|templateContent|contentType|broadcast)\\b(?=\\s*:)",
-      "name": "support.class.section.treatments-yaml"
-    },
-
-    "condition-key": {
-      "comment": "Keys within condition blocks",
-      "match": "(?<=^\\s*)\\b(conditions|comparator|reference|position)\\b(?=\\s*:)",
-      "name": "keyword.operator.condition.treatments-yaml"
-    },
-
-    "reference-prefix": {
-      "comment": "Reference namespace prefixes in reference strings (e.g. 'prompt.elementName')",
-      "match": "\\b(prompt|survey|discussion|participantInfo|urlParams|submitButton|qualtrics|trackedLink|connectionInfo|browserInfo)\\.",
-      "captures": {
-        "1": { "name": "support.function.reference.treatments-yaml" }
-      }
-    },
-
-    "separator-style": {
-      "comment": "Separator style enum values",
-      "match": "(?<=style:\\s)\\b(thin|thick|regular)\\b",
-      "name": "constant.other.separator-style.treatments-yaml"
-    },
-
-    "domain-enum-value": {
-      "comment": "Domain-specific enum values: position selectors and chat types",
-      "match": "(?<=:\\s)\\b(shared|player|all|any|percentAgreement|text|audio|video)\\b",
-      "name": "constant.language.enum.treatments-yaml"
     }
   }
 }

--- a/apps/vscode/tsconfig.json
+++ b/apps/vscode/tsconfig.json
@@ -8,6 +8,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
+    "jsx": "react-jsx",
     "outDir": "dist",
     "rootDir": "src",
     "sourceMap": true,

--- a/apps/vscode/tsconfig.json
+++ b/apps/vscode/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+    "declaration": false
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/vscode/vitest.config.ts
+++ b/apps/vscode/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    passWithNoTests: true,
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,12 +26,10 @@
         "stagebook": "*"
       },
       "devDependencies": {
-        "@tailwindcss/vite": "^4.2.2",
         "@types/js-yaml": "^4.0.9",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.5.2",
-        "tailwindcss": "^4.2.2",
         "typescript": "^5.5.0",
         "vite": "^6.3.3",
         "vitest": "^4.1.4"
@@ -3099,278 +3097,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tailwindcss/node": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
-      "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.19.0",
-        "jiti": "^2.6.1",
-        "lightningcss": "1.32.0",
-        "magic-string": "^0.30.21",
-        "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.2"
-      }
-    },
-    "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
-      "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 20"
-      },
-      "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.2",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
-        "@tailwindcss/oxide-darwin-x64": "4.2.2",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.2.tgz",
-      "integrity": "sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.2.tgz",
-      "integrity": "sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.2.tgz",
-      "integrity": "sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.2.tgz",
-      "integrity": "sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.2.tgz",
-      "integrity": "sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.2.tgz",
-      "integrity": "sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.2.tgz",
-      "integrity": "sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.2.tgz",
-      "integrity": "sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.2.tgz",
-      "integrity": "sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.2.tgz",
-      "integrity": "sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==",
-      "bundleDependencies": [
-        "@napi-rs/wasm-runtime",
-        "@emnapi/core",
-        "@emnapi/runtime",
-        "@tybys/wasm-util",
-        "@emnapi/wasi-threads",
-        "tslib"
-      ],
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.8.1",
-        "@emnapi/runtime": "^1.8.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.1",
-        "@tybys/wasm-util": "^0.10.1",
-        "tslib": "^2.8.1"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
-      "integrity": "sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.2.tgz",
-      "integrity": "sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@tailwindcss/vite": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
-      "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tailwindcss/node": "4.2.2",
-        "@tailwindcss/oxide": "4.2.2",
-        "tailwindcss": "4.2.2"
-      },
-      "peerDependencies": {
-        "vite": "^5.2.0 || ^6 || ^7 || ^8"
-      }
-    },
     "node_modules/@textlint/ast-node-types": {
       "version": "15.5.4",
       "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.5.4.tgz",
@@ -5427,6 +5153,7 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5606,20 +5333,6 @@
       "optional": true,
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
       }
     },
     "node_modules/entities": {
@@ -7085,6 +6798,8 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -7348,6 +7063,8 @@
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
       "license": "MPL-2.0",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -11035,27 +10752,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/tailwindcss": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
-      "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tapable": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
-      "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
     "node_modules/tar-fs": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -13991,7 +13687,6 @@
       "devDependencies": {
         "@hello-pangea/dnd": "^18.0.1",
         "@playwright/experimental-ct-react": "^1.58.2",
-        "@tailwindcss/vite": "^4.2.2",
         "@types/js-yaml": "^4.0.9",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -14004,7 +13699,6 @@
         "react-dom": "^19.2.4",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
-        "tailwindcss": "^4.2.2",
         "tsup": "^8.0.0",
         "typescript": "^5.5.0",
         "typescript-eslint": "^8.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -297,6 +297,510 @@
         }
       }
     },
+    "apps/vscode": {
+      "name": "stagebook-vscode",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^4.1.1",
+        "stagebook": "*",
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
+        "@types/node": "^22.0.0",
+        "@types/vscode": "^1.96.0",
+        "esbuild": "^0.25.0",
+        "typescript": "^5.5.0"
+      },
+      "engines": {
+        "vscode": "^1.96.0"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.10",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
@@ -2258,6 +2762,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -2289,6 +2803,13 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.115.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.115.0.tgz",
+      "integrity": "sha512-/M8cdznOlqtMqduHKKlIF00v4eum4ZWKgn8YoPRKcN6PDdvoWeeqDaQSnw63ipDbq1Uzz78Wndk/d0uSPwORfA==",
       "dev": true,
       "license": "MIT"
     },
@@ -6646,6 +7167,10 @@
       "resolved": "apps/viewer",
       "link": true
     },
+    "node_modules/stagebook-vscode": {
+      "resolved": "apps/vscode",
+      "link": true
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -7190,6 +7715,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -9245,7 +9777,6 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -9263,7 +9794,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -300,12 +300,17 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
         "stagebook": "*",
+        "stagebook-viewer": "*",
         "yaml": "^2.8.3",
         "zod": "^3.23.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "@types/vscode": "1.115.0",
         "@vscode/vsce": "^3.0.0",
         "esbuild": "^0.25.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,14 +309,14 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
-        "@types/vscode": "1.96.0",
+        "@types/vscode": "1.115.0",
         "@vscode/vsce": "^3.0.0",
         "esbuild": "^0.25.0",
         "typescript": "^5.5.0",
         "vitest": "^4.1.4"
       },
       "engines": {
-        "vscode": "^1.96.0"
+        "vscode": "^1.115.0"
       }
     },
     "apps/vscode/node_modules/@esbuild/aix-ppc64": {
@@ -760,13 +760,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "apps/vscode/node_modules/@types/vscode": {
-      "version": "1.96.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.96.0.tgz",
-      "integrity": "sha512-qvZbSZo+K4ZYmmDuaodMbAa67Pl6VDQzLKFka6rq+3WUTY4Kro7Bwoi0CuZLO/wema0ygcmpwow7zZfPJTs5jg==",
-      "dev": true,
-      "license": "MIT"
     },
     "apps/vscode/node_modules/@vitest/expect": {
       "version": "4.1.4",
@@ -3667,6 +3660,13 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/vscode": {
+      "version": "1.115.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.115.0.tgz",
+      "integrity": "sha512-/M8cdznOlqtMqduHKKlIF00v4eum4ZWKgn8YoPRKcN6PDdvoWeeqDaQSnw63ipDbq1Uzz78Wndk/d0uSPwORfA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -312,7 +312,8 @@
         "@vscode/vsce": "^3.0.0",
         "esbuild": "^0.25.0",
         "typescript": "^5.5.0",
-        "vitest": "^4.1.4"
+        "vitest": "^4.1.4",
+        "vscode-tmgrammar-test": "^0.1.3"
       },
       "engines": {
         "vscode": "^1.115.0"
@@ -4597,6 +4598,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/bottleneck": {
+      "version": "2.19.5",
+      "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
+      "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/boundary": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
@@ -5390,6 +5398,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -6181,6 +6199,13 @@
         "node": ">=14.14"
       }
     },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -6751,13 +6776,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
@@ -9129,7 +9165,6 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -9391,6 +9426,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -13409,6 +13454,150 @@
         }
       }
     },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",
+      "integrity": "sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-textmate": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-7.0.4.tgz",
+      "integrity": "sha512-9hJp0xL7HW1Q5OgGe03NACo7yiCTMEk3WU/rtKXUbncLtdg6rVVNJnHwD88UhbIYU2KoxY0Dih0x+kIsmUKn2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-tmgrammar-test": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.1.3.tgz",
+      "integrity": "sha512-Wg6Pz+ePAT1O+F/A1Fc4wS5vY2X+HNtgN4qMdL+65NLQYd1/zdDWH4fhwsLjX8wTzeXkMy49Cr4ZqWTJ7VnVxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bottleneck": "^2.19.5",
+        "chalk": "^2.4.2",
+        "commander": "^9.2.0",
+        "diff": "^4.0.2",
+        "glob": "^7.1.6",
+        "vscode-oniguruma": "^1.5.1",
+        "vscode-textmate": "^7.0.1"
+      },
+      "bin": {
+        "vscode-tmgrammar-snap": "dist/snapshot.js",
+        "vscode-tmgrammar-test": "dist/unit.js"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -13537,8 +13726,7 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/wsl-utils": {
       "version": "0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -309,7 +309,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
-        "@types/vscode": "^1.96.0",
+        "@types/vscode": "1.96.0",
         "@vscode/vsce": "^3.0.0",
         "esbuild": "^0.25.0",
         "typescript": "^5.5.0",
@@ -760,6 +760,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "apps/vscode/node_modules/@types/vscode": {
+      "version": "1.96.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.96.0.tgz",
+      "integrity": "sha512-qvZbSZo+K4ZYmmDuaodMbAa67Pl6VDQzLKFka6rq+3WUTY4Kro7Bwoi0CuZLO/wema0ygcmpwow7zZfPJTs5jg==",
+      "dev": true,
+      "license": "MIT"
     },
     "apps/vscode/node_modules/@vitest/expect": {
       "version": "4.1.4",
@@ -3660,13 +3667,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/vscode": {
-      "version": "1.115.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.115.0.tgz",
-      "integrity": "sha512-/M8cdznOlqtMqduHKKlIF00v4eum4ZWKgn8YoPRKcN6PDdvoWeeqDaQSnw63ipDbq1Uzz78Wndk/d0uSPwORfA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,18 +20,18 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@tailwindcss/vite": "^4.2.2",
         "js-yaml": "^4.1.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
-        "stagebook": "*",
-        "tailwindcss": "^4.2.2"
+        "stagebook": "*"
       },
       "devDependencies": {
+        "@tailwindcss/vite": "^4.2.2",
         "@types/js-yaml": "^4.0.9",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.5.2",
+        "tailwindcss": "^4.2.2",
         "typescript": "^5.5.0",
         "vite": "^6.3.3",
         "vitest": "^4.1.4"
@@ -2421,6 +2421,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2431,6 +2432,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -2441,6 +2443,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2450,12 +2453,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2546,6 +2551,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2559,6 +2565,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2572,6 +2579,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2585,6 +2593,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2598,6 +2607,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2611,6 +2621,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2624,6 +2635,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2637,6 +2649,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2650,6 +2663,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2663,6 +2677,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2676,6 +2691,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2689,6 +2705,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2702,6 +2719,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2715,6 +2733,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2728,6 +2747,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2741,6 +2761,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2754,6 +2775,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2767,6 +2789,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2780,6 +2803,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2793,6 +2817,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2806,6 +2831,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2819,6 +2845,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2832,6 +2859,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2845,6 +2873,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2858,6 +2887,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3073,6 +3103,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.2.tgz",
       "integrity": "sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
@@ -3088,6 +3119,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
       "integrity": "sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
@@ -3114,6 +3146,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3130,6 +3163,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3146,6 +3180,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3162,6 +3197,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3178,6 +3214,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3194,6 +3231,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3210,6 +3248,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3226,6 +3265,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3242,6 +3282,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3266,6 +3307,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3287,6 +3329,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3303,6 +3346,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3316,6 +3360,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.2.2.tgz",
       "integrity": "sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@tailwindcss/node": "4.2.2",
@@ -3552,6 +3597,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree-jsx": {
@@ -3609,7 +3655,7 @@
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
       "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -5379,6 +5425,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -5565,6 +5612,7 @@
       "version": "5.20.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
       "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -6210,6 +6258,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6451,6 +6500,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-flag": {
@@ -7033,6 +7083,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7295,6 +7346,7 @@
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -7327,11 +7379,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7347,11 +7401,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7367,11 +7423,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7387,11 +7445,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7407,11 +7467,13 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7427,11 +7489,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7447,11 +7511,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7467,11 +7533,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7487,11 +7555,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7507,11 +7577,13 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7527,11 +7599,13 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -7797,6 +7871,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -8949,6 +9024,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9516,6 +9592,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -9612,6 +9689,7 @@
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
       "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -10173,6 +10251,7 @@
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -10551,6 +10630,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -10959,12 +11039,14 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.2.tgz",
       "integrity": "sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
       "integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11094,6 +11176,7 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -11110,6 +11193,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -11127,6 +11211,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -11290,7 +11375,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "devOptional": true,
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsup": {
@@ -11491,7 +11576,7 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -11744,6 +11829,7 @@
       "version": "6.4.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
@@ -12356,6 +12442,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12372,6 +12459,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12388,6 +12476,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12404,6 +12493,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12420,6 +12510,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12436,6 +12527,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12452,6 +12544,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12468,6 +12561,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12484,6 +12578,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12500,6 +12595,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12516,6 +12612,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12532,6 +12629,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12548,6 +12646,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12564,6 +12663,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12580,6 +12680,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12596,6 +12697,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12612,6 +12714,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12628,6 +12731,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12644,6 +12748,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12660,6 +12765,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12676,6 +12782,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12692,6 +12799,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12708,6 +12816,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12724,6 +12833,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12740,6 +12850,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12756,6 +12867,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12769,6 +12881,7 @@
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -12810,6 +12923,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -12827,6 +12941,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12841,6 +12956,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package-lock.json
+++ b/package-lock.json
@@ -310,8 +310,10 @@
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
         "@types/vscode": "^1.96.0",
+        "@vscode/vsce": "^3.0.0",
         "esbuild": "^0.25.0",
-        "typescript": "^5.5.0"
+        "typescript": "^5.5.0",
+        "vitest": "^4.1.4"
       },
       "engines": {
         "vscode": "^1.96.0"
@@ -759,6 +761,109 @@
         "node": ">=18"
       }
     },
+    "apps/vscode/node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/vscode/node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/vscode/node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/vscode/node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/vscode/node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/vscode/node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "apps/vscode/node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "apps/vscode/node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -801,6 +906,163 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
+    "apps/vscode/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "apps/vscode/node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/vscode/node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "apps/vscode/node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "apps/vscode/node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "apps/vscode/node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.1.10",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.10.tgz",
@@ -839,6 +1101,192 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@azu/format-text": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azu/format-text/-/format-text-1.0.2.tgz",
+      "integrity": "sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@azu/style-format": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azu/style-format/-/style-format-1.0.1.tgz",
+      "integrity": "sha512-AHcTojlNBdD/3/KxIKlg8sxIWHfOtQszLvOpagLTO+bjC3u7SAszu1lf//u7JJC50aUSH+BVWDD/KvaA6Gfn5g==",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "@azu/format-text": "^1.0.1"
+      }
+    },
+    "node_modules/@azure/abort-controller": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-2.1.2.tgz",
+      "integrity": "sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@azure/core-auth": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.10.1.tgz",
+      "integrity": "sha512-ykRMW8PjVAn+RS6ww5cmK9U2CyH9p4Q88YJwvUslfuMmN98w/2rdGRLPqJYObapBCdzBVeDgYWdJnFPFb7qzpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-util": "^1.13.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-client": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-client/-/core-client-1.10.1.tgz",
+      "integrity": "sha512-Nh5PhEOeY6PrnxNPsEHRr9eimxLwgLlpmguQaHKBinFYA/RU9+kOYVOQqOrTsCL+KSxrLLl1gD8Dk5BFW/7l/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-rest-pipeline": "^1.22.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-rest-pipeline": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.23.0.tgz",
+      "integrity": "sha512-Evs1INHo+jUjwHi1T6SG6Ua/LHOQBCLuKEEE6efIpt4ZOoNonaT1kP32GoOcdNDbfqsD2445CPri3MubBy5DEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@azure/core-auth": "^1.10.0",
+        "@azure/core-tracing": "^1.3.0",
+        "@azure/core-util": "^1.13.0",
+        "@azure/logger": "^1.3.0",
+        "@typespec/ts-http-runtime": "^0.3.4",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-tracing": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.3.1.tgz",
+      "integrity": "sha512-9MWKevR7Hz8kNzzPLfX4EAtGM2b8mr50HPDBvio96bURP/9C+HjdH3sBlLSNNrvRAr5/k/svoH457gB5IKpmwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-util": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-util/-/core-util-1.13.1.tgz",
+      "integrity": "sha512-XPArKLzsvl0Hf0CaGyKHUyVgF7oDnhKoP85Xv6M4StF/1AhfORhZudHtOyf2s+FcbuQ9dPRAjB8J2KvRRMUK2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.1.2",
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/identity": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+      "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/abort-controller": "^2.0.0",
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-rest-pipeline": "^1.17.0",
+        "@azure/core-tracing": "^1.0.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/logger": "^1.0.0",
+        "@azure/msal-browser": "^5.5.0",
+        "@azure/msal-node": "^5.1.0",
+        "open": "^10.1.0",
+        "tslib": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/logger": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.3.0.tgz",
+      "integrity": "sha512-fCqPIfOcLE+CGqGPd66c8bZpwAji98tZ4JI9i/mlTNTlsIWslCfpg48s/ypyLxZTump5sypjrKn2/kY7q8oAbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typespec/ts-http-runtime": "^0.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/msal-browser": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.6.3.tgz",
+      "integrity": "sha512-sTjMtUm+bJpENU/1WlRzHEsgEHppZDZ1EtNyaOODg/sQBtMxxJzGB+MOCM+T2Q5Qe1fKBrdxUmjyRxm0r7Ez9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.4.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.4.1.tgz",
+      "integrity": "sha512-Bl8f+w37xkXsYh7QRkAKCFGYtWMYuOVO7Lv+BxILrvGz3HbIEF22Pt0ugyj0QPOl6NLrHcnNUQ9yeew98P/5iw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.2.tgz",
+      "integrity": "sha512-DoeSJ9U5KPAIZoHsPywvfEj2MhBniQe0+FSpjLUTdWoIkI999GB5USkW6nNEHnIaLVxROHXvprWA1KzdS1VQ4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "16.4.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -1959,6 +2407,16 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2002,6 +2460,44 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@playwright/experimental-ct-core": {
@@ -2368,6 +2864,204 @@
         "win32"
       ]
     },
+    "node_modules/@secretlint/config-creator": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
+      "integrity": "sha512-BynOBe7Hn3LJjb3CqCHZjeNB09s/vgf0baBaHVw67w7gHF0d25c3ZsZ5+vv8TgwSchRdUCRrbbcq5i2B1fJ2QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/types": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/config-loader": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/config-loader/-/config-loader-10.2.2.tgz",
+      "integrity": "sha512-ndjjQNgLg4DIcMJp4iaRD6xb9ijWQZVbd9694Ol2IszBIbGPPkwZHzJYKICbTBmh6AH/pLr0CiCaWdGJU7RbpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/profiler": "^10.2.2",
+        "@secretlint/resolver": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "ajv": "^8.17.1",
+        "debug": "^4.4.1",
+        "rc-config-loader": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/config-loader/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@secretlint/config-loader/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@secretlint/core": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/core/-/core-10.2.2.tgz",
+      "integrity": "sha512-6rdwBwLP9+TO3rRjMVW1tX+lQeo5gBbxl1I5F8nh8bgGtKwdlCMhMKsBWzWg1ostxx/tIG7OjZI0/BxsP8bUgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/profiler": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "debug": "^4.4.1",
+        "structured-source": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/formatter": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/formatter/-/formatter-10.2.2.tgz",
+      "integrity": "sha512-10f/eKV+8YdGKNQmoDUD1QnYL7TzhI2kzyx95vsJKbEa8akzLAR5ZrWIZ3LbcMmBLzxlSQMMccRmi05yDQ5YDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/resolver": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "@textlint/linter-formatter": "^15.2.0",
+        "@textlint/module-interop": "^15.2.0",
+        "@textlint/types": "^15.2.0",
+        "chalk": "^5.4.1",
+        "debug": "^4.4.1",
+        "pluralize": "^8.0.0",
+        "strip-ansi": "^7.1.0",
+        "table": "^6.9.0",
+        "terminal-link": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/node": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/node/-/node-10.2.2.tgz",
+      "integrity": "sha512-eZGJQgcg/3WRBwX1bRnss7RmHHK/YlP/l7zOQsrjexYt6l+JJa5YhUmHbuGXS94yW0++3YkEJp0kQGYhiw1DMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/config-loader": "^10.2.2",
+        "@secretlint/core": "^10.2.2",
+        "@secretlint/formatter": "^10.2.2",
+        "@secretlint/profiler": "^10.2.2",
+        "@secretlint/source-creator": "^10.2.2",
+        "@secretlint/types": "^10.2.2",
+        "debug": "^4.4.1",
+        "p-map": "^7.0.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/profiler": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/profiler/-/profiler-10.2.2.tgz",
+      "integrity": "sha512-qm9rWfkh/o8OvzMIfY8a5bCmgIniSpltbVlUVl983zDG1bUuQNd1/5lUEeWx5o/WJ99bXxS7yNI4/KIXfHexig==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@secretlint/resolver": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/resolver/-/resolver-10.2.2.tgz",
+      "integrity": "sha512-3md0cp12e+Ae5V+crPQYGd6aaO7ahw95s28OlULGyclyyUtf861UoRGS2prnUrKh7MZb23kdDOyGCYb9br5e4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@secretlint/secretlint-formatter-sarif": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-formatter-sarif/-/secretlint-formatter-sarif-10.2.2.tgz",
+      "integrity": "sha512-ojiF9TGRKJJw308DnYBucHxkpNovDNu1XvPh7IfUp0A12gzTtxuWDqdpuVezL7/IP8Ua7mp5/VkDMN9OLp1doQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-sarif-builder": "^3.2.0"
+      }
+    },
+    "node_modules/@secretlint/secretlint-rule-no-dotenv": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-no-dotenv/-/secretlint-rule-no-dotenv-10.2.2.tgz",
+      "integrity": "sha512-KJRbIShA9DVc5Va3yArtJ6QDzGjg3PRa1uYp9As4RsyKtKSSZjI64jVca57FZ8gbuk4em0/0Jq+uy6485wxIdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/types": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/secretlint-rule-preset-recommend": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/secretlint-rule-preset-recommend/-/secretlint-rule-preset-recommend-10.2.2.tgz",
+      "integrity": "sha512-K3jPqjva8bQndDKJqctnGfwuAxU2n9XNCPtbXVI5JvC7FnQiNg/yWlQPbMUlBXtBoBGFYp08A94m6fvtc9v+zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/source-creator": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/source-creator/-/source-creator-10.2.2.tgz",
+      "integrity": "sha512-h6I87xJfwfUTgQ7irWq7UTdq/Bm1RuQ/fYhA3dtTIAop5BwSFmZyrchph4WcoEvbN460BWKmk4RYSvPElIIvxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/types": "^10.2.2",
+        "istextorbinary": "^9.5.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@secretlint/types": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/@secretlint/types/-/types-10.2.2.tgz",
+      "integrity": "sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2632,6 +3326,155 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@textlint/ast-node-types": {
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.5.4.tgz",
+      "integrity": "sha512-bVtB6VEy9U9DpW8cTt25k5T+lz86zV5w6ImePZqY1AXzSuPhqQNT77lkMPxonXzUducEIlSvUu3o7sKw3y9+Sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/linter-formatter": {
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.5.4.tgz",
+      "integrity": "sha512-D9qJedKBLmAo+kiudop4UKgSxXMi4O8U86KrCidVXZ9RsK0NSVIw6+r2rlMUOExq79iEY81FRENyzmNVRxDBsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azu/format-text": "^1.0.2",
+        "@azu/style-format": "^1.0.1",
+        "@textlint/module-interop": "15.5.4",
+        "@textlint/resolver": "15.5.4",
+        "@textlint/types": "15.5.4",
+        "chalk": "^4.1.2",
+        "debug": "^4.4.3",
+        "js-yaml": "^4.1.1",
+        "lodash": "^4.18.1",
+        "pluralize": "^2.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "table": "^6.9.0",
+        "text-table": "^0.2.0"
+      }
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/pluralize": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-2.0.0.tgz",
+      "integrity": "sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@textlint/linter-formatter/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@textlint/module-interop": {
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.5.4.tgz",
+      "integrity": "sha512-JyAUd26ll3IFF87LP0uGoa8Tzw5ZKiYvGs6v8jLlzyND1lUYCI4+2oIAslrODLkf0qwoCaJrBQWM3wsw+asVGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/resolver": {
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.5.4.tgz",
+      "integrity": "sha512-5GUagtpQuYcmhlOzBGdmVBvDu5lKgVTjwbxtdfoidN4OIqblIxThJHHjazU+ic+/bCIIzI2JcOjHGSaRmE8Gcg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@textlint/types": {
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.5.4.tgz",
+      "integrity": "sha512-mY28j2U7nrWmZbxyKnRvB8vJxJab4AxqOobLfb6iozrLelJbqxcOTvBQednadWPfAk9XWaZVMqUr9Nird3mutg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "15.5.4"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2772,6 +3615,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
+      "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -2791,6 +3641,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/sarif": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+      "integrity": "sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -3108,6 +3965,21 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@typespec/ts-http-runtime": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
@@ -3236,6 +4108,254 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@vscode/vsce": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.8.0.tgz",
+      "integrity": "sha512-dFLXkYPG6j1IBp6b1ammHNfRoY2dk93kBtve0Hp4SiTOE2HKeNel15doJ1aea6mrr23Wz9uwkw24EJti2eMRPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/identity": "^4.1.0",
+        "@secretlint/node": "^10.1.2",
+        "@secretlint/secretlint-formatter-sarif": "^10.1.2",
+        "@secretlint/secretlint-rule-no-dotenv": "^10.1.2",
+        "@secretlint/secretlint-rule-preset-recommend": "^10.1.2",
+        "@vscode/vsce-sign": "^2.0.0",
+        "azure-devops-node-api": "^12.5.0",
+        "chalk": "^4.1.2",
+        "cheerio": "^1.0.0-rc.9",
+        "cockatiel": "^3.1.2",
+        "commander": "^12.1.0",
+        "form-data": "^4.0.0",
+        "glob": "^11.0.0",
+        "hosted-git-info": "^4.0.2",
+        "jsonc-parser": "^3.2.0",
+        "leven": "^3.1.0",
+        "markdown-it": "^14.1.0",
+        "mime": "^1.3.4",
+        "minimatch": "^3.0.3",
+        "parse-semver": "^1.1.1",
+        "read": "^1.0.7",
+        "secretlint": "^10.1.2",
+        "semver": "^7.5.2",
+        "tmp": "^0.2.3",
+        "typed-rest-client": "^1.8.4",
+        "url-join": "^4.0.1",
+        "xml2js": "^0.5.0",
+        "yauzl": "^3.2.1",
+        "yazl": "^2.2.2"
+      },
+      "bin": {
+        "vsce": "vsce"
+      },
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "keytar": "^7.7.0"
+      }
+    },
+    "node_modules/@vscode/vsce-sign": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign/-/vsce-sign-2.0.9.tgz",
+      "integrity": "sha512-8IvaRvtFyzUnGGl3f5+1Cnor3LqaUWvhaUjAYO8Y39OUYlOf3cRd+dowuQYLpZcP3uwSG+mURwjEBOSq4SOJ0g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optionalDependencies": {
+        "@vscode/vsce-sign-alpine-arm64": "2.0.6",
+        "@vscode/vsce-sign-alpine-x64": "2.0.6",
+        "@vscode/vsce-sign-darwin-arm64": "2.0.6",
+        "@vscode/vsce-sign-darwin-x64": "2.0.6",
+        "@vscode/vsce-sign-linux-arm": "2.0.6",
+        "@vscode/vsce-sign-linux-arm64": "2.0.6",
+        "@vscode/vsce-sign-linux-x64": "2.0.6",
+        "@vscode/vsce-sign-win32-arm64": "2.0.6",
+        "@vscode/vsce-sign-win32-x64": "2.0.6"
+      }
+    },
+    "node_modules/@vscode/vsce-sign-alpine-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-arm64/-/vsce-sign-alpine-arm64-2.0.6.tgz",
+      "integrity": "sha512-wKkJBsvKF+f0GfsUuGT0tSW0kZL87QggEiqNqK6/8hvqsXvpx8OsTEc3mnE1kejkh5r+qUyQ7PtF8jZYN0mo8Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-alpine-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-alpine-x64/-/vsce-sign-alpine-x64-2.0.6.tgz",
+      "integrity": "sha512-YoAGlmdK39vKi9jA18i4ufBbd95OqGJxRvF3n6ZbCyziwy3O+JgOpIUPxv5tjeO6gQfx29qBivQ8ZZTUF2Ba0w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "alpine"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-arm64/-/vsce-sign-darwin-arm64-2.0.6.tgz",
+      "integrity": "sha512-5HMHaJRIQuozm/XQIiJiA0W9uhdblwwl2ZNDSSAeXGO9YhB9MH5C4KIHOmvyjUnKy4UCuiP43VKpIxW1VWP4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-darwin-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-darwin-x64/-/vsce-sign-darwin-x64-2.0.6.tgz",
+      "integrity": "sha512-25GsUbTAiNfHSuRItoQafXOIpxlYj+IXb4/qarrXu7kmbH94jlm5sdWSCKrrREs8+GsXF1b+l3OB7VJy5jsykw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm/-/vsce-sign-linux-arm-2.0.6.tgz",
+      "integrity": "sha512-UndEc2Xlq4HsuMPnwu7420uqceXjs4yb5W8E2/UkaHBB9OWCwMd3/bRe/1eLe3D8kPpxzcaeTyXiK3RdzS/1CA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-arm64/-/vsce-sign-linux-arm64-2.0.6.tgz",
+      "integrity": "sha512-cfb1qK7lygtMa4NUl2582nP7aliLYuDEVpAbXJMkDq1qE+olIw/es+C8j1LJwvcRq1I2yWGtSn3EkDp9Dq5FdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-linux-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-linux-x64/-/vsce-sign-linux-x64-2.0.6.tgz",
+      "integrity": "sha512-/olerl1A4sOqdP+hjvJ1sbQjKN07Y3DVnxO4gnbn/ahtQvFrdhUi0G1VsZXDNjfqmXw57DmPi5ASnj/8PGZhAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-arm64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-arm64/-/vsce-sign-win32-arm64-2.0.6.tgz",
+      "integrity": "sha512-ivM/MiGIY0PJNZBoGtlRBM/xDpwbdlCWomUWuLmIxbi1Cxe/1nooYrEQoaHD8ojVRgzdQEUzMsRbyF5cJJgYOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/vsce-sign-win32-x64": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce-sign-win32-x64/-/vsce-sign-win32-x64-2.0.6.tgz",
+      "integrity": "sha512-mgth9Kvze+u8CruYMmhHw6Zgy3GRX2S+Ed5oSokDEK5vPEwGGKnmuXua9tmFhomeAnhgJnL4DCna3TiNuGrBTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.txt",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/vsce/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vscode/vsce/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3257,6 +4377,16 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -3341,6 +4471,34 @@
         "node": ">=12"
       }
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/azure-devops-node-api": {
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-12.5.0.tgz",
+      "integrity": "sha512-R5eFskGvOm3U/GzeAuxRkUsAl0hrAwGgWn6zAd2KrZmrEhWZVqLew4OOupbQlXUuojUzpGtq62SmdhJ06N88og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tunnel": "0.0.6",
+        "typed-rest-client": "^1.8.4"
+      }
+    },
     "node_modules/bail": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
@@ -3358,6 +4516,28 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.18",
@@ -3381,6 +4561,49 @@
       "dependencies": {
         "require-from-string": "^2.0.2"
       }
+    },
+    "node_modules/binaryextensions": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-6.11.0.tgz",
+      "integrity": "sha512-sXnYK/Ij80TO3lcqZVV2YgfKN5QjUWIRk/XSm2J/4bd/lPko3lvk0O4ZppH6m+6hB2/GTu+ptNwVFe1xh+QLQw==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/boundary": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boundary/-/boundary-2.0.0.tgz",
+      "integrity": "sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -3440,6 +4663,65 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/bundle-require": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
@@ -3464,6 +4746,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -3592,6 +4905,73 @@
         "node": ">= 16"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chokidar": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -3607,6 +4987,14 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -3641,6 +5029,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cockatiel": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/cockatiel/-/cockatiel-3.2.1.tgz",
+      "integrity": "sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3667,6 +5065,19 @@
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -3745,6 +5156,23 @@
         "tiny-invariant": "^1.0.6"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/css-tree": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
@@ -3757,6 +5185,19 @@
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/csstype": {
@@ -3819,6 +5260,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
@@ -3829,12 +5287,76 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/dequal": {
       "version": "2.0.3",
@@ -3869,6 +5391,120 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/editions": {
+      "version": "6.22.0",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-6.22.0.tgz",
+      "integrity": "sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "version-range": "^4.15.0"
+      },
+      "engines": {
+        "ecmascript": ">= es5",
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.335",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
@@ -3882,6 +5518,31 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/enhanced-resolve": {
       "version": "5.20.1",
@@ -3922,12 +5583,61 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.7",
@@ -4233,6 +5943,17 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4257,6 +5978,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4270,6 +6021,33 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -4347,6 +6125,63 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -4359,6 +6194,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gensync": {
@@ -4384,6 +6229,45 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-stream": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
@@ -4395,6 +6279,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -4410,6 +6327,45 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -4421,6 +6377,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -4437,6 +6437,48 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-to-jsx-runtime": {
@@ -4481,6 +6523,39 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -4503,6 +6578,67 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -4530,6 +6666,41 @@
       "funding": {
         "url": "https://github.com/sponsors/typicode"
       }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -4567,6 +6738,35 @@
       "engines": {
         "node": ">=0.8.19"
       }
+    },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -4610,6 +6810,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-extglob": {
@@ -4659,6 +6875,25 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -4702,12 +6937,62 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/istextorbinary": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-9.5.0.tgz",
+      "integrity": "sha512-5mbUj3SiZXCuRf9fT3ibzbSSEWiy63gFfksmGfdOzujPjW3k+z8WvIBxcJHBoQNlaZaiyB25deviif2+osLmLw==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "binaryextensions": "^6.11.0",
+        "editions": "^6.21.0",
+        "textextensions": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -4845,6 +7130,98 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+      "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
+      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/keytar": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/keytar/-/keytar-7.9.0.tgz",
+      "integrity": "sha512-VPD8mtVtm5JNtA2AErl6Chp06JBfy7diFQ7TQQhdpWOl6MrCRB+eRbvAZUsbGQS9kiMq0coJsy0W0vHpDCkWsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.0.1"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -4853,6 +7230,16 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/levn": {
@@ -5138,6 +7525,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "15.5.2",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.5.2.tgz",
@@ -5210,10 +7607,73 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true,
       "license": "MIT"
     },
@@ -5307,6 +7767,37 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/markdown-table": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
@@ -5316,6 +7807,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mdast-util-find-and-replace": {
@@ -5623,12 +8124,29 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/micromark": {
       "version": "4.0.2",
@@ -6235,6 +8753,42 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
@@ -6261,6 +8815,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -6273,6 +8841,35 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/mlly": {
       "version": "1.8.2",
@@ -6293,6 +8890,13 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -6324,6 +8928,14 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -6331,12 +8943,110 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.37",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-sarif-builder": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.4.0.tgz",
+      "integrity": "sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sarif": "^2.1.7",
+        "fs-extra": "^11.1.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/hosted-git-info": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -6367,6 +9077,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6375,6 +9098,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/obug": {
@@ -6388,6 +9124,17 @@
       ],
       "license": "MIT"
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -6399,6 +9146,25 @@
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
+      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "wsl-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6454,6 +9220,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -6494,10 +9280,101 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/parse-json": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-semver": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/parse-semver/-/parse-semver-1.1.1.tgz",
+      "integrity": "sha512-Eg1OuNntBMH0ojvEKSrvDSnwLmvVuUOSdylH/pSCPNMIspLlweJyIWXCE+k/5hm3cj/EBUYwmWkjhBALNP4LXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^5.1.0"
+      }
+    },
+    "node_modules/parse-semver/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/parse5": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream/node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6527,6 +9404,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
@@ -6543,6 +9460,13 @@
       "engines": {
         "node": ">= 14.16"
       }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6630,6 +9554,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.9",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
@@ -6701,6 +9635,35 @@
         }
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6738,6 +9701,18 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6748,12 +9723,100 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/raf-schd": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
       "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc-config-loader": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-4.1.4.tgz",
+      "integrity": "sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "js-yaml": "^4.1.1",
+        "json5": "^2.2.3",
+        "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/react": {
       "version": "19.2.5",
@@ -6836,6 +9899,68 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg/node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdirp": {
@@ -6982,6 +10107,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rfdc": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
@@ -7033,6 +10169,81 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -7051,6 +10262,28 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/secretlint": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/secretlint/-/secretlint-10.2.2.tgz",
+      "integrity": "sha512-xVpkeHV/aoWe4vP4TansF622nBEImzCY73y/0042DuJ29iKIaqgoJ8fGxre3rVSHHbxar4FdJobmTnLp9AU0eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@secretlint/config-creator": "^10.2.2",
+        "@secretlint/formatter": "^10.2.2",
+        "@secretlint/node": "^10.2.2",
+        "@secretlint/profiler": "^10.2.2",
+        "debug": "^4.4.1",
+        "globby": "^14.1.0",
+        "read-pkg": "^9.0.1"
+      },
+      "bin": {
+        "secretlint": "bin/secretlint.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "6.3.1",
@@ -7085,6 +10318,82 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -7103,6 +10412,68 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/slice-ansi": {
@@ -7152,6 +10523,42 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -7177,6 +10584,17 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
     },
     "node_modules/string-argv": {
       "version": "0.3.2",
@@ -7263,6 +10681,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/structured-source": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/structured-source/-/structured-source-4.0.0.tgz",
+      "integrity": "sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boundary": "^2.0.0"
+      }
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -7329,12 +10757,159 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-hyperlinks": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+      "integrity": "sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-hyperlinks?sponsor=1"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/table": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+      "integrity": "sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/table/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/table/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/table/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "4.2.2",
@@ -7353,6 +10928,78 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/terminal-link": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-4.0.0.tgz",
+      "integrity": "sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "supports-hyperlinks": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/textextensions": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-6.11.0.tgz",
+      "integrity": "sha512-tXJwSr9355kFJI3lbCkPpUH5cP8/M0GGy2xLO34aZCjMXBaK3SoPnZwr/oWmo1FdCnELcs4npdCIOFtq9W3ruQ==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "dependencies": {
+        "editions": "^6.21.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/thenify": {
@@ -7494,6 +11141,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7585,6 +11242,13 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "devOptional": true,
+      "license": "0BSD"
+    },
     "node_modules/tsup": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
@@ -7648,6 +11312,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/tunnel": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7659,6 +11347,31 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.11.tgz",
+      "integrity": "sha512-5UvfMpd1oelmUPRbbaVnq+rHP7ng2cE4qoQkQeAqxRL6PklkxsM0g32/HL0yfvruK6ojQ5x8EE+HF4YV6DtuCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.9.1",
+        "tunnel": "0.0.6",
+        "underscore": "^1.12.1"
       }
     },
     "node_modules/typescript": {
@@ -7699,10 +11412,24 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ufo": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
       "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/underscore": {
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
+      "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7722,6 +11449,19 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -7816,6 +11556,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -7857,6 +11607,13 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -7865,6 +11622,48 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/version-range": {
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/version-range/-/version-range-4.15.0.tgz",
+      "integrity": "sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==",
+      "dev": true,
+      "license": "Artistic-2.0",
+      "engines": {
+        "node": ">=4"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
       }
     },
     "node_modules/vfile": {
@@ -9634,6 +13433,20 @@
         "node": ">=20"
       }
     },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/whatwg-mimetype": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
@@ -9720,6 +13533,30 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
+      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -9728,6 +13565,30 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmlchars": {
@@ -9758,6 +13619,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
+      "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yazl": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+      "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3"
       }
     },
     "node_modules/yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,12 +302,11 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "js-yaml": "^4.1.1",
         "stagebook": "*",
+        "yaml": "^2.8.3",
         "zod": "^3.23.0"
       },
       "devDependencies": {
-        "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
         "@types/vscode": "1.115.0",
         "@vscode/vsce": "^3.0.0",
@@ -13609,7 +13608,6 @@
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
       "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13682,7 +13682,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -66,7 +66,6 @@
   "devDependencies": {
     "@hello-pangea/dnd": "^18.0.1",
     "@playwright/experimental-ct-react": "^1.58.2",
-    "@tailwindcss/vite": "^4.2.2",
     "@types/js-yaml": "^4.0.9",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
@@ -79,7 +78,6 @@
     "react-dom": "^19.2.4",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
-    "tailwindcss": "^4.2.2",
     "tsup": "^8.0.0",
     "typescript": "^5.5.0",
     "typescript-eslint": "^8.0.0",

--- a/packages/stagebook/playwright-ct.config.ts
+++ b/packages/stagebook/playwright-ct.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig, devices } from "@playwright/experimental-ct-react";
-import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   testDir: "./src",
@@ -13,9 +12,6 @@ export default defineConfig({
   use: {
     trace: "on-first-retry",
     ctPort: 3100,
-    ctViteConfig: {
-      plugins: [tailwindcss()],
-    },
   },
   projects: [
     {

--- a/packages/stagebook/src/components/elements/ImageElement.ct.tsx
+++ b/packages/stagebook/src/components/elements/ImageElement.ct.tsx
@@ -10,14 +10,20 @@ test("renders image with src", async ({ mount }) => {
   await expect(component.locator("img")).toBeVisible();
 });
 
-test("renders with custom width", async ({ mount }) => {
+test("renders with custom width via style", async ({ mount }) => {
   const component = await mount(<ImageElement src={testImage} width={50} />);
-  await expect(component.locator("img")).toHaveAttribute("width", "50%");
+  const img = component.locator("img");
+  await expect(img).toBeVisible();
+  const style = await img.getAttribute("style");
+  expect(style).toContain("50%");
 });
 
-test("defaults to 100% width", async ({ mount }) => {
+test("defaults to 100% width via style", async ({ mount }) => {
   const component = await mount(<ImageElement src={testImage} />);
-  await expect(component.locator("img")).toHaveAttribute("width", "100%");
+  const img = component.locator("img");
+  await expect(img).toBeVisible();
+  const style = await img.getAttribute("style");
+  expect(style).toContain("100%");
 });
 
 test("renders nothing when src is empty", async ({ mount }) => {

--- a/packages/stagebook/src/components/elements/ImageElement.tsx
+++ b/packages/stagebook/src/components/elements/ImageElement.tsx
@@ -9,7 +9,7 @@ export function ImageElement({ src, width }: ImageElementProps) {
   if (!src) return null;
 
   return (
-    <div className="flex justify-center">
+    <div style={{ display: "flex", justifyContent: "center" }}>
       <img src={src} alt="" width={width ? `${width}%` : "100%"} />
     </div>
   );

--- a/packages/stagebook/src/components/elements/ImageElement.tsx
+++ b/packages/stagebook/src/components/elements/ImageElement.tsx
@@ -10,7 +10,15 @@ export function ImageElement({ src, width }: ImageElementProps) {
 
   return (
     <div style={{ display: "flex", justifyContent: "center" }}>
-      <img src={src} alt="" width={width ? `${width}%` : "100%"} />
+      <img
+        src={src}
+        alt=""
+        style={{
+          width: width ? `${width}%` : "100%",
+          maxWidth: "100%",
+          height: "auto",
+        }}
+      />
     </div>
   );
 }

--- a/packages/stagebook/src/components/form/Separator.ct.tsx
+++ b/packages/stagebook/src/components/form/Separator.ct.tsx
@@ -3,16 +3,17 @@ import { Separator } from "./Separator";
 
 test("renders regular separator by default", async ({ mount }) => {
   const component = await mount(<Separator />);
-  await expect(component.locator("hr")).toBeVisible();
-  await expect(component.locator("hr")).toHaveClass(/h-3px/);
+  const hr = component.locator("hr");
+  await expect(hr).toBeVisible();
+  await expect(hr).toHaveCSS("height", "3px");
 });
 
 test("renders thin separator", async ({ mount }) => {
   const component = await mount(<Separator style="thin" />);
-  await expect(component.locator("hr")).toHaveClass(/h-1px/);
+  await expect(component.locator("hr")).toHaveCSS("height", "1px");
 });
 
 test("renders thick separator", async ({ mount }) => {
   const component = await mount(<Separator style="thick" />);
-  await expect(component.locator("hr")).toHaveClass(/h-5px/);
+  await expect(component.locator("hr")).toHaveCSS("height", "5px");
 });

--- a/packages/stagebook/src/components/form/Separator.tsx
+++ b/packages/stagebook/src/components/form/Separator.tsx
@@ -4,14 +4,36 @@ export interface SeparatorProps {
   style?: "" | "thin" | "regular" | "thick";
 }
 
+const baseStyle: React.CSSProperties = {
+  margin: "1rem 0",
+  width: "100%",
+  border: "none",
+};
+
+const thinStyle: React.CSSProperties = {
+  ...baseStyle,
+  height: "1px",
+  backgroundColor: "#9ca3af",
+};
+
+const regularStyle: React.CSSProperties = {
+  ...baseStyle,
+  height: "3px",
+  backgroundColor: "#9ca3af",
+};
+
+const thickStyle: React.CSSProperties = {
+  ...baseStyle,
+  height: "5px",
+  backgroundColor: "#6b7280",
+};
+
 export function Separator({ style = "" }: SeparatorProps) {
   return (
     <div>
-      {style === "thin" && <hr className="h-1px my-4 w-full bg-gray-400" />}
-      {(style === "" || style === "regular") && (
-        <hr className="h-3px my-4 w-full bg-gray-400" />
-      )}
-      {style === "thick" && <hr className="h-5px my-4 w-full bg-gray-500" />}
+      {style === "thin" && <hr style={thinStyle} />}
+      {(style === "" || style === "regular") && <hr style={regularStyle} />}
+      {style === "thick" && <hr style={thickStyle} />}
     </div>
   );
 }

--- a/packages/stagebook/src/components/form/Separator.tsx
+++ b/packages/stagebook/src/components/form/Separator.tsx
@@ -13,19 +13,19 @@ const baseStyle: React.CSSProperties = {
 const thinStyle: React.CSSProperties = {
   ...baseStyle,
   height: "1px",
-  backgroundColor: "#9ca3af",
+  backgroundColor: "var(--stagebook-text-faint, #9ca3af)",
 };
 
 const regularStyle: React.CSSProperties = {
   ...baseStyle,
   height: "3px",
-  backgroundColor: "#9ca3af",
+  backgroundColor: "var(--stagebook-text-faint, #9ca3af)",
 };
 
 const thickStyle: React.CSSProperties = {
   ...baseStyle,
   height: "5px",
-  backgroundColor: "#6b7280",
+  backgroundColor: "var(--stagebook-text-muted, #6b7280)",
 };
 
 export function Separator({ style = "" }: SeparatorProps) {

--- a/packages/stagebook/src/schemas/index.ts
+++ b/packages/stagebook/src/schemas/index.ts
@@ -73,6 +73,9 @@ export {
   type TreatmentFileType,
   type DiscussionType,
   type TimelineType,
+  validElementTypes,
+  validComparators,
+  validReferenceTypes,
 } from "./treatment.js";
 
 export {

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -898,8 +898,7 @@ const trackedLinkSchema = elementBaseSchema
   })
   .strict();
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const validElementTypes = [
+export const validElementTypes = [
   "audio",
   "display",
   "image",
@@ -914,7 +913,39 @@ const validElementTypes = [
   "mediaPlayer",
   "timeline",
   "trackedLink",
-];
+] as const;
+
+export const validComparators = [
+  "exists",
+  "doesNotExist",
+  "equals",
+  "doesNotEqual",
+  "isAbove",
+  "isBelow",
+  "isAtLeast",
+  "isAtMost",
+  "hasLengthAtLeast",
+  "hasLengthAtMost",
+  "includes",
+  "doesNotInclude",
+  "matches",
+  "doesNotMatch",
+  "isOneOf",
+  "isNotOneOf",
+] as const;
+
+export const validReferenceTypes = [
+  "survey",
+  "submitButton",
+  "qualtrics",
+  "prompt",
+  "trackedLink",
+  "urlParams",
+  "connectionInfo",
+  "browserInfo",
+  "participantInfo",
+  "discussion",
+] as const;
 
 export const elementSchema = altTemplateContext(
   z.any().superRefine((data, ctx) => {

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -13,7 +13,6 @@
  * the Inter webfont is registered.
  *
  * Provides:
- * - Tailwind CSS utilities
  * - Inter font
  * - Stagebook CSS custom properties at :root (default values)
  * - Form input resets
@@ -33,8 +32,6 @@
  * No selector-based CSS, no specificity battles.
  */
 
-@import "tailwindcss";
-
 /* ------------------------------------------------------------------ */
 /* Font                                                                */
 /* ------------------------------------------------------------------ */
@@ -46,22 +43,6 @@
   font-display: swap;
   src: url("https://rsms.me/inter/font-files/InterVariable.woff2")
     format("woff2");
-}
-
-@theme {
-  --font-sans: "Inter", ui-sans-serif, system-ui, sans-serif;
-
-  /* Stagebook color palette — replaces Empirica's brand colors */
-  --color-stagebook-50: #eff6ff;
-  --color-stagebook-100: #dbeafe;
-  --color-stagebook-200: #bfdbfe;
-  --color-stagebook-300: #93c5fd;
-  --color-stagebook-400: #60a5fa;
-  --color-stagebook-500: #3b82f6;
-  --color-stagebook-600: #2563eb;
-  --color-stagebook-700: #1d4ed8;
-  --color-stagebook-800: #1e40af;
-  --color-stagebook-900: #1e3a8a;
 }
 
 /* ------------------------------------------------------------------ */
@@ -147,129 +128,127 @@
 /* without writing any selector-based CSS. See issue #33.               */
 /* ------------------------------------------------------------------ */
 
-@layer base {
-  body {
-    font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
-  }
+body {
+  font-family: "Inter", ui-sans-serif, system-ui, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
 
-  /* ---------------------------------------------------------------- */
-  /* Form resets                                                        */
-  /* ---------------------------------------------------------------- */
+/* ------------------------------------------------------------------ */
+/* Form resets                                                          */
+/* ------------------------------------------------------------------ */
 
-  input[type="text"],
-  input[type="email"],
-  input[type="url"],
-  input[type="password"],
-  input[type="number"],
-  input[type="search"],
-  input[type="tel"],
-  textarea,
-  select {
-    appearance: none;
-    border: 1px solid #d1d5db;
-    border-radius: 0.375rem;
-    padding: 0.5rem 0.75rem;
-    font-size: 0.875rem;
-    line-height: 1.25rem;
-    color: #1f2937;
-    background-color: #fff;
-  }
+input[type="text"],
+input[type="email"],
+input[type="url"],
+input[type="password"],
+input[type="number"],
+input[type="search"],
+input[type="tel"],
+textarea,
+select {
+  appearance: none;
+  border: 1px solid #d1d5db;
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  color: #1f2937;
+  background-color: #fff;
+}
 
-  input[type="text"]:focus,
-  input[type="email"]:focus,
-  input[type="url"]:focus,
-  input[type="password"]:focus,
-  input[type="number"]:focus,
-  input[type="search"]:focus,
-  input[type="tel"]:focus,
-  textarea:focus,
-  select:focus {
-    outline: none;
-    border-color: #3b82f6;
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
-  }
+input[type="text"]:focus,
+input[type="email"]:focus,
+input[type="url"]:focus,
+input[type="password"]:focus,
+input[type="number"]:focus,
+input[type="search"]:focus,
+input[type="tel"]:focus,
+textarea:focus,
+select:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+}
 
-  input[type="checkbox"],
-  input[type="radio"] {
-    appearance: none;
-    width: 1rem;
-    height: 1rem;
-    border: 1px solid #d1d5db;
-    border-radius: 0.125rem;
-    background-color: #fff;
-    vertical-align: middle;
-    cursor: pointer;
-  }
+input[type="checkbox"],
+input[type="radio"] {
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.125rem;
+  background-color: #fff;
+  vertical-align: middle;
+  cursor: pointer;
+}
 
-  input[type="radio"] {
-    border-radius: 9999px;
-  }
+input[type="radio"] {
+  border-radius: 9999px;
+}
 
-  input[type="checkbox"]:checked,
-  input[type="radio"]:checked {
-    background-color: #3b82f6;
-    border-color: #3b82f6;
-    background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
-    background-size: 100% 100%;
-    background-position: center;
-    background-repeat: no-repeat;
-  }
+input[type="checkbox"]:checked,
+input[type="radio"]:checked {
+  background-color: #3b82f6;
+  border-color: #3b82f6;
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+}
 
-  input[type="radio"]:checked {
-    background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e");
-  }
+input[type="radio"]:checked {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e");
+}
 
-  input[type="checkbox"]:focus,
-  input[type="radio"]:focus {
-    outline: none;
-    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
-  }
+input[type="checkbox"]:focus,
+input[type="radio"]:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+}
 
-  /* Remove number input spinners */
-  input[type="number"]::-webkit-outer-spin-button,
-  input[type="number"]::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-  }
+/* Remove number input spinners */
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
 
-  input[type="number"] {
-    -moz-appearance: textfield;
-  }
+input[type="number"] {
+  -moz-appearance: textfield;
+}
 
-  /*
-   * GFM tables (rendered by react-markdown).
-   *
-   * Intentionally NOT inlined into Markdown.tsx like headings/lists/etc.
-   * The table style surface is large (table + th + td + collapse behavior
-   * + cell borders) and inlining would roughly double Markdown.tsx. As a
-   * result: hosts that import this stylesheet get nice tables; hosts that
-   * don't get browser-default unstyled tables (functional but ugly).
-   *
-   * If a researcher needs portable table styling on a non-stylesheet host,
-   * follow the pattern in Markdown.tsx and add table/thead/tbody/tr/th/td
-   * entries to the components map. See issue #33.
-   */
-  table {
-    border-collapse: collapse;
-    margin: 1rem 0;
-    width: 100%;
-    max-width: 36rem;
-  }
+/*
+ * GFM tables (rendered by react-markdown).
+ *
+ * Intentionally NOT inlined into Markdown.tsx like headings/lists/etc.
+ * The table style surface is large (table + th + td + collapse behavior
+ * + cell borders) and inlining would roughly double Markdown.tsx. As a
+ * result: hosts that import this stylesheet get nice tables; hosts that
+ * don't get browser-default unstyled tables (functional but ugly).
+ *
+ * If a researcher needs portable table styling on a non-stylesheet host,
+ * follow the pattern in Markdown.tsx and add table/thead/tbody/tr/th/td
+ * entries to the components map. See issue #33.
+ */
+table {
+  border-collapse: collapse;
+  margin: 1rem 0;
+  width: 100%;
+  max-width: 36rem;
+}
 
-  th,
-  td {
-    border: 1px solid #d1d5db;
-    padding: 0.5rem 0.75rem;
-    text-align: left;
-    font-size: 0.875rem;
-    color: #4a5568;
-  }
+th,
+td {
+  border: 1px solid #d1d5db;
+  padding: 0.5rem 0.75rem;
+  text-align: left;
+  font-size: 0.875rem;
+  color: #4a5568;
+}
 
-  th {
-    background-color: #f9fafb;
-    font-weight: 500;
-    color: #1a202c;
-  }
+th {
+  background-color: #f9fafb;
+  font-weight: 500;
+  color: #1a202c;
 }


### PR DESCRIPTION
Merges the `vscode-extension` work (now held on `release-v0.4.0`, which is `vscode-extension` + a version bump) into `main` at stagebook v0.4.0.

## Headline additions

### New package: `apps/vscode/` — Stagebook VS Code extension
- Live diagnostics for `*.treatments.yaml` and `*.prompt.md` using the canonical stagebook schemas (no reimplemented validation)
- Zod error paths map to precise YAML source positions via a custom AST position map
- Syntax highlighting via a TextMate grammar + a semantic-tokens provider for template variables and schema keywords
- File-reference validation (prompt files, media assets) with a Levenshtein-based quick-fix
- Completion provider for file paths
- Preview webview that embeds the viewer (`Preview Treatment`) — now with field resolution, refresh button, and prompt-file cache busting
- `Preview Expanded Templates` virtual document (read-only, auto-refreshes)
- Still `"private": true` — marketplace publishing is a separate follow-up (README / CHANGELOG / icon / publisher handle)

### Viewer refactor
- `stagebook-viewer/preview` export surface: `Viewer`, `PreviewHost`, `FieldForm`, `TreatmentPicker`, and a suite of lib utilities (state store, steps flattening, reference extraction, content fns)
- `Viewer` now accepts pluggable `getTextContent`/`getAssetURL` content functions — the same component renders from GitHub URLs in the SPA and from `vscode.workspace.fs` in the extension webview
- `PreviewHost` resolves unresolved `${field}` placeholders via a `FieldForm`, so stagebook components never see raw placeholder strings (no more `MediaPlayer.currentTime = NaN` in the preview)

### Tailwind removed
- `packages/stagebook` and `apps/viewer` no longer depend on Tailwind — all component styles are inline `CSSProperties` backed by `--stagebook-*` CSS custom properties for theming
- Host apps can `import "stagebook/styles"` for variable defaults + Inter font, or skip it and just override the variables themselves

## Behavior changes (library)

### `conditions`: `exists` no longer returns true on unanswered references
Before this release, `evaluateCondition` reached a vacuous `[].every(...) → true` when the resolved reference had no values — meaning a conditional submit button gated on `comparator: exists` would appear before any prompt had been answered.

`evaluateCondition` now short-circuits the empty-array case: no data means the condition is not satisfied, except `doesNotExist` which is satisfied. This is the intended semantics from the beginning — tagging it as a bugfix. No customers yet.

Fixes #126.

## Additions (library, additive)

- `mediaPlayer.startAt` / `stopAt` / `stepDuration` accept `${field}` placeholders in treatment YAML — study/player context substitutes at runtime (#124)
- New exports: `validElementTypes`, `validComparators`, `validReferenceTypes` (used by the extension's diagnostics + future autocomplete)

## Issues closed

- #65 — VS Code extension: treatment authoring and preview (parent)
- #73–#81 — VS Code extension subtasks (scaffold, error mapping, treatment + prompt validation, TextMate grammar, semantic tokens, expanded-templates preview, file-path quick-fix, webview preview)
- #120 — file paths resolved relative to treatment file (via #121)
- #125 — preview webview crashed on unresolved `${field}` placeholders (via #128)
- #126 — conditional `exists` vacuous-truth bug (via #127)

## Still open, not shipping in this release

- #112 — validate expanded template output
- #119 — schema-aware autocomplete for element types / comparators / reference paths
- #123 — improve "Unrecognized key" diagnostics with nearest-match suggestions
- Marketplace publish for the extension (README, icon, CHANGELOG, publisher handle)
- Integration tests with `@vscode/test-electron`

## Test plan

- [x] `npm run build` across workspaces — clean
- [x] `npm test` — 485 stagebook + 59 viewer + 136 vscode = 680 tests pass
- [x] `npm run lint` clean
- [x] Manual preview testing against a real study file (conditional submit buttons, `${field}` resolution, refresh, `.prompt.md` edits, deleted stages)
- [ ] CI: unit tests, Playwright component tests, lint, build (should pass — same as #128)

## Post-merge

- Tag `v0.4.0` on `main`
- Release cut + `npm publish` happen together in a separate step, per repo workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)