### PR TITLE
Add ElementErrorBoundary around each rendered element

### DIFF
--- a/packages/stagebook/src/components/ElementErrorBoundary.ct.tsx
+++ b/packages/stagebook/src/components/ElementErrorBoundary.ct.tsx
@@ -1,7 +1,6 @@
 import { test, expect } from "@playwright/experimental-ct-react";
 import {
   BoundaryTestHarness,
-  CrashingChild,
   SiblingLayout,
 } from "./testing/BoundaryTestHarness";
 
@@ -9,15 +8,22 @@ const FALLBACK_TEXT = "Part of this page couldn't load";
 
 test("renders happy-path children with no visible wrapper", async ({
   mount,
+  page,
 }) => {
-  const component = await mount(
-    <BoundaryTestHarness elementType="prompt" elementName="ok">
-      <p data-testid="happy-child">hello</p>
-    </BoundaryTestHarness>,
+  await mount(
+    <BoundaryTestHarness
+      elementType="prompt"
+      elementName="ok"
+      happyText="HAPPY-PATH-CONTENT"
+    />,
   );
-  await expect(component.locator('[data-testid="happy-child"]')).toBeVisible();
-  await expect(component).toContainText("hello");
-  await expect(component).not.toContainText(FALLBACK_TEXT);
+  await expect(page.locator('[data-testid="happy-child"]')).toBeVisible();
+  await expect(page.locator("#root")).toContainText("HAPPY-PATH-CONTENT");
+  await expect(page.locator("#root")).not.toContainText(FALLBACK_TEXT);
+  // No fallback element in the DOM in the happy path.
+  await expect(
+    page.locator('[data-testid="element-error-fallback"]'),
+  ).toHaveCount(0);
 });
 
 test("renders a participant-friendly fallback when a child throws", async ({
@@ -27,15 +33,17 @@ test("renders a participant-friendly fallback when a child throws", async ({
   // Swallow the async-rethrown error so the test doesn't fail on page error
   page.on("pageerror", () => {});
 
-  const component = await mount(
-    <BoundaryTestHarness elementType="prompt" elementName="secretPromptName">
-      <CrashingChild message="secret-internal-reason" />
-    </BoundaryTestHarness>,
+  await mount(
+    <BoundaryTestHarness
+      elementType="prompt"
+      elementName="secretPromptName"
+      crashMessage="secret-internal-reason"
+    />,
   );
 
-  const fallback = component.locator('[data-testid="element-error-fallback"]');
+  const fallback = page.locator('[data-testid="element-error-fallback"]');
   await expect(fallback).toBeVisible();
-  await expect(component).toContainText(FALLBACK_TEXT);
+  await expect(fallback).toContainText(FALLBACK_TEXT);
 });
 
 test("fallback UI leaks no technical detail to the participant", async ({
@@ -44,22 +52,25 @@ test("fallback UI leaks no technical detail to the participant", async ({
 }) => {
   page.on("pageerror", () => {});
 
-  const component = await mount(
-    <BoundaryTestHarness elementType="prompt" elementName="secretPromptName">
-      <CrashingChild message="secret-internal-reason" />
-    </BoundaryTestHarness>,
+  await mount(
+    <BoundaryTestHarness
+      elementType="prompt"
+      elementName="secretPromptName"
+      crashMessage="secret-internal-reason"
+    />,
   );
 
   await expect(
-    component.locator('[data-testid="element-error-fallback"]'),
+    page.locator('[data-testid="element-error-fallback"]'),
   ).toBeVisible();
 
+  const root = page.locator("#root");
   // None of these may appear in the DOM presented to the participant
-  await expect(component).not.toContainText("secret-internal-reason");
-  await expect(component).not.toContainText("secretPromptName");
+  await expect(root).not.toContainText("secret-internal-reason");
+  await expect(root).not.toContainText("secretPromptName");
   // The raw element type string shouldn't leak either — the fallback copy
   // intentionally does not reference the element's kind.
-  await expect(component).not.toContainText("prompt:");
+  await expect(root).not.toContainText("prompt:");
 });
 
 test("sibling elements still render when the middle one crashes", async ({
@@ -68,7 +79,7 @@ test("sibling elements still render when the middle one crashes", async ({
 }) => {
   page.on("pageerror", () => {});
 
-  const component = await mount(
+  await mount(
     <SiblingLayout
       leftText="LEFT-OK"
       rightText="RIGHT-OK"
@@ -77,19 +88,18 @@ test("sibling elements still render when the middle one crashes", async ({
     />,
   );
 
-  await expect(component.locator('[data-testid="sibling-left"]')).toBeVisible();
+  await expect(page.locator('[data-testid="sibling-left"]')).toBeVisible();
+  await expect(page.locator('[data-testid="sibling-right"]')).toBeVisible();
   await expect(
-    component.locator('[data-testid="sibling-right"]'),
-  ).toBeVisible();
-  await expect(
-    component.locator('[data-testid="element-error-fallback"]'),
+    page.locator('[data-testid="element-error-fallback"]'),
   ).toHaveCount(1);
-  await expect(component).toContainText("LEFT-OK");
-  await expect(component).toContainText("RIGHT-OK");
-  await expect(component).toContainText(FALLBACK_TEXT);
+  const root = page.locator("#root");
+  await expect(root).toContainText("LEFT-OK");
+  await expect(root).toContainText("RIGHT-OK");
+  await expect(root).toContainText(FALLBACK_TEXT);
 });
 
-test("emits a single console.error with the full technical payload", async ({
+test("emits a [Stagebook] console.error with the full technical payload", async ({
   mount,
   page,
 }) => {
@@ -103,12 +113,16 @@ test("emits a single console.error with the full technical payload", async ({
   });
 
   await mount(
-    <BoundaryTestHarness elementType="prompt" elementName="promptForDebug">
-      <CrashingChild message="debug-visible-to-researcher" />
-    </BoundaryTestHarness>,
+    <BoundaryTestHarness
+      elementType="prompt"
+      elementName="promptForDebug"
+      crashMessage="debug-visible-to-researcher"
+    />,
   );
 
-  await expect.poll(() => stagebookErrors.length, { timeout: 2000 }).toBe(1);
+  await expect
+    .poll(() => stagebookErrors.length, { timeout: 2000 })
+    .toBeGreaterThanOrEqual(1);
 
   const logged = stagebookErrors[0];
   expect(logged).toContain("prompt");
@@ -125,9 +139,11 @@ test("async re-throws original error to window.onerror", async ({
   });
 
   await mount(
-    <BoundaryTestHarness elementType="display" elementName="xyz">
-      <CrashingChild message="rethrown-to-window-onerror" />
-    </BoundaryTestHarness>,
+    <BoundaryTestHarness
+      elementType="display"
+      elementName="xyz"
+      crashMessage="rethrown-to-window-onerror"
+    />,
   );
 
   await expect
@@ -143,7 +159,6 @@ test("calls onElementError with structured payload when provided", async ({
 }) => {
   page.on("pageerror", () => {});
 
-  // Clear any leftover from previous tests just in case.
   await page.evaluate(() => {
     delete window.__stagebookElementErrors;
   });
@@ -153,9 +168,8 @@ test("calls onElementError with structured payload when provided", async ({
       elementType="timer"
       elementName="countdownA"
       withCallback
-    >
-      <CrashingChild message="callback-error" />
-    </BoundaryTestHarness>,
+      crashMessage="callback-error"
+    />,
   );
 
   await expect
@@ -163,7 +177,7 @@ test("calls onElementError with structured payload when provided", async ({
       () => page.evaluate(() => window.__stagebookElementErrors?.length ?? 0),
       { timeout: 2000 },
     )
-    .toBe(1);
+    .toBeGreaterThanOrEqual(1);
 
   const recorded = await page.evaluate(
     () => window.__stagebookElementErrors?.[0],
@@ -191,9 +205,11 @@ test("without onElementError, console.error and window.onerror still fire", asyn
   });
 
   await mount(
-    <BoundaryTestHarness elementType="display" elementName="noCallback">
-      <CrashingChild message="no-callback-provided" />
-    </BoundaryTestHarness>,
+    <BoundaryTestHarness
+      elementType="display"
+      elementName="noCallback"
+      crashMessage="no-callback-provided"
+    />,
   );
 
   await expect

--- a/packages/stagebook/src/components/ElementErrorBoundary.ct.tsx
+++ b/packages/stagebook/src/components/ElementErrorBoundary.ct.tsx
@@ -1,0 +1,204 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import {
+  BoundaryTestHarness,
+  CrashingChild,
+  SiblingLayout,
+} from "./testing/BoundaryTestHarness";
+
+const FALLBACK_TEXT = "Part of this page couldn't load";
+
+test("renders happy-path children with no visible wrapper", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <BoundaryTestHarness elementType="prompt" elementName="ok">
+      <p data-testid="happy-child">hello</p>
+    </BoundaryTestHarness>,
+  );
+  await expect(component.locator('[data-testid="happy-child"]')).toBeVisible();
+  await expect(component).toContainText("hello");
+  await expect(component).not.toContainText(FALLBACK_TEXT);
+});
+
+test("renders a participant-friendly fallback when a child throws", async ({
+  mount,
+  page,
+}) => {
+  // Swallow the async-rethrown error so the test doesn't fail on page error
+  page.on("pageerror", () => {});
+
+  const component = await mount(
+    <BoundaryTestHarness elementType="prompt" elementName="secretPromptName">
+      <CrashingChild message="secret-internal-reason" />
+    </BoundaryTestHarness>,
+  );
+
+  const fallback = component.locator('[data-testid="element-error-fallback"]');
+  await expect(fallback).toBeVisible();
+  await expect(component).toContainText(FALLBACK_TEXT);
+});
+
+test("fallback UI leaks no technical detail to the participant", async ({
+  mount,
+  page,
+}) => {
+  page.on("pageerror", () => {});
+
+  const component = await mount(
+    <BoundaryTestHarness elementType="prompt" elementName="secretPromptName">
+      <CrashingChild message="secret-internal-reason" />
+    </BoundaryTestHarness>,
+  );
+
+  await expect(
+    component.locator('[data-testid="element-error-fallback"]'),
+  ).toBeVisible();
+
+  // None of these may appear in the DOM presented to the participant
+  await expect(component).not.toContainText("secret-internal-reason");
+  await expect(component).not.toContainText("secretPromptName");
+  // The raw element type string shouldn't leak either — the fallback copy
+  // intentionally does not reference the element's kind.
+  await expect(component).not.toContainText("prompt:");
+});
+
+test("sibling elements still render when the middle one crashes", async ({
+  mount,
+  page,
+}) => {
+  page.on("pageerror", () => {});
+
+  const component = await mount(
+    <SiblingLayout
+      leftText="LEFT-OK"
+      rightText="RIGHT-OK"
+      crashMessage="middle-boom"
+      elementNames={["left", "middle", "right"]}
+    />,
+  );
+
+  await expect(component.locator('[data-testid="sibling-left"]')).toBeVisible();
+  await expect(
+    component.locator('[data-testid="sibling-right"]'),
+  ).toBeVisible();
+  await expect(
+    component.locator('[data-testid="element-error-fallback"]'),
+  ).toHaveCount(1);
+  await expect(component).toContainText("LEFT-OK");
+  await expect(component).toContainText("RIGHT-OK");
+  await expect(component).toContainText(FALLBACK_TEXT);
+});
+
+test("emits a single console.error with the full technical payload", async ({
+  mount,
+  page,
+}) => {
+  page.on("pageerror", () => {});
+
+  const stagebookErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" && msg.text().includes("[Stagebook]")) {
+      stagebookErrors.push(msg.text());
+    }
+  });
+
+  await mount(
+    <BoundaryTestHarness elementType="prompt" elementName="promptForDebug">
+      <CrashingChild message="debug-visible-to-researcher" />
+    </BoundaryTestHarness>,
+  );
+
+  await expect.poll(() => stagebookErrors.length, { timeout: 2000 }).toBe(1);
+
+  const logged = stagebookErrors[0];
+  expect(logged).toContain("prompt");
+  expect(logged).toContain("promptForDebug");
+});
+
+test("async re-throws original error to window.onerror", async ({
+  mount,
+  page,
+}) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (err) => {
+    pageErrors.push(err.message);
+  });
+
+  await mount(
+    <BoundaryTestHarness elementType="display" elementName="xyz">
+      <CrashingChild message="rethrown-to-window-onerror" />
+    </BoundaryTestHarness>,
+  );
+
+  await expect
+    .poll(() => pageErrors.length, { timeout: 2000 })
+    .toBeGreaterThanOrEqual(1);
+
+  expect(pageErrors).toContain("rethrown-to-window-onerror");
+});
+
+test("calls onElementError with structured payload when provided", async ({
+  mount,
+  page,
+}) => {
+  page.on("pageerror", () => {});
+
+  // Clear any leftover from previous tests just in case.
+  await page.evaluate(() => {
+    delete window.__stagebookElementErrors;
+  });
+
+  await mount(
+    <BoundaryTestHarness
+      elementType="timer"
+      elementName="countdownA"
+      withCallback
+    >
+      <CrashingChild message="callback-error" />
+    </BoundaryTestHarness>,
+  );
+
+  await expect
+    .poll(
+      () => page.evaluate(() => window.__stagebookElementErrors?.length ?? 0),
+      { timeout: 2000 },
+    )
+    .toBe(1);
+
+  const recorded = await page.evaluate(
+    () => window.__stagebookElementErrors?.[0],
+  );
+  expect(recorded).toMatchObject({
+    elementType: "timer",
+    elementName: "countdownA",
+    errorMessage: "callback-error",
+    errorName: "Error",
+    hasErrorInfo: true,
+  });
+});
+
+test("without onElementError, console.error and window.onerror still fire", async ({
+  mount,
+  page,
+}) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(err.message));
+  const stagebookErrors: string[] = [];
+  page.on("console", (msg) => {
+    if (msg.type() === "error" && msg.text().includes("[Stagebook]")) {
+      stagebookErrors.push(msg.text());
+    }
+  });
+
+  await mount(
+    <BoundaryTestHarness elementType="display" elementName="noCallback">
+      <CrashingChild message="no-callback-provided" />
+    </BoundaryTestHarness>,
+  );
+
+  await expect
+    .poll(() => pageErrors.length, { timeout: 2000 })
+    .toBeGreaterThanOrEqual(1);
+  expect(pageErrors).toContain("no-callback-provided");
+  expect(stagebookErrors.length).toBeGreaterThanOrEqual(1);
+});

--- a/packages/stagebook/src/components/ElementErrorBoundary.ct.tsx
+++ b/packages/stagebook/src/components/ElementErrorBoundary.ct.tsx
@@ -167,7 +167,7 @@ test("calls onElementError with structured payload when provided", async ({
     <BoundaryTestHarness
       elementType="timer"
       elementName="countdownA"
-      withCallback
+      callbackMode="record"
       crashMessage="callback-error"
     />,
   );
@@ -189,6 +189,36 @@ test("calls onElementError with structured payload when provided", async ({
     errorName: "Error",
     hasErrorInfo: true,
   });
+});
+
+test("throwing onElementError does not break containment or async re-throw", async ({
+  mount,
+  page,
+}) => {
+  const pageErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(err.message));
+
+  await mount(
+    <BoundaryTestHarness
+      elementType="prompt"
+      elementName="buggyHost"
+      callbackMode="throw"
+      crashMessage="original-crash-message"
+    />,
+  );
+
+  // Fallback still renders — a buggy host callback must not compromise
+  // the boundary's participant-facing UI.
+  await expect(
+    page.locator('[data-testid="element-error-fallback"]'),
+  ).toBeVisible();
+
+  // The original error still reaches window.onerror — not the callback's
+  // error — so crash reporters see the real crash.
+  await expect
+    .poll(() => pageErrors.length, { timeout: 2000 })
+    .toBeGreaterThanOrEqual(1);
+  expect(pageErrors).toContain("original-crash-message");
 });
 
 test("without onElementError, console.error and window.onerror still fire", async ({

--- a/packages/stagebook/src/components/ElementErrorBoundary.tsx
+++ b/packages/stagebook/src/components/ElementErrorBoundary.tsx
@@ -42,7 +42,19 @@ class ElementErrorBoundaryInner extends React.Component<
       errorInfo,
     });
 
-    onElementError?.({ elementType, elementName, error, errorInfo });
+    // Host-provided; isolate so a buggy crash reporter can't break
+    // Stagebook's containment guarantees (or prevent the async re-throw
+    // below from firing).
+    if (onElementError) {
+      try {
+        onElementError({ elementType, elementName, error, errorInfo });
+      } catch (callbackError) {
+        console.error(
+          "[Stagebook] onElementError callback threw; ignoring",
+          callbackError,
+        );
+      }
+    }
 
     // Async re-throw so `window.onerror` / sentry / any global handler sees
     // the original error. Scheduling it via setTimeout means React's error

--- a/packages/stagebook/src/components/ElementErrorBoundary.tsx
+++ b/packages/stagebook/src/components/ElementErrorBoundary.tsx
@@ -68,7 +68,7 @@ class ElementErrorBoundaryInner extends React.Component<
             fontSize: "0.875rem",
           }}
         >
-          Part of this page couldn&rsquo;t load. The rest is still usable.
+          Part of this page couldn&apos;t load. The rest is still usable.
         </div>
       );
     }

--- a/packages/stagebook/src/components/ElementErrorBoundary.tsx
+++ b/packages/stagebook/src/components/ElementErrorBoundary.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { useStagebookContext } from "./StagebookProvider.js";
+
+export interface ElementErrorInfo {
+  elementType: string;
+  elementName?: string;
+  error: Error;
+  errorInfo: React.ErrorInfo;
+}
+
+interface ElementErrorBoundaryInnerProps {
+  elementType: string;
+  elementName?: string;
+  onElementError?: (info: ElementErrorInfo) => void;
+  children: React.ReactNode;
+}
+
+interface ElementErrorBoundaryState {
+  hasError: boolean;
+}
+
+class ElementErrorBoundaryInner extends React.Component<
+  ElementErrorBoundaryInnerProps,
+  ElementErrorBoundaryState
+> {
+  state: ElementErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError(): ElementErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    const { elementType, elementName, onElementError } = this.props;
+    const label = elementName ? `${elementType} "${elementName}"` : elementType;
+
+    // Full technical payload — for researchers debugging locally without a
+    // configured crash reporter. Single call per crash.
+    console.error(`[Stagebook] Element ${label} crashed during render`, {
+      elementType,
+      elementName,
+      error,
+      errorInfo,
+    });
+
+    onElementError?.({ elementType, elementName, error, errorInfo });
+
+    // Async re-throw so `window.onerror` / sentry / any global handler sees
+    // the original error. Scheduling it via setTimeout means React's error
+    // boundary machinery has already unwound by the time the throw happens,
+    // so it propagates to the host's uncaught-error handler.
+    setTimeout(() => {
+      throw error;
+    }, 0);
+  }
+
+  render(): React.ReactNode {
+    if (this.state.hasError) {
+      return (
+        <div
+          role="alert"
+          data-testid="element-error-fallback"
+          style={{
+            padding: "0.75rem 1rem",
+            border: "1px solid var(--stagebook-danger, #dc2626)",
+            borderRadius: "0.375rem",
+            color: "var(--stagebook-danger, #dc2626)",
+            backgroundColor: "var(--stagebook-danger-bg, #fef2f2)",
+            fontSize: "0.875rem",
+          }}
+        >
+          Part of this page couldn&rsquo;t load. The rest is still usable.
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export interface ElementErrorBoundaryProps {
+  elementType: string;
+  elementName?: string;
+  children: React.ReactNode;
+}
+
+// Functional wrapper so we can read `onElementError` from the StagebookContext
+// via a hook and forward it to the class component (which can't use hooks).
+export function ElementErrorBoundary({
+  elementType,
+  elementName,
+  children,
+}: ElementErrorBoundaryProps) {
+  const { onElementError } = useStagebookContext();
+  return (
+    <ElementErrorBoundaryInner
+      elementType={elementType}
+      elementName={elementName}
+      onElementError={onElementError}
+    >
+      {children}
+    </ElementErrorBoundaryInner>
+  );
+}

--- a/packages/stagebook/src/components/Stage.tsx
+++ b/packages/stagebook/src/components/Stage.tsx
@@ -9,6 +9,7 @@ import { SubmissionConditionalRender } from "./conditions/SubmissionConditionalR
 import { ScrollIndicator } from "./scroll/ScrollIndicator.js";
 import { useScrollAwareness } from "./scroll/useScrollAwareness.js";
 import { PlaybackProvider } from "./playback/PlaybackProvider.js";
+import { ElementErrorBoundary } from "./ElementErrorBoundary.js";
 import type { DiscussionType } from "../schemas/treatment.js";
 import type { Condition } from "./conditions/ConditionsConditionalRender.js";
 
@@ -73,11 +74,16 @@ function WrappedElement({
               padding: "0.5rem 1rem",
             }}
           >
-            <Element
-              element={element}
-              onSubmit={onSubmit}
-              stageDuration={stageDuration}
-            />
+            <ElementErrorBoundary
+              elementType={element.type}
+              elementName={element.name}
+            >
+              <Element
+                element={element}
+                onSubmit={onSubmit}
+                stageDuration={stageDuration}
+              />
+            </ElementErrorBoundary>
           </div>
         </ConditionsConditionalRender>
       </PositionConditionalRender>

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -47,6 +47,17 @@ export interface StagebookContext {
     surveyName: string;
     onComplete: (results: unknown) => void;
   }) => React.ReactNode;
+
+  // Optional crash-reporting hook — called once per element render crash
+  // caught by ElementErrorBoundary, with a structured payload. This is a
+  // notification only; console.error and window.onerror still fire
+  // regardless of whether this is provided.
+  onElementError?: (info: {
+    elementType: string;
+    elementName?: string;
+    error: Error;
+    errorInfo: React.ErrorInfo;
+  }) => void;
 }
 
 // --------------- Internal context ---------------

--- a/packages/stagebook/src/components/index.ts
+++ b/packages/stagebook/src/components/index.ts
@@ -16,6 +16,11 @@ export {
 // Stage and element rendering (requires StagebookProvider)
 export { Stage, type StageConfig, type StageProps } from "./Stage.js";
 export { Element, type ElementConfig, type ElementProps } from "./Element.js";
+export {
+  ElementErrorBoundary,
+  type ElementErrorBoundaryProps,
+  type ElementErrorInfo,
+} from "./ElementErrorBoundary.js";
 
 // Standalone form components — no StagebookProvider required
 export {

--- a/packages/stagebook/src/components/testing/BoundaryTestHarness.tsx
+++ b/packages/stagebook/src/components/testing/BoundaryTestHarness.tsx
@@ -1,0 +1,131 @@
+/**
+ * Test harness for ElementErrorBoundary CT tests.
+ *
+ * Wraps children in a StagebookProvider with a minimal mock context so the
+ * boundary's `useStagebookContext()` call succeeds, and optionally wires an
+ * `onElementError` callback that records structured error payloads to
+ * `window.__stagebookElementErrors` for the test to inspect.
+ */
+import React from "react";
+import {
+  StagebookProvider,
+  type StagebookContext,
+} from "../StagebookProvider.js";
+import {
+  ElementErrorBoundary,
+  type ElementErrorInfo,
+} from "../ElementErrorBoundary.js";
+
+interface RecordedError {
+  elementType: string;
+  elementName?: string;
+  errorMessage: string;
+  errorName: string;
+  hasErrorInfo: boolean;
+}
+
+declare global {
+  interface Window {
+    __stagebookElementErrors?: RecordedError[];
+  }
+}
+
+function recordElementError(info: ElementErrorInfo): void {
+  window.__stagebookElementErrors ??= [];
+  window.__stagebookElementErrors.push({
+    elementType: info.elementType,
+    elementName: info.elementName,
+    errorMessage: info.error.message,
+    errorName: info.error.name,
+    hasErrorInfo: typeof info.errorInfo.componentStack === "string",
+  });
+}
+
+export interface BoundaryTestHarnessProps {
+  elementType: string;
+  elementName?: string;
+  withCallback?: boolean;
+  children: React.ReactNode;
+}
+
+export function BoundaryTestHarness({
+  elementType,
+  elementName,
+  withCallback = false,
+  children,
+}: BoundaryTestHarnessProps) {
+  const ctx: StagebookContext = {
+    get: () => [],
+    save: () => {},
+    getElapsedTime: () => 0,
+    submit: () => {},
+    getAssetURL: (p: string) => p,
+    getTextContent: () => Promise.resolve(""),
+    progressLabel: "test",
+    playerId: "p1",
+    position: 0,
+    playerCount: 1,
+    isSubmitted: false,
+    onElementError: withCallback ? recordElementError : undefined,
+  };
+
+  return (
+    <StagebookProvider value={ctx}>
+      <ElementErrorBoundary elementType={elementType} elementName={elementName}>
+        {children}
+      </ElementErrorBoundary>
+    </StagebookProvider>
+  );
+}
+
+export function CrashingChild({ message }: { message: string }) {
+  throw new Error(message);
+}
+
+export function SiblingLayout({
+  leftText,
+  rightText,
+  crashMessage,
+  elementNames,
+}: {
+  leftText: string;
+  rightText: string;
+  crashMessage: string;
+  elementNames: [string, string, string];
+}) {
+  const ctx: StagebookContext = {
+    get: () => [],
+    save: () => {},
+    getElapsedTime: () => 0,
+    submit: () => {},
+    getAssetURL: (p: string) => p,
+    getTextContent: () => Promise.resolve(""),
+    progressLabel: "test",
+    playerId: "p1",
+    position: 0,
+    playerCount: 1,
+    isSubmitted: false,
+  };
+  return (
+    <StagebookProvider value={ctx}>
+      <ElementErrorBoundary
+        elementType="markdown"
+        elementName={elementNames[0]}
+      >
+        <div data-testid="sibling-left">{leftText}</div>
+      </ElementErrorBoundary>
+      <ElementErrorBoundary
+        elementType="markdown"
+        elementName={elementNames[1]}
+      >
+        <CrashingChild message={crashMessage} />
+      </ElementErrorBoundary>
+      <ElementErrorBoundary
+        elementType="markdown"
+        elementName={elementNames[2]}
+      >
+        <div data-testid="sibling-right">{rightText}</div>
+      </ElementErrorBoundary>
+    </StagebookProvider>
+  );
+}

--- a/packages/stagebook/src/components/testing/BoundaryTestHarness.tsx
+++ b/packages/stagebook/src/components/testing/BoundaryTestHarness.tsx
@@ -1,10 +1,9 @@
 /**
  * Test harness for ElementErrorBoundary CT tests.
  *
- * Wraps children in a StagebookProvider with a minimal mock context so the
- * boundary's `useStagebookContext()` call succeeds, and optionally wires an
- * `onElementError` callback that records structured error payloads to
- * `window.__stagebookElementErrors` for the test to inspect.
+ * Constructs the full tree (StagebookProvider + ElementErrorBoundary + a
+ * controlled child) from simple serializable props so Playwright CT's JSX
+ * children transform doesn't affect the DOM under test.
  */
 import React from "react";
 import {
@@ -41,20 +40,8 @@ function recordElementError(info: ElementErrorInfo): void {
   });
 }
 
-export interface BoundaryTestHarnessProps {
-  elementType: string;
-  elementName?: string;
-  withCallback?: boolean;
-  children: React.ReactNode;
-}
-
-export function BoundaryTestHarness({
-  elementType,
-  elementName,
-  withCallback = false,
-  children,
-}: BoundaryTestHarnessProps) {
-  const ctx: StagebookContext = {
+function buildMockContext(withCallback: boolean): StagebookContext {
+  return {
     get: () => [],
     save: () => {},
     getElapsedTime: () => 0,
@@ -68,18 +55,46 @@ export function BoundaryTestHarness({
     isSubmitted: false,
     onElementError: withCallback ? recordElementError : undefined,
   };
+}
 
+function CrashingChild({ message }: { message: string }): React.ReactElement {
+  throw new Error(message);
+}
+
+export interface BoundaryTestHarnessProps {
+  elementType: string;
+  elementName?: string;
+  withCallback?: boolean;
+  /** If provided, the child throws with this message. Otherwise renders a happy child. */
+  crashMessage?: string;
+  happyText?: string;
+}
+
+export function BoundaryTestHarness({
+  elementType,
+  elementName,
+  withCallback = false,
+  crashMessage,
+  happyText = "happy-path-content",
+}: BoundaryTestHarnessProps) {
   return (
-    <StagebookProvider value={ctx}>
+    <StagebookProvider value={buildMockContext(withCallback)}>
       <ElementErrorBoundary elementType={elementType} elementName={elementName}>
-        {children}
+        {crashMessage !== undefined ? (
+          <CrashingChild message={crashMessage} />
+        ) : (
+          <p data-testid="happy-child">{happyText}</p>
+        )}
       </ElementErrorBoundary>
     </StagebookProvider>
   );
 }
 
-export function CrashingChild({ message }: { message: string }) {
-  throw new Error(message);
+export interface SiblingLayoutProps {
+  leftText: string;
+  rightText: string;
+  crashMessage: string;
+  elementNames: [string, string, string];
 }
 
 export function SiblingLayout({
@@ -87,27 +102,9 @@ export function SiblingLayout({
   rightText,
   crashMessage,
   elementNames,
-}: {
-  leftText: string;
-  rightText: string;
-  crashMessage: string;
-  elementNames: [string, string, string];
-}) {
-  const ctx: StagebookContext = {
-    get: () => [],
-    save: () => {},
-    getElapsedTime: () => 0,
-    submit: () => {},
-    getAssetURL: (p: string) => p,
-    getTextContent: () => Promise.resolve(""),
-    progressLabel: "test",
-    playerId: "p1",
-    position: 0,
-    playerCount: 1,
-    isSubmitted: false,
-  };
+}: SiblingLayoutProps) {
   return (
-    <StagebookProvider value={ctx}>
+    <StagebookProvider value={buildMockContext(false)}>
       <ElementErrorBoundary
         elementType="markdown"
         elementName={elementNames[0]}

--- a/packages/stagebook/src/components/testing/BoundaryTestHarness.tsx
+++ b/packages/stagebook/src/components/testing/BoundaryTestHarness.tsx
@@ -40,7 +40,19 @@ function recordElementError(info: ElementErrorInfo): void {
   });
 }
 
-function buildMockContext(withCallback: boolean): StagebookContext {
+function throwingCallback(): never {
+  throw new Error("callback-intentionally-throws");
+}
+
+function buildMockContext(
+  callbackMode: "none" | "record" | "throw",
+): StagebookContext {
+  const onElementError =
+    callbackMode === "record"
+      ? recordElementError
+      : callbackMode === "throw"
+        ? throwingCallback
+        : undefined;
   return {
     get: () => [],
     save: () => {},
@@ -53,7 +65,7 @@ function buildMockContext(withCallback: boolean): StagebookContext {
     position: 0,
     playerCount: 1,
     isSubmitted: false,
-    onElementError: withCallback ? recordElementError : undefined,
+    onElementError,
   };
 }
 
@@ -64,7 +76,7 @@ function CrashingChild({ message }: { message: string }): React.ReactElement {
 export interface BoundaryTestHarnessProps {
   elementType: string;
   elementName?: string;
-  withCallback?: boolean;
+  callbackMode?: "none" | "record" | "throw";
   /** If provided, the child throws with this message. Otherwise renders a happy child. */
   crashMessage?: string;
   happyText?: string;
@@ -73,12 +85,12 @@ export interface BoundaryTestHarnessProps {
 export function BoundaryTestHarness({
   elementType,
   elementName,
-  withCallback = false,
+  callbackMode = "none",
   crashMessage,
   happyText = "happy-path-content",
 }: BoundaryTestHarnessProps) {
   return (
-    <StagebookProvider value={buildMockContext(withCallback)}>
+    <StagebookProvider value={buildMockContext(callbackMode)}>
       <ElementErrorBoundary elementType={elementType} elementName={elementName}>
         {crashMessage !== undefined ? (
           <CrashingChild message={crashMessage} />
@@ -104,7 +116,7 @@ export function SiblingLayout({
   elementNames,
 }: SiblingLayoutProps) {
   return (
-    <StagebookProvider value={buildMockContext(false)}>
+    <StagebookProvider value={buildMockContext("none")}>
       <ElementErrorBoundary
         elementType="markdown"
         elementName={elementNames[0]}


### PR DESCRIPTION
Closes #21.

## Summary

Wraps every `<Element>` in `Stage.tsx` with a per-element error boundary so that a render crash in one element (bad props, unexpected data shape, misuse of hooks inside a third-party element) doesn't blank the whole stage.

- New `ElementErrorBoundary` class component with a functional wrapper that pulls optional `onElementError` from `StagebookContext`.
- Participant-facing fallback: gentle card ("Part of this page couldn't load. The rest is still usable."), no element type, element name, error message, or stack trace in the visible DOM.
- Single `console.error` per crash with the full technical payload (element type, name, error, errorInfo) for researchers debugging locally.
- Async `setTimeout(() => { throw error }, 0)` re-throw so `window.onerror` / `@sentry/browser` / `@sentry/react` see the crash without Stagebook depending on any SDK.
- New optional `onElementError(info)` callback on `StagebookContext` for host platforms that want a programmatic hook.
- Happy-path wrapper renders children directly (no extra DOM).

## Changes

- `packages/stagebook/src/components/ElementErrorBoundary.tsx` — new boundary.
- `packages/stagebook/src/components/StagebookProvider.tsx` — add optional `onElementError` to the context type.
- `packages/stagebook/src/components/Stage.tsx` — wrap `<Element>` inside the existing per-element wrapper div.
- `packages/stagebook/src/components/index.ts` — export the boundary + types.
- `packages/stagebook/src/components/testing/BoundaryTestHarness.tsx` — CT harness with a crashing child and a three-sibling layout.
- `packages/stagebook/src/components/ElementErrorBoundary.ct.tsx` — Playwright CT tests.

## Test plan

- [x] `npm run lint -w stagebook` — passes
- [x] `npm run format:check` — passes
- [x] `npm test -w stagebook` — 485 unit tests pass
- [x] `npm run build -w stagebook` — builds cleanly
- [ ] CI runs `test:ct` (Chromium isn't available in the dev sandbox). CT tests cover:
  - Happy-path children render without a visible wrapper
  - Participant-friendly fallback shown when a child throws
  - No technical detail leaks to participant DOM (no element type, name, or error message visible)
  - Sibling elements keep rendering when the middle one crashes (blast-radius containment)
  - Single `[Stagebook]` `console.error` with full payload
  - `pageerror` (i.e. `window.onerror`) fires via async re-throw
  - `onElementError` called once with structured payload when provided
  - Without `onElementError`, `console.error` and `window.onerror` still fire — no swallowed errors