### PR TITLE
Pass discussion through to Stage for two-column layout + rich placeholder

### DIFF
--- a/apps/viewer/src/components/SkeletonPlaceholder.tsx
+++ b/apps/viewer/src/components/SkeletonPlaceholder.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import type { DiscussionType } from "stagebook";
 
 interface SkeletonPlaceholderProps {
   type: string;
@@ -21,77 +22,60 @@ const chatTypeLabels: Record<string, string> = {
  * Build a human-readable summary of discussion configuration options,
  * filtered to only those relevant to the chatType.
  */
-function describeDiscussionConfig(config: Record<string, unknown>): string[] {
+function describeDiscussionConfig(config: DiscussionType): string[] {
   const lines: string[] = [];
-  const chatType = config.chatType as string | undefined;
 
-  if (config.showNickname !== undefined) {
-    lines.push(`Nicknames: ${config.showNickname ? "shown" : "hidden"}`);
-  }
+  lines.push(`Nicknames: ${config.showNickname ? "shown" : "hidden"}`);
 
-  if (chatType === "video" && config.showSelfView !== undefined) {
+  if (config.chatType === "video") {
     lines.push(`Self-view: ${config.showSelfView ? "shown" : "hidden"}`);
   }
 
-  if (config.showReportMissing !== undefined) {
-    lines.push(
-      `Report missing: ${config.showReportMissing ? "available" : "unavailable"}`,
-    );
-  }
+  lines.push(
+    `Report missing: ${config.showReportMissing ? "available" : "unavailable"}`,
+  );
 
-  if (
-    (chatType === "audio" || chatType === "video") &&
-    config.showAudioMute !== undefined
-  ) {
+  if (config.chatType === "audio" || config.chatType === "video") {
     lines.push(
       `Audio mute: ${config.showAudioMute ? "available" : "unavailable"}`,
     );
   }
 
-  if (chatType === "video" && config.showVideoMute !== undefined) {
+  if (config.chatType === "video") {
     lines.push(
       `Video mute: ${config.showVideoMute ? "available" : "unavailable"}`,
     );
   }
 
-  if (chatType === "text") {
+  if (config.chatType === "text") {
     if (
-      Array.isArray(config.reactionEmojisAvailable) &&
+      config.reactionEmojisAvailable &&
       config.reactionEmojisAvailable.length > 0
     ) {
-      lines.push(
-        `Reactions: ${(config.reactionEmojisAvailable as string[]).join(" ")}`,
-      );
+      lines.push(`Reactions: ${config.reactionEmojisAvailable.join(" ")}`);
     }
     if (config.numReactionsPerMessage !== undefined) {
-      lines.push(
-        `Reactions per message: ${config.numReactionsPerMessage as number}`,
-      );
+      lines.push(`Reactions per message: ${config.numReactionsPerMessage}`);
     }
     if (config.reactToSelf !== undefined) {
       lines.push(`React to own messages: ${config.reactToSelf ? "yes" : "no"}`);
     }
   }
 
-  if (chatType === "video" && config.rooms !== undefined) {
-    const rooms = config.rooms as unknown[];
-    lines.push(`Rooms: ${rooms.length} configured`);
+  if (config.chatType === "video" && config.rooms) {
+    lines.push(`Rooms: ${config.rooms.length} configured`);
   }
 
-  if (chatType === "video" && config.layout !== undefined) {
+  if (config.chatType === "video" && config.layout) {
     lines.push("Layout: custom layout configured");
   }
 
-  if (config.showToPositions !== undefined) {
-    lines.push(
-      `Shown to positions: ${(config.showToPositions as number[]).join(", ")}`,
-    );
+  if (config.showToPositions) {
+    lines.push(`Shown to positions: ${config.showToPositions.join(", ")}`);
   }
 
-  if (config.hideFromPositions !== undefined) {
-    lines.push(
-      `Hidden from positions: ${(config.hideFromPositions as number[]).join(", ")}`,
-    );
+  if (config.hideFromPositions) {
+    lines.push(`Hidden from positions: ${config.hideFromPositions.join(", ")}`);
   }
 
   return lines;
@@ -103,10 +87,10 @@ export function SkeletonPlaceholder({
 }: SkeletonPlaceholderProps) {
   // Discussion gets a rich, type-aware placeholder
   if (type === "discussion" && config) {
-    const chatType = config.chatType as string | undefined;
-    const icon = chatType ? chatTypeIcons[chatType] : undefined;
-    const label = chatType ? chatTypeLabels[chatType] : "Discussion";
-    const configLines = describeDiscussionConfig(config);
+    const discussion = config as unknown as DiscussionType;
+    const icon = chatTypeIcons[discussion.chatType];
+    const label = chatTypeLabels[discussion.chatType] ?? "Discussion";
+    const configLines = describeDiscussionConfig(discussion);
 
     return (
       <div style={discussionContainerStyle}>

--- a/apps/viewer/src/components/SkeletonPlaceholder.tsx
+++ b/apps/viewer/src/components/SkeletonPlaceholder.tsx
@@ -5,13 +5,133 @@ interface SkeletonPlaceholderProps {
   config?: Record<string, unknown>;
 }
 
+const chatTypeIcons: Record<string, string> = {
+  video: "\uD83D\uDCF9", // 📹
+  audio: "\uD83C\uDFA7", // 🎧
+  text: "\uD83D\uDCAC", // 💬
+};
+
+const chatTypeLabels: Record<string, string> = {
+  video: "Video Call",
+  audio: "Audio Call",
+  text: "Text Chat",
+};
+
+/**
+ * Build a human-readable summary of discussion configuration options,
+ * filtered to only those relevant to the chatType.
+ */
+function describeDiscussionConfig(config: Record<string, unknown>): string[] {
+  const lines: string[] = [];
+  const chatType = config.chatType as string | undefined;
+
+  if (config.showNickname !== undefined) {
+    lines.push(`Nicknames: ${config.showNickname ? "shown" : "hidden"}`);
+  }
+
+  if (chatType === "video" && config.showSelfView !== undefined) {
+    lines.push(`Self-view: ${config.showSelfView ? "shown" : "hidden"}`);
+  }
+
+  if (config.showReportMissing !== undefined) {
+    lines.push(
+      `Report missing: ${config.showReportMissing ? "available" : "unavailable"}`,
+    );
+  }
+
+  if (
+    (chatType === "audio" || chatType === "video") &&
+    config.showAudioMute !== undefined
+  ) {
+    lines.push(
+      `Audio mute: ${config.showAudioMute ? "available" : "unavailable"}`,
+    );
+  }
+
+  if (chatType === "video" && config.showVideoMute !== undefined) {
+    lines.push(
+      `Video mute: ${config.showVideoMute ? "available" : "unavailable"}`,
+    );
+  }
+
+  if (chatType === "text") {
+    if (
+      Array.isArray(config.reactionEmojisAvailable) &&
+      config.reactionEmojisAvailable.length > 0
+    ) {
+      lines.push(
+        `Reactions: ${(config.reactionEmojisAvailable as string[]).join(" ")}`,
+      );
+    }
+    if (config.numReactionsPerMessage !== undefined) {
+      lines.push(
+        `Reactions per message: ${config.numReactionsPerMessage as number}`,
+      );
+    }
+    if (config.reactToSelf !== undefined) {
+      lines.push(`React to own messages: ${config.reactToSelf ? "yes" : "no"}`);
+    }
+  }
+
+  if (chatType === "video" && config.rooms !== undefined) {
+    const rooms = config.rooms as unknown[];
+    lines.push(`Rooms: ${rooms.length} configured`);
+  }
+
+  if (chatType === "video" && config.layout !== undefined) {
+    lines.push("Layout: custom layout configured");
+  }
+
+  if (config.showToPositions !== undefined) {
+    lines.push(
+      `Shown to positions: ${(config.showToPositions as number[]).join(", ")}`,
+    );
+  }
+
+  if (config.hideFromPositions !== undefined) {
+    lines.push(
+      `Hidden from positions: ${(config.hideFromPositions as number[]).join(", ")}`,
+    );
+  }
+
+  return lines;
+}
+
 export function SkeletonPlaceholder({
   type,
   config,
 }: SkeletonPlaceholderProps) {
+  // Discussion gets a rich, type-aware placeholder
+  if (type === "discussion" && config) {
+    const chatType = config.chatType as string | undefined;
+    const icon = chatType ? chatTypeIcons[chatType] : undefined;
+    const label = chatType ? chatTypeLabels[chatType] : "Discussion";
+    const configLines = describeDiscussionConfig(config);
+
+    return (
+      <div style={discussionContainerStyle}>
+        <div style={discussionHeaderStyle}>
+          {icon && <span style={discussionIconStyle}>{icon}</span>}
+          <span style={discussionTitleStyle}>{label}</span>
+        </div>
+        <p style={discussionSubtitleStyle}>
+          Requires live session with multiple participants
+        </p>
+        {configLines.length > 0 && (
+          <ul style={configListStyle}>
+            {configLines.map((line) => (
+              <li key={line} style={configItemStyle}>
+                {line}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  }
+
+  // Generic placeholder for other platform-coupled elements
   const labels: Record<string, string> = {
-    discussion:
-      "Discussion element — requires live session with multiple participants",
     survey: "Survey element — requires external survey platform",
     sharedNotepad:
       "Shared notepad — requires live session with multiple participants",
@@ -62,7 +182,62 @@ export function createSkeletonRenderers() {
   };
 }
 
-// --- Styles ---
+// --- Discussion placeholder styles ---
+
+const discussionContainerStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: "0.75rem",
+  padding: "2rem",
+  border: "2px dashed #93c5fd",
+  borderRadius: "0.75rem",
+  backgroundColor: "#eff6ff",
+  minHeight: "16rem",
+  height: "100%",
+};
+
+const discussionHeaderStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+};
+
+const discussionIconStyle: React.CSSProperties = {
+  fontSize: "1.5rem",
+};
+
+const discussionTitleStyle: React.CSSProperties = {
+  fontSize: "1rem",
+  fontWeight: 600,
+  color: "#1e40af",
+};
+
+const discussionSubtitleStyle: React.CSSProperties = {
+  fontSize: "0.8125rem",
+  color: "#3b82f6",
+  margin: 0,
+  textAlign: "center",
+};
+
+const configListStyle: React.CSSProperties = {
+  listStyle: "none",
+  padding: 0,
+  margin: 0,
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.25rem",
+  marginTop: "0.5rem",
+};
+
+const configItemStyle: React.CSSProperties = {
+  fontSize: "0.75rem",
+  color: "#6b7280",
+  textAlign: "center",
+};
+
+// --- Generic placeholder styles ---
 
 const containerStyle: React.CSSProperties = {
   display: "flex",

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -126,6 +126,7 @@ export function Viewer({
     name: currentStep.name,
     duration: currentStep.duration,
     elements: currentStep.elements,
+    discussion: currentStep.discussion,
   };
 
   return (

--- a/apps/viewer/src/lib/steps.test.ts
+++ b/apps/viewer/src/lib/steps.test.ts
@@ -114,6 +114,10 @@ describe("flattenSteps", () => {
       chatType: "video" as const,
       showNickname: true,
       showTitle: true,
+      showSelfView: true,
+      showReportMissing: true,
+      showAudioMute: true,
+      showVideoMute: true,
     };
     const withDiscussion = {
       ...treatment,

--- a/apps/viewer/src/lib/steps.test.ts
+++ b/apps/viewer/src/lib/steps.test.ts
@@ -108,4 +108,24 @@ describe("flattenSteps", () => {
     const steps = flattenSteps(introSequence, treatment);
     expect(steps.map((s) => s.index)).toEqual([0, 1, 2, 3, 4]);
   });
+
+  it("carries discussion through on game stages", () => {
+    const discussion = {
+      chatType: "video" as const,
+      showNickname: true,
+      showTitle: true,
+    };
+    const withDiscussion = {
+      ...treatment,
+      gameStages: [
+        { ...treatment.gameStages[0], discussion },
+        treatment.gameStages[1],
+      ],
+    };
+    const steps = flattenSteps(introSequence, withDiscussion);
+    const round1 = steps.find((s) => s.name === "round1")!;
+    const round2 = steps.find((s) => s.name === "round2")!;
+    expect(round1.discussion).toEqual(discussion);
+    expect(round2.discussion).toBeUndefined();
+  });
 });

--- a/apps/viewer/src/lib/steps.ts
+++ b/apps/viewer/src/lib/steps.ts
@@ -1,4 +1,4 @@
-import type { ElementType } from "stagebook";
+import type { ElementType, DiscussionType } from "stagebook";
 
 export type Phase = "intro" | "game" | "exit";
 
@@ -8,6 +8,7 @@ export interface ViewerStep {
   name: string;
   elements: ElementType[];
   duration?: number;
+  discussion?: DiscussionType;
 }
 
 interface IntroSequence {
@@ -18,7 +19,12 @@ interface IntroSequence {
 interface Treatment {
   name: string;
   playerCount: number;
-  gameStages: { name: string; duration?: number; elements: ElementType[] }[];
+  gameStages: {
+    name: string;
+    duration?: number;
+    elements: ElementType[];
+    discussion?: DiscussionType;
+  }[];
   exitSequence?: { name: string; elements: ElementType[] }[];
 }
 
@@ -49,6 +55,7 @@ export function flattenSteps(
       name: stage.name,
       elements: stage.elements,
       duration: stage.duration,
+      discussion: stage.discussion,
     });
   }
 

--- a/packages/stagebook/src/components/Stage.tsx
+++ b/packages/stagebook/src/components/Stage.tsx
@@ -168,6 +168,7 @@ export function Stage({ stage, onSubmit }: StageProps) {
       <div
         style={{
           display: "flex",
+          flexWrap: "wrap",
           height: "100%",
           width: "100%",
           flexDirection: "row",

--- a/packages/stagebook/src/components/Stage.tsx
+++ b/packages/stagebook/src/components/Stage.tsx
@@ -193,13 +193,14 @@ export function Stage({ stage, onSubmit }: StageProps) {
           {renderDiscussion(stage.discussion)}
         </div>
 
-        {/* Elements column — scrollable independently */}
+        {/* Elements column — scrollable independently.
+            flex: "1 1 20rem" lets it share space in row mode (40vw preferred)
+            but stretch to full width when the container wraps to column. */}
         <div
           ref={discussionContentRef}
           data-testid="stageContent"
           style={{
-            width: "40vw",
-            minWidth: "20rem",
+            flex: "1 1 20rem",
             maxWidth: "48rem",
             overflowY: "auto",
             scrollBehavior: "smooth",


### PR DESCRIPTION
## Summary

- `flattenSteps` and `Viewer.tsx` were dropping the `discussion` field from game stages, so `Stage.tsx` never triggered the two-column layout. The layout code and skeleton placeholder infrastructure were both already there — just the plumbing was missing.
- Discussion skeleton placeholder now shows the chatType (Video Call / Audio Call / Text Chat) with an icon, plus a readable summary of the researcher's configuration (nicknames, self-view, mute controls, reactions, rooms, etc.), filtered to only show fields relevant to the chatType.
- Added `flexWrap: "wrap"` to the discussion layout container so it stacks vertically on narrow screens (matching deliberation-empirica's responsive behavior).

Fixes #161

## Changes

| File | Change |
|---|---|
| `apps/viewer/src/lib/steps.ts` | Add `discussion` to `ViewerStep` interface + `flattenSteps` |
| `apps/viewer/src/lib/steps.test.ts` | Test that discussion carries through |
| `apps/viewer/src/components/Viewer.tsx` | Include `discussion` in `stageConfig` |
| `packages/stagebook/src/components/Stage.tsx` | Add `flexWrap: "wrap"` to discussion container |
| `apps/viewer/src/components/SkeletonPlaceholder.tsx` | Rich discussion placeholder with type-aware icon + config summary |

## Test plan
- [x] `npm test` passes (749 tests)
- [x] `npm run lint` clean
- [ ] Manual: load a treatment with a `discussion` stage in the viewer → two-column layout with rich placeholder on left, elements on right
- [ ] Manual: narrow the viewport → columns stack vertically

🤖 Generated with [Claude Code](https://claude.com/claude-code)