### PR TITLE
Release v0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13682,7 +13682,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Bumps `stagebook` to `0.5.0`. Release notes below will be reused for the GitHub release after merge.

---

## What's new

### Timeline annotation UX
The Timeline element got a big round of interaction polish:
- Draggable playhead with handle tooltips.
- Spacebar toggles play/pause; arrow keys scrub the playhead ±1s when no selection is active; comma/period scrub ±1 frame (#173).
- Arrow-key hold behavior unified across both directions (discrete seeks), in the Timeline and the MediaPlayer.
- Per-track mute controls backed by a `GainNode` audio chain (#52).
- Compressed waveform now rendered in the timeline minimap (#51).
- Selection times rounded to millisecond precision (#167).
- Timeline references now accepted in `referenceSchema` (#131).
- Documented timeline selection reference syntax in the conditions docs.

### VS Code extension
- Preview Expanded Templates command now validates the expanded treatment and highlights errors in place (#112).
- Semantic tokens align with the raw source slice for quoted YAML scalars (#132).
- Offset→line/col lookup uses binary search (#133).

### Stability
- Every rendered element now lives inside an `ElementErrorBoundary`, so a single element's crash no longer takes down the stage. `onElementError` callbacks are isolated from the boundary itself so a buggy callback can't break containment.
- Hooks into `StagebookContext` now use the stable-ref pattern so consumers passing fresh callbacks no longer cause unnecessary re-registration (#105). Callback-stability expectations documented.
- New `contentVersion` on `StagebookContext` for cache-busted content re-fetches.
- New `durationVersion` on `PlaybackHandle` so Timeline re-renders when media metadata changes (#161).

### Authoring utilities
- `getReferencedAssets()` — enumerates every asset (prompt file, media URL, image, etc.) referenced by a treatment (#137).
- `computeBroadcastSize()` — computes the preview expansion size for templates (#39).

### Styling / theming
- Hardcoded values in `styles.css` migrated to `--stagebook-*` tokens (#116).
- Missing CSS custom properties (`--stagebook-danger-bg` and others) declared (#59).
- CSS block comments stripped in `extractDefined`.

### Bug fixes
- Help popover no longer clipped by the timeline's `overflow: hidden` — now rendered through a React portal with viewport-clamped fixed positioning (#174).
- Playhead drag no longer broken by tooltip style spread order.
- Non-array broadcast dimensions now throw instead of silently misbehaving.
- CT tests switched to `page.locator` where needed; ASCII apostrophes in fixtures.

### Examples & docs
- New annotated walkthrough example (#92).
- Example catalog + landing-page cards.

## Infra
- CI split into per-workspace jobs with path filtering (#64).
- Added a CI Gate job for branch protection.

## Test plan
- [x] Full CI green on `fix/issue-174` (merged into main as #175); the only commit on this branch is the version bump.
- [ ] After merge, tag `v0.5.0` and publish the GitHub release — the `npm-publish.yml` workflow picks it up automatically.