### PR TITLE
Add CI Gate job for branch protection with path-filtered checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,9 @@ jobs:
     steps:
       - name: Check for failures
         run: |
-          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
-            echo "One or more CI jobs failed"
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "One or more CI jobs failed or were cancelled"
+            echo "Upstream job results:"
+            echo '${{ toJson(needs) }}'
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,3 +140,16 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+
+  ci-gate:
+    name: CI Gate
+    if: always()
+    needs: [changes, lint, test-stagebook, test-viewer, test-vscode, test-ct, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for failures
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "One or more CI jobs failed"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Adds a `CI Gate` job that always runs, depends on all other CI jobs, and fails if any of them failed. Skipped jobs (from path filtering) don't block the gate.

This fixes the problem where a docs-only or viewer-only PR is blocked by branch protection because `Unit Tests (stagebook)` was correctly skipped but a skipped check doesn't satisfy a required check.

## Change

Branch protection should be updated to require only `CI Gate` instead of the 7 individual checks. Individual checks still appear in the PR checks list for visibility.

## Test plan
- [ ] CI passes on this PR (the gate job should appear and pass)
- [ ] After merging, update branch protection to require only `CI Gate`

🤖 Generated with [Claude Code](https://claude.com/claude-code)