### PR TITLE
Add getReferencedAssets() utility and use it in VS Code asset check (#137)

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -13,7 +13,11 @@ import {
 import { expandAndValidate } from "./lib/expandAndValidate";
 import { findClosestMatch } from "./lib/levenshtein";
 import { isWithinWorkspace, relativizePath } from "./lib/filePaths";
-import { fillTemplates, treatmentFileSchema } from "stagebook";
+import {
+  fillTemplates,
+  getReferencedAssets,
+  treatmentFileSchema,
+} from "stagebook";
 import { parse as parseYaml } from "yaml";
 
 const diagnosticCollection =
@@ -127,8 +131,11 @@ function validateTreatmentFile(document: vscode.TextDocument): void {
 }
 
 /**
- * Walk the parsed treatment object looking for `file:` fields.
- * Check that referenced files exist and have the right extension.
+ * Walk the parsed treatment object and check that every local-asset path
+ * referenced by an element exists. `getReferencedAssets` owns the per-element-
+ * type allowlist of file-like fields (prompt.file, image.file, audio.file,
+ * mediaPlayer.url, mediaPlayer.captionsFile) and filters out template
+ * placeholders and full URLs; we still apply a path-traversal guard here.
  */
 function checkFileReferences(
   document: vscode.TextDocument,
@@ -136,53 +143,37 @@ function checkFileReferences(
   source: string,
   diagnostics: vscode.Diagnostic[],
   version: number,
-  objPath: (string | number)[] = [],
 ): void {
-  if (Array.isArray(obj)) {
-    obj.forEach((item, i) =>
-      checkFileReferences(document, item, source, diagnostics, version, [
-        ...objPath,
-        i,
-      ]),
-    );
-    return;
-  }
+  const assets = getReferencedAssets(obj);
+  if (assets.length === 0) return;
 
-  if (typeof obj !== "object" || obj === null) return;
+  const treatmentDir = vscode.Uri.joinPath(document.uri, "..");
+  const workspaceFolder =
+    vscode.workspace.getWorkspaceFolder(document.uri) ??
+    vscode.workspace.workspaceFolders![0];
+  const uriKey = document.uri.toString();
 
-  const record = obj as Record<string, unknown>;
+  for (const asset of assets) {
+    const fileUri = vscode.Uri.joinPath(treatmentDir, asset.path);
+    const diagPath = [...asset.pathInTree, asset.field];
 
-  if (typeof record.file === "string" && record.file.length > 0) {
-    const filePath = record.file;
-    // Resolve relative to the treatment file's directory, not workspace root
-    const treatmentDir = vscode.Uri.joinPath(document.uri, "..");
-    const fileUri = vscode.Uri.joinPath(treatmentDir, filePath);
-
-    // Guard against path traversal (check before template placeholder skip)
-    const workspaceFolder =
-      vscode.workspace.getWorkspaceFolder(document.uri) ??
-      vscode.workspace.workspaceFolders![0];
     if (!isWithinWorkspace(fileUri.fsPath, workspaceFolder.uri.fsPath)) {
       diagnostics.push(
         makeFileDiagnostic(
           source,
-          [...objPath, "file"],
-          `File path escapes workspace: ${filePath}`,
+          diagPath,
+          `File path escapes workspace: ${asset.path}`,
           vscode.DiagnosticSeverity.Error,
         ),
       );
       diagnosticCollection.set(document.uri, diagnostics);
-      return;
+      continue;
     }
 
-    // Skip file existence check if the path contains template placeholders
-    if (/\$\{[a-zA-Z0-9_]+\}/.test(filePath)) return;
-
-    const uriKey = document.uri.toString();
     vscode.workspace.fs.stat(fileUri).then(
       () => {
-        // File exists — .prompt.md extension is enforced by the schema
-        // (promptFilePathSchema), so no redundant check needed here.
+        // File exists — extension validity (e.g. .prompt.md for prompts) is
+        // enforced by schema (promptFilePathSchema), so no redundant check.
       },
       () => {
         if (validationVersions.get(uriKey) !== version) return;
@@ -190,22 +181,14 @@ function checkFileReferences(
         diagnostics.push(
           makeFileDiagnostic(
             source,
-            [...objPath, "file"],
-            `File not found: ${filePath}`,
+            diagPath,
+            `File not found: ${asset.path}`,
             vscode.DiagnosticSeverity.Error,
           ),
         );
         diagnosticCollection.set(document.uri, diagnostics);
       },
     );
-  }
-
-  for (const [key, value] of Object.entries(record)) {
-    if (key === "file") continue;
-    checkFileReferences(document, value, source, diagnostics, version, [
-      ...objPath,
-      key,
-    ]);
   }
 }
 

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -155,13 +155,12 @@ function checkFileReferences(
 
   for (const asset of assets) {
     const fileUri = vscode.Uri.joinPath(treatmentDir, asset.path);
-    const diagPath = [...asset.pathInTree, asset.field];
 
     if (!isWithinWorkspace(fileUri.fsPath, workspaceFolder.uri.fsPath)) {
       diagnostics.push(
         makeFileDiagnostic(
           source,
-          diagPath,
+          asset.pathInTree,
           `File path escapes workspace: ${asset.path}`,
           vscode.DiagnosticSeverity.Error,
         ),
@@ -181,7 +180,7 @@ function checkFileReferences(
         diagnostics.push(
           makeFileDiagnostic(
             source,
-            diagPath,
+            asset.pathInTree,
             `File not found: ${asset.path}`,
             vscode.DiagnosticSeverity.Error,
           ),

--- a/packages/stagebook/src/utils/index.ts
+++ b/packages/stagebook/src/utils/index.ts
@@ -10,3 +10,7 @@ export {
   evaluateConditions,
   type Condition,
 } from "./evaluateConditions.js";
+export {
+  getReferencedAssets,
+  type ReferencedAsset,
+} from "./referencedAssets.js";

--- a/packages/stagebook/src/utils/referencedAssets.test.ts
+++ b/packages/stagebook/src/utils/referencedAssets.test.ts
@@ -71,7 +71,7 @@ describe("getReferencedAssets — element type allowlist", () => {
         field: "file",
         elementType: "image",
         elementName: "diagram",
-        pathInTree: ["treatments", 0, "gameStages", 0, "elements", 0],
+        pathInTree: ["treatments", 0, "gameStages", 0, "elements", 0, "file"],
       },
     ]);
   });
@@ -252,7 +252,7 @@ describe("getReferencedAssets — structural walk", () => {
       field: "file",
       elementType: "image",
       elementName: "target",
-      pathInTree: ["treatments", 0, "gameStages", 1, "elements", 1],
+      pathInTree: ["treatments", 0, "gameStages", 1, "elements", 1, "file"],
     });
   });
 
@@ -311,5 +311,124 @@ describe("getReferencedAssets — structural walk", () => {
     const assets = getReferencedAssets(tree);
     expect(assets).toHaveLength(1);
     expect(assets[0].elementName).toBeUndefined();
+  });
+
+  test("pathInTree for mediaPlayer points at the specific field, not the element", () => {
+    // Regression guard: pathInTree must include the field name so that
+    // consumers can do source mapping directly without appending `field`.
+    const tree = treatmentWithElements([
+      {
+        type: "mediaPlayer",
+        url: "videos/x.mp4",
+        captionsFile: "videos/x.vtt",
+      },
+    ]);
+    const assets = getReferencedAssets(tree);
+    expect(assets[0].pathInTree).toEqual([
+      "treatments",
+      0,
+      "gameStages",
+      0,
+      "elements",
+      0,
+      "url",
+    ]);
+    expect(assets[1].pathInTree).toEqual([
+      "treatments",
+      0,
+      "gameStages",
+      0,
+      "elements",
+      0,
+      "captionsFile",
+    ]);
+  });
+});
+
+describe("getReferencedAssets — prompt shorthand", () => {
+  test("bare .prompt.md string inside elements is collected as prompt.file", () => {
+    const tree = treatmentWithElements(["intro.prompt.md"]);
+    const assets = getReferencedAssets(tree);
+    expect(assets).toEqual<ReferencedAsset[]>([
+      {
+        path: "intro.prompt.md",
+        field: "file",
+        elementType: "prompt",
+        elementName: "intro.prompt.md",
+        pathInTree: ["treatments", 0, "gameStages", 0, "elements", 0],
+      },
+    ]);
+  });
+
+  test("shorthand works in intro and exit steps too", () => {
+    const tree = {
+      introSequences: [
+        {
+          name: "seq",
+          introSteps: [{ name: "s", elements: ["intro.prompt.md"] }],
+        },
+      ],
+      treatments: [
+        {
+          name: "t",
+          playerCount: 1,
+          gameStages: [
+            { name: "g", duration: 1, elements: [{ type: "submitButton" }] },
+          ],
+          exitSequence: [{ name: "e", elements: ["exit.prompt.md"] }],
+        },
+      ],
+    };
+    const paths = getReferencedAssets(tree).map((a) => a.path);
+    expect(paths).toEqual(["intro.prompt.md", "exit.prompt.md"]);
+  });
+
+  test("non-.prompt.md strings inside elements are not collected", () => {
+    const tree = treatmentWithElements(["not-a-prompt.txt", 42, null]);
+    expect(getReferencedAssets(tree)).toEqual([]);
+  });
+
+  test("shorthand with template placeholder is excluded", () => {
+    const tree = treatmentWithElements(["${variant}.prompt.md"]);
+    expect(getReferencedAssets(tree)).toEqual([]);
+  });
+
+  test("bare .prompt.md strings outside an elements array are ignored", () => {
+    // Safety: only recognise shorthand where the schema actually allows it.
+    const tree = {
+      introSequences: [],
+      treatments: [
+        {
+          name: "t",
+          playerCount: 1,
+          notes: "see intro.prompt.md",
+          gameStages: [
+            {
+              name: "g",
+              duration: 1,
+              elements: [{ type: "submitButton" }],
+              // Some unrelated field that happens to hold a .prompt.md string
+              foo: "bar.prompt.md",
+            },
+          ],
+        },
+      ],
+    };
+    expect(getReferencedAssets(tree)).toEqual([]);
+  });
+});
+
+describe("getReferencedAssets — malformed input safety", () => {
+  test("element with a prototype-chain `type` value doesn't crash the walker", () => {
+    // `type in FILE_FIELDS_BY_ELEMENT_TYPE` would match built-in
+    // Object.prototype keys like `toString`; using Object.hasOwn keeps the
+    // walker safe from untrusted YAML that sets `type: "toString"`.
+    const tree = treatmentWithElements([
+      { type: "toString", file: "whatever" },
+      { type: "constructor", file: "whatever" },
+      { type: "__proto__", file: "whatever" },
+    ]);
+    expect(() => getReferencedAssets(tree)).not.toThrow();
+    expect(getReferencedAssets(tree)).toEqual([]);
   });
 });

--- a/packages/stagebook/src/utils/referencedAssets.test.ts
+++ b/packages/stagebook/src/utils/referencedAssets.test.ts
@@ -1,0 +1,315 @@
+import { describe, test, expect } from "vitest";
+import {
+  getReferencedAssets,
+  type ReferencedAsset,
+} from "./referencedAssets.js";
+
+// Helper: wrap a set of elements into a minimal treatmentFile-shaped object so
+// tests exercise the real tree-walk (top level → treatments → gameStages →
+// elements) rather than passing elements in isolation.
+function treatmentWithElements(elements: unknown[]): unknown {
+  return {
+    introSequences: [],
+    treatments: [
+      {
+        name: "t1",
+        playerCount: 1,
+        gameStages: [
+          {
+            name: "stage1",
+            duration: 60,
+            elements,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("getReferencedAssets — defensive input handling", () => {
+  test("returns [] for null", () => {
+    expect(getReferencedAssets(null)).toEqual([]);
+  });
+
+  test("returns [] for undefined", () => {
+    expect(getReferencedAssets(undefined)).toEqual([]);
+  });
+
+  test("returns [] for primitive", () => {
+    expect(getReferencedAssets("foo")).toEqual([]);
+    expect(getReferencedAssets(42)).toEqual([]);
+    expect(getReferencedAssets(true)).toEqual([]);
+  });
+
+  test("returns [] for empty object", () => {
+    expect(getReferencedAssets({})).toEqual([]);
+  });
+});
+
+describe("getReferencedAssets — element type allowlist", () => {
+  test("prompt.file is collected", () => {
+    const tree = treatmentWithElements([
+      { type: "prompt", file: "intro.prompt.md" },
+    ]);
+    const assets = getReferencedAssets(tree);
+    expect(assets).toHaveLength(1);
+    expect(assets[0]).toMatchObject({
+      path: "intro.prompt.md",
+      field: "file",
+      elementType: "prompt",
+    });
+  });
+
+  test("image.file is collected", () => {
+    const tree = treatmentWithElements([
+      { type: "image", file: "assets/diagram.png", name: "diagram" },
+    ]);
+    const assets = getReferencedAssets(tree);
+    expect(assets).toEqual<ReferencedAsset[]>([
+      {
+        path: "assets/diagram.png",
+        field: "file",
+        elementType: "image",
+        elementName: "diagram",
+        pathInTree: ["treatments", 0, "gameStages", 0, "elements", 0],
+      },
+    ]);
+  });
+
+  test("audio.file is collected", () => {
+    const tree = treatmentWithElements([
+      { type: "audio", file: "sounds/bell.mp3" },
+    ]);
+    const assets = getReferencedAssets(tree);
+    expect(assets).toHaveLength(1);
+    expect(assets[0]).toMatchObject({
+      path: "sounds/bell.mp3",
+      field: "file",
+      elementType: "audio",
+    });
+  });
+
+  test("mediaPlayer.url and mediaPlayer.captionsFile are both collected", () => {
+    const tree = treatmentWithElements([
+      {
+        type: "mediaPlayer",
+        url: "videos/intro.mp4",
+        captionsFile: "videos/intro.vtt",
+      },
+    ]);
+    const assets = getReferencedAssets(tree);
+    expect(assets.map((a) => ({ path: a.path, field: a.field }))).toEqual([
+      { path: "videos/intro.mp4", field: "url" },
+      { path: "videos/intro.vtt", field: "captionsFile" },
+    ]);
+    expect(assets.every((a) => a.elementType === "mediaPlayer")).toBe(true);
+  });
+
+  test("timeline has no file-like fields — source is a name ref, not collected", () => {
+    const tree = treatmentWithElements([
+      {
+        type: "timeline",
+        name: "annots",
+        source: "someElementName",
+        selectionType: "point",
+      },
+    ]);
+    expect(getReferencedAssets(tree)).toEqual([]);
+  });
+
+  test("element types not in the allowlist contribute nothing", () => {
+    const tree = treatmentWithElements([
+      {
+        type: "trackedLink",
+        name: "followUp",
+        url: "https://example.com/f",
+        displayText: "Go",
+      },
+      { type: "qualtrics", url: "https://example.com/q" },
+      { type: "survey", surveyName: "bigFive" },
+      { type: "submitButton" },
+      { type: "separator" },
+    ]);
+    expect(getReferencedAssets(tree)).toEqual([]);
+  });
+});
+
+describe("getReferencedAssets — exclusions", () => {
+  test("excludes entries with ${…} placeholder in the path", () => {
+    const tree = treatmentWithElements([
+      { type: "image", file: "${region}/logo.png" },
+      { type: "prompt", file: "prompts/${variant}.prompt.md" },
+    ]);
+    expect(getReferencedAssets(tree)).toEqual([]);
+  });
+
+  test("excludes mediaPlayer.url when the value is a full https URL", () => {
+    const tree = treatmentWithElements([
+      { type: "mediaPlayer", url: "https://example.com/foo.mp4" },
+    ]);
+    expect(getReferencedAssets(tree)).toEqual([]);
+  });
+
+  test("excludes full http and protocol-relative URLs", () => {
+    const tree = treatmentWithElements([
+      { type: "mediaPlayer", url: "http://example.com/a.mp4" },
+      { type: "mediaPlayer", url: "//cdn.example.com/b.mp4" },
+    ]);
+    expect(getReferencedAssets(tree)).toEqual([]);
+  });
+
+  test("excludes empty string paths", () => {
+    const tree = treatmentWithElements([
+      { type: "image", file: "" },
+      { type: "mediaPlayer", url: "", captionsFile: "" },
+    ]);
+    expect(getReferencedAssets(tree)).toEqual([]);
+  });
+
+  test("keeps local paths that merely contain a placeholder-like substring without braces", () => {
+    // Only ${...} with braces counts as a template placeholder; a literal "$"
+    // in a filename is fine.
+    const tree = treatmentWithElements([
+      { type: "image", file: "assets/price_$_99.png" },
+    ]);
+    expect(getReferencedAssets(tree)).toHaveLength(1);
+  });
+});
+
+describe("getReferencedAssets — structural walk", () => {
+  test("collects from intro sequences, game stages, and exit sequence in file order", () => {
+    const tree = {
+      introSequences: [
+        {
+          name: "seq1",
+          introSteps: [
+            {
+              name: "welcome",
+              elements: [{ type: "image", file: "intro/banner.png" }],
+            },
+          ],
+        },
+      ],
+      treatments: [
+        {
+          name: "t1",
+          playerCount: 1,
+          gameStages: [
+            {
+              name: "stage1",
+              duration: 60,
+              elements: [
+                { type: "audio", file: "stage/ping.mp3" },
+                { type: "image", file: "stage/diagram.png" },
+              ],
+            },
+          ],
+          exitSequence: [
+            {
+              name: "goodbye",
+              elements: [{ type: "prompt", file: "exit/thanks.prompt.md" }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const assets = getReferencedAssets(tree);
+    expect(assets.map((a) => a.path)).toEqual([
+      "intro/banner.png",
+      "stage/ping.mp3",
+      "stage/diagram.png",
+      "exit/thanks.prompt.md",
+    ]);
+  });
+
+  test("returns correct pathInTree for an asset deep inside a gameStages array", () => {
+    const tree = {
+      introSequences: [],
+      treatments: [
+        {
+          name: "t1",
+          playerCount: 1,
+          gameStages: [
+            { name: "s0", duration: 60, elements: [{ type: "separator" }] },
+            {
+              name: "s1",
+              duration: 60,
+              elements: [
+                { type: "separator" },
+                { type: "image", file: "deep/nested.png", name: "target" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const assets = getReferencedAssets(tree);
+    expect(assets).toHaveLength(1);
+    expect(assets[0]).toMatchObject({
+      path: "deep/nested.png",
+      field: "file",
+      elementType: "image",
+      elementName: "target",
+      pathInTree: ["treatments", 0, "gameStages", 1, "elements", 1],
+    });
+  });
+
+  test("walks into templates so templated element trees contribute assets", () => {
+    const tree = {
+      templates: [
+        {
+          templateName: "introTpl",
+          contentType: "elements",
+          templateContent: [{ type: "image", file: "templated/img.png" }],
+        },
+      ],
+      introSequences: [],
+      treatments: [],
+    };
+    const assets = getReferencedAssets(tree);
+    expect(assets.map((a) => a.path)).toEqual(["templated/img.png"]);
+  });
+
+  test("mediaPlayer captionsFile is collected even when url is a full URL", () => {
+    // Under-validation regression guard: the reason this utility exists is
+    // that the VS Code extension only checked `file`, missing captionsFile.
+    const tree = treatmentWithElements([
+      {
+        type: "mediaPlayer",
+        url: "https://example.com/foo.mp4",
+        captionsFile: "captions/foo.vtt",
+      },
+    ]);
+    const assets = getReferencedAssets(tree);
+    expect(assets).toHaveLength(1);
+    expect(assets[0]).toMatchObject({
+      path: "captions/foo.vtt",
+      field: "captionsFile",
+    });
+  });
+
+  test("order within a single element follows field-declaration order (url before captionsFile)", () => {
+    const tree = treatmentWithElements([
+      {
+        // Author wrote captionsFile first, url second — utility order is
+        // governed by the allowlist table, not YAML key order.
+        captionsFile: "cap.vtt",
+        url: "video.mp4",
+        type: "mediaPlayer",
+      },
+    ]);
+    const assets = getReferencedAssets(tree);
+    expect(assets.map((a) => a.field)).toEqual(["url", "captionsFile"]);
+  });
+
+  test("omits elementName when the element has no name", () => {
+    const tree = treatmentWithElements([
+      { type: "image", file: "assets/unnamed.png" },
+    ]);
+    const assets = getReferencedAssets(tree);
+    expect(assets).toHaveLength(1);
+    expect(assets[0].elementName).toBeUndefined();
+  });
+});

--- a/packages/stagebook/src/utils/referencedAssets.ts
+++ b/packages/stagebook/src/utils/referencedAssets.ts
@@ -15,6 +15,12 @@ const FILE_FIELDS_BY_ELEMENT_TYPE: Record<string, readonly string[]> = {
   timeline: [],
 };
 
+// Keys whose array values hold elements. Strings inside these arrays are
+// recognised as the prompt-shorthand form (see promptShorthandSchema): a bare
+// `*.prompt.md` path stands in for `{ type: "prompt", file: <path> }`.
+const ELEMENTS_ARRAY_KEYS = new Set(["elements"]);
+const PROMPT_SHORTHAND_SUFFIX = ".prompt.md";
+
 const PLACEHOLDER_PATTERN = /\$\{[^}]*\}/;
 const FULL_URL_PATTERN = /^(?:https?:)?\/\//i;
 
@@ -27,7 +33,9 @@ export interface ReferencedAsset {
   elementType: string;
   /** Element name if the element has one. */
   elementName?: string;
-  /** Location of the element in the parsed object, useful for source mapping. */
+  /** Location of the scalar value in the parsed object, useful for source
+   *  mapping. For object elements this is `[…element path, fieldName]`; for
+   *  prompt-shorthand strings this is the scalar's own path. */
   pathInTree: (string | number)[];
 }
 
@@ -41,7 +49,8 @@ function isCollectableLocalPath(value: unknown): value is string {
 
 /**
  * Walk a parsed treatment file and return every local-asset path it
- * references, per the per-element-type allowlist above.
+ * references, per the per-element-type allowlist above (plus prompt
+ * shorthand — bare `*.prompt.md` strings inside `elements` arrays).
  *
  * Accepts `unknown` because callers typically pass the raw result of
  * parsing YAML — before schema validation — so that the asset list is
@@ -55,18 +64,38 @@ function isCollectableLocalPath(value: unknown): value is string {
  */
 export function getReferencedAssets(treatmentFile: unknown): ReferencedAsset[] {
   const results: ReferencedAsset[] = [];
-  walk(treatmentFile, [], results);
+  walk(treatmentFile, [], false, results);
   return results;
 }
 
 function walk(
   node: unknown,
   path: (string | number)[],
+  insideElementsArray: boolean,
   acc: ReferencedAsset[],
 ): void {
   if (Array.isArray(node)) {
     node.forEach((item, i) => {
-      walk(item, [...path, i], acc);
+      walk(item, [...path, i], insideElementsArray, acc);
+    });
+    return;
+  }
+
+  // Prompt shorthand: a bare ".prompt.md" string within an `elements` array
+  // stands in for `{ type: "prompt", file: <string> }`. We emit it as such so
+  // consumers (file-existence checks, asset manifests) don't silently miss it.
+  if (
+    insideElementsArray &&
+    typeof node === "string" &&
+    node.endsWith(PROMPT_SHORTHAND_SUFFIX) &&
+    isCollectableLocalPath(node)
+  ) {
+    acc.push({
+      path: node,
+      field: "file",
+      elementType: "prompt",
+      elementName: node,
+      pathInTree: [...path],
     });
     return;
   }
@@ -76,7 +105,12 @@ function walk(
   const record = node as Record<string, unknown>;
   const type = record.type;
 
-  if (typeof type === "string" && type in FILE_FIELDS_BY_ELEMENT_TYPE) {
+  // `Object.hasOwn` rather than `in` so prototype-chain keys
+  // (e.g. type: "toString") can't turn `fields` into a non-array.
+  if (
+    typeof type === "string" &&
+    Object.hasOwn(FILE_FIELDS_BY_ELEMENT_TYPE, type)
+  ) {
     const fields = FILE_FIELDS_BY_ELEMENT_TYPE[type];
     for (const field of fields) {
       const value = record[field];
@@ -85,7 +119,7 @@ function walk(
           path: value,
           field,
           elementType: type,
-          pathInTree: [...path],
+          pathInTree: [...path, field],
         };
         if (typeof record.name === "string") {
           asset.elementName = record.name;
@@ -96,6 +130,6 @@ function walk(
   }
 
   for (const [key, value] of Object.entries(record)) {
-    walk(value, [...path, key], acc);
+    walk(value, [...path, key], ELEMENTS_ARRAY_KEYS.has(key), acc);
   }
 }

--- a/packages/stagebook/src/utils/referencedAssets.ts
+++ b/packages/stagebook/src/utils/referencedAssets.ts
@@ -1,0 +1,101 @@
+// Which element types have file-like fields, and which fields they are.
+// This table is the single source of truth for "what counts as a local asset
+// reference" — callers (VS Code extension file-existence checks, annotator
+// manifest freezes, docs/CI tooling) depend on it instead of hard-coding
+// field names like `file`.
+//
+// Order within each entry is the "field-declaration order" used to order
+// results within a single element.
+const FILE_FIELDS_BY_ELEMENT_TYPE: Record<string, readonly string[]> = {
+  prompt: ["file"],
+  image: ["file"],
+  audio: ["file"],
+  mediaPlayer: ["url", "captionsFile"],
+  // timeline.source is a name reference to another element, not a file path
+  timeline: [],
+};
+
+const PLACEHOLDER_PATTERN = /\$\{[^}]*\}/;
+const FULL_URL_PATTERN = /^(?:https?:)?\/\//i;
+
+export interface ReferencedAsset {
+  /** The raw path as it appears in the treatment YAML. */
+  path: string;
+  /** Which field the path came from (e.g. "file", "captionsFile", "url"). */
+  field: string;
+  /** The element type ("prompt", "mediaPlayer", "image", "audio", …). */
+  elementType: string;
+  /** Element name if the element has one. */
+  elementName?: string;
+  /** Location of the element in the parsed object, useful for source mapping. */
+  pathInTree: (string | number)[];
+}
+
+function isCollectableLocalPath(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+  if (value.length === 0) return false;
+  if (PLACEHOLDER_PATTERN.test(value)) return false;
+  if (FULL_URL_PATTERN.test(value)) return false;
+  return true;
+}
+
+/**
+ * Walk a parsed treatment file and return every local-asset path it
+ * references, per the per-element-type allowlist above.
+ *
+ * Accepts `unknown` because callers typically pass the raw result of
+ * parsing YAML — before schema validation — so that the asset list is
+ * available even if the treatment doesn't yet validate. Non-object input
+ * yields `[]`.
+ *
+ * Excludes template-placeholder paths (`${…}`), full URLs (`http://…`,
+ * `https://…`, `//…`), and empty strings. Order is stable tree-walk order
+ * (outer-to-inner, then insertion order within each object), with
+ * field-declaration order from the table above within a single element.
+ */
+export function getReferencedAssets(treatmentFile: unknown): ReferencedAsset[] {
+  const results: ReferencedAsset[] = [];
+  walk(treatmentFile, [], results);
+  return results;
+}
+
+function walk(
+  node: unknown,
+  path: (string | number)[],
+  acc: ReferencedAsset[],
+): void {
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => {
+      walk(item, [...path, i], acc);
+    });
+    return;
+  }
+
+  if (node === null || typeof node !== "object") return;
+
+  const record = node as Record<string, unknown>;
+  const type = record.type;
+
+  if (typeof type === "string" && type in FILE_FIELDS_BY_ELEMENT_TYPE) {
+    const fields = FILE_FIELDS_BY_ELEMENT_TYPE[type];
+    for (const field of fields) {
+      const value = record[field];
+      if (isCollectableLocalPath(value)) {
+        const asset: ReferencedAsset = {
+          path: value,
+          field,
+          elementType: type,
+          pathInTree: [...path],
+        };
+        if (typeof record.name === "string") {
+          asset.elementName = record.name;
+        }
+        acc.push(asset);
+      }
+    }
+  }
+
+  for (const [key, value] of Object.entries(record)) {
+    walk(value, [...path, key], acc);
+  }
+}


### PR DESCRIPTION
Closes #137.

## Summary

Stagebook's element schemas know which fields on which element types point to files. Until now that knowledge was implicit — consumers walked the tree and hard-coded field names. The VS Code extension's `checkFileReferences` only looked at literal `file`, so it silently missed `mediaPlayer.url` (when local) and `mediaPlayer.captionsFile`.

This PR adds `getReferencedAssets(treatmentFile: unknown): ReferencedAsset[]` as a public library utility that owns the per-element-type allowlist once, and rewires the VS Code extension to use it.

## The utility

`packages/stagebook/src/utils/referencedAssets.ts`:

```ts
export interface ReferencedAsset {
  path: string;
  field: string;
  elementType: string;
  elementName?: string;
  pathInTree: (string | number)[];
}

export function getReferencedAssets(treatmentFile: unknown): ReferencedAsset[];
```

Per-element-type allowlist (single source of truth):

| Element type  | File-like fields       |
|---------------|------------------------|
| `prompt`      | `file`                 |
| `image`       | `file`                 |
| `audio`       | `file`                 |
| `mediaPlayer` | `url`, `captionsFile`  |
| `timeline`    | *(none — name ref)*    |

Exclusions: template placeholders (`${…}`), full URLs (`http://…`, `https://…`, `//…`), empty strings. Accepts `unknown` so callers can feed raw YAML parse output *before* schema validation, as the downstream consumer examples in the issue do.

Order is stable tree-walk order (outer-to-inner, insertion order within each object), with field-declaration order per the table within a single element. This lets consumers diff results meaningfully across treatment edits.

## VS Code extension rewiring

`apps/vscode/src/extension.ts` `checkFileReferences` now iterates `getReferencedAssets(parsedObj)` instead of recursing for literal `file` keys. The path-traversal guard (`isWithinWorkspace`) is preserved. As a side effect, local `mediaPlayer.url` and `mediaPlayer.captionsFile` paths now get file-existence diagnostics too.

## Test plan

- [x] 21 unit tests in `referencedAssets.test.ts` covering each element type's file fields, every exclusion rule, deep `pathInTree` in templated `gameStages`, full-URL vs placeholder exclusion, and defensive `unknown` handling
- [x] `npm test` — stagebook 539, viewer 68, vscode 142 — all pass
- [x] `npm run lint` — clean (zero warnings)
- [x] `npm run format:check` — clean
- [x] `npm run build -w stagebook` — dts emits `getReferencedAssets` / `ReferencedAsset`
- [x] `npm run build -w stagebook-vscode` — extension bundles without error

https://claude.ai/code/session_012dNNMgyjojedBBx48fcADN