### PR TITLE
Fix prompt caching: add contentVersion for cache-busted re-fetches

### DIFF
--- a/apps/viewer/src/components/PreviewHost.tsx
+++ b/apps/viewer/src/components/PreviewHost.tsx
@@ -27,6 +27,8 @@ export interface PreviewHostProps {
   onFieldsResolved?: (values: Record<string, string>) => void;
   /** Optional refresh affordance passed through to the Viewer header. */
   onRefresh?: () => void;
+  /** Bump to force useTextContent to re-fetch all prompt files. */
+  contentVersion?: number;
 }
 
 /**
@@ -48,6 +50,7 @@ export function PreviewHost({
   onBack,
   onFieldsResolved,
   onRefresh,
+  contentVersion,
 }: PreviewHostProps) {
   const [userValues, setUserValues] = useState<Record<string, string> | null>(
     null,
@@ -86,6 +89,7 @@ export function PreviewHost({
       selectedTreatmentIndex={selectedTreatmentIndex}
       onBack={onBack}
       onRefresh={onRefresh}
+      contentVersion={contentVersion}
     />
   );
 }

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -37,6 +37,11 @@ export interface ViewerProps {
    * prop update since React doesn't unmount the component.
    */
   onRefresh?: () => void;
+  /**
+   * Bump to force useTextContent to re-fetch all prompt files. Optional —
+   * production hosts that never change content can omit it.
+   */
+  contentVersion?: number;
 }
 
 export function Viewer({
@@ -47,6 +52,7 @@ export function Viewer({
   selectedTreatmentIndex,
   onBack,
   onRefresh,
+  contentVersion,
 }: ViewerProps) {
   const treatment = treatmentFile.treatments[selectedTreatmentIndex];
   const introSequence = treatmentFile.introSequences[selectedIntroIndex];
@@ -105,6 +111,7 @@ export function Viewer({
         onSubmit: handleSubmit,
         getTextContent,
         getAssetURL,
+        contentVersion,
         renderers: createSkeletonRenderers(),
       }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -117,6 +124,7 @@ export function Viewer({
       handleSubmit,
       getTextContent,
       getAssetURL,
+      contentVersion,
     ],
   );
 

--- a/apps/viewer/src/lib/context.ts
+++ b/apps/viewer/src/lib/context.ts
@@ -9,6 +9,7 @@ export interface ViewerContextOptions {
   onSubmit: () => void;
   getTextContent: (path: string) => Promise<string>;
   getAssetURL: (path: string) => string;
+  contentVersion?: number;
   renderers?: Partial<
     Pick<
       StagebookContext,
@@ -37,6 +38,7 @@ export function createViewerContext(
     onSubmit,
     getTextContent,
     getAssetURL,
+    contentVersion,
     renderers,
   } = options;
 
@@ -64,6 +66,7 @@ export function createViewerContext(
 
     getAssetURL,
     getTextContent,
+    contentVersion,
 
     progressLabel: `game_${stageIndex}`,
     playerId: "viewer",

--- a/apps/vscode/src/webview/index.tsx
+++ b/apps/vscode/src/webview/index.tsx
@@ -139,6 +139,7 @@ function App() {
       selectedIntroIndex={introIndex}
       selectedTreatmentIndex={treatmentIndex}
       onRefresh={() => vscode.postMessage({ type: "refresh" })}
+      contentVersion={contentVersion}
     />
   );
 }

--- a/packages/stagebook/src/components/StagebookProvider.test.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.test.tsx
@@ -404,4 +404,54 @@ describe("useTextContent", () => {
 
     act(() => root.unmount());
   });
+
+  test("contentVersion bump triggers re-fetch even when path and getTextContent are stable", async () => {
+    const container = document.createElement("div");
+    let root: Root;
+    const result = { current: undefined as unknown as TextContentResult };
+    const getTextContent = vi.fn(() => Promise.resolve("# Original"));
+
+    function makeCtx(version: number): StagebookContext {
+      return {
+        ...createMockContext({ getTextContent }),
+        contentVersion: version,
+      };
+    }
+
+    function Harness(): ReactNode {
+      result.current = useTextContent("prompts/hello.md");
+      return null;
+    }
+
+    // Initial render with contentVersion 0
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <StagebookProvider value={makeCtx(0)}>
+          <Harness />
+        </StagebookProvider>,
+      );
+    });
+    await act(() => Promise.resolve());
+
+    expect(getTextContent).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toBe("# Original");
+
+    // Bump contentVersion — same path, same getTextContent identity
+    getTextContent.mockResolvedValue("# Updated");
+    act(() => {
+      root.render(
+        <StagebookProvider value={makeCtx(1)}>
+          <Harness />
+        </StagebookProvider>,
+      );
+    });
+    await act(() => Promise.resolve());
+
+    // Must have re-fetched because contentVersion changed
+    expect(getTextContent).toHaveBeenCalledTimes(2);
+    expect(result.current.data).toBe("# Updated");
+
+    act(() => root.unmount());
+  });
 });

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -33,6 +33,13 @@ export interface StagebookContext {
   getAssetURL(path: string): string;
   getTextContent(path: string): Promise<string>;
 
+  /**
+   * Monotonically increasing counter that signals cached content is stale.
+   * When bumped, useTextContent re-fetches all paths. Optional — hosts that
+   * never change content (production experiments) can omit it entirely.
+   */
+  contentVersion?: number;
+
   // Identity and progress
   progressLabel: string;
   playerId: string;
@@ -163,14 +170,15 @@ export interface TextContentResult {
 }
 
 export function useTextContent(path: string): TextContentResult {
-  const { getTextContent } = useStagebookContext();
+  const { getTextContent, contentVersion } = useStagebookContext();
   const [data, setData] = useState<string | undefined>(undefined);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | undefined>(undefined);
 
   // Ref `getTextContent` so a rebuilt StagebookContext (fresh function
-  // identity each render) doesn't cause the fetch effect to re-fire and
-  // refetch content on every parent re-render (#105).
+  // identity each render) doesn't cause the fetch effect to re-fire on
+  // every parent re-render (#105). Intentional cache busts are signaled
+  // via `contentVersion` instead of function identity.
   const getTextContentRef = useRef(getTextContent);
   getTextContentRef.current = getTextContent;
 
@@ -204,7 +212,10 @@ export function useTextContent(path: string): TextContentResult {
     return () => {
       cancelled = true;
     };
-  }, [path]);
+    // contentVersion is bumped by the host when cached content should be
+    // re-fetched (e.g. VS Code preview refresh). getTextContent is ref'd
+    // to avoid re-fetches from unstable context identity (#105).
+  }, [path, contentVersion ?? 0]);
 
   return { data, isLoading, error };
 }


### PR DESCRIPTION
## Problem

Clicking the VS Code extension's refresh button sometimes showed stale prompt content. The #105 unstable-callback fix ref'd `getTextContent` in `useTextContent` so that an unstable context identity doesn't cause spurious re-fetches — correct for production. But this also prevented *intentional* cache busts: the extension recreated `getTextContent` with a fresh cache on refresh, but the effect deps didn't include `getTextContent`, so the effect never re-ran.

## Fix

Add `contentVersion?: number` to `StagebookContext`. `useTextContent` includes it in the effect deps (defaulting to 0 when absent). The ref pattern for `getTextContent` stays — unstable identity still doesn't cause re-fetches.

**Risk to production experiments: zero.** Hosts that don't provide `contentVersion` (every production host today) get `undefined → 0` in the effect deps — identical to the pre-change behavior.

## How it flows

```
VS Code webview: contentVersion state (bumped on each "treatment" message)
  → PreviewHost prop → Viewer prop → createViewerContext option
  → StagebookContext.contentVersion → useTextContent effect dep
  → effect re-runs → getTextContentRef.current(path) re-fetches
```

## Tests

| Test | What it verifies |
|---|---|
| **Existing #105 test** (unchanged) | Unstable `getTextContent` identity does NOT cause re-fetches when path and contentVersion are stable |
| **New test** | `contentVersion` bump DOES trigger re-fetch even when path and `getTextContent` identity are both stable |

Both pass simultaneously — the ref pattern protects production, contentVersion enables intentional cache busts.

## Changes

| File | Change |
|---|---|
| `StagebookProvider.tsx` | Add `contentVersion?: number` to `StagebookContext`, use in `useTextContent` effect deps |
| `StagebookProvider.test.tsx` | Add test: contentVersion bump triggers re-fetch |
| `context.ts` | Thread `contentVersion` through `ViewerContextOptions` |
| `Viewer.tsx` | Accept + pass `contentVersion` prop |
| `PreviewHost.tsx` | Accept + pass `contentVersion` prop |
| `webview/index.tsx` | Pass `contentVersion` to PreviewHost |

## Test plan
- [x] All 808 tests pass (561 stagebook + 69 viewer + 178 vscode)
- [x] `npm run lint` clean
- [x] #105 stability test passes (no regression)
- [x] New contentVersion re-fetch test passes
- [ ] Manual: edit a `.prompt.md` file, save, click refresh in VS Code preview → new content appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)