### PR TITLE
Split CI into per-workspace jobs with path filtering (#64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,29 +18,41 @@ jobs:
       lint: ${{ steps.filter.outputs.lint }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Needed so dorny/paths-filter can diff base vs HEAD reliably on push events.
+          fetch-depth: 0
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
             stagebook:
               - 'packages/stagebook/**'
+              - 'package.json'
+              - 'package-lock.json'
               - '.github/workflows/ci.yml'
             viewer:
               - 'apps/viewer/**'
               - 'packages/stagebook/**'
+              - 'package.json'
+              - 'package-lock.json'
               - '.github/workflows/ci.yml'
             vscode:
               - 'apps/vscode/**'
               - 'packages/stagebook/**'
+              - 'package.json'
+              - 'package-lock.json'
               - '.github/workflows/ci.yml'
             ct:
               - 'packages/stagebook/**'
+              - 'package.json'
+              - 'package-lock.json'
               - '.github/workflows/ci.yml'
             lint:
               - '**/*.ts'
               - '**/*.tsx'
               - '**/*.js'
               - '**/*.json'
+              - '.prettierrc'
               - '.github/workflows/ci.yml'
 
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,51 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, vscode-extension]
+    branches: [main]
   push:
-    branches: [main, vscode-extension]
+    branches: [main]
 
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      stagebook: ${{ steps.filter.outputs.stagebook }}
+      viewer: ${{ steps.filter.outputs.viewer }}
+      vscode: ${{ steps.filter.outputs.vscode }}
+      ct: ${{ steps.filter.outputs.ct }}
+      lint: ${{ steps.filter.outputs.lint }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            stagebook:
+              - 'packages/stagebook/**'
+              - '.github/workflows/ci.yml'
+            viewer:
+              - 'apps/viewer/**'
+              - 'packages/stagebook/**'
+              - '.github/workflows/ci.yml'
+            vscode:
+              - 'apps/vscode/**'
+              - 'packages/stagebook/**'
+              - '.github/workflows/ci.yml'
+            ct:
+              - 'packages/stagebook/**'
+              - '.github/workflows/ci.yml'
+            lint:
+              - '**/*.ts'
+              - '**/*.tsx'
+              - '**/*.js'
+              - '**/*.json'
+              - '.github/workflows/ci.yml'
+
   lint:
     name: Lint & Format
+    needs: changes
+    if: needs.changes.outputs.lint == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,8 +58,24 @@ jobs:
       - run: npm run lint
       - run: npm run format:check
 
-  test:
-    name: Unit Tests (vitest)
+  test-stagebook:
+    name: Unit Tests (stagebook)
+    needs: changes
+    if: needs.changes.outputs.stagebook == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm test -w stagebook
+
+  test-viewer:
+    name: Unit Tests (viewer)
+    needs: changes
+    if: needs.changes.outputs.viewer == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,10 +85,27 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build -w stagebook
-      - run: npm test
+      - run: npm test -w stagebook-viewer
+
+  test-vscode:
+    name: Unit Tests (vscode)
+    needs: changes
+    if: needs.changes.outputs.vscode == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run build -w stagebook
+      - run: npm test -w stagebook-vscode
 
   test-ct:
     name: Component Tests (Playwright)
+    needs: changes
+    if: needs.changes.outputs.ct == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Drop the deleted `vscode-extension` branch from the `on.push`/`on.pull_request` triggers in `.github/workflows/ci.yml`.
- Replace the single "Unit Tests (vitest)" job with three per-workspace jobs: `test-stagebook`, `test-viewer`, `test-vscode`.
- Add a `changes` detection job (using `dorny/paths-filter@v3`) and gate each test job's `if:` on its output, so unaffected workspaces are skipped.
- Viewer and vscode jobs still `npm run build -w stagebook` first, because they import stagebook via the workspace link and resolve against `dist/`.

Closes #64.

## Path filter matrix

| Job | Triggers on changes to |
|-----|----------------------|
| `test-stagebook` | `packages/stagebook/**`, `.github/workflows/ci.yml` |
| `test-viewer` | `apps/viewer/**`, `packages/stagebook/**`, `.github/workflows/ci.yml` |
| `test-vscode` | `apps/vscode/**`, `packages/stagebook/**`, `.github/workflows/ci.yml` |
| `test-ct` (Playwright) | `packages/stagebook/**`, `.github/workflows/ci.yml` |
| `lint` | `**/*.ts`, `**/*.tsx`, `**/*.js`, `**/*.json`, `.github/workflows/ci.yml` |
| `build` | always (no filter — catches packaging regressions) |

`.github/workflows/ci.yml` is included in every filter so workflow edits force a full run.

## Test plan

- [x] `npm run format:check` passes locally.
- [ ] On this PR (which touches only `.github/workflows/ci.yml`), all jobs run — verifies the "workflow change = full run" behavior.
- [ ] A follow-up viewer-only PR would run `test-viewer` + `build` + `lint` only — skipping `test-stagebook`, `test-vscode`, and `test-ct`. (Not exercised here; verifiable once merged.)
- [ ] A follow-up docs-only PR would skip all test jobs + lint; only `build` runs. (Not exercised here.)
