### PR TITLE
Address hygiene fixes from issue #99

### DIFF
--- a/apps/viewer/src/lib/context.test.ts
+++ b/apps/viewer/src/lib/context.test.ts
@@ -62,12 +62,15 @@ describe("createViewerContext", () => {
       expect(values).toEqual([{ value: "a" }, { value: "b" }]);
     });
 
-    it("get with 'any' returns raw values from all positions", () => {
-      const { store, ctx } = makeContext();
-      store.save("prompt_q1", { value: "a" }, "player", 0, 0);
-      store.save("prompt_q1", { value: "b" }, "player", 1, 0);
-      const values = ctx.get("prompt_q1", "any");
-      expect(values).toEqual([{ value: "a" }, { value: "b" }]);
+    it("get with non-finite numeric scope falls back to current position", () => {
+      // Number("Infinity"), Number("-Infinity"), and negative numbers
+      // must not be accepted as position indices.
+      const { store, ctx } = makeContext({ position: 0 });
+      store.save("prompt_q1", { value: "own" }, "player", 0, 0);
+      expect(ctx.get("prompt_q1", "Infinity")).toEqual([{ value: "own" }]);
+      expect(ctx.get("prompt_q1", "-Infinity")).toEqual([{ value: "own" }]);
+      expect(ctx.get("prompt_q1", "-1")).toEqual([{ value: "own" }]);
+      expect(ctx.get("prompt_q1", "1.5")).toEqual([{ value: "own" }]);
     });
   });
 

--- a/apps/viewer/src/lib/context.ts
+++ b/apps/viewer/src/lib/context.ts
@@ -46,7 +46,7 @@ export function createViewerContext(
       if (typeof mapped === "number" || mapped === "shared") {
         return store.lookup(key, mapped);
       }
-      // "all", "any", "percentAgreement" → return from all player positions
+      // "all" → return from all player positions
       return store.lookup(key);
     },
 
@@ -88,15 +88,11 @@ function mapPosition(
   if (positionArg === "shared") {
     return "shared";
   }
-  if (
-    positionArg === "all" ||
-    positionArg === "any" ||
-    positionArg === "percentAgreement"
-  ) {
+  if (positionArg === "all") {
     return "all";
   }
   const num = Number(positionArg);
-  if (!Number.isNaN(num)) {
+  if (Number.isFinite(num) && Number.isInteger(num) && num >= 0) {
     return num;
   }
   return currentPosition;

--- a/docs/engineer/platform-requirements.md
+++ b/docs/engineer/platform-requirements.md
@@ -84,7 +84,7 @@ The platform stores this under the key `browserInfo` in player state.
 - `participantInfo.name` — nickname entered during onboarding
 - `participantInfo.sampleId` — identifier from recruiting platform
 
-The platform stores individual fields directly in player state (e.g., key `name` with the nickname value).
+The platform stores this under the key `participantInfo` in player state as a nested object (e.g., `{ name: "alice", sampleId: "P123" }`). Internally, Stagebook's `resolve("participantInfo.name")` calls `get("participantInfo")` and traverses `.name`.
 
 If these namespaces are not populated, conditions referencing them will evaluate to `undefined`, which causes the condition to return "can't determine yet" (not a hard failure).
 
@@ -114,6 +114,20 @@ The platform must:
 - Provide a `submit()` function that advances to the next step
 - Track the start time of each step (for `getElapsedTime()` — use `Date.now()`)
 - Set `progressLabel` to a unique identifier (e.g., `"intro_0_consent"`)
+
+### `progressLabel` Uniqueness (required)
+
+`progressLabel` must be **unique across every step of the experiment** (intro steps, every game stage, exit steps). Two distinct responsibilities rely on it:
+
+1. **Saved-record metadata.** Stagebook stamps `step: progressLabel` onto every value written via `save()`, so downstream analysis can attribute a response to the step where it was produced.
+2. **Auto-generated storage keys.** When a `prompt` element has no explicit `name`, Stagebook derives a storage key of the form `prompt_<progressLabel>_<file-metadata-name>`. Two steps sharing the same `progressLabel` will therefore derive the same storage key for a given prompt file — the second participant response silently overwrites the first with no error surfaced to the participant.
+
+Recommended schemes:
+- `"intro_<index>_<slug>"` for intro steps
+- `"game_<stageIndex>_<slug>"` for game stages
+- `"exit_<index>_<slug>"` for exit steps
+
+Collisions are difficult to detect after the fact because the saved-record metadata also gets overwritten, so treat `progressLabel` uniqueness as a hard invariant in the platform.
 
 ### Game Stages (synchronous, group)
 

--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -15,8 +15,10 @@ import { Prompt } from "./elements/Prompt.js";
 import { Qualtrics } from "./elements/Qualtrics.js";
 import { Loading } from "./form/Loading.js";
 
-// Resolve URL params for TrackedLink using the StagebookProvider's resolve
-function useResolvedParams(
+// Resolve URL params for TrackedLink using the StagebookProvider's resolve.
+// Plain function — no hooks — so it's safe to call conditionally (e.g. in
+// a switch case) without violating the Rules of Hooks.
+function resolveParams(
   urlParams:
     | Array<{
         key: string;
@@ -122,7 +124,7 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
     error: promptError,
   } = useTextContent(promptFile ?? "");
 
-  const resolvedParams = useResolvedParams(
+  const resolvedParams = resolveParams(
     element.type === "trackedLink" ? element.urlParams : undefined,
     resolve,
   );
@@ -326,7 +328,7 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
       );
 
     case "qualtrics": {
-      const qualtricsParams = useResolvedParams(element.urlParams, resolve);
+      const qualtricsParams = resolveParams(element.urlParams, resolve);
       return (
         <Qualtrics
           url={element.url ?? ""}

--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -15,7 +15,7 @@ import { Prompt } from "./elements/Prompt.js";
 import { Qualtrics } from "./elements/Qualtrics.js";
 import { Loading } from "./form/Loading.js";
 
-// Resolve URL params for TrackedLink using the StagebookProvider's resolve.
+// Resolve element URL params using the StagebookProvider's resolve.
 // Plain function — no hooks — so it's safe to call conditionally (e.g. in
 // a switch case) without violating the Rules of Hooks.
 function resolveParams(

--- a/packages/stagebook/src/components/StagebookProvider.test.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.test.tsx
@@ -193,6 +193,28 @@ describe("Provider-level resolve (get → resolve pipeline)", () => {
     unmount();
   });
 
+  test("normalizes 'any' scope to 'all' before calling get", () => {
+    // The platform's get() shouldn't need to understand condition
+    // evaluation semantics — "any" is a downstream concern.
+    const get = vi.fn(() => []);
+    const ctx = createMockContext({ get });
+
+    const { unmount } = renderUseResolve("prompt.q1", ctx, "any");
+
+    expect(get).toHaveBeenCalledWith("prompt_q1", "all");
+    unmount();
+  });
+
+  test("normalizes 'percentAgreement' scope to 'all' before calling get", () => {
+    const get = vi.fn(() => []);
+    const ctx = createMockContext({ get });
+
+    const { unmount } = renderUseResolve("prompt.q1", ctx, "percentAgreement");
+
+    expect(get).toHaveBeenCalledWith("prompt_q1", "all");
+    unmount();
+  });
+
   test("filters out undefined path results", () => {
     // Record exists but doesn't have the nested .value path
     const get = vi.fn(() => [{ name: "q1" }]);

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -10,8 +10,8 @@ import {
 
 export interface StagebookContext {
   // Look up raw stored values by storage key.
-  // scope: "player" (default), "shared", "all", "any", "percentAgreement",
-  // or a numeric string for a specific position.
+  // scope: "player" (default), "shared", "all", or a numeric string
+  // for a specific position.
   get(key: string, scope?: string): unknown[];
 
   // Write state under a DSL-derived key
@@ -41,7 +41,11 @@ export interface StagebookContext {
 
   // Platform-provided renderers for service-coupled elements
   renderDiscussion?: (config: DiscussionType) => React.ReactNode;
-  renderSharedNotepad?: (config: { padName: string }) => React.ReactNode;
+  renderSharedNotepad?: (config: {
+    padName: string;
+    defaultText?: string;
+    rows?: number;
+  }) => React.ReactNode;
   renderTalkMeter?: () => React.ReactNode;
   renderSurvey?: (config: {
     surveyName: string;
@@ -89,7 +93,14 @@ export function StagebookProvider({
         console.error(`Invalid reference: "${reference}"`);
         return [];
       }
-      const rawValues = value.get(referenceKey, position);
+      // "any" and "percentAgreement" are evaluation semantics applied
+      // downstream in evaluateCondition. The platform's get() only needs
+      // to know the storage scope, so we normalize both to "all" here.
+      const storageScope =
+        position === "any" || position === "percentAgreement"
+          ? "all"
+          : position;
+      const rawValues = value.get(referenceKey, storageScope);
       return rawValues
         .map((v) => getNestedValueByPath(v, path))
         .filter((v) => v !== undefined);

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -470,7 +470,6 @@ export const referenceSchema = z
         }
         break;
       case "discussion":
-      case "participantInfo":
       case "prompt":
       case "trackedLink":
         [, name] = arr;
@@ -485,6 +484,7 @@ export const referenceSchema = z
       case "urlParams":
       case "connectionInfo":
       case "browserInfo":
+      case "participantInfo":
         [, ...path] = arr;
         if (path.length < 1) {
           ctx.addIssue({

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -489,7 +489,7 @@ export const referenceSchema = z
         if (path.length < 1) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            message: `A path must be provided, e.g. '${givenType}.object.selectors.here.`,
+            message: `A path must be provided, e.g. '${givenType}.object.selectors.here'.`,
             path: [],
           });
         }

--- a/packages/stagebook/src/utils/evaluateConditions.test.ts
+++ b/packages/stagebook/src/utils/evaluateConditions.test.ts
@@ -223,6 +223,22 @@ describe("evaluateCondition", () => {
         ),
       ).toBe(true);
     });
+
+    test("response values matching Object.prototype keys count correctly", () => {
+      // Regression: the counts map must not inherit from Object.prototype,
+      // or responses like "constructor" produce NaN counts.
+      expect(
+        evaluateCondition(
+          {
+            reference: "prompt.q1",
+            position: "percentAgreement",
+            comparator: "equals",
+            value: 100,
+          },
+          ["constructor", "constructor", "constructor"],
+        ),
+      ).toBe(true);
+    });
   });
 
   describe("comparator edge cases", () => {

--- a/packages/stagebook/src/utils/evaluateConditions.ts
+++ b/packages/stagebook/src/utils/evaluateConditions.ts
@@ -27,7 +27,10 @@ export function evaluateCondition(
   }
 
   if (position === "percentAgreement") {
-    const counts: Record<string, number> = {};
+    // Use a null-prototype object so response values like "constructor"
+    // or "toString" don't collide with inherited properties and produce
+    // NaN counts.
+    const counts = Object.create(null) as Record<string, number>;
     const definedValues = referenceValues.filter((val) => val !== undefined);
 
     if (definedValues.length === 0) return false;

--- a/packages/stagebook/src/utils/reference.test.ts
+++ b/packages/stagebook/src/utils/reference.test.ts
@@ -88,6 +88,23 @@ describe("getReferenceKeyAndPath", () => {
   test("throws on missing name segment", () => {
     expect(() => getReferenceKeyAndPath("survey")).toThrow();
   });
+
+  test("throws on missing path segment for nested namespaces", () => {
+    // Keeps runtime parsing consistent with referenceSchema, which requires
+    // at least one path segment for these flat-namespace references.
+    expect(() => getReferenceKeyAndPath("participantInfo")).toThrow(
+      "missing a path segment",
+    );
+    expect(() => getReferenceKeyAndPath("connectionInfo")).toThrow(
+      "missing a path segment",
+    );
+    expect(() => getReferenceKeyAndPath("browserInfo")).toThrow(
+      "missing a path segment",
+    );
+    expect(() => getReferenceKeyAndPath("urlParams")).toThrow(
+      "missing a path segment",
+    );
+  });
 });
 
 // ----------- getNestedValueByPath ------------

--- a/packages/stagebook/src/utils/reference.test.ts
+++ b/packages/stagebook/src/utils/reference.test.ts
@@ -53,9 +53,18 @@ describe("getReferenceKeyAndPath", () => {
   });
 
   test("participantInfo reference", () => {
-    const result = getReferenceKeyAndPath("participantInfo.nickname.value");
-    expect(result.referenceKey).toBe("nickname");
-    expect(result.path).toEqual(["value"]);
+    // participantInfo uses the same flat-namespace pattern as connectionInfo
+    // and browserInfo — stored under a single `participantInfo` key with
+    // the field addressed via the nested path.
+    const result = getReferenceKeyAndPath("participantInfo.name");
+    expect(result.referenceKey).toBe("participantInfo");
+    expect(result.path).toEqual(["name"]);
+  });
+
+  test("participantInfo reference with deep path", () => {
+    const result = getReferenceKeyAndPath("participantInfo.sampleId.raw");
+    expect(result.referenceKey).toBe("participantInfo");
+    expect(result.path).toEqual(["sampleId", "raw"]);
   });
 
   test("timeline reference", () => {
@@ -102,5 +111,17 @@ describe("getNestedValueByPath", () => {
   test("default path is empty array", () => {
     const obj = { a: 1 };
     expect(getNestedValueByPath(obj)).toEqual({ a: 1 });
+  });
+
+  test("rejects prototype-polluting path segments", () => {
+    // Arbitrary reference paths must not be able to traverse into
+    // Object.prototype — these segments are denied even if present.
+    const obj = {};
+    expect(getNestedValueByPath(obj, ["__proto__"])).toBeUndefined();
+    expect(getNestedValueByPath(obj, ["constructor"])).toBeUndefined();
+    expect(getNestedValueByPath(obj, ["prototype"])).toBeUndefined();
+    expect(
+      getNestedValueByPath(obj, ["__proto__", "polluted"]),
+    ).toBeUndefined();
   });
 });

--- a/packages/stagebook/src/utils/reference.ts
+++ b/packages/stagebook/src/utils/reference.ts
@@ -1,14 +1,22 @@
+// Path segments that traverse into Object.prototype are rejected to prevent
+// accidental exposure of inherited properties (e.g. `constructor`) via
+// arbitrary reference strings. Read-only today, but the viewer's
+// StateInspector combines path traversal with writes — defence in depth.
+const DISALLOWED_PATH_SEGMENTS = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
 export function getNestedValueByPath(
   obj: unknown,
   path: string[] = [],
 ): unknown {
-  return path.reduce(
-    (acc: unknown, key: string) =>
-      acc !== null && acc !== undefined
-        ? (acc as Record<string, unknown>)[key]
-        : undefined,
-    obj,
-  );
+  return path.reduce((acc: unknown, key: string) => {
+    if (acc === null || acc === undefined) return undefined;
+    if (DISALLOWED_PATH_SEGMENTS.has(key)) return undefined;
+    return (acc as Record<string, unknown>)[key];
+  }, obj);
 }
 
 export interface ReferenceKeyAndPath {
@@ -33,10 +41,14 @@ export function getReferenceKeyAndPath(reference: string): ReferenceKeyAndPath {
   } else if (type === "trackedLink") {
     [name, ...path] = rest;
     referenceKey = `trackedLink_${name}`;
-  } else if (["urlParams", "connectionInfo", "browserInfo"].includes(type)) {
+  } else if (
+    ["urlParams", "connectionInfo", "browserInfo", "participantInfo"].includes(
+      type,
+    )
+  ) {
     path = rest;
     referenceKey = type;
-  } else if (["participantInfo", "discussion"].includes(type)) {
+  } else if (type === "discussion") {
     [name, ...path] = rest;
     referenceKey = name;
   } else {
@@ -53,7 +65,6 @@ export function getReferenceKeyAndPath(reference: string): ReferenceKeyAndPath {
         "timeline",
         "prompt",
         "trackedLink",
-        "participantInfo",
         "discussion",
       ].includes(type))
   ) {

--- a/packages/stagebook/src/utils/reference.ts
+++ b/packages/stagebook/src/utils/reference.ts
@@ -46,6 +46,9 @@ export function getReferenceKeyAndPath(reference: string): ReferenceKeyAndPath {
       type,
     )
   ) {
+    if (rest.length === 0) {
+      throw new Error(`Reference ${reference} is missing a path segment.`);
+    }
     path = rest;
     referenceKey = type;
   } else if (type === "discussion") {


### PR DESCRIPTION
Closes #99.

All 8 items from the issue are addressed. Breaking changes and design choices follow the decisions posted on the issue by @jamesphoughton.

## Interface / type hygiene

- `renderSharedNotepad` in `StagebookContext` now declares `defaultText?: string` and `rows?: number` so its type matches what `Prompt.tsx` actually passes.
- `useResolvedParams` → `resolveParams`. It's a plain function (no hook calls), so the `use` prefix was misleading and would have turned the conditional call site in the `qualtrics` case into a Rules-of-Hooks violation the moment it ever grew internal hooks.

## Platform contract cleanup

- `StagebookProvider.resolve()` now maps `"any"` and `"percentAgreement"` to `"all"` before calling `platform.get()`. Platforms now see a minimal scope vocabulary: `"player" | "shared" | "all" | numeric string`. Condition-evaluation semantics stay in `evaluateCondition()`, where the original position is still available on the condition object. The viewer's `mapPosition` is simplified accordingly.
- `participantInfo.<field>` now resolves to storage key `"participantInfo"` with nested path `[field, ...]`, matching `connectionInfo`/`browserInfo`. **Breaking change** — platforms must store participant info as a nested object under `participantInfo` instead of flat keys. Schema validation and `platform-requirements.md` are updated to match.
- Added a `progressLabel` uniqueness section to `docs/engineer/platform-requirements.md` explaining the hard invariant and why collisions silently overwrite data.

## Defense in depth

- `evaluateConditions.ts`: the `percentAgreement` counts map is now `Object.create(null)`, so response values like `"constructor"` or `"toString"` no longer inherit from `Object.prototype` and produce `NaN` counts. Regression test added.
- `context.ts` `mapPosition`: the numeric branch now requires `Number.isFinite(num) && Number.isInteger(num) && num >= 0`. `"Infinity"`, `"-Infinity"`, `"-1"`, and `"1.5"` fall through to the current position. Regression test added.
- `getNestedValueByPath`: path segments `__proto__`, `constructor`, `prototype` are denied. Read-only in this context, but `StateInspector` combines path traversal with writes, so it's a cheap defence-in-depth. Regression test added.

## Test plan

- [x] `npm test` — 685 tests across three workspaces, all pass
- [x] `npm run lint` — zero warnings
- [x] `npm run format:check` — clean
- [x] `npm run build -w stagebook` — succeeds, dts emitted