### PR TITLE
Validate and syntax-highlight expanded templates preview (#112)

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -468,12 +468,37 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
     return result.yaml;
   }
 
+  /**
+   * Request a re-render of the expanded preview for `sourceUri`. Debounced
+   * per-source so that rapid keystrokes don't each trigger full expand +
+   * schema-validation work in `provideTextDocumentContent`.
+   */
   refreshForSource(sourceUri: vscode.Uri): void {
-    const expandedUri = vscode.Uri.parse(
-      `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${encodeURIComponent(sourceUri.toString())}`,
+    const key = sourceUri.toString();
+    const existing = this.refreshTimers.get(key);
+    if (existing) clearTimeout(existing);
+
+    this.refreshTimers.set(
+      key,
+      setTimeout(() => {
+        this.refreshTimers.delete(key);
+        const expandedUri = vscode.Uri.parse(
+          `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${encodeURIComponent(sourceUri.toString())}`,
+        );
+        this._onDidChange.fire(expandedUri);
+      }, DEBOUNCE_MS),
     );
-    this._onDidChange.fire(expandedUri);
   }
+
+  dispose(): void {
+    for (const timer of this.refreshTimers.values()) clearTimeout(timer);
+    this.refreshTimers.clear();
+  }
+
+  private readonly refreshTimers = new Map<
+    string,
+    ReturnType<typeof setTimeout>
+  >();
 }
 
 // --- Stage Preview Webview ---
@@ -659,6 +684,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
   // Register expanded templates content provider
   const expandedProvider = new ExpandedTemplatesProvider(diagnosticCollection);
+  context.subscriptions.push(expandedProvider);
   context.subscriptions.push(
     vscode.workspace.registerTextDocumentContentProvider(
       EXPANDED_SCHEME,

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -10,7 +10,7 @@ import {
   computeSemanticTokens,
   type SemanticTokenType,
 } from "./lib/semanticTokens";
-import { expandTreatmentSource } from "./lib/expandTreatment";
+import { expandAndValidate } from "./lib/expandAndValidate";
 import { findClosestMatch } from "./lib/levenshtein";
 import { isWithinWorkspace, relativizePath } from "./lib/filePaths";
 import { fillTemplates, treatmentFileSchema } from "stagebook";
@@ -18,6 +18,8 @@ import { parse as parseYaml } from "yaml";
 
 const diagnosticCollection =
   vscode.languages.createDiagnosticCollection("stagebook");
+
+const EXPANDED_SCHEME = "stagebook-expanded";
 
 const DEBOUNCE_MS = 300;
 const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
@@ -40,6 +42,11 @@ function isStagebookPrompt(document: vscode.TextDocument): boolean {
 }
 
 function validateDocument(document: vscode.TextDocument): void {
+  // The expanded-preview virtual documents also carry the treatmentsYaml
+  // language (for syntax highlighting), but their diagnostics are owned by
+  // ExpandedTemplatesProvider. Skip them here to avoid clobbering.
+  if (document.uri.scheme === EXPANDED_SCHEME) return;
+
   if (isTreatmentsYaml(document)) {
     validateTreatmentFile(document);
   } else if (isStagebookPrompt(document)) {
@@ -418,11 +425,11 @@ class FilePathCompletionProvider implements vscode.CompletionItemProvider {
 
 // --- Expanded Templates Preview ---
 
-const EXPANDED_SCHEME = "stagebook-expanded";
-
 class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
   private _onDidChange = new vscode.EventEmitter<vscode.Uri>();
   readonly onDidChange = this._onDidChange.event;
+
+  constructor(private readonly diagnostics: vscode.DiagnosticCollection) {}
 
   provideTextDocumentContent(uri: vscode.Uri): string {
     const sourceUri = vscode.Uri.parse(decodeURIComponent(uri.query));
@@ -430,17 +437,34 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
       (d) => d.uri.toString() === sourceUri.toString(),
     );
     if (!sourceDoc) {
+      this.diagnostics.delete(uri);
       return "# Source document not found. Please reopen the preview.";
     }
 
-    const result = expandTreatmentSource(sourceDoc.getText());
-    if (result.error) {
-      const commentedError = result.error
+    const result = expandAndValidate(sourceDoc.getText());
+    if (result.expandError) {
+      this.diagnostics.delete(uri);
+      const commentedError = result.expandError
         .split(/\r?\n/)
         .map((line) => `# ${line}`)
         .join("\n");
       return `# Template expansion error:\n${commentedError}`;
     }
+
+    // Attach schema-validation diagnostics to the expanded preview URI.
+    // Positions reference the full expanded YAML; diagnostics past the
+    // truncation line still appear in the Problems panel.
+    const vscodeDiagnostics = result.diagnostics.map((d) => {
+      const diag = new vscode.Diagnostic(
+        toVscodeRange(d.range),
+        d.message,
+        toSeverity(d.severity),
+      );
+      diag.source = "stagebook";
+      return diag;
+    });
+    this.diagnostics.set(uri, vscodeDiagnostics);
+
     return result.yaml;
   }
 
@@ -634,7 +658,7 @@ export function activate(context: vscode.ExtensionContext): void {
   );
 
   // Register expanded templates content provider
-  const expandedProvider = new ExpandedTemplatesProvider();
+  const expandedProvider = new ExpandedTemplatesProvider(diagnosticCollection);
   context.subscriptions.push(
     vscode.workspace.registerTextDocumentContentProvider(
       EXPANDED_SCHEME,
@@ -666,16 +690,25 @@ export function activate(context: vscode.ExtensionContext): void {
           preview: true,
           preserveFocus: true,
         });
-        // Set language for syntax highlighting
-        await vscode.languages.setTextDocumentLanguage(doc, "yaml");
+        // Set language for syntax highlighting. Using treatmentsYaml (rather
+        // than plain yaml) wires up the TextMate grammar and semantic-tokens
+        // provider, so the expanded preview gets the same colorization as
+        // source treatment files (element types, comparators, template
+        // variables, schema keywords).
+        await vscode.languages.setTextDocumentLanguage(doc, "treatmentsYaml");
       },
     ),
   );
 
-  // Auto-refresh the expanded preview when the source changes
+  // Auto-refresh the expanded preview when the source changes. The preview
+  // document itself also has languageId "treatmentsYaml"; skip it by scheme
+  // so we don't feed its (read-only, virtual) text back as a "source".
   context.subscriptions.push(
     vscode.workspace.onDidChangeTextDocument((e) => {
-      if (isTreatmentsYaml(e.document)) {
+      if (
+        e.document.uri.scheme !== EXPANDED_SCHEME &&
+        isTreatmentsYaml(e.document)
+      ) {
         expandedProvider.refreshForSource(e.document.uri);
       }
     }),

--- a/apps/vscode/src/lib/expandAndValidate.test.ts
+++ b/apps/vscode/src/lib/expandAndValidate.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { expandAndValidate } from "./expandAndValidate";
+
+describe("expandAndValidate", () => {
+  describe("valid expansion", () => {
+    it("returns no diagnostics when the expanded treatment is valid", () => {
+      const src = `templates:
+  - templateName: myStage
+    contentType: stage
+    templateContent:
+      name: stage1
+      duration: 300
+      elements:
+        - type: submitButton
+introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: myStage`;
+      const result = expandAndValidate(src);
+      expect(result.expandError).toBeNull();
+      expect(result.diagnostics.filter((d) => d.severity === "error")).toEqual(
+        [],
+      );
+      expect(result.yaml).toContain("name: stage1");
+    });
+  });
+
+  describe("invalid expanded output from valid-looking source", () => {
+    it("surfaces schema errors that only appear after template expansion", () => {
+      // The source looks fine on its own (templateContent uses altTemplateContext),
+      // but after expansion the resulting treatment has duration: -1 which is
+      // invalid per durationSchema.
+      const src = `templates:
+  - templateName: badStage
+    templateContent:
+      name: stage1
+      duration: -1
+      elements:
+        - type: submitButton
+introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: badStage`;
+      const result = expandAndValidate(src);
+      expect(result.expandError).toBeNull();
+      const errors = result.diagnostics.filter((d) => d.severity === "error");
+      expect(errors.length).toBeGreaterThan(0);
+    });
+
+    it("positions diagnostics within the expanded YAML (not the source)", () => {
+      // The expanded YAML has a different shape than the source — the template
+      // reference at gameStages[0] gets replaced with the expanded stage object.
+      // Diagnostics should point at lines in the expanded YAML output.
+      const src = `templates:
+  - templateName: badStage
+    templateContent:
+      name: stage1
+      duration: notANumber
+      elements:
+        - type: submitButton
+introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: badStage`;
+      const result = expandAndValidate(src);
+      const errors = result.diagnostics.filter(
+        (d) => d.severity === "error" && d.range !== null,
+      );
+      expect(errors.length).toBeGreaterThan(0);
+      // The diagnostic should point into the expanded yaml. Find the line in
+      // result.yaml that contains "duration:" and verify at least one error
+      // targets it.
+      const expandedLines = result.yaml.split("\n");
+      const durationLine = expandedLines.findIndex((l) =>
+        l.includes("duration:"),
+      );
+      expect(durationLine).toBeGreaterThanOrEqual(0);
+      const hasRangeNearDuration = errors.some(
+        (d) => d.range && d.range.startLine === durationLine,
+      );
+      expect(hasRangeNearDuration).toBe(true);
+    });
+  });
+
+  describe("expansion errors", () => {
+    it("returns the expansion error and no diagnostics when expansion fails", () => {
+      const src = `templates:
+  - templateName: myStage
+    templateContent:
+      name: stage1
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: nonexistentStage`;
+      const result = expandAndValidate(src);
+      expect(result.expandError).not.toBeNull();
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("returns an error when YAML is unparseable", () => {
+      const result = expandAndValidate("[[[invalid");
+      expect(result.expandError).not.toBeNull();
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+
+  describe("full expansion validation (not truncated)", () => {
+    it("validates the full expansion even when display output is truncated", () => {
+      // Broadcast that produces many stages, one of which will have an invalid
+      // duration derived from a field. The truncated display cuts off early,
+      // but we should still catch the error.
+      const topics = Array.from({ length: 50 }, (_, i) => ({
+        topic: `topic${i}`,
+        duration: i === 49 ? -1 : 300,
+      }));
+      const broadcastItems = topics
+        .map(
+          (t) =>
+            `            - topic: ${t.topic}\n              duration: ${t.duration}`,
+        )
+        .join("\n");
+      const src = `templates:
+  - templateName: manyStage
+    templateContent:
+      name: \${topic}_stage
+      duration: \${duration}
+      elements:
+        - type: submitButton
+introSequences:
+  - name: intro1
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    gameStages:
+      - template: manyStage
+        broadcast:
+          d0:
+${broadcastItems}`;
+      const result = expandAndValidate(src, { maxLines: 50 });
+      expect(result.expandError).toBeNull();
+      expect(result.truncated).toBe(true);
+      const errors = result.diagnostics.filter((d) => d.severity === "error");
+      expect(errors.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/vscode/src/lib/expandAndValidate.test.ts
+++ b/apps/vscode/src/lib/expandAndValidate.test.ts
@@ -34,14 +34,16 @@ treatments:
 
   describe("invalid expanded output from valid-looking source", () => {
     it("surfaces schema errors that only appear after template expansion", () => {
-      // The source looks fine on its own (templateContent uses altTemplateContext),
-      // but after expansion the resulting treatment has duration: -1 which is
+      // Source validates: the template is typed (contentType: stage) and the
+      // duration is a ${placeholder}, which the stage schema allows. After
+      // field substitution the expanded stage has duration: -1, which is
       // invalid per durationSchema.
       const src = `templates:
   - templateName: badStage
+    contentType: stage
     templateContent:
       name: stage1
-      duration: -1
+      duration: \${duration}
       elements:
         - type: submitButton
 introSequences:
@@ -54,7 +56,9 @@ treatments:
   - name: study1
     playerCount: 1
     gameStages:
-      - template: badStage`;
+      - template: badStage
+        fields:
+          duration: -1`;
       const result = expandAndValidate(src);
       expect(result.expandError).toBeNull();
       const errors = result.diagnostics.filter((d) => d.severity === "error");
@@ -62,14 +66,16 @@ treatments:
     });
 
     it("positions diagnostics within the expanded YAML (not the source)", () => {
-      // The expanded YAML has a different shape than the source — the template
-      // reference at gameStages[0] gets replaced with the expanded stage object.
-      // Diagnostics should point at lines in the expanded YAML output.
+      // Same pattern: source is valid (duration uses a placeholder), but the
+      // field value ("notANumber") makes the expanded duration a string where
+      // a number is required. The diagnostic should land on the expanded
+      // duration: line in result.yaml.
       const src = `templates:
   - templateName: badStage
+    contentType: stage
     templateContent:
       name: stage1
-      duration: notANumber
+      duration: \${duration}
       elements:
         - type: submitButton
 introSequences:
@@ -82,7 +88,9 @@ treatments:
   - name: study1
     playerCount: 1
     gameStages:
-      - template: badStage`;
+      - template: badStage
+        fields:
+          duration: notANumber`;
       const result = expandAndValidate(src);
       const errors = result.diagnostics.filter(
         (d) => d.severity === "error" && d.range !== null,
@@ -143,6 +151,7 @@ treatments:
         .join("\n");
       const src = `templates:
   - templateName: manyStage
+    contentType: stage
     templateContent:
       name: \${topic}_stage
       duration: \${duration}

--- a/apps/vscode/src/lib/expandAndValidate.ts
+++ b/apps/vscode/src/lib/expandAndValidate.ts
@@ -1,0 +1,54 @@
+import { expandTreatmentSource, type ExpandOptions } from "./expandTreatment";
+import { validateTreatmentSource } from "./validateTreatment";
+import type { Diagnostic } from "./types";
+
+export interface ExpandAndValidateResult {
+  /** The expanded YAML as displayed (possibly truncated). "" if expansion failed. */
+  yaml: string;
+  /** Whether the displayed YAML was truncated for size. */
+  truncated: boolean;
+  /** Expansion error message (e.g. YAML parse, missing template). null on success. */
+  expandError: string | null;
+  /**
+   * Schema validation diagnostics, with line/column positions referring to
+   * the full (untruncated) expanded YAML. Empty when expansion failed.
+   */
+  diagnostics: Diagnostic[];
+}
+
+/**
+ * Expand templates in a treatment YAML source and validate the expanded
+ * result against the treatment file schema.
+ *
+ * Validation runs on the full (untruncated) expansion so that errors past
+ * the display truncation point are still surfaced. Diagnostic positions
+ * reference the full expanded YAML string.
+ *
+ * This is a pure function — no VS Code dependency. The caller is responsible
+ * for converting `diagnostics` into `vscode.Diagnostic` objects and attaching
+ * them to the expanded preview document's URI.
+ */
+export function expandAndValidate(
+  source: string,
+  options?: ExpandOptions,
+): ExpandAndValidateResult {
+  const expanded = expandTreatmentSource(source, options);
+
+  if (expanded.error) {
+    return {
+      yaml: expanded.yaml,
+      truncated: expanded.truncated,
+      expandError: expanded.error,
+      diagnostics: [],
+    };
+  }
+
+  const { diagnostics } = validateTreatmentSource(expanded.fullYaml);
+
+  return {
+    yaml: expanded.yaml,
+    truncated: expanded.truncated,
+    expandError: null,
+    diagnostics,
+  };
+}

--- a/apps/vscode/src/lib/expandTreatment.ts
+++ b/apps/vscode/src/lib/expandTreatment.ts
@@ -5,8 +5,14 @@ const DEFAULT_MAX_LINES = 5000;
 const DEFAULT_MAX_BROADCAST = 10000;
 
 export interface ExpandResult {
-  /** The expanded YAML string, or "" on error. */
+  /** The expanded YAML string as displayed (possibly truncated), or "" on error. */
   yaml: string;
+  /**
+   * The full, untruncated expanded YAML. Equal to `yaml` when no truncation
+   * was needed. Consumers that need to validate the complete expansion
+   * (rather than its truncated display form) should use this.
+   */
+  fullYaml: string;
   /** Error message if expansion failed, null on success. */
   error: string | null;
   /** Whether the output was truncated due to line limit. */
@@ -79,6 +85,7 @@ export function expandTreatmentSource(
   } catch (e) {
     return {
       yaml: "",
+      fullYaml: "",
       error: `YAML parse error: ${e instanceof Error ? e.message : String(e)}`,
       truncated: false,
     };
@@ -87,6 +94,7 @@ export function expandTreatmentSource(
   if (typeof obj !== "object" || obj === null || Array.isArray(obj)) {
     return {
       yaml: "",
+      fullYaml: "",
       error:
         "Treatment file must be a YAML mapping (object), not a scalar or array.",
       truncated: false,
@@ -98,6 +106,7 @@ export function expandTreatmentSource(
   if (record.templates !== undefined && !Array.isArray(record.templates)) {
     return {
       yaml: "",
+      fullYaml: "",
       error: "The 'templates' key must be an array.",
       truncated: false,
     };
@@ -110,7 +119,7 @@ export function expandTreatmentSource(
   const broadcastLimit = options?.maxBroadcastProduct ?? DEFAULT_MAX_BROADCAST;
   const sizeError = checkBroadcastSize(record, broadcastLimit);
   if (sizeError) {
-    return { yaml: "", error: sizeError, truncated: false };
+    return { yaml: "", fullYaml: "", error: sizeError, truncated: false };
   }
 
   // Expand templates
@@ -129,6 +138,7 @@ export function expandTreatmentSource(
   } catch (e) {
     return {
       yaml: "",
+      fullYaml: "",
       error: `Template expansion failed: ${e instanceof Error ? e.message : String(e)}`,
       truncated: false,
     };
@@ -144,6 +154,7 @@ export function expandTreatmentSource(
   } catch (e) {
     return {
       yaml: "",
+      fullYaml: "",
       error: `YAML serialization failed: ${e instanceof Error ? e.message : String(e)}`,
       truncated: false,
     };
@@ -157,10 +168,11 @@ export function expandTreatmentSource(
       yaml:
         truncatedYaml +
         `\n\n# --- Output truncated at ${maxLines} lines (${lines.length} total) ---`,
+      fullYaml: yaml,
       error: null,
       truncated: true,
     };
   }
 
-  return { yaml, error: null, truncated: false };
+  return { yaml, fullYaml: yaml, error: null, truncated: false };
 }


### PR DESCRIPTION
Closes #112.

## Summary

Closes the two gaps on the expanded templates preview:

1. **Schema validation on the expanded output.** After templates are filled, the resulting YAML is validated against `treatmentFileSchema` and any Zod issues become diagnostics on the expanded preview URI — so a template body with, say, `duration: -1` now shows red squigglies on the expanded line, not a silent pass.
2. **`treatmentsYaml` language for the preview.** Switched `setTextDocumentLanguage(doc, "yaml")` → `"treatmentsYaml"` so the preview gets the same TextMate grammar + semantic-tokens provider as source files (element types, comparators, template variables, schema keywords).

## Implementation

- Added `fullYaml` to `ExpandResult` so validation can run on the untruncated expansion even when the display is truncated (per the issue's note that validation should cover the full result).
- New pure helper `expandAndValidate(source, options)` (in `apps/vscode/src/lib/expandAndValidate.ts`) that expands then validates, returning the truncated display YAML, the expansion error (if any), and the schema diagnostics keyed to the full expanded YAML.
- `ExpandedTemplatesProvider` now holds the `DiagnosticCollection` and sets/clears diagnostics on the expanded URI inside `provideTextDocumentContent`. Refresh on source-change flows through the same path.
- Guarded `validateDocument` and the auto-refresh listener against `EXPANDED_SCHEME` URIs — necessary now that the preview's languageId is `treatmentsYaml`, so the general validator doesn't clobber the preview's diagnostics and the source-change refresh doesn't feed the virtual preview back in as a source.

## Test plan

- [x] 5 new vitest unit tests in `expandAndValidate.test.ts` covering: valid expansion passes, schema errors from template bodies surface after expansion, positions target lines in the expanded YAML, expansion errors suppress validation, and validation runs on the full expansion under truncation.
- [x] `npm test` — stagebook 518, viewer 68, vscode 142 — all pass.
- [x] `npm run lint -w stagebook` — zero warnings.
- [x] `npm run format:check` — clean.
- [x] `npm run build -w stagebook-vscode` — bundle + sourcemap emit fine.

https://claude.ai/code/session_01D8R9g8sdswuhes6MGrxpyK