### PR TITLE
Fix Timeline selection positioning before video metadata loads

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -14,6 +14,11 @@ import { expandAndValidate } from "./lib/expandAndValidate";
 import { findClosestMatch } from "./lib/levenshtein";
 import { isWithinWorkspace, relativizePath } from "./lib/filePaths";
 import {
+  ASSET_GLOB,
+  buildCompletionGlob,
+  parseFilePathCompletionContext,
+} from "./lib/filePathCompletion";
+import {
   fillTemplates,
   getReferencedAssets,
   treatmentFileSchema,
@@ -307,10 +312,7 @@ class FilePathQuickFixProvider implements vscode.CodeActionProvider {
       this.cachedTreatmentDir !== treatmentDirFsPath
     ) {
       const allFiles = await vscode.workspace.findFiles(
-        new vscode.RelativePattern(
-          workspaceFolder,
-          "**/*.{prompt.md,md,yaml,jpg,jpeg,png,mp3,mp4}",
-        ),
+        new vscode.RelativePattern(workspaceFolder, ASSET_GLOB),
         "**/node_modules/**",
         5000,
       );
@@ -351,8 +353,11 @@ class FilePathCompletionProvider implements vscode.CompletionItemProvider {
     const line = document.lineAt(position).text;
     const prefix = line.substring(0, position.character);
 
-    // Trigger after "file:" anywhere in the line (handles "- file:", indented, etc.)
-    if (!/\bfile:\s/.test(prefix)) return undefined;
+    // Trigger inside the value of any recognised file-path field:
+    // `file:` (prompt/image/audio), `url:` (mediaPlayer — including local
+    // video files), or `captionsFile:` (mediaPlayer captions).
+    const ctx = parseFilePathCompletionContext(prefix);
+    if (!ctx) return undefined;
 
     if (!vscode.workspace.workspaceFolders?.length) return undefined;
 
@@ -362,15 +367,7 @@ class FilePathCompletionProvider implements vscode.CompletionItemProvider {
     // Completions should be relative to the treatment file's directory
     const treatmentDirFsPath = vscode.Uri.joinPath(document.uri, "..").fsPath;
 
-    // Get the partial path the user has typed so far
-    const fileValueMatch = prefix.match(/\bfile:\s+(.*)/);
-    const partial = fileValueMatch?.[1] ?? "";
-
-    // Sanitize glob metacharacters in user input
-    const sanitized = partial.replace(/[*?[\]{}]/g, "\\$&");
-    const globPattern = sanitized
-      ? `**/${sanitized}*`
-      : "**/*.{prompt.md,md,yaml}";
+    const globPattern = buildCompletionGlob(ctx.partial);
     const files = await vscode.workspace.findFiles(
       new vscode.RelativePattern(workspaceFolder, globPattern),
       "**/node_modules/**",
@@ -391,12 +388,9 @@ class FilePathCompletionProvider implements vscode.CompletionItemProvider {
       );
       item.insertText = relativePath;
       // Replace only the value portion (not trailing comments)
-      const valueStart = prefix.lastIndexOf("file:") + "file:".length;
-      const whitespaceAfterColon =
-        prefix.substring(valueStart).match(/^\s*/)?.[0] ?? " ";
       item.range = new vscode.Range(
         position.line,
-        valueStart + whitespaceAfterColon.length,
+        ctx.valueStart,
         position.line,
         valueEnd,
       );

--- a/apps/vscode/src/lib/filePathCompletion.test.ts
+++ b/apps/vscode/src/lib/filePathCompletion.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  ASSET_GLOB,
+  buildCompletionGlob,
+  parseFilePathCompletionContext,
+} from "./filePathCompletion";
+
+describe("parseFilePathCompletionContext", () => {
+  it("triggers on bare `file:` with whitespace", () => {
+    const ctx = parseFilePathCompletionContext("  - file: ");
+    expect(ctx).not.toBeNull();
+    expect(ctx!.field).toBe("file");
+    expect(ctx!.partial).toBe("");
+    expect(ctx!.valueStart).toBe("  - file: ".length);
+  });
+
+  it("triggers on `url:` for mediaPlayer — the whole point of this change", () => {
+    const ctx = parseFilePathCompletionContext("      url: videos/intro");
+    expect(ctx).not.toBeNull();
+    expect(ctx!.field).toBe("url");
+    expect(ctx!.partial).toBe("videos/intro");
+  });
+
+  it("triggers on `captionsFile:` for mediaPlayer captions", () => {
+    const ctx = parseFilePathCompletionContext(
+      "      captionsFile: subs/intro.vtt",
+    );
+    expect(ctx).not.toBeNull();
+    expect(ctx!.field).toBe("captionsFile");
+    expect(ctx!.partial).toBe("subs/intro.vtt");
+  });
+
+  it("returns the partial path the user has typed so far", () => {
+    const ctx = parseFilePathCompletionContext("  file: ./assets/in");
+    expect(ctx!.partial).toBe("./assets/in");
+  });
+
+  it("returns null when the line does not contain a recognized field", () => {
+    expect(parseFilePathCompletionContext("  name: foo")).toBeNull();
+    expect(parseFilePathCompletionContext("# comment only")).toBeNull();
+    expect(parseFilePathCompletionContext("")).toBeNull();
+  });
+
+  it("does not match substrings of other identifiers (fileName, captionsFileName)", () => {
+    expect(parseFilePathCompletionContext("  fileName: foo")).toBeNull();
+    expect(
+      parseFilePathCompletionContext("  captionsFileName: foo"),
+    ).toBeNull();
+  });
+
+  it("does not match `sourceFile` or other words that happen to end in file", () => {
+    // `sourceFile` ends in "file" but isn't the field name `file`. The field
+    // regex requires a word boundary immediately before the field name; an
+    // identifier character (like the `e` in `source`) breaks that.
+    expect(parseFilePathCompletionContext("  sourceFile: foo")).toBeNull();
+  });
+
+  it("picks the rightmost field when multiple appear on the same line", () => {
+    // Inline/flow YAML — rare but valid.
+    const ctx = parseFilePathCompletionContext("{ name: x, url: videos/y ");
+    expect(ctx!.field).toBe("url");
+    expect(ctx!.partial).toBe("videos/y ");
+  });
+
+  it("requires at least one whitespace char between colon and value", () => {
+    // YAML value must be separated by whitespace from the colon.
+    expect(parseFilePathCompletionContext("  file:foo")).toBeNull();
+  });
+
+  it("reports valueStart as the column right after whitespace", () => {
+    const line = "    url:   vids/";
+    const ctx = parseFilePathCompletionContext(line);
+    expect(ctx!.valueStart).toBe(line.indexOf("vids/"));
+    expect(ctx!.partial).toBe("vids/");
+  });
+});
+
+describe("buildCompletionGlob", () => {
+  it("returns the asset glob when no partial is typed", () => {
+    expect(buildCompletionGlob("")).toBe(ASSET_GLOB);
+  });
+
+  it("prefixes the partial with **/ and suffixes with * for narrowing", () => {
+    expect(buildCompletionGlob("videos/intro")).toBe("**/videos/intro*");
+  });
+
+  it("escapes glob metacharacters in user input", () => {
+    expect(buildCompletionGlob("foo[bar]")).toBe("**/foo\\[bar\\]*");
+    expect(buildCompletionGlob("a*b?c")).toBe("**/a\\*b\\?c*");
+    expect(buildCompletionGlob("a{b,c}")).toBe("**/a\\{b,c\\}*");
+  });
+});
+
+describe("ASSET_GLOB", () => {
+  it("includes the common local video container formats", () => {
+    // The whole reason this glob exists is so local video file references
+    // (mediaPlayer.url) surface in completions + quick-fixes.
+    expect(ASSET_GLOB).toContain("mp4");
+    expect(ASSET_GLOB).toContain("webm");
+    expect(ASSET_GLOB).toContain("mov");
+  });
+
+  it("includes common audio and caption formats", () => {
+    expect(ASSET_GLOB).toContain("mp3");
+    expect(ASSET_GLOB).toContain("wav");
+    expect(ASSET_GLOB).toContain("vtt");
+  });
+
+  it("keeps the prompt/markdown/yaml file types the autocomplete relied on", () => {
+    expect(ASSET_GLOB).toContain("prompt.md");
+    expect(ASSET_GLOB).toContain("md");
+    expect(ASSET_GLOB).toContain("yaml");
+  });
+});

--- a/apps/vscode/src/lib/filePathCompletion.ts
+++ b/apps/vscode/src/lib/filePathCompletion.ts
@@ -1,0 +1,85 @@
+/**
+ * Pure-function helpers for file-path completion / quick-fix in treatment
+ * YAML. Kept VS Code-free so they can be unit-tested with vitest; the
+ * extension host wires them into CompletionItemProvider / CodeActionProvider.
+ *
+ * The set of YAML field names covered here MUST stay in sync with
+ * `FILE_FIELDS_BY_ELEMENT_TYPE` in `stagebook/utils/referencedAssets.ts` —
+ * that table is what drives "file not found" diagnostics, so the same fields
+ * should offer completions.
+ */
+
+/**
+ * YAML field names that point at local asset paths and should trigger
+ * file-path completion or surface quick-fix suggestions.
+ */
+export const FILE_PATH_FIELDS = ["file", "url", "captionsFile"] as const;
+
+/**
+ * Glob pattern covering every local-asset file type the extension cares
+ * about (prompt/treatment docs, images, audio, video, captions). Used for
+ * quick-fix suggestion candidates and as the default completion glob when
+ * the user hasn't typed a partial path yet.
+ */
+export const ASSET_GLOB =
+  "**/*.{prompt.md,md,yaml,jpg,jpeg,png,gif,webp,mp3,wav,m4a,ogg,mp4,webm,mov,vtt}";
+
+export interface FilePathCompletionContext {
+  /** The triggering field name (e.g. "file", "url", "captionsFile"). */
+  field: (typeof FILE_PATH_FIELDS)[number];
+  /** The partial path the user has typed after `<field>:<whitespace>`. */
+  partial: string;
+  /**
+   * Column index (0-based) in the original line where the value portion
+   * begins — i.e. the first character after `<field>:` and its whitespace.
+   */
+  valueStart: number;
+}
+
+// `[^\s#]` guards against treating the same field name embedded in a larger
+// word (`fileName:`) as a match. Captured group 1 is the field name, group 2
+// is any whitespace between `:` and the value (always at least one space to
+// be valid YAML).
+const FIELD_PATTERN = new RegExp(
+  `(?:^|[^\\w-])(${FILE_PATH_FIELDS.join("|")})\\s*:(\\s+)`,
+  "g",
+);
+
+/**
+ * Inspect the line-prefix up to the cursor and decide whether to offer file
+ * completions. Returns the matched field name, the partial path typed so
+ * far, and the column at which the value begins — or null if the prefix
+ * doesn't end inside the value of one of the recognised fields.
+ *
+ * Takes the LAST occurrence so inline YAML like `{ name: x, file: ./y }`
+ * resolves to the rightmost field.
+ */
+export function parseFilePathCompletionContext(
+  lineBeforeCursor: string,
+): FilePathCompletionContext | null {
+  let last: RegExpExecArray | null = null;
+  FIELD_PATTERN.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = FIELD_PATTERN.exec(lineBeforeCursor)) !== null) {
+    last = m;
+  }
+  if (!last) return null;
+
+  const field = last[1] as (typeof FILE_PATH_FIELDS)[number];
+  // last.index points at the character before the field (or -1 when the
+  // match is anchored at start — `(?:^|...)` consumes 0 chars in that case).
+  const fieldStart = last.index + (last[0].startsWith(field) ? 0 : 1);
+  const valueStart = fieldStart + field.length + 1 + last[2].length; // +1 for ":"
+  const partial = lineBeforeCursor.substring(valueStart);
+  return { field, partial, valueStart };
+}
+
+/**
+ * Build the glob pattern for the completion search given the partial path
+ * already typed. When there's no partial, fall back to the full asset glob
+ * so the user sees every candidate in the workspace.
+ */
+export function buildCompletionGlob(partial: string): string {
+  const sanitized = partial.replace(/[*?[\]{}]/g, "\\$&");
+  return sanitized ? `**/${sanitized}*` : ASSET_GLOB;
+}

--- a/apps/vscode/src/lib/filePathCompletion.ts
+++ b/apps/vscode/src/lib/filePathCompletion.ts
@@ -4,9 +4,10 @@
  * extension host wires them into CompletionItemProvider / CodeActionProvider.
  *
  * The set of YAML field names covered here MUST stay in sync with
- * `FILE_FIELDS_BY_ELEMENT_TYPE` in `stagebook/utils/referencedAssets.ts` —
- * that table is what drives "file not found" diagnostics, so the same fields
- * should offer completions.
+ * `FILE_FIELDS_BY_ELEMENT_TYPE` in
+ * `packages/stagebook/src/utils/referencedAssets.ts` — that table is what
+ * drives "file not found" diagnostics, so the same fields should offer
+ * completions.
  */
 
 /**
@@ -36,10 +37,10 @@ export interface FilePathCompletionContext {
   valueStart: number;
 }
 
-// `[^\s#]` guards against treating the same field name embedded in a larger
-// word (`fileName:`) as a match. Captured group 1 is the field name, group 2
-// is any whitespace between `:` and the value (always at least one space to
-// be valid YAML).
+// `(?:^|[^\w-])` guards against treating the same field name embedded in a
+// larger word or hyphenated identifier (`fileName:`, `my-file:`) as a match.
+// Captured group 1 is the field name; group 2 is the whitespace matched by
+// `\s+` between `:` and the value (at least one whitespace character).
 const FIELD_PATTERN = new RegExp(
   `(?:^|[^\\w-])(${FILE_PATH_FIELDS.join("|")})\\s*:(\\s+)`,
   "g",
@@ -66,8 +67,10 @@ export function parseFilePathCompletionContext(
   if (!last) return null;
 
   const field = last[1] as (typeof FILE_PATH_FIELDS)[number];
-  // last.index points at the character before the field (or -1 when the
-  // match is anchored at start — `(?:^|...)` consumes 0 chars in that case).
+  // `last.index` is the start offset of the overall match. If the regex
+  // matched a preceding non-word/non-hyphen character via `(?:^|[^\w-])`,
+  // the field starts one character later; if it matched `^`, the field
+  // starts exactly at `last.index` (which is 0 at the beginning of the line).
   const fieldStart = last.index + (last[0].startsWith(field) ? 0 : 1);
   const valueStart = fieldStart + field.length + 1 + last[2].length; // +1 for ":"
   const partial = lineBeforeCursor.substring(valueStart);

--- a/packages/stagebook/src/components/elements/MediaPlayer.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.tsx
@@ -67,6 +67,17 @@ export interface MediaPlayerProps {
 
 const SPEEDS = [0.5, 0.75, 1, 1.25, 1.5, 2] as const;
 
+// Subtle edge for the video viewport. Without this, near-white content
+// (a washed-out background, a whiteboard) bleeds into the surrounding page.
+// A 1px inset ring via boxShadow keeps layout identical to a border-less
+// viewport (no size inflation) while still delimiting the edge.
+const VIEWPORT_STYLE: React.CSSProperties = {
+  position: "relative",
+  borderRadius: "0.5rem",
+  overflow: "hidden",
+  boxShadow: "0 0 0 1px rgba(0, 0, 0, 0.12), 0 1px 3px rgba(0, 0, 0, 0.06)",
+};
+
 /** Reject URLs with dangerous protocols (javascript:, data:, vbscript:, etc.) */
 function isSafeURL(url: string): boolean {
   try {
@@ -1031,10 +1042,7 @@ export function MediaPlayer({
         onMouseLeave={() => setIsHovered(false)}
         style={{ position: "relative" }}
       >
-        <div
-          data-testid="mediaPlayer-viewport"
-          style={{ position: "relative" }}
-        >
+        <div data-testid="mediaPlayer-viewport" style={VIEWPORT_STYLE}>
           <YouTubePlayer
             videoId={youtubeVideoId}
             startAt={startAt}
@@ -1148,10 +1156,7 @@ export function MediaPlayer({
 
       {/* Video viewport — video + captions + overlay controls */}
       {playVideo && (
-        <div
-          data-testid="mediaPlayer-viewport"
-          style={{ position: "relative" }}
-        >
+        <div data-testid="mediaPlayer-viewport" style={VIEWPORT_STYLE}>
           <video
             ref={videoRef}
             data-testid="mediaPlayer-video"

--- a/packages/stagebook/src/components/elements/MediaPlayer.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.tsx
@@ -188,6 +188,7 @@ export function MediaPlayer({
   // Render token: bumps every time peaks are mutated, so consumers can
   // re-run effects despite the array reference being stable.
   const peaksVersionRef = useRef(0);
+  const durationVersionRef = useRef(0);
   const [channelCount, setChannelCount] = useState(0);
   const waveformRafRef = useRef<number>(0);
   // Promote waveformActive to state so React effects (e.g., the RAF loop)
@@ -396,6 +397,9 @@ export function MediaPlayer({
       get peaksVersion() {
         return peaksVersionRef.current;
       },
+      get durationVersion() {
+        return durationVersionRef.current;
+      },
       requestWaveformCapture: startWaveformCapture,
       setChannelMuted: (channel: number, muted: boolean) => {
         setChannelGain(gainNodesRef.current, channel, muted);
@@ -533,6 +537,7 @@ export function MediaPlayer({
     (e: React.SyntheticEvent<HTMLVideoElement>) => {
       const v = e.currentTarget;
       setDuration(v.duration);
+      durationVersionRef.current += 1;
 
       // Detect likely server-side range-request misconfiguration for
       // finite-duration media. Skip the check entirely for live streams or

--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -1428,7 +1428,7 @@ test("Space key never intercepted by timeline", async ({ mount }) => {
 
 // -- Footer / zoom / minimap / help (#49) --
 
-test("footer renders with default zoom buttons and selection summary", async ({
+test("footer renders with selection summary and help button", async ({
   mount,
 }) => {
   const component = await mount(
@@ -1444,13 +1444,61 @@ test("footer renders with default zoom buttons and selection summary", async ({
     component.locator('[data-testid="timeline-footer"]'),
   ).toBeAttached();
   await expect(
-    component.locator('[data-testid="timeline-zoom-in"]'),
-  ).toBeAttached();
-  await expect(
-    component.locator('[data-testid="timeline-zoom-out"]'),
-  ).toBeAttached();
-  await expect(
     component.locator('[data-testid="timeline-help-button"]'),
+  ).toBeAttached();
+});
+
+test("zoom buttons live in the header, not the footer", async ({ mount }) => {
+  // Issue #129: the minimap sits at the top; zoom controls belong next to
+  // it for context. Keep the data-testids stable so click-driven tests
+  // elsewhere keep working, but move them into `timeline-header`.
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="ranges"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const header = component.locator('[data-testid="timeline-header"]');
+  await expect(header).toBeAttached();
+  await expect(
+    header.locator('[data-testid="timeline-zoom-in"]'),
+  ).toBeAttached();
+  await expect(
+    header.locator('[data-testid="timeline-zoom-out"]'),
+  ).toBeAttached();
+
+  // Footer must no longer own them.
+  const footer = component.locator('[data-testid="timeline-footer"]');
+  await expect(footer.locator('[data-testid="timeline-zoom-in"]')).toHaveCount(
+    0,
+  );
+  await expect(footer.locator('[data-testid="timeline-zoom-out"]')).toHaveCount(
+    0,
+  );
+});
+
+test("zoom controls share the header row with the minimap once zoomed", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="ranges"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  const header = component.locator('[data-testid="timeline-header"]');
+  await expect(
+    header.locator('[data-testid="timeline-minimap"]'),
+  ).toBeAttached();
+  await expect(
+    header.locator('[data-testid="timeline-zoom-in"]'),
   ).toBeAttached();
 });
 

--- a/packages/stagebook/src/components/elements/Timeline.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.tsx
@@ -261,7 +261,7 @@ export function Timeline({
   // re-run when new data arrives.
   const [isPaused, setIsPaused] = useState(true);
   const [peaksVersion, setPeaksVersion] = useState(0);
-  const [durationVersion, setDurationVersion] = useState(0);
+  const [, setDurationVersion] = useState(0);
   useEffect(() => {
     let cancelled = false;
     let lastValue = -1;
@@ -289,7 +289,7 @@ export function Timeline({
           lastPeaksVersion = v;
           setPeaksVersion(v);
         }
-        const dv = h.durationVersion;
+        const dv = h.durationVersion ?? 0;
         if (dv !== lastDurationVersion) {
           lastDurationVersion = dv;
           setDurationVersion(dv);
@@ -509,10 +509,10 @@ export function Timeline({
     );
   }
 
-  // durationVersion triggers a re-render when loadedmetadata fires, so
-  // getDuration() returns the real value instead of 0. Without this,
-  // saved selections render at x=0 until the first timeupdate event.
-  void durationVersion;
+  // durationVersion (polled in the RAF loop above) triggers a re-render
+  // when loadedmetadata fires, so getDuration() returns the real value
+  // instead of 0. Without this, saved selections render at x=0 until
+  // the first timeupdate event.
   const duration = handle.getDuration();
   const channelCount = handle.channelCount || 1;
   const peaks = handle.peaks;

--- a/packages/stagebook/src/components/elements/Timeline.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.tsx
@@ -260,11 +260,13 @@ export function Timeline({
   // re-run when new data arrives.
   const [isPaused, setIsPaused] = useState(true);
   const [peaksVersion, setPeaksVersion] = useState(0);
+  const [durationVersion, setDurationVersion] = useState(0);
   useEffect(() => {
     let cancelled = false;
     let lastValue = -1;
     let lastPaused: boolean | null = null;
     let lastPeaksVersion = -1;
+    let lastDurationVersion = -1;
     let rafId = 0;
 
     function tick() {
@@ -285,6 +287,11 @@ export function Timeline({
         if (v !== lastPeaksVersion) {
           lastPeaksVersion = v;
           setPeaksVersion(v);
+        }
+        const dv = h.durationVersion;
+        if (dv !== lastDurationVersion) {
+          lastDurationVersion = dv;
+          setDurationVersion(dv);
         }
       }
       rafId = requestAnimationFrame(tick);
@@ -501,6 +508,10 @@ export function Timeline({
     );
   }
 
+  // durationVersion triggers a re-render when loadedmetadata fires, so
+  // getDuration() returns the real value instead of 0. Without this,
+  // saved selections render at x=0 until the first timeupdate event.
+  void durationVersion;
   const duration = handle.getDuration();
   const channelCount = handle.channelCount || 1;
   const peaks = handle.peaks;

--- a/packages/stagebook/src/components/elements/Timeline.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.tsx
@@ -11,6 +11,7 @@ import { TimelineTrack, GUTTER_WIDTH } from "./timeline/TimelineTrack.js";
 import { Playhead } from "./timeline/Playhead.js";
 import { SelectionOverlay } from "./timeline/SelectionOverlay.js";
 import { TimelineFooter } from "./timeline/TimelineFooter.js";
+import { TimelineHeader } from "./timeline/TimelineHeader.js";
 import { Minimap } from "./timeline/Minimap.js";
 import { HelpPopover } from "./timeline/HelpPopover.js";
 import { computeBucketCount } from "./mediaPlayer/waveformCapture.js";
@@ -557,23 +558,29 @@ export function Timeline({
         position: "relative",
       }}
     >
-      {/* Minimap — only when zoomed in */}
-      {zoomLevel > 1 && (
-        <div style={{ marginLeft: `${String(GUTTER_WIDTH)}px` }}>
-          <Minimap
-            duration={duration}
-            width={waveformWidth}
-            zoomLevel={zoomLevel}
-            viewportStart={viewportStart}
-            currentTime={currentTime}
-            selections={state.selections}
-            peaks={peaks}
-            peaksVersion={peaksVersion}
-            totalBuckets={totalBuckets}
-            onViewportChange={onMinimapPan}
-          />
-        </div>
-      )}
+      {/* Header: zoom controls (always) + minimap (when zoomed in) — puts
+          the zoom buttons next to the minimap for context (issue #129). */}
+      <TimelineHeader
+        zoomLevel={zoomLevel}
+        onZoomIn={onZoomIn}
+        onZoomOut={onZoomOut}
+        minimap={
+          zoomLevel > 1 ? (
+            <Minimap
+              duration={duration}
+              width={waveformWidth}
+              zoomLevel={zoomLevel}
+              viewportStart={viewportStart}
+              currentTime={currentTime}
+              selections={state.selections}
+              peaks={peaks}
+              peaksVersion={peaksVersion}
+              totalBuckets={totalBuckets}
+              onViewportChange={onMinimapPan}
+            />
+          ) : null
+        }
+      />
 
       {/* Time ruler — offset by gutter width */}
       <div style={{ marginLeft: `${String(GUTTER_WIDTH)}px` }}>
@@ -692,9 +699,6 @@ export function Timeline({
         selectionType={selectionType}
         selections={state.selections}
         activeIndex={state.activeIndex}
-        zoomLevel={zoomLevel}
-        onZoomIn={onZoomIn}
-        onZoomOut={onZoomOut}
         onHelpToggle={() => setHelpOpen((v) => !v)}
         helpOpen={helpOpen}
       />

--- a/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
+++ b/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
@@ -58,6 +58,51 @@ test("renders an iframe for YouTube URL", async ({ mount }) => {
   ).not.toBeAttached();
 });
 
+// -- Viewport border: edges stay visible when video content is near-white --
+// Without a border or subtle outline, light-colored content (a washed-out
+// blurred background, a whiteboard) bleeds into the page. The viewport div
+// is where the definition needs to live so it applies equally to HTML5 and
+// YouTube embeds.
+
+test("video viewport has a visible edge for white-content visibility", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockMediaPlayer url="/sample-video.mp4" name="test" />,
+  );
+  const viewport = component.locator('[data-testid="mediaPlayer-viewport"]');
+  const { borderTopWidth, boxShadow } = await viewport.evaluate((el) => {
+    const s = window.getComputedStyle(el);
+    return {
+      borderTopWidth: s.borderTopWidth,
+      boxShadow: s.boxShadow,
+    };
+  });
+  // Either a non-zero border or a non-"none" box-shadow suffices.
+  const hasBorder = borderTopWidth !== "0px";
+  const hasShadow = boxShadow !== "none";
+  expect(hasBorder || hasShadow).toBe(true);
+});
+
+test("YouTube viewport has the same visible edge as HTML5", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockMediaPlayer url="https://youtu.be/QC8iQqtG0hg" name="test" />,
+  );
+  const viewport = component.locator('[data-testid="mediaPlayer-viewport"]');
+  const { borderTopWidth, boxShadow } = await viewport.evaluate((el) => {
+    const s = window.getComputedStyle(el);
+    return {
+      borderTopWidth: s.borderTopWidth,
+      boxShadow: s.boxShadow,
+    };
+  });
+  const hasBorder = borderTopWidth !== "0px";
+  const hasShadow = boxShadow !== "none";
+  expect(hasBorder || hasShadow).toBe(true);
+});
+
 // -- YouTube IFrame API integration --
 
 // Injects a synchronous mock window.YT into the page so YouTubePlayer's

--- a/packages/stagebook/src/components/elements/mediaPlayer/YouTubePlayer.tsx
+++ b/packages/stagebook/src/components/elements/mediaPlayer/YouTubePlayer.tsx
@@ -123,6 +123,7 @@ export function buildYouTubeHandle(player: YTPlayer): PlaybackHandle {
     channelCount: 0,
     peaks: [],
     peaksVersion: 0,
+    durationVersion: 1, // YouTube duration is available immediately from the API
     requestWaveformCapture() {}, // no-op for YouTube
     setChannelMuted() {}, // no-op for YouTube
     isChannelMuted: () => false,

--- a/packages/stagebook/src/components/elements/timeline/Minimap.tsx
+++ b/packages/stagebook/src/components/elements/timeline/Minimap.tsx
@@ -213,7 +213,6 @@ export function Minimap({
         height: `${String(HEIGHT)}px`,
         width: `${String(width)}px`,
         background: "var(--stagebook-bg-muted, #f9fafb)",
-        borderBottom: "1px solid var(--stagebook-border, #e5e7eb)",
         cursor: "pointer",
         userSelect: "none",
         touchAction: "none",

--- a/packages/stagebook/src/components/elements/timeline/TimelineFooter.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineFooter.tsx
@@ -1,15 +1,11 @@
 import React from "react";
 import { formatTime } from "../../../utils/formatTime.js";
 import type { TimelineValue } from "./selections.js";
-import { MIN_ZOOM, MAX_ZOOM } from "./viewport.js";
 
 export interface TimelineFooterProps {
   selectionType: "range" | "point";
   selections: TimelineValue;
   activeIndex: number | null;
-  zoomLevel: number;
-  onZoomIn: () => void;
-  onZoomOut: () => void;
   onHelpToggle: () => void;
   helpOpen: boolean;
 }
@@ -65,19 +61,10 @@ const buttonStyle: React.CSSProperties = {
   color: "inherit",
 };
 
-const disabledStyle: React.CSSProperties = {
-  ...buttonStyle,
-  cursor: "not-allowed",
-  opacity: 0.4,
-};
-
 export function TimelineFooter({
   selectionType,
   selections,
   activeIndex,
-  zoomLevel,
-  onZoomIn,
-  onZoomOut,
   onHelpToggle,
   helpOpen,
 }: TimelineFooterProps) {
@@ -95,31 +82,7 @@ export function TimelineFooter({
         userSelect: "none",
       }}
     >
-      {/* Left: zoom controls */}
-      <div style={{ display: "flex", alignItems: "center", gap: "0.25rem" }}>
-        <button
-          type="button"
-          data-testid="timeline-zoom-out"
-          onClick={onZoomOut}
-          disabled={zoomLevel <= MIN_ZOOM}
-          aria-label="Zoom out"
-          style={zoomLevel <= MIN_ZOOM ? disabledStyle : buttonStyle}
-        >
-          −
-        </button>
-        <button
-          type="button"
-          data-testid="timeline-zoom-in"
-          onClick={onZoomIn}
-          disabled={zoomLevel >= MAX_ZOOM}
-          aria-label="Zoom in"
-          style={zoomLevel >= MAX_ZOOM ? disabledStyle : buttonStyle}
-        >
-          +
-        </button>
-      </div>
-
-      {/* Center: selection summary */}
+      {/* Left: selection summary */}
       <div data-testid="timeline-selection-summary">
         {summary(selectionType, selections, activeIndex)}
       </div>

--- a/packages/stagebook/src/components/elements/timeline/TimelineHeader.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineHeader.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import { MIN_ZOOM, MAX_ZOOM } from "./viewport.js";
+import { GUTTER_WIDTH } from "./TimelineTrack.js";
+
+export interface TimelineHeaderProps {
+  zoomLevel: number;
+  onZoomIn: () => void;
+  onZoomOut: () => void;
+  /**
+   * The minimap is rendered here (as children) when the timeline is zoomed
+   * in — so the zoom controls sit right next to the minimap for visual
+   * context (issue #129). When zoomLevel === 1 the parent passes null and
+   * the header shows only the zoom controls.
+   */
+  minimap?: React.ReactNode;
+}
+
+const buttonStyle: React.CSSProperties = {
+  width: "24px",
+  height: "24px",
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  border: "1px solid var(--stagebook-border, #e5e7eb)",
+  borderRadius: "0.25rem",
+  background: "var(--stagebook-bg, #ffffff)",
+  cursor: "pointer",
+  fontSize: "0.875rem",
+  lineHeight: 1,
+  padding: 0,
+  color: "inherit",
+};
+
+const disabledStyle: React.CSSProperties = {
+  ...buttonStyle,
+  cursor: "not-allowed",
+  opacity: 0.4,
+};
+
+export function TimelineHeader({
+  zoomLevel,
+  onZoomIn,
+  onZoomOut,
+  minimap,
+}: TimelineHeaderProps) {
+  return (
+    <div
+      data-testid="timeline-header"
+      style={{
+        display: "flex",
+        alignItems: "center",
+        borderBottom: "1px solid var(--stagebook-border, #e5e7eb)",
+        userSelect: "none",
+      }}
+    >
+      {/* Gutter-width zoom controls — align with the per-track labels below */}
+      <div
+        style={{
+          width: `${String(GUTTER_WIDTH)}px`,
+          minWidth: `${String(GUTTER_WIDTH)}px`,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: "0.25rem",
+          padding: "0.25rem",
+          boxSizing: "border-box",
+        }}
+      >
+        <button
+          type="button"
+          data-testid="timeline-zoom-out"
+          onClick={onZoomOut}
+          disabled={zoomLevel <= MIN_ZOOM}
+          aria-label="Zoom out"
+          style={zoomLevel <= MIN_ZOOM ? disabledStyle : buttonStyle}
+        >
+          −
+        </button>
+        <button
+          type="button"
+          data-testid="timeline-zoom-in"
+          onClick={onZoomIn}
+          disabled={zoomLevel >= MAX_ZOOM}
+          aria-label="Zoom in"
+          style={zoomLevel >= MAX_ZOOM ? disabledStyle : buttonStyle}
+        >
+          +
+        </button>
+      </div>
+      {/* Minimap sits alongside the zoom controls so participants see which
+          region they're zooming relative to. Null when zoomLevel === 1. */}
+      <div style={{ flex: "1 1 auto", minWidth: 0 }}>{minimap}</div>
+    </div>
+  );
+}

--- a/packages/stagebook/src/components/playback/PlaybackHandle.ts
+++ b/packages/stagebook/src/components/playback/PlaybackHandle.ts
@@ -36,8 +36,11 @@ export interface PlaybackHandle {
    * becomes known (loadedmetadata). Consumers that render based on duration
    * (e.g., Timeline selection positioning) should read this to trigger a
    * re-render once the duration is available.
+   *
+   * Optional for backward compatibility — external PlaybackHandle
+   * implementations that predate this field treat undefined as 0.
    */
-  readonly durationVersion: number;
+  readonly durationVersion?: number;
 
   /**
    * Request the MediaPlayer to start capturing waveform data.

--- a/packages/stagebook/src/components/playback/PlaybackHandle.ts
+++ b/packages/stagebook/src/components/playback/PlaybackHandle.ts
@@ -32,6 +32,14 @@ export interface PlaybackHandle {
   readonly peaksVersion: number;
 
   /**
+   * Monotonically increasing counter that bumps when the media duration
+   * becomes known (loadedmetadata). Consumers that render based on duration
+   * (e.g., Timeline selection positioning) should read this to trigger a
+   * re-render once the duration is available.
+   */
+  readonly durationVersion: number;
+
+  /**
    * Request the MediaPlayer to start capturing waveform data.
    * Lazily creates AudioContext + AnalyserNodes on first call.
    * No-op on subsequent calls. No-op for YouTube sources.

--- a/packages/stagebook/src/components/playback/PlaybackProvider.test.tsx
+++ b/packages/stagebook/src/components/playback/PlaybackProvider.test.tsx
@@ -22,6 +22,7 @@ function makeHandle(overrides: Partial<PlaybackHandle> = {}): PlaybackHandle {
     channelCount: 0,
     peaks: [],
     peaksVersion: 0,
+    durationVersion: 1,
     requestWaveformCapture() {},
     setChannelMuted() {},
     isChannelMuted: () => false,

--- a/packages/stagebook/src/components/playback/playbackStories.tsx
+++ b/packages/stagebook/src/components/playback/playbackStories.tsx
@@ -23,6 +23,7 @@ export function makeHandle(
     channelCount: 0,
     peaks: [],
     peaksVersion: 0,
+    durationVersion: 1,
     requestWaveformCapture() {},
     setChannelMuted() {},
     isChannelMuted: () => false,

--- a/packages/stagebook/src/components/testing/MockTimeline.tsx
+++ b/packages/stagebook/src/components/testing/MockTimeline.tsx
@@ -41,6 +41,7 @@ function makeRefBackedHandle(refs: {
   captureCallCount: { current: number };
   peaks: { current: Float32Array[] };
   peaksVersion: { current: number };
+  durationVersion: { current: number };
   muted: { current: boolean[] };
 }): PlaybackHandle {
   return {
@@ -65,6 +66,9 @@ function makeRefBackedHandle(refs: {
     },
     get peaksVersion() {
       return refs.peaksVersion.current;
+    },
+    get durationVersion() {
+      return refs.durationVersion.current;
     },
     requestWaveformCapture() {
       refs.captureCallCount.current += 1;
@@ -135,6 +139,7 @@ export function MockTimeline({
   const captureCallCountRef = useRef(0);
   const peaksRef = useRef<Float32Array[]>([]);
   const peaksVersionRef = useRef(0);
+  const durationVersionRef = useRef(1);
   // Channel mute state the handle reports. Tests read this through the
   // <div data-testid="mute-state"> below.
   const mutedRef = useRef<boolean[]>([]);
@@ -174,6 +179,7 @@ export function MockTimeline({
         captureCallCount: captureCallCountRef,
         peaks: peaksRef,
         peaksVersion: peaksVersionRef,
+        durationVersion: durationVersionRef,
         muted: mutedRef,
       }),
     // Refs only — handle is stable for the lifetime of the mock.


### PR DESCRIPTION
## Summary

Saved Timeline selections rendered at x=0 (squished to the left edge) until the video started playing. Root cause: Timeline reads `handle.getDuration()` on each render, but nothing triggered a re-render after `loadedmetadata` fired. The duration was correct in the DOM; Timeline just hadn't re-rendered to read it.

Adds `durationVersion` to `PlaybackHandle`, following the existing `peaksVersion` pattern. MediaPlayer bumps it in `handleLoadedMetadata`, Timeline polls it in its RAF loop and stores it in state — the state change triggers a re-render where `getDuration()` returns the real value.

Fixes #164

## Changes

| File | Change |
|---|---|
| `PlaybackHandle.ts` | Add `readonly durationVersion: number` to the interface |
| `MediaPlayer.tsx` | Add `durationVersionRef`, bump in `handleLoadedMetadata`, expose on handle |
| `Timeline.tsx` | Poll `durationVersion` in RAF loop, store in state |
| `YouTubePlayer.tsx` | Set `durationVersion: 1` (YouTube duration is immediately available) |
| `PlaybackProvider.test.tsx` | Add `durationVersion: 1` to mock handle |
| `playbackStories.tsx` | Add `durationVersion: 1` to mock handle |
| `MockTimeline.tsx` | Add `durationVersionRef` to ref-backed handle |

## Test plan
- [x] All 749 tests pass
- [x] `npm run lint` clean
- [ ] Manual: load a treatment with a Timeline + saved selections → selections should render at correct positions immediately (once metadata loads), not squished to x=0

🤖 Generated with [Claude Code](https://claude.com/claude-code)