### PR TITLE
Align semantic tokens with raw source for quoted YAML scalars (#132)

### DIFF
--- a/apps/vscode/src/lib/semanticTokens.test.ts
+++ b/apps/vscode/src/lib/semanticTokens.test.ts
@@ -231,6 +231,118 @@ duration: 300`;
     });
   });
 
+  describe("quoted YAML scalars", () => {
+    it("aligns token for double-quoted element type", () => {
+      const src = `type: "prompt"`;
+      const tokens = computeSemanticTokens(src);
+      const typeTokens = tokens.filter((t) => t.tokenType === "type");
+      expect(typeTokens).toHaveLength(1);
+      expect(typeTokens[0]).toMatchObject({
+        line: 0,
+        startCol: 7,
+        length: 6,
+        text: "prompt",
+      });
+    });
+
+    it("aligns token for single-quoted element type", () => {
+      const src = `type: 'prompt'`;
+      const tokens = computeSemanticTokens(src);
+      const typeTokens = tokens.filter((t) => t.tokenType === "type");
+      expect(typeTokens).toHaveLength(1);
+      expect(typeTokens[0]).toMatchObject({
+        line: 0,
+        startCol: 7,
+        length: 6,
+        text: "prompt",
+      });
+    });
+
+    it("aligns token for double-quoted file path", () => {
+      const src = `file: "prompts/q1.prompt.md"`;
+      const tokens = computeSemanticTokens(src);
+      const fileTokens = tokens.filter((t) => t.tokenType === "string");
+      expect(fileTokens).toHaveLength(1);
+      expect(fileTokens[0]).toMatchObject({
+        line: 0,
+        startCol: 7,
+        length: 20,
+        text: "prompts/q1.prompt.md",
+      });
+    });
+
+    it("aligns token for single-quoted file path", () => {
+      const src = `file: 'prompts/q1.prompt.md'`;
+      const tokens = computeSemanticTokens(src);
+      const fileTokens = tokens.filter((t) => t.tokenType === "string");
+      expect(fileTokens).toHaveLength(1);
+      expect(fileTokens[0]).toMatchObject({
+        line: 0,
+        startCol: 7,
+        length: 20,
+        text: "prompts/q1.prompt.md",
+      });
+    });
+
+    it("aligns token for double-quoted reference", () => {
+      const src = `reference: "prompt.q1"`;
+      const tokens = computeSemanticTokens(src);
+      const refTokens = tokens.filter((t) => t.tokenType === "variable");
+      expect(refTokens).toHaveLength(1);
+      expect(refTokens[0]).toMatchObject({
+        line: 0,
+        startCol: 12,
+        length: 9,
+        text: "prompt.q1",
+      });
+    });
+
+    it("aligns token for double-quoted comparator", () => {
+      const src = `comparator: "equals"`;
+      const tokens = computeSemanticTokens(src);
+      const compTokens = tokens.filter((t) => t.tokenType === "keyword");
+      expect(compTokens).toHaveLength(1);
+      expect(compTokens[0]).toMatchObject({
+        line: 0,
+        startCol: 13,
+        length: 6,
+        text: "equals",
+      });
+    });
+
+    it("aligns template-var tokens inside a double-quoted file path", () => {
+      const src = `file: "projects/\${topic}/q1.prompt.md"`;
+      const tokens = computeSemanticTokens(src);
+      const fileTokens = tokens.filter((t) => t.tokenType === "string");
+      const varTokens = tokens.filter((t) => t.tokenType === "variable");
+      expect(fileTokens).toHaveLength(2);
+      expect(fileTokens[0]).toMatchObject({
+        startCol: 7,
+        text: "projects/",
+      });
+      expect(varTokens).toHaveLength(1);
+      expect(varTokens[0]).toMatchObject({
+        startCol: 16,
+        length: 8,
+        text: "${topic}",
+      });
+      expect(fileTokens[1]).toMatchObject({ text: "/q1.prompt.md" });
+    });
+
+    it("aligns template-var tokens inside a double-quoted non-file value", () => {
+      const src = `name: "\${topic}_suffix"`;
+      const tokens = computeSemanticTokens(src);
+      const varTokens = tokens.filter((t) => t.tokenType === "variable");
+      expect(varTokens).toHaveLength(1);
+      expect(varTokens[0]).toMatchObject({
+        line: 0,
+        startCol: 7,
+        length: 8,
+        text: "${topic}",
+      });
+    });
+  });
+
   describe("mixed content", () => {
     it("handles a realistic treatment snippet", () => {
       const src = `treatments:

--- a/apps/vscode/src/lib/semanticTokens.ts
+++ b/apps/vscode/src/lib/semanticTokens.ts
@@ -119,6 +119,28 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
     });
   }
 
+  /**
+   * Get the on-disk text and starting offset of a scalar value, with the
+   * surrounding quotes stripped for `"..."` / `'...'` scalars. The yaml
+   * library's `range` spans the whole quoted form while `value.value` holds
+   * only the unquoted content, so deriving both text and offset from the raw
+   * source slice keeps semantic tokens aligned with what the user typed.
+   */
+  function getScalarSource(
+    range: [number, number, number] | undefined,
+  ): { offset: number; text: string } | null {
+    if (!range) return null;
+    const raw = source.slice(range[0], range[1]);
+    if (
+      raw.length >= 2 &&
+      ((raw[0] === '"' && raw[raw.length - 1] === '"') ||
+        (raw[0] === "'" && raw[raw.length - 1] === "'"))
+    ) {
+      return { offset: range[0] + 1, text: raw.slice(1, -1) };
+    }
+    return { offset: range[0], text: raw };
+  }
+
   const TEMPLATE_VAR_RE = /\$\{[a-zA-Z0-9_]+\}/g;
 
   /**
@@ -179,79 +201,82 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
         if (isScalar(key) && typeof key.value === "string") {
           const k = key.value;
 
+          const scalarSrc =
+            isScalar(value) && typeof value.value === "string"
+              ? getScalarSource(value.range)
+              : null;
+
           if (
             k === "type" &&
             isScalar(value) &&
             typeof value.value === "string" &&
-            value.range
+            scalarSrc
           ) {
             if (elementTypeSet.has(value.value)) {
-              addToken(value.range[0], value.value, "type");
+              addToken(scalarSrc.offset, scalarSrc.text, "type");
             }
           } else if (
             k === "comparator" &&
             isScalar(value) &&
             typeof value.value === "string" &&
-            value.range
+            scalarSrc
           ) {
             if (comparatorSet.has(value.value)) {
-              addToken(value.range[0], value.value, "keyword");
+              addToken(scalarSrc.offset, scalarSrc.text, "keyword");
             }
           } else if (
             k === "reference" &&
             isScalar(value) &&
             typeof value.value === "string" &&
-            value.range
+            scalarSrc
           ) {
             const refType = value.value.split(".")[0];
             if (referenceTypeSet.has(refType)) {
-              addToken(value.range[0], value.value, "variable");
+              addToken(scalarSrc.offset, scalarSrc.text, "variable");
             }
           } else if (
             k === "file" &&
             isScalar(value) &&
             typeof value.value === "string" &&
-            value.range
+            scalarSrc
           ) {
-            addFilePathTokens(value.range[0], value.value);
+            addFilePathTokens(scalarSrc.offset, scalarSrc.text);
           } else if (
             k === "contentType" &&
             isScalar(value) &&
             typeof value.value === "string" &&
-            value.range &&
+            scalarSrc &&
             contentTypeSet.has(value.value)
           ) {
-            addToken(value.range[0], value.value, "type");
+            addToken(scalarSrc.offset, scalarSrc.text, "type");
           } else if (
             k === "style" &&
             isScalar(value) &&
             typeof value.value === "string" &&
-            value.range &&
+            scalarSrc &&
             separatorStyles.has(value.value)
           ) {
-            addToken(value.range[0], value.value, "keyword");
+            addToken(scalarSrc.offset, scalarSrc.text, "keyword");
           } else if (
             (k === "position" || k === "chatType") &&
             isScalar(value) &&
             typeof value.value === "string" &&
-            value.range &&
+            scalarSrc &&
             enumValues.has(value.value)
           ) {
-            addToken(value.range[0], value.value, "keyword");
+            addToken(scalarSrc.offset, scalarSrc.text, "keyword");
           }
 
           // For any other scalar value containing ${...} placeholders,
           // emit variable tokens so template fields are highlighted
           // consistently everywhere they appear.
           if (
-            isScalar(value) &&
-            typeof value.value === "string" &&
-            value.range &&
+            scalarSrc &&
+            k !== "file" && // file paths already handled above
             ((TEMPLATE_VAR_RE.lastIndex = 0),
-            TEMPLATE_VAR_RE.test(value.value)) &&
-            k !== "file" // file paths already handled above
+            TEMPLATE_VAR_RE.test(scalarSrc.text))
           ) {
-            emitTemplateVarTokens(value.range[0], value.value);
+            emitTemplateVarTokens(scalarSrc.offset, scalarSrc.text);
           }
 
           // Recurse into the value


### PR DESCRIPTION
Closes #132.

## Problem

`computeSemanticTokens` in `apps/vscode/src/lib/semanticTokens.ts` emitted each token at `value.range[0]` with `value.value` as the text. For quoted YAML scalars the `yaml` library's `range` spans the surrounding quotes while `value.value` holds only the content, so every highlight was shifted one character to the left and one character short at the end:

```yaml
type: "prompt"           # token landed on `"prompt`, not `prompt`
file: "path/to/file.md"  # same shift
```

## Fix

Added a small `getScalarSource(range)` helper that reads `source.slice(range[0], range[1])` and, when the slice starts and ends with a matching `"` or `'`, strips the pair and bumps the offset by one. All call sites that previously used `(value.range[0], value.value)` now use `(scalarSrc.offset, scalarSrc.text)` — including the `file:` path splitter and the generic `${...}` template-variable emitter — so the on-screen token lines up with what the user typed regardless of quoting style. Set-membership checks (`elementTypeSet.has(...)`, etc.) still run against `value.value` so only semantically valid values are highlighted.

## Test plan

- [x] 8 new unit tests in `semanticTokens.test.ts` covering double-quoted and single-quoted variants of `type`, `file`, `reference`, `comparator`, plus template-var splitting inside a double-quoted file path and a double-quoted non-file value. All went red before the fix, green after.
- [x] `npm test` — stagebook 518, viewer 68, vscode 144 (↑8) — all pass.
- [x] `npm run lint` — zero warnings.
- [x] `npm run format:check` — clean.
