### PR TITLE
Add claim/lock pattern to agent instructions

### DIFF
--- a/.github/AGENT_INSTRUCTIONS.md
+++ b/.github/AGENT_INSTRUCTIONS.md
@@ -14,9 +14,9 @@ cloud sessions) working issues in this repo.
 ## Workflow
 
 1. **Check for an existing claim.** Read the issue comments
-   (`gh issue view <number> --json comments`). If any comment contains
+   (`gh issue view <number> --comments`). If any comment contains
    the marker `🔧 Working on this`, check whether there is also an
-   open PR referencing this issue (`gh pr list --search "issue-<number>"`).
+   open PR for this issue (`gh pr list --state open --search "<number>"`).
    - If there is an open PR: another agent is actively handling this.
      **Stop immediately** — do not duplicate the work.
    - If there is NO open PR: the previous agent likely stalled. Proceed

--- a/.github/AGENT_INSTRUCTIONS.md
+++ b/.github/AGENT_INSTRUCTIONS.md
@@ -13,24 +13,31 @@ cloud sessions) working issues in this repo.
 
 ## Workflow
 
-1. Read the issue fully, then investigate the relevant code.
-2. If anything about the spec is unclear or you hit a design question,
+1. **Check for an existing claim.** Read the issue comments
+   (`gh issue view <number> --json comments`). If any comment contains
+   the marker `🔧 Working on this`, another agent is already handling it.
+   **Stop immediately** — do not duplicate the work.
+2. **Claim the issue.** Post a comment on the issue:
+   `🔧 Working on this — started <current UTC timestamp>`
+   This prevents other agents from picking up the same issue.
+3. Read the issue fully, then investigate the relevant code.
+4. If anything about the spec is unclear or you hit a design question,
    **comment on the issue tagging @jamesphoughton** with your question
    and **wait for a response** before proceeding.
-3. Follow TDD: write a failing test first, then implement the fix, then
+5. Follow TDD: write a failing test first, then implement the fix, then
    refactor.
-4. Run `npm test` and `npm run lint` — fix any failures before committing.
-5. Create a branch (e.g. `fix/issue-<number>`), commit, push, and open a
+6. Run `npm test` and `npm run lint` — fix any failures before committing.
+7. Create a branch (e.g. `fix/issue-<number>`), commit, push, and open a
    **draft** PR to `main` referencing the issue.
-6. Watch CI (`gh pr checks <number> --watch`). If checks fail, read the
+8. Watch CI (`gh pr checks <number> --watch`). If checks fail, read the
    failure, fix, push, and re-check. Keep iterating until CI is green.
-7. Once CI is green, **mark the PR ready for review**
+9. Once CI is green, **mark the PR ready for review**
    (`gh pr ready <number>`). This triggers Copilot review.
-8. Wait for Copilot review comments
-   (`gh api repos/deliberation-lab/stagebook/pulls/<number>/comments`).
-   Address each with a follow-up commit, push, and re-check CI.
-9. Once CI is green and all Copilot comments are addressed, comment on the
-   PR: **"Ready for review — @jamesphoughton"** and stop.
+10. Wait for Copilot review comments
+    (`gh api repos/deliberation-lab/stagebook/pulls/<number>/comments`).
+    Address each with a follow-up commit, push, and re-check CI.
+11. Once CI is green and all Copilot comments are addressed, comment on the
+    PR: **"Ready for review — @jamesphoughton"** and stop.
 
 ## Rules
 

--- a/.github/AGENT_INSTRUCTIONS.md
+++ b/.github/AGENT_INSTRUCTIONS.md
@@ -15,8 +15,12 @@ cloud sessions) working issues in this repo.
 
 1. **Check for an existing claim.** Read the issue comments
    (`gh issue view <number> --json comments`). If any comment contains
-   the marker `🔧 Working on this`, another agent is already handling it.
-   **Stop immediately** — do not duplicate the work.
+   the marker `🔧 Working on this`, check whether there is also an
+   open PR referencing this issue (`gh pr list --search "issue-<number>"`).
+   - If there is an open PR: another agent is actively handling this.
+     **Stop immediately** — do not duplicate the work.
+   - If there is NO open PR: the previous agent likely stalled. Proceed
+     and post your own claim (it's safe to pick up where they left off).
 2. **Claim the issue.** Post a comment on the issue:
    `🔧 Working on this — started <current UTC timestamp>`
    This prevents other agents from picking up the same issue.


### PR DESCRIPTION
## Summary
- Agents check for a "🔧 Working on this" comment before starting, preventing duplicate work
- If a claim exists but no open PR references the issue, the agent treats it as stale and proceeds (prevents permanently locked issues from stalled agents)

Follow-up to #139.

## Test plan
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)