### PR TITLE
Apply ref pattern to unstable callback dependencies (#105)

### DIFF
--- a/docs/engineer/platform-requirements.md
+++ b/docs/engineer/platform-requirements.md
@@ -99,6 +99,33 @@ Stagebook components are tested against modern browsers. The platform should ver
 
 Mobile devices are not supported for interactive experiments with video/audio. The platform should detect and block mobile browsers during onboarding.
 
+### Callback Stability (recommended)
+
+The methods the platform provides on `StagebookContext` — `get`, `save`, `getTextContent`, `getAssetURL`, `getElapsedTime`, `submit`, and the optional `render*` slots — are safest when their identities are stable across renders.
+
+Stagebook internally protects against unstable callback identities (it stores these references in refs so effects and event listeners aren't torn down and re-registered each render). But stable callbacks still help in a few ways:
+
+- Prompt components that read state via `get()` re-run resolution whenever the context identity changes. A stable context object (same `get` identity across renders) lets React skip work.
+- Platform-side React devtools and profiling are easier to read when the context value isn't churning.
+- If a future Stagebook component is written without the defensive ref pattern, stable callbacks are what keeps it correct.
+
+The simplest way to get stable references is to wrap each method in `useCallback` (or define it outside the render, or on a class) and memoize the final context object with `useMemo`:
+
+```tsx
+const save = useCallback((key, value, scope) => { /* ... */ }, [/* store deps */]);
+const get = useCallback((key, scope) => { /* ... */ }, [/* store deps */]);
+const getTextContent = useCallback((path) => fetch(resolve(path)), []);
+
+const ctx = useMemo<StagebookContext>(() => ({
+  get, save, getTextContent, getAssetURL, getElapsedTime, submit,
+  progressLabel, playerId, position, playerCount, isSubmitted,
+}), [get, save, getTextContent, /* ... */]);
+
+return <StagebookProvider value={ctx}>{children}</StagebookProvider>;
+```
+
+This is a recommendation, not a hard requirement — Stagebook will behave correctly either way.
+
 ---
 
 ## 2. Stage Orchestration (required)

--- a/packages/stagebook/src/components/StagebookProvider.test.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.test.tsx
@@ -326,4 +326,60 @@ describe("useTextContent", () => {
     expect(result.current.error).toBeUndefined();
     unmount();
   });
+
+  // Regression for #105: useTextContent previously listed `getTextContent`
+  // in its effect deps. If the platform rebuilds its StagebookContext each
+  // render (very common) and does not wrap `getTextContent` in `useCallback`,
+  // the effect re-fires every render — refetching content on every parent
+  // state change. The ref pattern fixes this.
+  test("does not refetch when getTextContent identity changes but path is stable", async () => {
+    const container = document.createElement("div");
+    let root: Root;
+    const result = { current: undefined as unknown as TextContentResult };
+    const getTextContent = vi.fn(() => Promise.resolve("# Hello"));
+    // Rebuild the context object each render — same underlying function,
+    // different outer identity. Because `get` is wrapped but `getTextContent`
+    // is not, the resolved context returns a new getTextContent ref each render.
+    function makeCtx(): StagebookContext {
+      return createMockContext({
+        // fresh identity per invocation
+        getTextContent: (p: string) => getTextContent(p),
+      });
+    }
+
+    function Harness(): ReactNode {
+      result.current = useTextContent("prompts/hello.md");
+      return null;
+    }
+
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <StagebookProvider value={makeCtx()}>
+          <Harness />
+        </StagebookProvider>,
+      );
+    });
+    await act(() => Promise.resolve());
+
+    expect(getTextContent).toHaveBeenCalledTimes(1);
+
+    // Force re-renders with fresh getTextContent identities
+    for (let i = 0; i < 5; i++) {
+      act(() => {
+        root.render(
+          <StagebookProvider value={makeCtx()}>
+            <Harness />
+          </StagebookProvider>,
+        );
+      });
+      await act(() => Promise.resolve());
+    }
+
+    // Path never changed — effect must not refetch just because
+    // getTextContent changed identity
+    expect(getTextContent).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+  });
 });

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -1,5 +1,11 @@
 /* eslint-disable @typescript-eslint/unbound-method */
-import React, { createContext, useContext, useState, useEffect } from "react";
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useRef,
+} from "react";
 import type { DiscussionType } from "../schemas/treatment.js";
 import {
   getReferenceKeyAndPath,
@@ -140,6 +146,12 @@ export function useTextContent(path: string): TextContentResult {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | undefined>(undefined);
 
+  // Ref `getTextContent` so a rebuilt StagebookContext (fresh function
+  // identity each render) doesn't cause the fetch effect to re-fire and
+  // refetch content on every parent re-render (#105).
+  const getTextContentRef = useRef(getTextContent);
+  getTextContentRef.current = getTextContent;
+
   useEffect(() => {
     if (!path) {
       setData(undefined);
@@ -152,7 +164,8 @@ export function useTextContent(path: string): TextContentResult {
     setIsLoading(true);
     setError(undefined);
 
-    getTextContent(path)
+    getTextContentRef
+      .current(path)
       .then((text) => {
         if (!cancelled) {
           setData(text);
@@ -169,7 +182,7 @@ export function useTextContent(path: string): TextContentResult {
     return () => {
       cancelled = true;
     };
-  }, [path, getTextContent]);
+  }, [path]);
 
   return { data, isLoading, error };
 }

--- a/packages/stagebook/src/components/elements/AudioElement.test.tsx
+++ b/packages/stagebook/src/components/elements/AudioElement.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import React, { type ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { AudioElement } from "./AudioElement.js";
+
+// Track addEventListener / removeEventListener calls on Audio instances.
+let audioAddSpy: ReturnType<typeof vi.spyOn>;
+let audioRemoveSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  // jsdom provides window.Audio but no real decoding — the "canplaythrough"
+  // event is never fired, which is fine for this test: we only care about
+  // effect churn (setup/teardown of listeners), not playback itself.
+  audioAddSpy = vi.spyOn(window.HTMLMediaElement.prototype, "addEventListener");
+  audioRemoveSpy = vi.spyOn(
+    window.HTMLMediaElement.prototype,
+    "removeEventListener",
+  );
+});
+
+afterEach(() => {
+  audioAddSpy.mockRestore();
+  audioRemoveSpy.mockRestore();
+});
+
+describe("AudioElement — unstable callback audit (#105)", () => {
+  test("does not churn canplaythrough listener when save is unstable", () => {
+    const container = document.createElement("div");
+    let root: Root;
+
+    function Parent({ tick }: { tick: number }): ReactNode {
+      void tick;
+      // Fresh inline callback every render — worst case for effect dep stability
+      return (
+        <AudioElement
+          src="https://example.com/chime.mp3"
+          save={(_k, _v) => {}}
+          name="chime"
+        />
+      );
+    }
+
+    act(() => {
+      root = createRoot(container);
+      root.render(<Parent tick={0} />);
+    });
+
+    const addCallsAfterMount = audioAddSpy.mock.calls.filter(
+      ([type]) => type === "canplaythrough",
+    ).length;
+    const removeCallsAfterMount = audioRemoveSpy.mock.calls.filter(
+      ([type]) => type === "canplaythrough",
+    ).length;
+
+    // Re-render several times with fresh save references
+    for (let i = 1; i <= 5; i++) {
+      act(() => {
+        root.render(<Parent tick={i} />);
+      });
+    }
+
+    const addCallsAfterReRender = audioAddSpy.mock.calls.filter(
+      ([type]) => type === "canplaythrough",
+    ).length;
+    const removeCallsAfterReRender = audioRemoveSpy.mock.calls.filter(
+      ([type]) => type === "canplaythrough",
+    ).length;
+
+    // The listener should not be torn down and re-added on every re-render
+    expect(addCallsAfterReRender).toBe(addCallsAfterMount);
+    expect(removeCallsAfterReRender).toBe(removeCallsAfterMount);
+
+    act(() => root.unmount());
+  });
+});

--- a/packages/stagebook/src/components/elements/AudioElement.tsx
+++ b/packages/stagebook/src/components/elements/AudioElement.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 export interface AudioElementProps {
   src: string;
@@ -7,6 +7,11 @@ export interface AudioElementProps {
 }
 
 export function AudioElement({ src, save, name }: AudioElementProps) {
+  // Ref `save` so the effect below isn't torn down and re-set up whenever
+  // the parent passes a fresh save callback (#105).
+  const saveRef = useRef(save);
+  saveRef.current = save;
+
   useEffect(() => {
     if (!src) return undefined;
 
@@ -18,11 +23,15 @@ export function AudioElement({ src, save, name }: AudioElementProps) {
         .play()
         .then(() => {
           console.log(`[AudioElement] Playing: ${src}`);
-          save?.(key, { event: "play", src });
+          saveRef.current?.(key, { event: "play", src });
         })
         .catch((err: Error) => {
           console.warn(`[AudioElement] Play failed: ${src}`, err.message);
-          save?.(key, { event: "playFailed", src, error: err.message });
+          saveRef.current?.(key, {
+            event: "playFailed",
+            src,
+            error: err.message,
+          });
         });
     };
 
@@ -33,7 +42,7 @@ export function AudioElement({ src, save, name }: AudioElementProps) {
       sound.pause();
       sound.src = "";
     };
-  }, [src, save, name]);
+  }, [src, name]);
 
   return null;
 }

--- a/packages/stagebook/src/components/elements/MediaPlayer.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.tsx
@@ -124,6 +124,19 @@ export function MediaPlayer({
   const videoRef = useRef<HTMLVideoElement>(null);
   const autoplayAttemptedRef = useRef(false);
 
+  // Ref unstable callbacks so `recordEvent`, `handleEnded`, and
+  // `handleTimeUpdate` stay identity-stable even when the parent passes
+  // fresh `save` / `onComplete` / `getElapsedTime` references (#105).
+  // `handleTimeUpdate` in particular fires every animation frame during
+  // playback — re-creating its closure on every render cascades through
+  // every JSX handler tied to the <video> element.
+  const saveRef = useRef(save);
+  saveRef.current = save;
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+  const getElapsedTimeRef = useRef(getElapsedTime);
+  getElapsedTimeRef.current = getElapsedTime;
+
   const [isPaused, setIsPaused] = useState(true);
   const [showPlayOnce, setShowPlayOnce] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
@@ -401,7 +414,8 @@ export function MediaPlayer({
   useEffect(() => {
     if (!videoRef.current) return;
     if (syncToStageTime) {
-      videoRef.current.currentTime = getElapsedTime() + (startAt ?? 0);
+      videoRef.current.currentTime =
+        getElapsedTimeRef.current() + (startAt ?? 0);
     } else if (startAt !== undefined) {
       videoRef.current.currentTime = startAt;
     }
@@ -432,7 +446,7 @@ export function MediaPlayer({
       const event: VideoEvent = {
         type,
         videoTime,
-        stageTimeElapsed: getElapsedTime(),
+        stageTimeElapsed: getElapsedTimeRef.current(),
         ...extra,
       };
       eventsRef.current = [...eventsRef.current, event];
@@ -445,9 +459,9 @@ export function MediaPlayer({
         lastVideoTime: videoTime,
         watchedRanges: computeWatchedRanges(eventsRef.current),
       };
-      save(saveKey, record);
+      saveRef.current(saveKey, record);
     },
-    [getElapsedTime, name, url, startAt, stopAt, save, saveKey],
+    [name, url, startAt, stopAt, saveKey],
   );
 
   const handlePlay = useCallback(
@@ -478,10 +492,10 @@ export function MediaPlayer({
       setIsPaused(true);
       recordEvent("ended", e.currentTarget.currentTime);
       if (submitOnComplete) {
-        onComplete?.();
+        onCompleteRef.current?.();
       }
     },
-    [recordEvent, submitOnComplete, onComplete],
+    [recordEvent, submitOnComplete],
   );
 
   const handleLoadedMetadata = useCallback(
@@ -559,7 +573,7 @@ export function MediaPlayer({
         stopAtReachedRef.current = true;
         e.currentTarget.pause(); // fires "pause" event; handlePause suppresses it
         recordEvent("stopAt", ct);
-        if (submitOnComplete) onComplete?.();
+        if (submitOnComplete) onCompleteRef.current?.();
         return;
       }
 
@@ -569,7 +583,7 @@ export function MediaPlayer({
         setCaptionText(active?.text ?? null);
       }
     },
-    [stopAt, cues, recordEvent, submitOnComplete, onComplete],
+    [stopAt, cues, recordEvent, submitOnComplete],
   );
 
   // Clamp seek target to allowed range — works for both HTML5 and YouTube
@@ -1004,7 +1018,7 @@ export function MediaPlayer({
               if (stopAtReachedRef.current) {
                 stopAtReachedRef.current = false;
                 recordEvent("stopAt", t);
-                if (submitOnComplete) onComplete?.();
+                if (submitOnComplete) onCompleteRef.current?.();
                 return;
               }
               recordEvent("pause", t);
@@ -1013,7 +1027,7 @@ export function MediaPlayer({
               setIsPaused(true);
               setCurrentTime(t);
               recordEvent("ended", t);
-              if (submitOnComplete) onComplete?.();
+              if (submitOnComplete) onCompleteRef.current?.();
             }}
           />
           {ytControlsVisible && (

--- a/packages/stagebook/src/components/elements/Qualtrics.test.tsx
+++ b/packages/stagebook/src/components/elements/Qualtrics.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+import { describe, test, expect, vi } from "vitest";
+import React, { type ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Qualtrics } from "./Qualtrics.js";
+
+// Spy on window.addEventListener / removeEventListener for "message"
+function installMessageListenerSpy() {
+  const addSpy = vi.spyOn(window, "addEventListener");
+  const removeSpy = vi.spyOn(window, "removeEventListener");
+  return {
+    addCalls: () =>
+      addSpy.mock.calls.filter(([type]) => type === "message").length,
+    removeCalls: () =>
+      removeSpy.mock.calls.filter(([type]) => type === "message").length,
+    restore: () => {
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    },
+  };
+}
+
+describe("Qualtrics — unstable callback audit (#105)", () => {
+  test("does not churn the message listener when save/onComplete are unstable", () => {
+    const spy = installMessageListenerSpy();
+    const container = document.createElement("div");
+    let root: Root;
+
+    // Parent re-renders and always passes fresh inline callbacks —
+    // the worst case for effect dependency stability.
+    function Parent({ tick }: { tick: number }): ReactNode {
+      void tick;
+      return (
+        <Qualtrics
+          url="https://example.qualtrics.com/jfe/form/SV_abc"
+          save={(_key, _value) => {}}
+          onComplete={() => {}}
+        />
+      );
+    }
+
+    act(() => {
+      root = createRoot(container);
+      root.render(<Parent tick={0} />);
+    });
+
+    // Force several re-renders with fresh callback references
+    for (let i = 1; i <= 5; i++) {
+      act(() => {
+        root.render(<Parent tick={i} />);
+      });
+    }
+
+    // Effect setup should run once on mount; fresh callback refs must not
+    // cause teardown/re-setup of the window "message" listener.
+    expect(spy.addCalls()).toBe(1);
+    expect(spy.removeCalls()).toBe(0);
+
+    act(() => root.unmount());
+    spy.restore();
+  });
+
+  test("still reads the latest onComplete / save when the message arrives", () => {
+    const container = document.createElement("div");
+    let root: Root;
+    const saveV1 = vi.fn();
+    const saveV2 = vi.fn();
+    const onCompleteV1 = vi.fn();
+    const onCompleteV2 = vi.fn();
+
+    function Parent({
+      save,
+      onComplete,
+    }: {
+      save: typeof saveV1;
+      onComplete: typeof onCompleteV1;
+    }): ReactNode {
+      return (
+        <Qualtrics
+          url="https://example.qualtrics.com/jfe/form/SV_abc"
+          save={save}
+          onComplete={onComplete}
+        />
+      );
+    }
+
+    act(() => {
+      root = createRoot(container);
+      root.render(<Parent save={saveV1} onComplete={onCompleteV1} />);
+    });
+
+    // Swap both callbacks on a re-render
+    act(() => {
+      root.render(<Parent save={saveV2} onComplete={onCompleteV2} />);
+    });
+
+    // Dispatch a synthetic Qualtrics EOS message
+    act(() => {
+      const event = new MessageEvent("message", {
+        data: "QualtricsEOS|SV_abc|session123",
+        origin: "https://example.qualtrics.com",
+      });
+      window.dispatchEvent(event);
+    });
+
+    // The latest callbacks should have been invoked, not the stale ones
+    expect(saveV1).not.toHaveBeenCalled();
+    expect(onCompleteV1).not.toHaveBeenCalled();
+    expect(saveV2).toHaveBeenCalledWith("qualtricsDataReady", {
+      surveyURL: "https://example.qualtrics.com/jfe/form/SV_abc",
+      surveyId: "SV_abc",
+      sessionId: "session123",
+    });
+    expect(onCompleteV2).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+  });
+});

--- a/packages/stagebook/src/components/elements/Qualtrics.tsx
+++ b/packages/stagebook/src/components/elements/Qualtrics.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 
 export interface ResolvedParam {
   key: string;
@@ -22,6 +22,15 @@ export function Qualtrics({
   save,
   onComplete,
 }: QualtricsProps) {
+  // Ref unstable callbacks so the listener-registration effect below
+  // doesn't tear down and re-add on every parent re-render (#105).
+  const saveRef = useRef(save);
+  saveRef.current = save;
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+  const urlRef = useRef(url);
+  urlRef.current = url;
+
   // Listen for Qualtrics end-of-survey message.
   // Validates origin to prevent spoofed messages from non-Qualtrics sources.
   // Checks *.qualtrics.com to handle datacenter redirects.
@@ -38,18 +47,18 @@ export function Qualtrics({
       const data: unknown = event.data;
       if (typeof data === "string" && data.startsWith("QualtricsEOS")) {
         const [, surveyId, sessionId] = data.split("|");
-        save("qualtricsDataReady", {
-          surveyURL: url,
+        saveRef.current("qualtricsDataReady", {
+          surveyURL: urlRef.current,
           surveyId,
           sessionId,
         });
-        onComplete();
+        onCompleteRef.current();
       }
     };
 
     window.addEventListener("message", onMessage);
     return () => window.removeEventListener("message", onMessage);
-  }, [url, save, onComplete]);
+  }, []);
 
   // Build the full URL with resolved params + standard identifiers
   const fullURL = useMemo(() => {

--- a/packages/stagebook/src/components/elements/Timeline.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.tsx
@@ -116,6 +116,12 @@ export function Timeline({
   const [containerWidth, setContainerWidth] = useState(0);
   const [currentTime, setCurrentTime] = useState(0);
 
+  // Ref `save` so the save-on-change effect below doesn't re-run (and
+  // potentially double-save) whenever the parent passes a fresh callback
+  // identity (#105).
+  const saveRef = useRef(save);
+  saveRef.current = save;
+
   // Callback ref: measures the container immediately on attach. Works
   // regardless of mount order — unlike useEffect, a callback ref fires when
   // React attaches the DOM element, even if the component re-renders later
@@ -201,12 +207,12 @@ export function Timeline({
       debounceNextSaveRef.current = false;
       saveTimerRef.current = setTimeout(() => {
         lastSavedRef.current = serialized;
-        save(`timeline_${name}`, state.selections);
+        saveRef.current(`timeline_${name}`, state.selections);
         saveTimerRef.current = null;
       }, 500);
     } else {
       lastSavedRef.current = serialized;
-      save(`timeline_${name}`, state.selections);
+      saveRef.current(`timeline_${name}`, state.selections);
     }
 
     return () => {
@@ -215,7 +221,7 @@ export function Timeline({
         saveTimerRef.current = null;
       }
     };
-  }, [state.selections, isDragging, name, save]);
+  }, [state.selections, isDragging, name]);
 
   // Measure container width. Read from getBoundingClientRect on every render
   // via a callback ref, and observe with ResizeObserver for ongoing updates.

--- a/packages/stagebook/src/components/elements/timeline/HelpPopover.test.tsx
+++ b/packages/stagebook/src/components/elements/timeline/HelpPopover.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { describe, test, expect, vi } from "vitest";
+import React, { type ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { HelpPopover } from "./HelpPopover.js";
+
+function installDocumentListenerSpy() {
+  const addSpy = vi.spyOn(document, "addEventListener");
+  const removeSpy = vi.spyOn(document, "removeEventListener");
+  return {
+    addCalls: (type: string) =>
+      addSpy.mock.calls.filter(([t]) => t === type).length,
+    removeCalls: (type: string) =>
+      removeSpy.mock.calls.filter(([t]) => t === type).length,
+    restore: () => {
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    },
+  };
+}
+
+describe("HelpPopover — unstable callback audit (#105)", () => {
+  test("does not churn document listeners when onClose is unstable", () => {
+    const spy = installDocumentListenerSpy();
+    const container = document.createElement("div");
+    let root: Root;
+
+    function Parent({ tick }: { tick: number }): ReactNode {
+      void tick;
+      // Fresh inline onClose every render
+      return <HelpPopover selectionType="range" onClose={() => {}} />;
+    }
+
+    act(() => {
+      root = createRoot(container);
+      root.render(<Parent tick={0} />);
+    });
+
+    const keyAddsAfterMount = spy.addCalls("keydown");
+    const mouseAddsAfterMount = spy.addCalls("mousedown");
+
+    for (let i = 1; i <= 5; i++) {
+      act(() => {
+        root.render(<Parent tick={i} />);
+      });
+    }
+
+    // No re-registration should occur from onClose identity changes
+    expect(spy.addCalls("keydown")).toBe(keyAddsAfterMount);
+    expect(spy.addCalls("mousedown")).toBe(mouseAddsAfterMount);
+    expect(spy.removeCalls("keydown")).toBe(0);
+    expect(spy.removeCalls("mousedown")).toBe(0);
+
+    act(() => root.unmount());
+    spy.restore();
+  });
+
+  test("Escape invokes the latest onClose after re-render", () => {
+    const container = document.createElement("div");
+    let root: Root;
+    const onCloseV1 = vi.fn();
+    const onCloseV2 = vi.fn();
+
+    function Parent({ onClose }: { onClose: () => void }): ReactNode {
+      return <HelpPopover selectionType="range" onClose={onClose} />;
+    }
+
+    act(() => {
+      root = createRoot(container);
+      root.render(<Parent onClose={onCloseV1} />);
+    });
+
+    act(() => {
+      root.render(<Parent onClose={onCloseV2} />);
+    });
+
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    });
+
+    expect(onCloseV1).not.toHaveBeenCalled();
+    expect(onCloseV2).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+  });
+});

--- a/packages/stagebook/src/components/elements/timeline/HelpPopover.tsx
+++ b/packages/stagebook/src/components/elements/timeline/HelpPopover.tsx
@@ -33,12 +33,17 @@ export function HelpPopover({ selectionType, onClose }: HelpPopoverProps) {
   const popoverRef = useRef<HTMLDivElement>(null);
   const shortcuts = selectionType === "range" ? rangeShortcuts : pointShortcuts;
 
+  // Ref `onClose` so the listener effect doesn't re-register document
+  // listeners when the parent passes a fresh callback identity (#105).
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
   // Close on Escape and click-outside
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
       if (e.key === "Escape") {
         e.stopPropagation();
-        onClose();
+        onCloseRef.current();
       }
     }
     function onClick(e: MouseEvent) {
@@ -46,7 +51,7 @@ export function HelpPopover({ selectionType, onClose }: HelpPopoverProps) {
         popoverRef.current &&
         !popoverRef.current.contains(e.target as Node)
       ) {
-        onClose();
+        onCloseRef.current();
       }
     }
     document.addEventListener("keydown", onKey, true);
@@ -57,7 +62,7 @@ export function HelpPopover({ selectionType, onClose }: HelpPopoverProps) {
       document.removeEventListener("keydown", onKey, true);
       document.removeEventListener("mousedown", onClick, true);
     };
-  }, [onClose]);
+  }, []);
 
   return (
     <div


### PR DESCRIPTION
Closes #105.

## Summary

Audit and mitigation for the latent render-loop risks flagged after the #103 fix. Every site the issue called out now stores the unstable callback in a `useRef`, reads `ref.current` inside the effect/handler, and drops the callback from the dependency array. Behavior is unchanged when parents already stabilize callbacks — components are now also defensive against parents that don't.

## Sites fixed

**High risk — effect depends on potentially unstable callback**

- `Qualtrics.tsx` (l. 52) — effect previously re-added its window `"message"` listener on every render when `save` / `onComplete` were unstable.
- `MediaPlayer.tsx` (ll. 450, 484, 572) — `recordEvent`, `handleEnded`, `handleTimeUpdate`, and the YouTube `onPause` / `onEnded` handlers depended on `save` / `onComplete` / `getElapsedTime`. `handleTimeUpdate` fires every animation frame during playback — churning its closure cascaded to every JSX handler tied to the `<video>` element.
- `AudioElement.tsx` (l. 36) — the single effect set up a `canplaythrough` listener on a fresh `Audio` instance; unstable `save` tore it down every render.
- `Timeline.tsx` (l. 218) — selection-save effect re-ran on every render when `save` was unstable; could double-save across renders.

**Moderate risk — context function as dependency**

- `StagebookProvider.tsx` / `useTextContent` (l. 172) — refetched content every render if the platform rebuilt its context without `useCallback`-ing `getTextContent`.
- `HelpPopover.tsx` (l. 60) — re-registered document `keydown` / `mousedown` listeners every render on unstable `onClose`.

## Approach

Used the ref pattern recommended by the issue (approach 1), matching the #103 fix:

```ts
const saveRef = useRef(save);
saveRef.current = save;

useEffect(() => {
  // read saveRef.current inside
}, [/* other deps, but not save */]);
```

This is the most defensive option — it works regardless of whether the parent memoizes the callback.

## Tests (red → green)

New regression tests for each tractable site. Each drives multiple re-renders with fresh inline callback identities and asserts the effect sets up exactly once. For `Qualtrics` and `HelpPopover`, a companion test confirms the *latest* callback is still invoked when the event eventually arrives (so refs are read, not closed-over).

- `packages/stagebook/src/components/elements/Qualtrics.test.tsx` (new)
- `packages/stagebook/src/components/elements/AudioElement.test.tsx` (new)
- `packages/stagebook/src/components/elements/timeline/HelpPopover.test.tsx` (new)
- `packages/stagebook/src/components/StagebookProvider.test.tsx` — added `useTextContent` case with a rebuilt context on every render

Each new test was observed to **fail on the unpatched tree** (6 setup calls instead of 1, or 6 fetches instead of 1) and pass after the ref-pattern edits.

## Test plan

- [x] `npm test` — stagebook 491, viewer 59, vscode 136 all pass
- [x] `npm run lint` — clean (zero warnings)
- [x] `npm run format:check` — clean
- [x] `npm run build -w stagebook` — succeeds
- [ ] Playwright CT — runs in CI (not available in sandbox)

## Notes

- `MediaPlayer.handleTimeUpdate` and `handleEnded` keep their `recordEvent` / `submitOnComplete` / `stopAt` / `cues` deps (still needed) but drop `onComplete`.
- `MediaPlayer.recordEvent` keeps `name` / `url` / `startAt` / `stopAt` / `saveKey` and drops `save` + `getElapsedTime`.
- `Timeline` effect keeps `state.selections` / `isDragging` / `name` and drops `save`.
- `useTextContent` effect keeps `path` and drops `getTextContent`.
- `HelpPopover` effect now has `[]` deps (everything it reads is either stable state or a ref).
