### PR TITLE
Bump actions/checkout and actions/setup-node to v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run lint
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm test -w stagebook
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build -w stagebook
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build -w stagebook
@@ -123,7 +123,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npx playwright install --with-deps chromium
@@ -136,7 +136,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       ct: ${{ steps.filter.outputs.ct }}
       lint: ${{ steps.filter.outputs.lint }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # Needed so dorny/paths-filter can diff base vs HEAD reliably on push events.
           fetch-depth: 0
@@ -61,8 +61,8 @@ jobs:
     if: needs.changes.outputs.lint == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -76,8 +76,8 @@ jobs:
     if: needs.changes.outputs.stagebook == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -90,8 +90,8 @@ jobs:
     if: needs.changes.outputs.viewer == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -105,8 +105,8 @@ jobs:
     if: needs.changes.outputs.vscode == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -120,8 +120,8 @@ jobs:
     if: needs.changes.outputs.ct == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -133,8 +133,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy-viewer.yml
+++ b/.github/workflows/deploy-viewer.yml
@@ -22,8 +22,8 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy-viewer.yml
+++ b/.github/workflows/deploy-viewer.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
       - run: npm ci
       - run: npm run build -w stagebook

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -12,8 +12,8 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout@v4` → `@v5` and `actions/setup-node@v4` → `@v5` across all three workflows ([ci.yml](.github/workflows/ci.yml), [npm-publish.yml](.github/workflows/npm-publish.yml), [deploy-viewer.yml](.github/workflows/deploy-viewer.yml)). Silences the Node 20 deprecation warning from the v0.5.0 publish run.
- Unifies all workflows on `node-version: 24` (ci.yml and deploy-viewer.yml were previously pinned to 22; npm-publish.yml was already 24). No package has a node engine constraint, so nothing blocks this.

## Why bump the actions
The @v4 tags of these JavaScript actions execute on a Node 20 runtime inside the GitHub runner. GitHub is rolling that runtime to Node 24 (default from June 2, 2026; Node 20 removed Sep 16, 2026). @v5 is rebuilt against Node 24. See https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Why bump project Node to 24
Keeps action-runtime and project-runtime aligned on the same major, and retires Node 22 (which goes EOL April 2027) ahead of the next boundary.

## Test plan
- [ ] CI passes on this branch with all three workflows on Node 24 + actions@v5.