### PR TITLE
Accept `timeline.*` references in referenceSchema (#131)

### DIFF
--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -59,6 +59,28 @@ test("reference tracked link with name", () => {
   expect(result.success).toBe(true);
 });
 
+test("reference timeline with name", () => {
+  const reference = "timeline.storySegment";
+  const result = referenceSchema.safeParse(reference);
+  if (!result.success) console.log(result.error);
+  expect(result.success).toBe(true);
+});
+
+test("reference timeline with nested path", () => {
+  const reference = "timeline.storySegment.0.start";
+  const result = referenceSchema.safeParse(reference);
+  if (!result.success) console.log(result.error);
+  expect(result.success).toBe(true);
+});
+
+test("reference timeline with no name", () => {
+  const reference = "timeline";
+  const result = referenceSchema.safeParse(reference);
+  if (!result.success)
+    console.log(result.error.message, "\npath:", result.error.path);
+  expect(result.success).toBe(false);
+});
+
 // ----------- Condition Schema ------------
 
 test("validCondition", () => {

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -79,6 +79,9 @@ test("reference timeline with no name", () => {
   if (!result.success)
     console.log(result.error.message, "\npath:", result.error.path);
   expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(result.error.issues[0].message).toContain("A name must be provided");
+  }
 });
 
 // ----------- Condition Schema ------------

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -471,6 +471,7 @@ export const referenceSchema = z
         break;
       case "discussion":
       case "prompt":
+      case "timeline":
       case "trackedLink":
         [, name] = arr;
         if (name === undefined || name.length < 1) {
@@ -497,7 +498,7 @@ export const referenceSchema = z
       default:
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: `Invalid reference type "${givenType}", need to be in form of a valid reference type such as 'survey', 'submitButton', 'qualtrics', 'discussion', 'participantInfo', 'prompt', 'urlParams', 'connectionInfo', or 'browserInfo' followed by a . and name or path.`,
+          message: `Invalid reference type "${givenType}", need to be in form of a valid reference type such as 'survey', 'submitButton', 'qualtrics', 'discussion', 'participantInfo', 'prompt', 'timeline', 'trackedLink', 'urlParams', 'connectionInfo', or 'browserInfo' followed by a . and name or path.`,
           path: [],
         });
     }


### PR DESCRIPTION
Closes #131.

## Summary

The `referenceSchema` switch in `packages/stagebook/src/schemas/treatment.ts` predated the `timeline` element, so valid `timeline.*` references fell through to the `default` branch and were rejected at validation time — even though the runtime resolver (`packages/stagebook/src/utils/reference.ts`) already supports them.

## Changes

- Add `case "timeline":` alongside `discussion`/`prompt`/`trackedLink` in `referenceSchema` (name required, optional path — matches how timeline is resolved).
- Refresh the `default`-case error message to include `timeline` and `trackedLink` (`trackedLink` was already a valid case but missing from the list).
- Three new unit tests in `treatment.test.ts`:
  - `timeline.storySegment` — bare reference, passes
  - `timeline.storySegment.0.start` — nested path, passes
  - `timeline` alone — still fails with "name must be provided"

## Audit of other reference types

Compared the schema's `switch` cases against the resolver's `if/else if` chain. The schema handles every type the resolver handles *except* `timeline`, which this PR fixes. No other drift.

## Test plan

- [x] `npm test` — stagebook 524 (was 521, +3), viewer 68, vscode 136, all pass
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
