### PR TITLE
Add regression test for qualtrics urlParams forwarding through Element

### DIFF
--- a/packages/stagebook/src/components/Element.ct.tsx
+++ b/packages/stagebook/src/components/Element.ct.tsx
@@ -131,6 +131,31 @@ test.describe("Element router dispatch", () => {
     await expect(component.locator("iframe")).toBeVisible();
   });
 
+  // Regression guard: Element must forward `urlParams` through to the
+  // Qualtrics component. Prior versions of the sibling project
+  // (deliberation-empirica#1240) regressed this silently because the
+  // direct-mount Qualtrics tests bypassed the Element wrapper.
+  test("type: qualtrics forwards urlParams (static + reference) to iframe URL", async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <MockStageRenderer
+        stage={singleElementStage({
+          type: "qualtrics",
+          url: "https://upenn.qualtrics.com/jfe/form/SV_test",
+          urlParams: [
+            { key: "condition", value: "topicA" },
+            { key: "answer", reference: "prompt.myQ" },
+          ],
+        })}
+        stateValues={{ "prompt.myQ": "yes" }}
+      />,
+    );
+    const src = await component.locator("iframe").getAttribute("src");
+    expect(src).toContain("condition=topicA");
+    expect(src).toContain("answer=yes");
+  });
+
   test("type: mediaPlayer renders a video element", async ({ mount }) => {
     const component = await mount(
       <MockStageRenderer


### PR DESCRIPTION
## Summary
Mirrors [deliberation-empirica#1240](https://github.com/Watts-Lab/deliberation-empirica/pull/1240). That repo's `Element.jsx` was passing `params={element.params}` to the `<Qualtrics>` component while the schema and component both use `urlParams`, so configured URL params silently never reached the iframe. The bug slipped through because all Qualtrics component tests mounted `<Qualtrics>` directly and bypassed the Element wrapper.

**Stagebook does not have the code bug.** [Element.tsx:331](packages/stagebook/src/components/Element.tsx#L331) already reads `element.urlParams` and forwards it as `resolvedParams` — same pattern as `trackedLink`. The schema ([treatment.ts:875](packages/stagebook/src/schemas/treatment.ts#L875)) uses `urlParams`. So the code is fine.

**Stagebook does have the test gap.** The only Element→qualtrics test in [Element.ct.tsx:122](packages/stagebook/src/components/Element.ct.tsx#L122) only verified that an iframe rendered. Everything in [Qualtrics.ct.tsx](packages/stagebook/src/components/elements/Qualtrics.ct.tsx) mounts `<Qualtrics>` directly. So the equivalent regression could slip in here too.

This adds an Element-wrapper test that exercises `urlParams` end-to-end: both a static `value` and a `reference` (resolved via `stateValues`), and asserts both reach the iframe `src`.

## Test plan
- [x] New test passes: `npx playwright test --config playwright-ct.config.ts --grep "forwards urlParams"`.
- [x] Confirmed it fails on the buggy variant — temporarily changed Element.tsx to read `element.params` instead of `element.urlParams`; test failed with `Received string: "…?deliberationId=test-player-1"` (no configured params in URL), matching the deliberation-empirica bug symptom exactly.
- [x] Full qualtrics grep still green (7/7).