### PR TITLE
Define missing --stagebook-* custom properties (#59)

### DIFF
--- a/packages/stagebook/src/components/elements/timeline/HelpPopover.tsx
+++ b/packages/stagebook/src/components/elements/timeline/HelpPopover.tsx
@@ -110,7 +110,7 @@ export function HelpPopover({ selectionType, onClose }: HelpPopoverProps) {
               </td>
               <td
                 style={{
-                  color: "var(--stagebook-muted, #6b7280)",
+                  color: "var(--stagebook-text-muted, #6b7280)",
                   verticalAlign: "top",
                 }}
               >

--- a/packages/stagebook/src/components/elements/timeline/TimeRuler.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimeRuler.tsx
@@ -53,7 +53,7 @@ export function TimeRuler({
         width: `${String(width)}px`,
         overflow: "hidden",
         fontSize: "0.625rem",
-        color: "var(--stagebook-muted, #9ca3af)",
+        color: "var(--stagebook-text-faint, #9ca3af)",
         userSelect: "none",
       }}
     >

--- a/packages/stagebook/src/components/elements/timeline/TimelineFooter.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineFooter.tsx
@@ -91,7 +91,7 @@ export function TimelineFooter({
         padding: "0.25rem 0.5rem",
         borderTop: "1px solid var(--stagebook-border, #e5e7eb)",
         fontSize: "0.75rem",
-        color: "var(--stagebook-muted, #6b7280)",
+        color: "var(--stagebook-text-muted, #6b7280)",
         userSelect: "none",
       }}
     >

--- a/packages/stagebook/src/components/elements/timeline/TimelineTrack.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineTrack.tsx
@@ -54,7 +54,7 @@ export function TimelineTrack({
           justifyContent: "flex-end",
           paddingRight: "0.5rem",
           fontSize: "0.6875rem",
-          color: "var(--stagebook-muted, #9ca3af)",
+          color: "var(--stagebook-text-faint, #9ca3af)",
           userSelect: "none",
           overflow: "hidden",
           textOverflow: "ellipsis",

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -74,8 +74,12 @@
 
   /* Borders and backgrounds */
   --stagebook-border: #d1d5db;
+  --stagebook-bg: #ffffff;
   --stagebook-bg-muted: #f9fafb;
   --stagebook-bg-track: #e5e7eb;
+
+  /* Timeline waveform bars */
+  --stagebook-waveform-color: #6b7280;
 
   /* Loading spinner */
   --stagebook-spinner-track: #e5e7eb;
@@ -95,8 +99,8 @@
   --stagebook-prompt-h4-weight: 600;
   --stagebook-link: #2563eb;
   --stagebook-code-bg: rgba(0, 0, 0, 0.06);
-  --stagebook-code-font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    monospace;
+  --stagebook-code-font:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 
   /* Blockquote (used by Display element and markdown blockquotes) */
   --stagebook-blockquote-border: #d1d5db;

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -59,6 +59,7 @@
   /* Status colors */
   --stagebook-success: #16a34a;
   --stagebook-danger: #ef4444;
+  --stagebook-danger-bg: #fef2f2;
   --stagebook-warning: #dc2626;
 
   /* Timer */

--- a/packages/stagebook/src/styles.test.ts
+++ b/packages/stagebook/src/styles.test.ts
@@ -17,11 +17,16 @@ function collectFiles(dir: string, out: string[] = []): string[] {
 }
 
 function extractDefined(css: string): Set<string> {
+  // Strip block comments first so documented override examples like
+  // `--stagebook-foo: ...` inside `/* ... */` aren't mistaken for real
+  // declarations.
+  const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, "");
+
   // Matches `--stagebook-foo:` (only declarations on the left-hand side).
   const defined = new Set<string>();
   const re = /(--stagebook-[\w-]+)\s*:/g;
   let m: RegExpExecArray | null;
-  while ((m = re.exec(css)) !== null) defined.add(m[1]);
+  while ((m = re.exec(cssWithoutComments)) !== null) defined.add(m[1]);
   return defined;
 }
 

--- a/packages/stagebook/src/styles.test.ts
+++ b/packages/stagebook/src/styles.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const stylesPath = join(here, "styles.css");
+const componentsDir = join(here, "components");
+
+function collectFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    if (statSync(p).isDirectory()) collectFiles(p, out);
+    else if (/\.(ts|tsx)$/.test(entry)) out.push(p);
+  }
+  return out;
+}
+
+function extractDefined(css: string): Set<string> {
+  // Matches `--stagebook-foo:` (only declarations on the left-hand side).
+  const defined = new Set<string>();
+  const re = /(--stagebook-[\w-]+)\s*:/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(css)) !== null) defined.add(m[1]);
+  return defined;
+}
+
+function extractReferenced(source: string): Set<string> {
+  // Only match names in real reference contexts: var(--name), getComputedStyle
+  // property lookups, or CSSProperties / inline-style object keys. This
+  // avoids false positives from prose comments like `--stagebook-prompt-*`.
+  const referenced = new Set<string>();
+  const patterns = [
+    /var\(\s*(--stagebook-[a-z0-9][a-z0-9-]*)/gi,
+    /getPropertyValue\(\s*["'](--stagebook-[a-z0-9][a-z0-9-]*)["']/gi,
+    /["'](--stagebook-[a-z0-9][a-z0-9-]*)["']\s*:/gi,
+  ];
+  for (const re of patterns) {
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(source)) !== null) referenced.add(m[1]);
+  }
+  return referenced;
+}
+
+describe("styles.css custom property coverage", () => {
+  it("defines every --stagebook-* property referenced by component sources", () => {
+    const css = readFileSync(stylesPath, "utf8");
+    const defined = extractDefined(css);
+
+    const files = collectFiles(componentsDir);
+    const offenders: { file: string; name: string }[] = [];
+    for (const file of files) {
+      const src = readFileSync(file, "utf8");
+      for (const name of extractReferenced(src)) {
+        if (!defined.has(name)) {
+          offenders.push({ file, name });
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #59. Timeline components referenced CSS custom properties that were never declared in `styles.css`. Nothing broke at runtime thanks to inline fallbacks, but theme overrides targeting those variables silently did nothing.

## Changes

- **`--stagebook-muted` → existing defined variables.** Each reference now points at the variable whose default matches the component's current fallback color, preserving the exact visual behavior when `styles.css` is imported:
  - `TimeRuler.tsx` and `TimelineTrack.tsx` (`#9ca3af` fallbacks) → `--stagebook-text-faint`
  - `TimelineFooter.tsx` and `HelpPopover.tsx` (`#6b7280` fallbacks) → `--stagebook-text-muted`
- **New declarations in `styles.css`** for variables that don't map to existing ones:
  - `--stagebook-bg: #ffffff` (popover/button surface — sits alongside `--stagebook-bg-muted` / `--stagebook-bg-track`)
  - `--stagebook-waveform-color: #6b7280` (read from `getComputedStyle` in `WaveformRenderer`)
- **Regression test** (`styles.test.ts`) that walks every component source and asserts each `var(--stagebook-*)`, `getPropertyValue("--stagebook-*")`, and `CSSProperties` key resolves to a declaration in `styles.css`.

Follows the issue's recommended Option B (align with existing naming) for the muted case, and the comment thread's recommendation for the waveform variable.

## Test plan

- [x] Red/green: test fails on the un-fixed tree listing exactly the 6 flagged references plus the waveform one, then passes after the edits.
- [x] `npm test` — stagebook 487, viewer 59, vscode 136 all pass.
- [x] `npm run lint` — zero warnings.
- [x] `npx prettier --check` — all source files match.
