### PR TITLE
Draggable playhead, handle tooltips, and timeline interaction polish

### DIFF
--- a/docs/researcher/elements.md
+++ b/docs/researcher/elements.md
@@ -260,7 +260,7 @@ By default (`selectionScope: all`), selections span all audio channels. In `trac
     - "Participant"
 ```
 
-When `trackLabels` is omitted, tracks are labeled by position index: "Position 0", "Position 1", etc. (matching the channel order in the composed video). If there are more audio channels than labels, extra channels fall back to "Position N".
+When `trackLabels` is omitted, tracks are labeled by index: "Track 0", "Track 1", etc. (matching the channel order in the composed video). If there are more audio channels than labels, extra channels fall back to "Track N".
 
 ### Use case examples
 

--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -2568,3 +2568,32 @@ test("handle hover shows time tooltip", async ({ mount }) => {
   // Tooltip should appear with the formatted start time
   await expect(startHandle).toContainText("0:10");
 });
+
+test("playhead time box is draggable (pointerEvents: auto)", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockTimeline
+      source="coding_video"
+      playerName="coding_video"
+      name="drag_test"
+      selectionType="range"
+      mockCurrentTime={30}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await expect(timeline).toBeAttached();
+
+  const playhead = component.locator('[data-testid="playhead"]');
+  await expect(playhead).toBeAttached();
+
+  // The time box (first child of playhead) must have pointerEvents: auto
+  // so it can receive drag events. A regression occurred when shared
+  // tooltipBaseStyle (which has pointerEvents: none) was spread after
+  // the auto override, silently disabling dragging.
+  const timeBox = playhead.locator("div").first();
+  const pointerEvents = await timeBox.evaluate(
+    (el) => getComputedStyle(el).pointerEvents,
+  );
+  expect(pointerEvents).toBe("auto");
+});

--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -2428,3 +2428,143 @@ test("mute state is not written to the save log", async ({ mount }) => {
     expect(JSON.stringify(entry.value)).not.toContain("mute");
   }
 });
+
+// -- Handle z-index at edges --
+
+test("start handle is on top when range is at the right edge", async ({
+  mount,
+}) => {
+  // Range near the right edge of a 60s timeline (58-60s)
+  const component = await mount(
+    <MockTimeline
+      source="coding_video"
+      playerName="coding_video"
+      name="edge_test"
+      selectionType="range"
+      multiSelect={false}
+      initialSelections={[{ start: 58, end: 60 }]}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await expect(timeline).toBeAttached();
+
+  const startHandle = component.locator('[data-testid="range-0-handle-start"]');
+  const endHandle = component.locator('[data-testid="range-0-handle-end"]');
+  await expect(startHandle).toBeAttached();
+  await expect(endHandle).toBeAttached();
+
+  const startZ = await startHandle.evaluate(
+    (el) => getComputedStyle(el).zIndex,
+  );
+  const endZ = await endHandle.evaluate((el) => getComputedStyle(el).zIndex);
+  // Start handle should be on top so the user can drag it left
+  expect(Number(startZ)).toBeGreaterThan(Number(endZ));
+});
+
+test("end handle is on top when range is at the left edge", async ({
+  mount,
+}) => {
+  // Range near the left edge of a 60s timeline (0-2s)
+  const component = await mount(
+    <MockTimeline
+      source="coding_video"
+      playerName="coding_video"
+      name="edge_test"
+      selectionType="range"
+      multiSelect={false}
+      initialSelections={[{ start: 0, end: 2 }]}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await expect(timeline).toBeAttached();
+
+  const startHandle = component.locator('[data-testid="range-0-handle-start"]');
+  const endHandle = component.locator('[data-testid="range-0-handle-end"]');
+  await expect(startHandle).toBeAttached();
+  await expect(endHandle).toBeAttached();
+
+  const startZ = await startHandle.evaluate(
+    (el) => getComputedStyle(el).zIndex,
+  );
+  const endZ = await endHandle.evaluate((el) => getComputedStyle(el).zIndex);
+  // End handle should be on top so the user can drag it right
+  expect(Number(endZ)).toBeGreaterThan(Number(startZ));
+});
+
+test("end handle is on top when range is in the middle (default)", async ({
+  mount,
+}) => {
+  // Range in the middle of a 60s timeline (25-35s)
+  const component = await mount(
+    <MockTimeline
+      source="coding_video"
+      playerName="coding_video"
+      name="edge_test"
+      selectionType="range"
+      multiSelect={false}
+      initialSelections={[{ start: 25, end: 35 }]}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await expect(timeline).toBeAttached();
+
+  const startHandle = component.locator('[data-testid="range-0-handle-start"]');
+  const endHandle = component.locator('[data-testid="range-0-handle-end"]');
+  await expect(startHandle).toBeAttached();
+  await expect(endHandle).toBeAttached();
+
+  const startZ = await startHandle.evaluate(
+    (el) => getComputedStyle(el).zIndex,
+  );
+  const endZ = await endHandle.evaluate((el) => getComputedStyle(el).zIndex);
+  // Default: end handle on top
+  expect(Number(endZ)).toBeGreaterThan(Number(startZ));
+});
+
+test("playhead time box is visible and shows formatted time", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockTimeline
+      source="coding_video"
+      playerName="coding_video"
+      name="playhead_test"
+      selectionType="range"
+      mockCurrentTime={16.5}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await expect(timeline).toBeAttached();
+
+  const playhead = component.locator('[data-testid="playhead"]');
+  await expect(playhead).toBeAttached();
+  // Should display the formatted time with tenths at zoom 1
+  await expect(playhead).toContainText("0:16.5");
+});
+
+test("handle hover shows time tooltip", async ({ mount }) => {
+  const component = await mount(
+    <MockTimeline
+      source="coding_video"
+      playerName="coding_video"
+      name="tooltip_test"
+      selectionType="range"
+      multiSelect={false}
+      initialSelections={[{ start: 10, end: 30 }]}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await expect(timeline).toBeAttached();
+
+  const startHandle = component.locator('[data-testid="range-0-handle-start"]');
+  await expect(startHandle).toBeAttached();
+
+  // Before hover: no tooltip text visible on the handle
+  await expect(startHandle).not.toContainText("0:10");
+
+  // Hover the start handle
+  await startHandle.hover();
+
+  // Tooltip should appear with the formatted start time
+  await expect(startHandle).toContainText("0:10");
+});

--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -173,7 +173,7 @@ test("renders at least one track", async ({ mount }) => {
   await expect(tracks.first()).toBeAttached();
 });
 
-test("renders default track label as Position N", async ({ mount }) => {
+test("renders default track label as Track N", async ({ mount }) => {
   const component = await mount(
     <MockTimeline
       source="player"
@@ -185,8 +185,8 @@ test("renders default track label as Position N", async ({ mount }) => {
     />,
   );
   const labels = component.locator('[data-testid="track-label"]');
-  await expect(labels.nth(0)).toContainText("Position 0");
-  await expect(labels.nth(1)).toContainText("Position 1");
+  await expect(labels.nth(0)).toContainText("Track 0");
+  await expect(labels.nth(1)).toContainText("Track 1");
 });
 
 test("renders custom track labels", async ({ mount }) => {
@@ -206,7 +206,7 @@ test("renders custom track labels", async ({ mount }) => {
   await expect(labels.nth(1)).toContainText("Participant");
 });
 
-test("falls back to Position N for extra channels beyond trackLabels", async ({
+test("falls back to Track N for extra channels beyond trackLabels", async ({
   mount,
 }) => {
   const component = await mount(
@@ -222,8 +222,8 @@ test("falls back to Position N for extra channels beyond trackLabels", async ({
   );
   const labels = component.locator('[data-testid="track-label"]');
   await expect(labels.nth(0)).toContainText("Speaker A");
-  await expect(labels.nth(1)).toContainText("Position 1");
-  await expect(labels.nth(2)).toContainText("Position 2");
+  await expect(labels.nth(1)).toContainText("Track 1");
+  await expect(labels.nth(2)).toContainText("Track 2");
 });
 
 test("renders canvas for waveform", async ({ mount }) => {

--- a/packages/stagebook/src/components/elements/Timeline.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from "react";
 import { usePlayback } from "../playback/PlaybackProvider.js";
-import { TimeRuler } from "./timeline/TimeRuler.js";
+import { TimeRuler, RULER_HEIGHT } from "./timeline/TimeRuler.js";
 import { TimelineTrack, GUTTER_WIDTH } from "./timeline/TimelineTrack.js";
 import { Playhead } from "./timeline/Playhead.js";
 import { SelectionOverlay } from "./timeline/SelectionOverlay.js";
@@ -530,7 +530,7 @@ export function Timeline({
   // Build track labels
   const labels: string[] = [];
   for (let i = 0; i < channelCount; i++) {
-    labels.push(trackLabels?.[i] ?? `Position ${String(i)}`);
+    labels.push(trackLabels?.[i] ?? `Track ${String(i)}`);
   }
 
   const tracksHeight = channelCount * TRACK_HEIGHT;
@@ -682,14 +682,16 @@ export function Timeline({
             }
           />
 
-          {/* Playhead — over selection overlay */}
+          {/* Playhead — over selection overlay, extends into ruler via negative top */}
           <Playhead
             currentTime={currentTime}
             duration={duration}
             width={waveformWidth}
             height={tracksHeight}
+            rulerHeight={RULER_HEIGHT}
             zoomLevel={zoomLevel}
             viewportStart={viewportStart}
+            onSeek={(t) => handle.seekTo(t)}
           />
         </div>
       </div>

--- a/packages/stagebook/src/components/elements/timeline/Playhead.tsx
+++ b/packages/stagebook/src/components/elements/timeline/Playhead.tsx
@@ -97,6 +97,10 @@ export function Playhead({
     }
   }, []);
 
+  const handlePointerCancel = useCallback(() => {
+    isDragging.current = false;
+  }, []);
+
   // Early returns after all hooks
   if (!Number.isFinite(duration) || duration <= 0) return null;
 
@@ -114,7 +118,6 @@ export function Playhead({
         width: 0,
         height: `${String(height + rulerHeight)}px`,
         zIndex: 20,
-        transform: "translateX(-1px)",
         pointerEvents: "none",
       }}
     >
@@ -127,6 +130,8 @@ export function Playhead({
         }}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerCancel}
+        onLostPointerCapture={handlePointerCancel}
         style={{
           ...tooltipBaseStyle,
           position: "absolute",

--- a/packages/stagebook/src/components/elements/timeline/Playhead.tsx
+++ b/packages/stagebook/src/components/elements/timeline/Playhead.tsx
@@ -120,7 +120,11 @@ export function Playhead({
     >
       {/* Time box — draggable handle in the ruler area */}
       <div
-        onPointerDown={handlePointerDown}
+        draggable={false}
+        onPointerDown={(e) => {
+          e.preventDefault(); // suppress native drag-and-drop
+          handlePointerDown(e);
+        }}
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         style={{

--- a/packages/stagebook/src/components/elements/timeline/Playhead.tsx
+++ b/packages/stagebook/src/components/elements/timeline/Playhead.tsx
@@ -124,6 +124,7 @@ export function Playhead({
         onPointerMove={handlePointerMove}
         onPointerUp={handlePointerUp}
         style={{
+          ...tooltipBaseStyle,
           position: "absolute",
           top: 0,
           left: "50%",
@@ -132,7 +133,6 @@ export function Playhead({
           background: "var(--stagebook-playhead, #e11d48)",
           cursor: "ew-resize",
           userSelect: "none",
-          ...tooltipBaseStyle,
         }}
       >
         {formatTime(currentTime, zoomDecimals(zoomLevel))}

--- a/packages/stagebook/src/components/elements/timeline/Playhead.tsx
+++ b/packages/stagebook/src/components/elements/timeline/Playhead.tsx
@@ -1,5 +1,14 @@
-import React from "react";
-import { timeToPixel } from "./timelineLayout.js";
+import React, { useCallback, useRef } from "react";
+import { timeToPixel, pixelToTime } from "./timelineLayout.js";
+import { formatTime } from "../../../utils/formatTime.js";
+import { zoomDecimals, tooltipBaseStyle } from "./timelineStyles.js";
+
+/**
+ * How far off-screen (in pixels) the playhead can be before we skip
+ * rendering. Needs to be wide enough to keep the time box visible
+ * when the playhead line is just past the edge.
+ */
+const OFFSCREEN_PADDING = 20;
 
 export interface PlayheadProps {
   /** Current playback time in seconds. */
@@ -8,47 +17,140 @@ export interface PlayheadProps {
   duration: number;
   /** Width of the waveform area in pixels. */
   width: number;
-  /** Height to span (all tracks). */
+  /** Height of the tracks area in pixels. */
   height: number;
+  /** Height of the ruler area — playhead extends upward by this amount. */
+  rulerHeight: number;
   /** Current zoom level (1 = full duration visible). */
   zoomLevel: number;
   /** Left edge of the visible region in seconds. */
   viewportStart: number;
+  /** Called during drag to seek to a new time. */
+  onSeek: (time: number) => void;
 }
 
 /**
- * Thin vertical line tracking the current playback position.
- * Absolutely positioned over the waveform area.
+ * Vertical playhead line with a draggable time box in the ruler area.
+ *
+ * The time box sits above the tracks (via negative top) and is the only
+ * part that receives pointer events — the line stays pointerEvents: "none"
+ * so it doesn't interfere with the SelectionOverlay underneath.
+ *
+ * IMPORTANT: This component MUST live in the same position: relative
+ * container as the SelectionOverlay to guarantee pixel-perfect alignment.
+ * Both use timeToPixel from the same coordinate space.
  */
 export function Playhead({
   currentTime,
   duration,
   width,
   height,
+  rulerHeight,
   zoomLevel,
   viewportStart,
+  onSeek,
 }: PlayheadProps) {
+  // All hooks must be called before any early returns (Rules of Hooks).
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isDragging = useRef(false);
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    if (e.button !== 0) return;
+    e.stopPropagation();
+    try {
+      e.currentTarget.setPointerCapture(e.pointerId);
+    } catch {
+      // ignore in test environments
+    }
+    isDragging.current = true;
+  }, []);
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isDragging.current) return;
+      // Convert pointer position to time using the tracks container's rect.
+      // The playhead's parent is the same container as the SelectionOverlay,
+      // offset by GUTTER_WIDTH — so we use the parent's bounding rect.
+      const parent = containerRef.current?.parentElement;
+      if (!parent) return;
+      const rect = parent.getBoundingClientRect();
+      const localX = e.clientX - rect.left;
+      const time = pixelToTime(
+        localX,
+        duration,
+        width,
+        zoomLevel,
+        viewportStart,
+      );
+      const clamped = Math.max(0, Math.min(duration, time));
+      onSeek(clamped);
+    },
+    [duration, width, zoomLevel, viewportStart, onSeek],
+  );
+
+  const handlePointerUp = useCallback((e: React.PointerEvent) => {
+    isDragging.current = false;
+    try {
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  // Early returns after all hooks
   if (!Number.isFinite(duration) || duration <= 0) return null;
 
   const x = timeToPixel(currentTime, duration, width, zoomLevel, viewportStart);
-
-  // Don't render if off-screen
-  if (x < -1 || x > width + 1) return null;
+  if (x < -OFFSCREEN_PADDING || x > width + OFFSCREEN_PADDING) return null;
 
   return (
     <div
+      ref={containerRef}
       data-testid="playhead"
       style={{
         position: "absolute",
         left: `${String(x)}px`,
-        top: 0,
-        width: "2px",
-        height: `${String(height)}px`,
-        background: "var(--stagebook-primary, #3b82f6)",
-        pointerEvents: "none",
-        zIndex: 10,
+        top: `${String(-rulerHeight)}px`,
+        width: 0,
+        height: `${String(height + rulerHeight)}px`,
+        zIndex: 20,
         transform: "translateX(-1px)",
+        pointerEvents: "none",
       }}
-    />
+    >
+      {/* Time box — draggable handle in the ruler area */}
+      <div
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        style={{
+          position: "absolute",
+          top: 0,
+          left: "50%",
+          transform: "translateX(-50%)",
+          pointerEvents: "auto",
+          background: "var(--stagebook-playhead, #e11d48)",
+          cursor: "ew-resize",
+          userSelect: "none",
+          ...tooltipBaseStyle,
+        }}
+      >
+        {formatTime(currentTime, zoomDecimals(zoomLevel))}
+      </div>
+
+      {/* Vertical line — click-through */}
+      <div
+        style={{
+          position: "absolute",
+          top: 0,
+          left: "50%",
+          transform: "translateX(-50%)",
+          width: "2px",
+          height: "100%",
+          background: "var(--stagebook-playhead, #e11d48)",
+          pointerEvents: "none",
+        }}
+      />
+    </div>
   );
 }

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -448,7 +448,9 @@ export function SelectionOverlay({
           <div
             data-testid={`range-${String(i)}-handle-start`}
             data-active={isActive && activeHandle === "start"}
+            draggable={false}
             onPointerDown={(e) => {
+              e.preventDefault(); // suppress native drag-and-drop
               setHoveredHandle({ index: i, handle: "start" });
               handleHandlePointerDown(e, i, "start");
             }}
@@ -483,7 +485,9 @@ export function SelectionOverlay({
           <div
             data-testid={`range-${String(i)}-handle-end`}
             data-active={isActive && activeHandle === "end"}
+            draggable={false}
             onPointerDown={(e) => {
+              e.preventDefault(); // suppress native drag-and-drop
               setHoveredHandle({ index: i, handle: "end" });
               handleHandlePointerDown(e, i, "end");
             }}

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -264,7 +264,8 @@ export function SelectionOverlay({
       const drag = dragRef.current;
       if (!drag) return;
 
-      const time = eventToTime(e.clientX);
+      const rawTime = eventToTime(e.clientX);
+      const time = Math.max(0, Math.min(duration, rawTime));
       const track = drag.track;
 
       if (!drag.isDragging) {

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -2,6 +2,8 @@ import React, { useCallback, useRef, useState } from "react";
 import { pixelToTime, timeToPixel } from "./timelineLayout.js";
 import { clampToFreeGap } from "./selections.js";
 import type { RangeSelection, TimelineValue } from "./selections.js";
+import { formatTime } from "../../../utils/formatTime.js";
+import { zoomDecimals, handleTooltipStyle } from "./timelineStyles.js";
 
 export interface SelectionOverlayProps {
   /** Width of the waveform area in pixels (excludes gutter). */
@@ -130,6 +132,11 @@ export function SelectionOverlay({
     endTime: number;
     track: number | undefined;
   } | null>(null);
+  // Track which handle is hovered for time tooltip display
+  const [hoveredHandle, setHoveredHandle] = useState<{
+    index: number;
+    handle: "start" | "end";
+  } | null>(null);
 
   const trackHeight = channelCount > 0 ? height / channelCount : height;
 
@@ -211,7 +218,8 @@ export function SelectionOverlay({
         }
       }
 
-      const currentTime = eventToTime(e.clientX);
+      const rawTime = eventToTime(e.clientX);
+      const currentTime = Math.max(0, Math.min(duration, rawTime));
 
       if (drag.mode === "create-range") {
         setDragPreview({
@@ -242,6 +250,7 @@ export function SelectionOverlay({
     },
     [
       eventToTime,
+      duration,
       onAdjustHandle,
       onRepositionPoint,
       onBeginDrag,
@@ -285,6 +294,7 @@ export function SelectionOverlay({
         onRequestFocus();
       }
       dragRef.current = null;
+      setHoveredHandle(null);
     },
     [
       eventToTime,
@@ -370,6 +380,7 @@ export function SelectionOverlay({
       if (dragRef.current?.beganDrag) onEndDrag();
       dragRef.current = null;
       setDragPreview(null);
+      setHoveredHandle(null);
     },
     [onEndDrag, releasePointer],
   );
@@ -396,6 +407,12 @@ export function SelectionOverlay({
       );
       const left = Math.min(x1, x2);
       const rangeWidth = Math.abs(x2 - x1);
+
+      // When the end handle is near the right edge of the visible area,
+      // put the start handle on top so the user can grab it to drag left.
+      // At the left edge, the default (end handle on top via DOM order)
+      // is correct since the end handle is the one that can move right.
+      const startHandleOnTop = x2 > width - 10;
 
       // Per-track positioning in track scope
       const top =
@@ -431,7 +448,16 @@ export function SelectionOverlay({
           <div
             data-testid={`range-${String(i)}-handle-start`}
             data-active={isActive && activeHandle === "start"}
-            onPointerDown={(e) => handleHandlePointerDown(e, i, "start")}
+            onPointerDown={(e) => {
+              setHoveredHandle({ index: i, handle: "start" });
+              handleHandlePointerDown(e, i, "start");
+            }}
+            onPointerEnter={() =>
+              setHoveredHandle({ index: i, handle: "start" })
+            }
+            onPointerLeave={() => {
+              if (!dragRef.current) setHoveredHandle(null);
+            }}
             style={{
               position: "absolute",
               left: -3,
@@ -443,13 +469,28 @@ export function SelectionOverlay({
                   ? "rgba(37, 99, 235, 1)"
                   : "rgba(59, 130, 246, 0.7)",
               cursor: "ew-resize",
+              zIndex: startHandleOnTop ? 2 : 1,
             }}
-          />
+          >
+            {hoveredHandle?.index === i &&
+              hoveredHandle?.handle === "start" && (
+                <div style={handleTooltipStyle("start")}>
+                  {formatTime(range.start, zoomDecimals(zoomLevel))}
+                </div>
+              )}
+          </div>
           {/* End handle */}
           <div
             data-testid={`range-${String(i)}-handle-end`}
             data-active={isActive && activeHandle === "end"}
-            onPointerDown={(e) => handleHandlePointerDown(e, i, "end")}
+            onPointerDown={(e) => {
+              setHoveredHandle({ index: i, handle: "end" });
+              handleHandlePointerDown(e, i, "end");
+            }}
+            onPointerEnter={() => setHoveredHandle({ index: i, handle: "end" })}
+            onPointerLeave={() => {
+              if (!dragRef.current) setHoveredHandle(null);
+            }}
             style={{
               position: "absolute",
               right: -3,
@@ -461,8 +502,15 @@ export function SelectionOverlay({
                   ? "rgba(37, 99, 235, 1)"
                   : "rgba(59, 130, 246, 0.7)",
               cursor: "ew-resize",
+              zIndex: startHandleOnTop ? 1 : 2,
             }}
-          />
+          >
+            {hoveredHandle?.index === i && hoveredHandle?.handle === "end" && (
+              <div style={handleTooltipStyle("end")}>
+                {formatTime(range.end, zoomDecimals(zoomLevel))}
+              </div>
+            )}
+          </div>
         </div>
       );
     });

--- a/packages/stagebook/src/components/elements/timeline/TimeRuler.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimeRuler.tsx
@@ -17,7 +17,7 @@ export interface TimeRulerProps {
   viewportStart: number;
 }
 
-const RULER_HEIGHT = 24;
+export const RULER_HEIGHT = 24;
 
 /**
  * Time labels and tick marks along the top of the waveform area.
@@ -51,8 +51,8 @@ export function TimeRuler({
         position: "relative",
         height: `${String(RULER_HEIGHT)}px`,
         width: `${String(width)}px`,
-        overflow: "hidden",
-        fontSize: "0.625rem",
+        overflow: "visible",
+        fontSize: "0.72rem",
         color: "var(--stagebook-text-faint, #9ca3af)",
         userSelect: "none",
       }}
@@ -67,20 +67,13 @@ export function TimeRuler({
               position: "absolute",
               left: `${String(x)}px`,
               top: 0,
+              transform: "translateX(-50%)",
               display: "flex",
               flexDirection: "column",
               alignItems: "center",
             }}
           >
-            <span
-              style={{
-                whiteSpace: "nowrap",
-                transform: "translateX(-50%)",
-                display: "block",
-              }}
-            >
-              {formatTime(t)}
-            </span>
+            <span style={{ whiteSpace: "nowrap" }}>{formatTime(t)}</span>
             <div
               style={{
                 width: "1px",

--- a/packages/stagebook/src/components/elements/timeline/TimelineTrack.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineTrack.tsx
@@ -54,6 +54,7 @@ export function TimelineTrack({
       <div
         data-testid="track-gutter"
         style={{
+          boxSizing: "border-box",
           width: `${String(GUTTER_WIDTH)}px`,
           minWidth: `${String(GUTTER_WIDTH)}px`,
           display: "flex",
@@ -97,7 +98,7 @@ export function TimelineTrack({
             display: "flex",
             alignItems: "center",
             justifyContent: "flex-end",
-            fontSize: "0.6875rem",
+            fontSize: "0.79rem",
             color: "var(--stagebook-text-faint, #9ca3af)",
             userSelect: "none",
             overflow: "hidden",

--- a/packages/stagebook/src/components/elements/timeline/selections.test.ts
+++ b/packages/stagebook/src/components/elements/timeline/selections.test.ts
@@ -114,45 +114,51 @@ describe("clampToFreeGap", () => {
 
 describe("adjustHandle", () => {
   test("adjusts start handle within free space", () => {
-    const selections: RangeSelection[] = [{ start: 10, end: 20 }];
-    const result = adjustHandle(selections, 0, "start", 5);
+    const result = adjustHandle([{ start: 10, end: 20 }], 0, "start", 5);
     expect(result[0]).toEqual({ start: 5, end: 20 });
   });
 
   test("adjusts end handle within free space", () => {
-    const selections: RangeSelection[] = [{ start: 10, end: 20 }];
-    const result = adjustHandle(selections, 0, "end", 25);
+    const result = adjustHandle([{ start: 10, end: 20 }], 0, "end", 25);
     expect(result[0]).toEqual({ start: 10, end: 25 });
   });
 
   test("clamps start handle at neighbor boundary", () => {
-    const selections: RangeSelection[] = [
-      { start: 0, end: 10 },
-      { start: 15, end: 25 },
-    ];
-    const result = adjustHandle(selections, 1, "start", 5);
+    const result = adjustHandle(
+      [
+        { start: 0, end: 10 },
+        { start: 15, end: 25 },
+      ],
+      1,
+      "start",
+      5,
+    );
     expect(result[1]).toEqual({ start: 10, end: 25 });
   });
 
   test("clamps end handle at neighbor boundary", () => {
-    const selections: RangeSelection[] = [
-      { start: 0, end: 10 },
-      { start: 15, end: 25 },
-    ];
-    const result = adjustHandle(selections, 0, "end", 20);
+    const result = adjustHandle(
+      [
+        { start: 0, end: 10 },
+        { start: 15, end: 25 },
+      ],
+      0,
+      "end",
+      20,
+    );
     expect(result[0]).toEqual({ start: 0, end: 15 });
   });
 
-  test("start handle cannot cross end handle", () => {
-    const selections: RangeSelection[] = [{ start: 10, end: 20 }];
-    const result = adjustHandle(selections, 0, "start", 25);
-    expect(result[0].start).toBeLessThanOrEqual(result[0].end);
+  test("start handle clamps at end handle position", () => {
+    const result = adjustHandle([{ start: 10, end: 20 }], 0, "start", 25);
+    expect(result[0].start).toBe(20);
+    expect(result[0].end).toBe(20);
   });
 
-  test("end handle cannot cross start handle", () => {
-    const selections: RangeSelection[] = [{ start: 10, end: 20 }];
-    const result = adjustHandle(selections, 0, "end", 5);
-    expect(result[0].end).toBeGreaterThanOrEqual(result[0].start);
+  test("end handle clamps at start handle position", () => {
+    const result = adjustHandle([{ start: 10, end: 20 }], 0, "end", 5);
+    expect(result[0].start).toBe(10);
+    expect(result[0].end).toBe(10);
   });
 });
 

--- a/packages/stagebook/src/components/elements/timeline/selectionsReducer.test.ts
+++ b/packages/stagebook/src/components/elements/timeline/selectionsReducer.test.ts
@@ -561,4 +561,86 @@ describe("selectionsReducer", () => {
       expect(result.selections).toEqual([]);
     });
   });
+
+  describe("handle drag edge cases", () => {
+    it("start handle clamps at end handle position", () => {
+      const state: SelectionState = {
+        ...emptyState(),
+        selections: [{ start: 10, end: 20 }],
+        activeIndex: 0,
+        activeHandle: "start",
+      };
+      const result = selectionsReducer(state, {
+        type: "ADJUST_HANDLE",
+        index: 0,
+        handle: "start",
+        time: 25, // past the end
+        noSnapshot: true,
+      });
+      const range = result.selections[0] as { start: number; end: number };
+      expect(range.start).toBe(20);
+      expect(range.end).toBe(20);
+    });
+
+    it("end handle clamps at start handle position", () => {
+      const state: SelectionState = {
+        ...emptyState(),
+        selections: [{ start: 10, end: 20 }],
+        activeIndex: 0,
+        activeHandle: "end",
+      };
+      const result = selectionsReducer(state, {
+        type: "ADJUST_HANDLE",
+        index: 0,
+        handle: "end",
+        time: 5, // past the start
+        noSnapshot: true,
+      });
+      const range = result.selections[0] as { start: number; end: number };
+      expect(range.start).toBe(10);
+      expect(range.end).toBe(10);
+    });
+
+    it("start handle clamps exactly at neighbor end", () => {
+      const state: SelectionState = {
+        ...emptyState(),
+        selections: [
+          { start: 0, end: 10 },
+          { start: 15, end: 25 },
+        ],
+        activeIndex: 1,
+        activeHandle: "start",
+      };
+      const result = selectionsReducer(state, {
+        type: "ADJUST_HANDLE",
+        index: 1,
+        handle: "start",
+        time: 5, // into the first range
+        noSnapshot: true,
+      });
+      const ranges = result.selections as { start: number; end: number }[];
+      expect(ranges[1].start).toBe(10);
+    });
+
+    it("end handle clamps exactly at neighbor start", () => {
+      const state: SelectionState = {
+        ...emptyState(),
+        selections: [
+          { start: 0, end: 10 },
+          { start: 15, end: 25 },
+        ],
+        activeIndex: 0,
+        activeHandle: "end",
+      };
+      const result = selectionsReducer(state, {
+        type: "ADJUST_HANDLE",
+        index: 0,
+        handle: "end",
+        time: 20, // into the second range
+        noSnapshot: true,
+      });
+      const ranges = result.selections as { start: number; end: number }[];
+      expect(ranges[0].end).toBe(15);
+    });
+  });
 });

--- a/packages/stagebook/src/components/elements/timeline/timelineStyles.ts
+++ b/packages/stagebook/src/components/elements/timeline/timelineStyles.ts
@@ -1,0 +1,57 @@
+/**
+ * Shared constants and styles for timeline tooltip boxes (playhead time
+ * box and handle hover tooltips). Kept in one place so they don't drift.
+ */
+import type React from "react";
+
+/**
+ * Select fractional-second precision based on zoom level.
+ * At zoom 1 (full duration visible) show tenths; at 2× or above show
+ * hundredths — more zoom reveals more precision.
+ *
+ * @param zoomLevel - Current zoom level (1 = full duration visible).
+ * @returns Number of fractional digits: 1 or 2.
+ */
+export function zoomDecimals(zoomLevel: number): 0 | 1 | 2 {
+  if (zoomLevel >= 2) return 2;
+  return 1;
+}
+
+/** Monospace font stack used by all timeline time displays. */
+const TIMELINE_MONO_FONT =
+  "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace";
+
+/** Base styles shared between the playhead time box and handle tooltips. */
+export const tooltipBaseStyle: React.CSSProperties = {
+  fontSize: "0.65rem",
+  fontFamily: TIMELINE_MONO_FONT,
+  padding: "1px 4px",
+  borderRadius: "2px",
+  whiteSpace: "nowrap",
+  lineHeight: 1.4,
+  pointerEvents: "none",
+  color: "white",
+};
+
+/**
+ * Compute inline styles for a range-handle hover tooltip.
+ * Positions the tooltip to the left of the start handle or to the
+ * right of the end handle, vertically centered.
+ *
+ * @param handle - Which handle the tooltip is attached to.
+ */
+export function handleTooltipStyle(
+  handle: "start" | "end",
+): React.CSSProperties {
+  return {
+    position: "absolute",
+    top: "50%",
+    ...(handle === "start"
+      ? { right: "100%", marginRight: 4 }
+      : { left: "100%", marginLeft: 4 }),
+    transform: "translateY(-50%)",
+    background: "rgba(30, 64, 175, 0.9)",
+    zIndex: 5,
+    ...tooltipBaseStyle,
+  };
+}

--- a/packages/stagebook/src/components/elements/timeline/timelineStyles.ts
+++ b/packages/stagebook/src/components/elements/timeline/timelineStyles.ts
@@ -12,7 +12,7 @@ import type React from "react";
  * @param zoomLevel - Current zoom level (1 = full duration visible).
  * @returns Number of fractional digits: 1 or 2.
  */
-export function zoomDecimals(zoomLevel: number): 0 | 1 | 2 {
+export function zoomDecimals(zoomLevel: number): 1 | 2 {
   if (zoomLevel >= 2) return 2;
   return 1;
 }

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -62,6 +62,9 @@
   --stagebook-danger-bg: #fef2f2;
   --stagebook-warning: #dc2626;
 
+  /* Timeline playhead */
+  --stagebook-playhead: #e11d48;
+
   /* Timer */
   --stagebook-timer-fill: #60a5fa;
   --stagebook-timer-warn: #ef4444;

--- a/packages/stagebook/src/utils/formatTime.test.ts
+++ b/packages/stagebook/src/utils/formatTime.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { formatTime } from "./formatTime.js";
+import { zoomDecimals } from "../components/elements/timeline/timelineStyles.js";
 
 describe("formatTime", () => {
   it("formats zero as 0:00", () => {
@@ -40,5 +41,40 @@ describe("formatTime", () => {
 
   it("handles fractional seconds by flooring", () => {
     expect(formatTime(65.9)).toBe("1:05");
+  });
+
+  it("shows tenths when decimals=1", () => {
+    expect(formatTime(65.3, 1)).toBe("1:05.3");
+    expect(formatTime(0, 1)).toBe("0:00.0");
+    expect(formatTime(3661.7, 1)).toBe("1:01:01.7");
+  });
+
+  it("shows hundredths when decimals=2", () => {
+    expect(formatTime(65.34, 2)).toBe("1:05.34");
+    expect(formatTime(8.158, 2)).toBe("0:08.16");
+    expect(formatTime(0, 2)).toBe("0:00.00");
+  });
+
+  it("truncates fractional digits (no carry into seconds)", () => {
+    // 1.999 → ":01.9" not ":01.0" (which would happen if 0.999 rounded to 1.0)
+    expect(formatTime(1.999, 1)).toBe("0:01.9");
+    expect(formatTime(1.999, 2)).toBe("0:01.99");
+    expect(formatTime(59.999, 1)).toBe("0:59.9");
+  });
+});
+
+describe("zoomDecimals", () => {
+  it("returns 1 (tenths) at zoom level 1", () => {
+    expect(zoomDecimals(1)).toBe(1);
+  });
+
+  it("returns 1 (tenths) below zoom 2", () => {
+    expect(zoomDecimals(1.5)).toBe(1);
+  });
+
+  it("returns 2 (hundredths) at zoom 2 and above", () => {
+    expect(zoomDecimals(2)).toBe(2);
+    expect(zoomDecimals(4)).toBe(2);
+    expect(zoomDecimals(10)).toBe(2);
   });
 });

--- a/packages/stagebook/src/utils/formatTime.ts
+++ b/packages/stagebook/src/utils/formatTime.ts
@@ -2,16 +2,31 @@
  * Format a duration in seconds as a human-readable time string.
  * Under an hour: "M:SS". One hour or more: "H:MM:SS".
  * Non-finite input (NaN, Infinity) returns "0:00".
+ *
+ * @param decimals - Fractional-second digits to show (0, 1, or 2).
+ *   0 → "1:23", 1 → "1:23.4", 2 → "1:23.45". Default 0.
  */
-export function formatTime(seconds: number): string {
+export function formatTime(seconds: number, decimals: 0 | 1 | 2 = 0): string {
   if (!Number.isFinite(seconds) || seconds < 0) return "0:00";
   const total = Math.floor(seconds);
   const h = Math.floor(total / 3600);
   const m = Math.floor((total % 3600) / 60);
   const s = total % 60;
   const ss = String(s).padStart(2, "0");
-  if (h > 0) {
-    return `${String(h)}:${String(m).padStart(2, "0")}:${ss}`;
+
+  let frac = "";
+  if (decimals > 0) {
+    const fractional = seconds - total;
+    const factor = 10 ** decimals;
+    // Round to handle FP noise (65.3 - 65 = 0.2999... → 3 not 2),
+    // but cap at factor-1 to prevent carry into seconds digit
+    // (1.999 - 1 = 0.999 → round to 10, cap to 9 → ".9" not ".0").
+    const fracDigits = Math.min(Math.round(fractional * factor), factor - 1);
+    frac = "." + String(fracDigits).padStart(decimals, "0");
   }
-  return `${String(m)}:${ss}`;
+
+  if (h > 0) {
+    return `${String(h)}:${String(m).padStart(2, "0")}:${ss}${frac}`;
+  }
+  return `${String(m)}:${ss}${frac}`;
 }


### PR DESCRIPTION
## Summary

Timeline interaction improvements: draggable playhead with time display, handle hover tooltips, edge-case handle z-indexing, alignment fixes, and zoom-aware time precision.

Fixes #171

## Changes

### Playhead
- Draggable time box in the ruler area with pointer capture for smooth scrubbing
- Rose-colored (`--stagebook-playhead: #e11d48`) to distinguish from blue selections
- Zoom-aware precision: tenths at 1×, hundredths at 2×+
- Extends from ruler through tracks via negative top (same DOM container as SelectionOverlay for pixel-perfect alignment)

### Handle tooltips
- Hover a range handle to see the time value; tooltip follows during drag and clears on release

### Edge handling
- Z-index swap at right edge: start handle renders on top so the user can drag left
- Duration clamping prevents handles from escaping timeline bounds

### Alignment fixes
- Ruler ticks centered via `translateX(-50%)` on the container
- Gutter `box-sizing: border-box` so 1px border-right is inside GUTTER_WIDTH

### Code quality (from four review agents)
- Hooks before early returns (Rules of Hooks fix)
- Shared `timelineStyles.ts`: `zoomDecimals`, `tooltipBaseStyle`, `handleTooltipStyle`
- `RULER_HEIGHT` exported from TimeRuler (was duplicated)
- `OFFSCREEN_PADDING` named constant
- `formatTime` fractional seconds with carry prevention
- Track labels: "Position N" → "Track N" (code + docs)
- Reducer tests tightened with exact values

### Font sizes
- ~15% increase across timeline components (ruler, track labels, tooltips)

## Test plan
- [x] 577 unit tests pass
- [x] 5 new Playwright CT tests: z-index at right/left/middle edges, playhead time box display, handle hover tooltip
- [x] `npm run lint` clean
- [x] Manual testing in VS Code extension preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)