### PR TITLE
Round timeline selection times to millisecond precision

### DIFF
--- a/docs/researcher/conditions.md
+++ b/docs/researcher/conditions.md
@@ -94,6 +94,42 @@ participantInfo.name           # nickname
 participantInfo.sampleId       # recruiting platform ID
 ```
 
+### Timeline Selections
+
+```
+timeline.<name>                  # the full selections array
+timeline.<name>.length           # number of selections
+timeline.<name>.0.start          # start time of the first range selection (seconds)
+timeline.<name>.0.end            # end time of the first range selection (seconds)
+timeline.<name>.0.time           # time of the first point selection (seconds)
+timeline.<name>.0.track          # track index of the first selection (if track-scoped)
+```
+
+Array indices (0, 1, 2, ...) access individual selections in chronological order. Use this to validate that selections fall within expected time ranges:
+
+```yaml
+# Only show the submit button when the first selected range starts
+# between 15 and 19 seconds (validating annotation accuracy)
+- type: submitButton
+  conditions:
+    - reference: timeline.storySegment.0.start
+      comparator: isAtLeast
+      value: 15
+    - reference: timeline.storySegment.0.start
+      comparator: isAtMost
+      value: 19
+```
+
+You can also check that a minimum number of selections have been made:
+
+```yaml
+- type: submitButton
+  conditions:
+    - reference: timeline.storySegment.length
+      comparator: isAtLeast
+      value: 3
+```
+
 ### Discussion Metrics
 
 ```

--- a/packages/stagebook/src/components/elements/timeline/selections.test.ts
+++ b/packages/stagebook/src/components/elements/timeline/selections.test.ts
@@ -360,3 +360,34 @@ describe("edge cases", () => {
     expect(result).toEqual([]);
   });
 });
+
+describe("millisecond rounding", () => {
+  test("createRange rounds start/end to 3 decimal places", () => {
+    const result = createRange(
+      8.158326452250607,
+      13.313919717533455,
+      undefined,
+      [],
+    );
+    expect(result).not.toBeNull();
+    expect(result!.start).toBe(8.158);
+    expect(result!.end).toBe(13.314);
+  });
+
+  test("createPoint rounds time to 3 decimal places", () => {
+    const result = createPoint(8.158326452250607, undefined);
+    expect(result.time).toBe(8.158);
+  });
+
+  test("adjustHandle rounds to 3 decimal places", () => {
+    const selections = [{ start: 10, end: 20 }];
+    const result = adjustHandle(selections, 0, "start", 8.158326452250607);
+    expect(result[0].start).toBe(8.158);
+  });
+
+  test("repositionPoint rounds to 3 decimal places", () => {
+    const selections = [{ time: 10 }];
+    const result = repositionPoint(selections, 0, 8.158326452250607);
+    expect(result[0].time).toBe(8.158);
+  });
+});

--- a/packages/stagebook/src/components/elements/timeline/selections.ts
+++ b/packages/stagebook/src/components/elements/timeline/selections.ts
@@ -2,8 +2,28 @@
 // Pure TypeScript — no React/DOM dependencies.
 
 /** Round to millisecond precision (3 decimal places). */
-function roundMs(t: number): number {
+export function roundMs(t: number): number {
   return Math.round(t * 1000) / 1000;
+}
+
+/**
+ * Normalize all time values in a selections array to millisecond precision.
+ * Applied before clamping operations so that rounding after clamping can't
+ * violate neighbor boundaries established against full-precision values
+ * (e.g. from restored saved state with pre-rounding data).
+ */
+export function normalizeSelections<T extends RangeSelection | PointSelection>(
+  selections: T[],
+): T[] {
+  return selections.map((s) => {
+    if ("start" in s && "end" in s) {
+      return { ...s, start: roundMs(s.start), end: roundMs(s.end) } as T;
+    }
+    if ("time" in s) {
+      return { ...s, time: roundMs((s).time) } as T;
+    }
+    return s;
+  });
 }
 
 export interface RangeSelection {
@@ -115,7 +135,15 @@ export function createRange(
   track: number | undefined,
   existing: RangeSelection[],
 ): RangeSelection | null {
-  const clamped = clampToFreeGap(start, end, track, existing);
+  // Normalize existing selections to ms precision before clamping so that
+  // rounding the result can't violate boundaries established against
+  // full-precision neighbor values (e.g. from pre-rounding saved state).
+  const clamped = clampToFreeGap(
+    start,
+    end,
+    track,
+    normalizeSelections(existing),
+  );
   if (!clamped) return null;
 
   const range: RangeSelection = {
@@ -136,7 +164,9 @@ export function adjustHandle(
   handle: "start" | "end",
   newTime: number,
 ): RangeSelection[] {
-  const result = selections.map((s) => ({ ...s }));
+  // Normalize all selections to ms precision before computing neighbor
+  // boundaries, so rounding the result can't create overlaps.
+  const result = normalizeSelections(selections).map((s) => ({ ...s }));
   const target = result[index];
   if (!target) return result;
 

--- a/packages/stagebook/src/components/elements/timeline/selections.ts
+++ b/packages/stagebook/src/components/elements/timeline/selections.ts
@@ -1,6 +1,11 @@
 // Selection data model for Timeline component.
 // Pure TypeScript — no React/DOM dependencies.
 
+/** Round to millisecond precision (3 decimal places). */
+function roundMs(t: number): number {
+  return Math.round(t * 1000) / 1000;
+}
+
 export interface RangeSelection {
   track?: number;
   start: number;
@@ -114,8 +119,8 @@ export function createRange(
   if (!clamped) return null;
 
   const range: RangeSelection = {
-    start: clamped.start,
-    end: clamped.end,
+    start: roundMs(clamped.start),
+    end: roundMs(clamped.end),
   };
   if (track !== undefined) range.track = track;
   return range;
@@ -159,7 +164,7 @@ export function adjustHandle(
       }
     }
 
-    target.start = clampedTime;
+    target.start = roundMs(clampedTime);
   } else {
     let clampedTime = newTime;
 
@@ -174,7 +179,7 @@ export function adjustHandle(
       }
     }
 
-    target.end = clampedTime;
+    target.end = roundMs(clampedTime);
   }
 
   return result;
@@ -188,7 +193,7 @@ export function createPoint(
   time: number,
   track: number | undefined,
 ): PointSelection {
-  const point: PointSelection = { time };
+  const point: PointSelection = { time: roundMs(time) };
   if (track !== undefined) point.track = track;
   return point;
 }
@@ -198,7 +203,9 @@ export function repositionPoint(
   index: number,
   newTime: number,
 ): PointSelection[] {
-  return selections.map((s, i) => (i === index ? { ...s, time: newTime } : s));
+  return selections.map((s, i) =>
+    i === index ? { ...s, time: roundMs(newTime) } : s,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/stagebook/src/components/elements/timeline/selections.ts
+++ b/packages/stagebook/src/components/elements/timeline/selections.ts
@@ -20,7 +20,7 @@ export function normalizeSelections<T extends RangeSelection | PointSelection>(
       return { ...s, start: roundMs(s.start), end: roundMs(s.end) } as T;
     }
     if ("time" in s) {
-      return { ...s, time: roundMs((s).time) } as T;
+      return { ...s, time: roundMs(s.time) } as T;
     }
     return s;
   });

--- a/packages/stagebook/src/components/elements/timeline/selectionsReducer.test.ts
+++ b/packages/stagebook/src/components/elements/timeline/selectionsReducer.test.ts
@@ -531,4 +531,34 @@ describe("selectionsReducer", () => {
       expect(result.undoStack).toHaveLength(0);
     });
   });
+
+  describe("millisecond rounding", () => {
+    it("single-select CREATE_RANGE rounds to ms precision", () => {
+      const state = initialSelectionState();
+      const result = selectionsReducer(state, {
+        type: "CREATE_RANGE",
+        start: 8.158326452250607,
+        end: 13.313919717533455,
+        track: undefined,
+        multiSelect: false,
+      });
+      const range = result.selections[0] as { start: number; end: number };
+      expect(range.start).toBe(8.158);
+      expect(range.end).toBe(13.314);
+    });
+
+    it("single-select CREATE_RANGE rejects hi<=lo after rounding", () => {
+      const state = initialSelectionState();
+      // These round to the same value (10.000)
+      const result = selectionsReducer(state, {
+        type: "CREATE_RANGE",
+        start: 10.0001,
+        end: 10.0004,
+        track: undefined,
+        multiSelect: false,
+      });
+      // Should be rejected — no change to state
+      expect(result.selections).toEqual([]);
+    });
+  });
 });

--- a/packages/stagebook/src/components/elements/timeline/selectionsReducer.ts
+++ b/packages/stagebook/src/components/elements/timeline/selectionsReducer.ts
@@ -100,8 +100,8 @@ export function selectionsReducer(
       // clamp against ranges that are about to be discarded, and don't try
       // to "keep the last in time order" (that would keep the wrong one).
       if (!action.multiSelect) {
-        const lo = Math.min(action.start, action.end);
-        const hi = Math.max(action.start, action.end);
+        const lo = Math.round(Math.min(action.start, action.end) * 1000) / 1000;
+        const hi = Math.round(Math.max(action.start, action.end) * 1000) / 1000;
         if (hi <= lo) return state;
         const range: RangeSelection = { start: lo, end: hi };
         if (action.track !== undefined) range.track = action.track;

--- a/packages/stagebook/src/components/elements/timeline/selectionsReducer.ts
+++ b/packages/stagebook/src/components/elements/timeline/selectionsReducer.ts
@@ -16,6 +16,7 @@ import {
   sortPoints,
   pushUndo,
   popUndo,
+  roundMs,
 } from "./selections.js";
 
 export interface SelectionState {
@@ -100,8 +101,8 @@ export function selectionsReducer(
       // clamp against ranges that are about to be discarded, and don't try
       // to "keep the last in time order" (that would keep the wrong one).
       if (!action.multiSelect) {
-        const lo = Math.round(Math.min(action.start, action.end) * 1000) / 1000;
-        const hi = Math.round(Math.max(action.start, action.end) * 1000) / 1000;
+        const lo = roundMs(Math.min(action.start, action.end));
+        const hi = roundMs(Math.max(action.start, action.end));
         if (hi <= lo) return state;
         const range: RangeSelection = { start: lo, end: hi };
         if (action.track !== undefined) range.track = action.track;


### PR DESCRIPTION
## Problem

Timeline selections were saved with ~15 decimal places of floating-point noise:
```json
[{"start":8.158326452250607,"end":13.313919717533455}]
```

## Fix

Round to 3 decimal places (milliseconds) at every mutation point in the selection data model:
- `createRange` — start/end
- `createPoint` — time
- `adjustHandle` — start or end
- `repositionPoint` — time
- Single-select path in the reducer (bypasses `createRange`)

After: `[{"start":8.158,"end":13.314}]`

## Test plan
- [x] 4 new tests covering rounding in each mutation function
- [x] All 565 stagebook tests pass
- [x] No changes to rendering, comparisons, or condition evaluation — rounding is at the data model boundary only

🤖 Generated with [Claude Code](https://claude.com/claude-code)