### PR TITLE
Migrate hardcoded styles.css values to --stagebook-* tokens (#116)

### DIFF
--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -84,17 +84,19 @@
    * from the page background (e.g., darker cards on a white page). */
   --stagebook-surface: #fff;
 
-  /* Focus ring (derived from the primary color). Defaults to a 25% alpha
-   * version of the primary via color-mix; hosts that override
-   * --stagebook-primary get a matched focus ring automatically. Hosts can
-   * also override this token directly for a custom ring color. Browsers
-   * that don't support color-mix fall through to the var() fallback at the
-   * usage site. */
-  --stagebook-focus-ring: color-mix(
-    in srgb,
-    var(--stagebook-primary) 25%,
-    transparent
-  );
+  /* Focus ring. Default is a static rgba tint of the primary color so
+   * browsers without color-mix support still get a visible focus ring.
+   * In browsers that support color-mix, the @supports block below upgrades
+   * the token to a live 25% mix of --stagebook-primary, so overriding the
+   * primary token automatically retunes the focus ring. Hosts can always
+   * override this token directly for a fully custom ring color.
+   *
+   * Why not define it as color-mix() unconditionally: custom-property
+   * substitution is validated at computed-value time, so if color-mix()
+   * isn't supported the whole box-shadow declaration becomes invalid and
+   * the var() fallback at the usage site does NOT apply — the focus ring
+   * would just disappear. */
+  --stagebook-focus-ring: rgba(59, 130, 246, 0.25);
 
   /* Timeline waveform bars */
   --stagebook-waveform-color: #6b7280;
@@ -123,6 +125,19 @@
   /* Blockquote (used by Display element and markdown blockquotes) */
   --stagebook-blockquote-border: #d1d5db;
   --stagebook-blockquote-bg: #f9fafb;
+}
+
+/* Upgrade the focus ring to a live mix of --stagebook-primary only on
+ * browsers that support color-mix; otherwise the static rgba default
+ * above continues to apply. Feature-queried on the exact syntax used. */
+@supports (color: color-mix(in srgb, red, blue)) {
+  :root {
+    --stagebook-focus-ring: color-mix(
+      in srgb,
+      var(--stagebook-primary) 25%,
+      transparent
+    );
+  }
 }
 
 /* ------------------------------------------------------------------ */

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -79,6 +79,23 @@
   --stagebook-bg-muted: #f9fafb;
   --stagebook-bg-track: #e5e7eb;
 
+  /* Form control surface (input, textarea, select, checkbox, radio). Kept
+   * distinct from --stagebook-bg so hosts can tint form controls separately
+   * from the page background (e.g., darker cards on a white page). */
+  --stagebook-surface: #fff;
+
+  /* Focus ring (derived from the primary color). Defaults to a 25% alpha
+   * version of the primary via color-mix; hosts that override
+   * --stagebook-primary get a matched focus ring automatically. Hosts can
+   * also override this token directly for a custom ring color. Browsers
+   * that don't support color-mix fall through to the var() fallback at the
+   * usage site. */
+  --stagebook-focus-ring: color-mix(
+    in srgb,
+    var(--stagebook-primary) 25%,
+    transparent
+  );
+
   /* Timeline waveform bars */
   --stagebook-waveform-color: #6b7280;
 
@@ -153,13 +170,13 @@ input[type="tel"],
 textarea,
 select {
   appearance: none;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--stagebook-border, #d1d5db);
   border-radius: 0.375rem;
   padding: 0.5rem 0.75rem;
   font-size: 0.875rem;
   line-height: 1.25rem;
-  color: #1f2937;
-  background-color: #fff;
+  color: var(--stagebook-text, #1f2937);
+  background-color: var(--stagebook-surface, #fff);
 }
 
 input[type="text"]:focus,
@@ -172,8 +189,8 @@ input[type="tel"]:focus,
 textarea:focus,
 select:focus {
   outline: none;
-  border-color: #3b82f6;
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+  border-color: var(--stagebook-primary, #3b82f6);
+  box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
 }
 
 input[type="checkbox"],
@@ -181,9 +198,9 @@ input[type="radio"] {
   appearance: none;
   width: 1rem;
   height: 1rem;
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--stagebook-border, #d1d5db);
   border-radius: 0.125rem;
-  background-color: #fff;
+  background-color: var(--stagebook-surface, #fff);
   vertical-align: middle;
   cursor: pointer;
 }
@@ -194,8 +211,8 @@ input[type="radio"] {
 
 input[type="checkbox"]:checked,
 input[type="radio"]:checked {
-  background-color: #3b82f6;
-  border-color: #3b82f6;
+  background-color: var(--stagebook-primary, #3b82f6);
+  border-color: var(--stagebook-primary, #3b82f6);
   background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
   background-size: 100% 100%;
   background-position: center;
@@ -209,7 +226,7 @@ input[type="radio"]:checked {
 input[type="checkbox"]:focus,
 input[type="radio"]:focus {
   outline: none;
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+  box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
 }
 
 /* Remove number input spinners */
@@ -240,12 +257,12 @@ table {
   border-collapse: collapse;
   margin: 1rem 0;
   width: 100%;
-  max-width: 36rem;
+  max-width: var(--stagebook-prompt-max-width, 36rem);
 }
 
 th,
 td {
-  border: 1px solid #d1d5db;
+  border: 1px solid var(--stagebook-border, #d1d5db);
   padding: 0.5rem 0.75rem;
   text-align: left;
   font-size: 0.875rem;
@@ -253,7 +270,7 @@ td {
 }
 
 th {
-  background-color: #f9fafb;
+  background-color: var(--stagebook-bg-muted, #f9fafb);
   font-weight: 500;
   color: #1a202c;
 }

--- a/packages/stagebook/src/styles.test.ts
+++ b/packages/stagebook/src/styles.test.ts
@@ -75,13 +75,17 @@ describe("styles.css uses theme variables for hardcoded values (#116)", () => {
   const css = readFileSync(stylesPath, "utf8");
 
   // Strip the :root declaration block so we only look at rule bodies —
-  // otherwise the token declarations themselves would always match.
+  // otherwise the token declarations themselves would always match. Guard
+  // every index: if :root is renamed or deleted, indexOf returns -1 and
+  // the resulting slice would be silently wrong, causing bare-literal
+  // assertions to pass when they shouldn't.
   const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, "");
-  const rootOpenIdx = cssWithoutComments.indexOf(
-    "{",
-    cssWithoutComments.indexOf(":root"),
-  );
+  const rootSelectorIdx = cssWithoutComments.indexOf(":root");
+  expect(rootSelectorIdx).toBeGreaterThanOrEqual(0);
+  const rootOpenIdx = cssWithoutComments.indexOf("{", rootSelectorIdx);
+  expect(rootOpenIdx).toBeGreaterThanOrEqual(0);
   const rootCloseIdx = cssWithoutComments.indexOf("}", rootOpenIdx);
+  expect(rootCloseIdx).toBeGreaterThanOrEqual(0);
   const outsideRoot =
     cssWithoutComments.slice(0, rootOpenIdx) +
     cssWithoutComments.slice(rootCloseIdx + 1);
@@ -110,11 +114,13 @@ describe("styles.css uses theme variables for hardcoded values (#116)", () => {
 
   it("derives focus ring box-shadow from --stagebook-primary", () => {
     // Either direct reference to --stagebook-primary, or to the derived
-    // --stagebook-focus-ring token (which is defined at :root as a
-    // color-mix of --stagebook-primary).
-    const focusRingToken =
+    // --stagebook-focus-ring token. The focus-ring token must itself be
+    // derivable from --stagebook-primary, either unconditionally OR inside
+    // an @supports(color-mix) override — the unconditional default may be
+    // a static rgba so browsers without color-mix keep a visible ring.
+    const focusRingDerivesFromPrimary =
       /--stagebook-focus-ring\s*:\s*color-mix\([^)]*var\(--stagebook-primary/;
-    expect(css).toMatch(focusRingToken);
+    expect(css).toMatch(focusRingDerivesFromPrimary);
     expect(outsideRoot).toMatch(
       /box-shadow:[^;]*var\(--stagebook-(?:primary|focus-ring)/,
     );
@@ -141,7 +147,33 @@ describe("styles.css uses theme variables for hardcoded values (#116)", () => {
   // is missing, so hosts that override --stagebook-primary get their value.
   // What we want to catch is bare literal uses that bypass the variable
   // entirely.
-  const stripVarCalls = (s: string) => s.replace(/var\([^)]*\)/g, "");
+  //
+  // A naive /var\([^)]*\)/ regex would mis-handle nested parens in
+  // fallbacks like `var(--x, rgba(0,0,0,0.5))`, so scan with a balanced
+  // paren counter instead.
+  const stripVarCalls = (s: string): string => {
+    let out = "";
+    for (let i = 0; i < s.length; i += 1) {
+      if (s.startsWith("var(", i)) {
+        let depth = 0;
+        let j = i;
+        for (; j < s.length; j += 1) {
+          const ch = s[j];
+          if (ch === "(") depth += 1;
+          else if (ch === ")") {
+            depth -= 1;
+            if (depth === 0) break;
+          }
+        }
+        if (j < s.length && depth === 0) {
+          i = j;
+          continue;
+        }
+      }
+      out += s[i];
+    }
+    return out;
+  };
 
   it("has no bare literal #3b82f6 references outside :root and var() fallbacks", () => {
     expect(stripVarCalls(outsideRoot)).not.toMatch(/#3b82f6\b/i);

--- a/packages/stagebook/src/styles.test.ts
+++ b/packages/stagebook/src/styles.test.ts
@@ -66,3 +66,90 @@ describe("styles.css custom property coverage", () => {
     expect(offenders).toEqual([]);
   });
 });
+
+// Issue #116: form resets, focus rings, and table styles previously
+// hardcoded values instead of referencing the --stagebook-* tokens declared
+// at :root. These tests pin the migration so hardcoded values can't sneak
+// back in and drift from the themeable surface.
+describe("styles.css uses theme variables for hardcoded values (#116)", () => {
+  const css = readFileSync(stylesPath, "utf8");
+
+  // Strip the :root declaration block so we only look at rule bodies —
+  // otherwise the token declarations themselves would always match.
+  const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, "");
+  const rootOpenIdx = cssWithoutComments.indexOf(
+    "{",
+    cssWithoutComments.indexOf(":root"),
+  );
+  const rootCloseIdx = cssWithoutComments.indexOf("}", rootOpenIdx);
+  const outsideRoot =
+    cssWithoutComments.slice(0, rootOpenIdx) +
+    cssWithoutComments.slice(rootCloseIdx + 1);
+
+  it("declares a --stagebook-surface token for form control backgrounds", () => {
+    expect(css).toMatch(/--stagebook-surface\s*:/);
+  });
+
+  it.each([
+    ["var(--stagebook-border, #d1d5db)", "form/table border"],
+    ["var(--stagebook-text, #1f2937)", "form text color"],
+    ["var(--stagebook-surface, #fff)", "form control background"],
+    ["var(--stagebook-prompt-max-width, 36rem)", "table max-width"],
+    ["var(--stagebook-bg-muted, #f9fafb)", "table header background"],
+  ])("references %s (%s)", (needle) => {
+    expect(css).toContain(needle);
+  });
+
+  it("derives focus ring border-color from --stagebook-primary", () => {
+    // focus blocks appear after :root — they must reference the primary token
+    // rather than the literal #3b82f6.
+    expect(outsideRoot).toMatch(
+      /border-color:\s*var\(--stagebook-primary[^)]*\)/,
+    );
+  });
+
+  it("derives focus ring box-shadow from --stagebook-primary", () => {
+    // Either direct reference to --stagebook-primary, or to the derived
+    // --stagebook-focus-ring token (which is defined at :root as a
+    // color-mix of --stagebook-primary).
+    const focusRingToken =
+      /--stagebook-focus-ring\s*:\s*color-mix\([^)]*var\(--stagebook-primary/;
+    expect(css).toMatch(focusRingToken);
+    expect(outsideRoot).toMatch(
+      /box-shadow:[^;]*var\(--stagebook-(?:primary|focus-ring)/,
+    );
+  });
+
+  it("uses --stagebook-primary for checkbox/radio checked fill", () => {
+    // Find the :checked rule and assert it references the primary token for
+    // both background-color and border-color.
+    const checkedBlock =
+      /input\[type="checkbox"\]:checked,\s*input\[type="radio"\]:checked\s*\{([\s\S]+?)\}/.exec(
+        outsideRoot,
+      );
+    expect(checkedBlock?.[1]).toBeDefined();
+    expect(checkedBlock?.[1]).toMatch(
+      /background-color:\s*var\(--stagebook-primary/,
+    );
+    expect(checkedBlock?.[1]).toMatch(
+      /border-color:\s*var\(--stagebook-primary/,
+    );
+  });
+
+  // The literal-value checks strip `var(--token, fallback)` calls first: the
+  // fallback is the *documented* fallback and only resolves when the variable
+  // is missing, so hosts that override --stagebook-primary get their value.
+  // What we want to catch is bare literal uses that bypass the variable
+  // entirely.
+  const stripVarCalls = (s: string) => s.replace(/var\([^)]*\)/g, "");
+
+  it("has no bare literal #3b82f6 references outside :root and var() fallbacks", () => {
+    expect(stripVarCalls(outsideRoot)).not.toMatch(/#3b82f6\b/i);
+  });
+
+  it("has no bare literal rgba(59, 130, 246, ...) references outside :root and var() fallbacks", () => {
+    expect(stripVarCalls(outsideRoot)).not.toMatch(
+      /rgba\(\s*59\s*,\s*130\s*,\s*246/,
+    );
+  });
+});


### PR DESCRIPTION
Closes #116.

## Summary

Form resets, focus rings, and table styles in `packages/stagebook/src/styles.css` hardcoded colors and spacing instead of referencing the `--stagebook-*` tokens declared at `:root`. Now that Tailwind has been removed and `styles.css` is consumed directly by hosts, hardcoded values bypass the themeable surface.

Each changed declaration now uses `var(--stagebook-token, <literal>)` — matching the convention used throughout the React components — so hosts that override a token at `:root` get consistent theming, and hosts that don't import `styles.css` still render correctly via the literal fallback.

## New tokens added at `:root`

- **`--stagebook-surface`** (defaults to `#fff`) — form control background. Kept distinct from `--stagebook-bg` so hosts can tint form controls separately from the page background.
- **`--stagebook-focus-ring`** — 25% alpha of `--stagebook-primary` computed via `color-mix(in srgb, var(--stagebook-primary) 25%, transparent)`. Hosts that override `--stagebook-primary` get a matched focus ring automatically. Hosts can also override this token directly for a custom ring color. Browsers without `color-mix` support fall through to the `rgba(...)` fallback at the usage site.

## Migrations

| Declaration | Before | After |
|-------------|--------|-------|
| Form input `border` color | `#d1d5db` | `var(--stagebook-border, #d1d5db)` |
| Form input `color` | `#1f2937` | `var(--stagebook-text, #1f2937)` |
| Form input `background-color` | `#fff` | `var(--stagebook-surface, #fff)` |
| Focus `border-color` | `#3b82f6` | `var(--stagebook-primary, #3b82f6)` |
| Focus `box-shadow` tint | `rgba(59, 130, 246, 0.25)` | `var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25))` |
| Checkbox/radio checked `background-color` / `border-color` | `#3b82f6` | `var(--stagebook-primary, #3b82f6)` |
| Table `max-width` | `36rem` | `var(--stagebook-prompt-max-width, 36rem)` |
| Table cell `border` | `#d1d5db` | `var(--stagebook-border, #d1d5db)` |
| Table header `background-color` | `#f9fafb` | `var(--stagebook-bg-muted, #f9fafb)` |

Left alone (not called out in the issue): the table cell text colors `#4a5568` and `#1a202c` in `td`/`th` rules. Can be folded in later if desired.

## TDD

- Added 11 new tests to `src/styles.test.ts` under `styles.css uses theme variables for hardcoded values (#116)` — all failed red, then went green after the CSS edits.
- The "no bare literal" tests strip `var(..., fallback)` calls before checking, so the codebase convention of documented fallbacks continues to work.

## Test plan

- [x] `npm test` — stagebook 529, viewer 68, vscode 136 — all pass
- [x] `npm run lint` — zero warnings
- [x] `npm run format:check` — clean
- [x] `npx prettier --check packages/stagebook/src/styles.css` — clean
- [ ] CI green
- [ ] Copilot review comments addressed