### PR TITLE
Add computeBroadcastSize() to preview expansion size (#39)

### DIFF
--- a/packages/stagebook/src/templates/computeBroadcastSize.test.ts
+++ b/packages/stagebook/src/templates/computeBroadcastSize.test.ts
@@ -1,0 +1,189 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import { expect, test } from "vitest";
+import { computeBroadcastSize, fillTemplates } from "./fillTemplates.js";
+
+// ----------------------------------------------------------------
+// Basic cases
+// ----------------------------------------------------------------
+
+test("template context without broadcast returns 1", () => {
+  const templates = [
+    { templateName: "simple", templateContent: { val: "${x}" } },
+  ];
+
+  const size = computeBroadcastSize({
+    obj: { template: "simple", fields: { x: "hello" } },
+    templates,
+  });
+  expect(size).toBe(1);
+});
+
+test("single broadcast dimension returns its length", () => {
+  const templates = [{ templateName: "t", templateContent: { val: "${v}" } }];
+
+  const size = computeBroadcastSize({
+    obj: {
+      template: "t",
+      broadcast: { d0: [{ v: "a" }, { v: "b" }, { v: "c" }] },
+    },
+    templates,
+  });
+  expect(size).toBe(3);
+});
+
+test("multiple broadcast dimensions returns cartesian product", () => {
+  const templates = [
+    { templateName: "t", templateContent: { A: "${A}", B: "${B}" } },
+  ];
+
+  const size = computeBroadcastSize({
+    obj: {
+      template: "t",
+      broadcast: {
+        d0: [{ A: "A0" }, { A: "A1" }, { A: "A2" }],
+        d1: [{ B: "B0" }, { B: "B1" }],
+      },
+    },
+    templates,
+  });
+  expect(size).toBe(6);
+});
+
+test("three broadcast dimensions multiplies all", () => {
+  const templates = [
+    { templateName: "t", templateContent: { a: "${a}", b: "${b}", c: "${c}" } },
+  ];
+
+  const size = computeBroadcastSize({
+    obj: {
+      template: "t",
+      broadcast: {
+        d0: [{ a: 1 }, { a: 2 }],
+        d1: [{ b: 1 }, { b: 2 }, { b: 3 }],
+        d2: [{ c: 1 }, { c: 2 }, { c: 3 }, { c: 4 }],
+      },
+    },
+    templates,
+  });
+  expect(size).toBe(24);
+});
+
+// ----------------------------------------------------------------
+// Array of template contexts
+// ----------------------------------------------------------------
+
+test("array of template contexts sums broadcast sizes", () => {
+  const templates = [{ templateName: "t", templateContent: { val: "${v}" } }];
+
+  const size = computeBroadcastSize({
+    obj: [
+      {
+        template: "t",
+        broadcast: { d0: [{ v: "a" }, { v: "b" }] },
+      },
+      {
+        template: "t",
+        broadcast: { d0: [{ v: "x" }, { v: "y" }, { v: "z" }] },
+      },
+    ],
+    templates,
+  });
+  expect(size).toBe(5);
+});
+
+test("array mixing broadcast and non-broadcast contexts", () => {
+  const templates = [{ templateName: "t", templateContent: { val: "${v}" } }];
+
+  const size = computeBroadcastSize({
+    obj: [
+      { template: "t", fields: { v: "plain" } },
+      {
+        template: "t",
+        broadcast: { d0: [{ v: "a" }, { v: "b" }, { v: "c" }] },
+      },
+    ],
+    templates,
+  });
+  expect(size).toBe(4);
+});
+
+// ----------------------------------------------------------------
+// Broadcast dimensions from template references
+// ----------------------------------------------------------------
+
+test("broadcast dimension from template reference counts correctly", () => {
+  const templates = [
+    { templateName: "t", templateContent: { A: "${A}", B: "${B}" } },
+    {
+      templateName: "broadcastList",
+      templateContent: [{ A: "A0" }, { A: "A1" }, { A: "A2" }],
+    },
+  ];
+
+  const size = computeBroadcastSize({
+    obj: {
+      template: "t",
+      broadcast: {
+        d0: { template: "broadcastList" },
+        d1: [{ B: "B0" }, { B: "B1" }],
+      },
+    },
+    templates,
+  });
+  expect(size).toBe(6);
+});
+
+// ----------------------------------------------------------------
+// Edge cases
+// ----------------------------------------------------------------
+
+test("plain object without template returns 1", () => {
+  const size = computeBroadcastSize({
+    obj: { name: "plain", value: 42 },
+    templates: [],
+  });
+  expect(size).toBe(1);
+});
+
+test("single-item broadcast dimension returns 1", () => {
+  const templates = [{ templateName: "t", templateContent: { val: "${v}" } }];
+
+  const size = computeBroadcastSize({
+    obj: {
+      template: "t",
+      broadcast: { d0: [{ v: "only" }] },
+    },
+    templates,
+  });
+  expect(size).toBe(1);
+});
+
+test("matches fillTemplates output length", () => {
+  const templates = [
+    {
+      templateName: "rating",
+      templateContent: {
+        name: "rate_${dimension}",
+        A: "${A}",
+      },
+    },
+  ];
+
+  const obj = {
+    template: "rating",
+    broadcast: {
+      d0: [{ A: "A0" }, { A: "A1" }, { A: "A2" }],
+      d1: [
+        { dimension: "engagement" },
+        { dimension: "confidence" },
+        { dimension: "clarity" },
+        { dimension: "relevance" },
+      ],
+    },
+  };
+
+  const size = computeBroadcastSize({ obj, templates });
+  const { result } = fillTemplates({ obj, templates });
+  expect(size).toBe((result as unknown[]).length);
+});

--- a/packages/stagebook/src/templates/computeBroadcastSize.test.ts
+++ b/packages/stagebook/src/templates/computeBroadcastSize.test.ts
@@ -187,3 +187,20 @@ test("matches fillTemplates output length", () => {
   const { result } = fillTemplates({ obj, templates });
   expect(size).toBe((result as unknown[]).length);
 });
+
+test("throws when broadcast dimension resolves to non-array", () => {
+  const templates = [
+    { templateName: "t", templateContent: { val: "${v}" } },
+    { templateName: "notAnArray", templateContent: { v: "oops" } },
+  ];
+
+  expect(() =>
+    computeBroadcastSize({
+      obj: {
+        template: "t",
+        broadcast: { d0: { template: "notAnArray" } },
+      },
+      templates,
+    }),
+  ).toThrow('Broadcast dimension "d0" resolved to object, expected an array');
+});

--- a/packages/stagebook/src/templates/fillTemplates.ts
+++ b/packages/stagebook/src/templates/fillTemplates.ts
@@ -301,6 +301,68 @@ export function fillTemplates({
 }
 
 /**
+ * Calculate the number of treatments that {@link fillTemplates} would produce
+ * from the given object, without actually performing the expansion.
+ *
+ * For a template context with broadcast dimensions, this returns the cartesian
+ * product of the dimension sizes. For an array of template contexts, it sums
+ * the sizes. For anything else it returns 1.
+ *
+ * Broadcast dimensions that are themselves template references are resolved
+ * (cheaply — only the dimension arrays, not the full template content) so
+ * their lengths can be counted.
+ *
+ * @example
+ * const size = computeBroadcastSize({
+ *   obj: {
+ *     template: "rating",
+ *     broadcast: {
+ *       d0: [{ A: "A0" }, { A: "A1" }],
+ *       d1: [{ B: "B0" }, { B: "B1" }, { B: "B2" }],
+ *     },
+ *   },
+ *   templates,
+ * });
+ * // size === 6
+ */
+export function computeBroadcastSize({
+  obj,
+  templates,
+}: {
+  obj: any;
+  templates: any[];
+}): number {
+  if (Array.isArray(obj)) {
+    let total = 0;
+    for (const item of obj) {
+      total += computeBroadcastSize({ obj: item, templates });
+    }
+    return total;
+  }
+
+  if (obj && typeof obj === "object" && "template" in obj) {
+    if (!obj.broadcast) return 1;
+
+    // Resolve any template references inside broadcast dimensions
+    const resolvedBroadcast = recursivelyFillTemplates({
+      obj: obj.broadcast,
+      templates,
+    });
+
+    let size = 1;
+    for (const key of Object.keys(resolvedBroadcast)) {
+      const dimension = resolvedBroadcast[key];
+      if (Array.isArray(dimension)) {
+        size *= dimension.length;
+      }
+    }
+    return size;
+  }
+
+  return 1;
+}
+
+/**
  * Expand researcher-defined templates and return the set of placeholder
  * names that remain unresolved. Useful for platforms to discover which
  * additionalFields a treatment file expects.

--- a/packages/stagebook/src/templates/fillTemplates.ts
+++ b/packages/stagebook/src/templates/fillTemplates.ts
@@ -352,9 +352,12 @@ export function computeBroadcastSize({
     let size = 1;
     for (const key of Object.keys(resolvedBroadcast)) {
       const dimension = resolvedBroadcast[key];
-      if (Array.isArray(dimension)) {
-        size *= dimension.length;
+      if (!Array.isArray(dimension)) {
+        throw new Error(
+          `Broadcast dimension "${key}" resolved to ${typeof dimension}, expected an array`,
+        );
       }
+      size *= dimension.length;
     }
     return size;
   }

--- a/packages/stagebook/src/templates/index.ts
+++ b/packages/stagebook/src/templates/index.ts
@@ -3,5 +3,6 @@ export {
   expandTemplate,
   recursivelyFillTemplates,
   fillTemplates,
+  computeBroadcastSize,
   getUnresolvedFields,
 } from "./fillTemplates.js";


### PR DESCRIPTION
## Summary
- Adds `computeBroadcastSize()` utility that calculates the cartesian product of a treatment file's broadcast dimensions without performing the full expansion
- Lets platforms (e.g., the annotator) warn researchers during preview if a treatment file would produce an unexpectedly large number of treatments — without allocating/stringifying thousands of treatment objects just to count them
- Resolves template references inside broadcast dimensions (cheaply — only the dimension arrays, not the full template content)

Closes #39.

## API

```ts
import { computeBroadcastSize } from "stagebook";

const size = computeBroadcastSize({ obj: parsedYaml, templates });
// For broadcast { d0: [3 items], d1: [2 items] } → returns 6
```

- Template context without broadcast → `1`
- Template context with broadcast → product of dimension lengths
- Array of template contexts → sum of sizes
- Broadcast dimension that is a template reference → resolved to an array, then counted

## Test plan
- [x] Red/Green/Refactor: 10 new tests in `computeBroadcastSize.test.ts`, all failing before implementation, all passing after
- [x] Covers: no broadcast, single/multi-dimensional broadcast, array of contexts (including mixed broadcast/non-broadcast), template-reference dimensions, single-item dimension, plain objects
- [x] Cross-validation test that asserts `computeBroadcastSize` matches `fillTemplates` output `.length`
- [x] Full workspace test suite passes (stagebook 495, viewer 59, vscode 136)
- [x] Lint clean (zero warnings)

https://claude.ai/code/session_01SAiFyYJ8rkKKzUaLQf1xrF