### PR TITLE
Replace desc with notes in authoring schemas; strip from resolved (#158)

### DIFF
--- a/docs/researcher/conditions.md
+++ b/docs/researcher/conditions.md
@@ -260,13 +260,13 @@ You can also use URL parameters for pre-assigned roles:
 ```yaml
 groupComposition:
   - position: 0
-    desc: Confederate
+    title: Confederate
     conditions:
       - reference: urlParams.role
         comparator: equals
         value: confederate
   - position: 1
-    desc: Participant
+    title: Participant
     conditions:
       - reference: urlParams.role
         comparator: equals

--- a/docs/researcher/syntax-reference.md
+++ b/docs/researcher/syntax-reference.md
@@ -65,7 +65,7 @@ conditions:
 
 ## 6. Elements
 
-All elements accept: `name?`, `desc?`, `file?`, `displayTime?`, `hideTime?`, `showToPositions?`, `hideFromPositions?`, `conditions?`, `tags?`.
+All elements accept: `name?`, `notes?`, `file?`, `displayTime?`, `hideTime?`, `showToPositions?`, `hideFromPositions?`, `conditions?`, `tags?`.
 
 | Type | Key Fields |
 |------|-----------|

--- a/docs/researcher/treatment-files.md
+++ b/docs/researcher/treatment-files.md
@@ -51,7 +51,7 @@ introSequences:
 
 treatments:
   - name: two_player_discussion
-    desc: Simple two-player video discussion
+    notes: Simple two-player video discussion
     playerCount: 2
 
     gameStages:
@@ -93,8 +93,29 @@ Each game stage has:
 | `duration` | integer | yes | Stage length in seconds |
 | `discussion` | object | no | Video/text chat configuration (see [Discussions](discussions.md)) |
 | `elements` | array | yes | UI elements displayed during the stage |
+| `notes` | string | no | Researcher-facing rationale, citations, or design decisions (see [Notes](#notes)) |
 
 Intro and exit steps have `name` and `elements` but no `duration` (they are untimed).
+
+## Notes
+
+Any treatment, stage, intro/exit step, element, template, or introSequence can carry a `notes` field. Notes are **researcher-facing only** — they're visible in the viewer and to authoring tools, but the platform runtime strips them before any data reaches participants.
+
+Use YAML's block scalar syntax (`|`) for multi-line markdown:
+
+```yaml
+- name: story_ratings
+  duration: 180
+  notes: |
+    Adapted from the narrative engagement scale (Busselle & Bilandzic, 2009).
+
+    We use 5 items instead of the original 12 to reduce participant fatigue.
+  elements:
+    - type: prompt
+      file: task/story_well_told.prompt.md
+```
+
+> `notes` replaces the old `desc` field. Treatment files that still use `desc` will fail validation — rename them to `notes`.
 
 ## Positions
 

--- a/packages/stagebook/src/schemas/index.ts
+++ b/packages/stagebook/src/schemas/index.ts
@@ -11,7 +11,6 @@ export {
 
 export {
   nameSchema,
-  descriptionSchema,
   fileSchema,
   urlSchema,
   durationSchema,
@@ -48,7 +47,6 @@ export {
   timelineSchema,
   matchContentType,
   type NameType,
-  type DescriptionType,
   type FileType,
   type UrlType,
   type DurationType,

--- a/packages/stagebook/src/schemas/resolved.test.ts
+++ b/packages/stagebook/src/schemas/resolved.test.ts
@@ -11,7 +11,47 @@ import { resolvedTreatmentSchema } from "./resolved.js";
  * keeps notes from reaching participants. See #158 / #136.
  */
 describe("resolved schemas strip researcher `notes`", () => {
+  // A minimally-valid treatment file that exercises `notes` at every
+  // authoring level mentioned in #158: treatments, stages, intro/exit
+  // steps, elements, introSequences, and templates.
   const authoringYaml = {
+    templates: [
+      {
+        templateName: "tpl_with_notes",
+        templateDesc: "A template",
+        notes: "Template rationale for researchers.",
+        contentType: "stage" as const,
+        templateContent: {
+          name: "tpl_stage",
+          duration: 30,
+          elements: [
+            { type: "prompt", file: "prompts/tpl.prompt.md" },
+            { type: "submitButton" },
+          ],
+        },
+      },
+    ],
+    introSequences: [
+      {
+        name: "seq_with_notes",
+        notes: "Intro sequence rationale.",
+        introSteps: [
+          {
+            name: "welcome",
+            notes: "Step-level note on intro.",
+            elements: [
+              {
+                type: "prompt",
+                name: "intro_prompt",
+                notes: "Element-level note on intro.",
+                file: "prompts/welcome.prompt.md",
+              },
+              { type: "submitButton" },
+            ],
+          },
+        ],
+      },
+    ],
     treatments: [
       {
         name: "t_with_notes",
@@ -47,15 +87,16 @@ describe("resolved schemas strip researcher `notes`", () => {
     ],
   };
 
-  test("authoring schema accepts `notes` on treatments, stages, elements, and intro/exit steps", () => {
+  test("authoring schema accepts `notes` on treatments, stages, intro/exit steps, elements, introSequences, and templates", () => {
     const result = treatmentFileSchema.safeParse(authoringYaml);
     if (!result.success) console.error(result.error.issues);
     expect(result.success).toBe(true);
   });
 
   test("resolvedTreatmentSchema strips every `notes` in the output tree", () => {
-    const resolvedInput = authoringYaml.treatments[0];
-    const result = resolvedTreatmentSchema.safeParse(resolvedInput);
+    const result = resolvedTreatmentSchema.safeParse(
+      authoringYaml.treatments[0],
+    );
     if (!result.success) console.error(result.error.issues);
     expect(result.success).toBe(true);
 
@@ -81,12 +122,28 @@ describe("resolved schemas strip researcher `notes`", () => {
     expect(findNotesKey(result.data)).toBe(null);
   });
 
-  test("`desc` is no longer accepted as a key in authoring schemas (#158)", () => {
-    const withDesc = {
+  test("legacy `desc:` is rejected (and the same fixture without `desc` would validate)", () => {
+    // Build a minimally-valid treatment file without `desc` first, then
+    // confirm the same fixture with an added `desc:` at treatment level
+    // fails — so we isolate the cause of failure to the `desc` field.
+    const baseFixture = {
+      introSequences: [
+        {
+          name: "seq",
+          introSteps: [
+            {
+              name: "welcome",
+              elements: [
+                { type: "prompt", file: "p.prompt.md" },
+                { type: "submitButton" },
+              ],
+            },
+          ],
+        },
+      ],
       treatments: [
         {
-          name: "t_old",
-          desc: "legacy description field",
+          name: "t",
           playerCount: 2,
           gameStages: [
             {
@@ -101,7 +158,31 @@ describe("resolved schemas strip researcher `notes`", () => {
         },
       ],
     };
+
+    // Sanity check: without `desc`, the fixture validates.
+    const withoutDesc = treatmentFileSchema.safeParse(baseFixture);
+    if (!withoutDesc.success) console.error(withoutDesc.error.issues);
+    expect(withoutDesc.success).toBe(true);
+
+    // Now add `desc:` at treatment level. Should fail specifically
+    // because `desc` is no longer a recognized key.
+    const withDesc = {
+      ...baseFixture,
+      treatments: [
+        { ...baseFixture.treatments[0], desc: "legacy description field" },
+      ],
+    };
     const result = treatmentFileSchema.safeParse(withDesc);
     expect(result.success).toBe(false);
+    if (!result.success) {
+      // Confirm the failure is specifically "unrecognized key `desc`"
+      // — not an unrelated problem with the fixture.
+      const descIssue = result.error.issues.find(
+        (i) =>
+          i.code === "unrecognized_keys" &&
+          (i as { keys?: string[] }).keys?.includes("desc"),
+      );
+      expect(descIssue).toBeDefined();
+    }
   });
 });

--- a/packages/stagebook/src/schemas/resolved.test.ts
+++ b/packages/stagebook/src/schemas/resolved.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "vitest";
+
+import { treatmentFileSchema } from "./treatment.js";
+import { resolvedTreatmentSchema } from "./resolved.js";
+
+/**
+ * `notes` is researcher-facing metadata. It's valid in authoring schemas so
+ * researchers can document rationale, citations, and design decisions inline
+ * in their treatment YAML, but it MUST be stripped from the output when
+ * parsed through the resolved schemas — that's the security boundary that
+ * keeps notes from reaching participants. See #158 / #136.
+ */
+describe("resolved schemas strip researcher `notes`", () => {
+  const authoringYaml = {
+    treatments: [
+      {
+        name: "t_with_notes",
+        notes: "Top-level treatment rationale.",
+        playerCount: 2,
+        gameStages: [
+          {
+            name: "s_with_notes",
+            notes: "Adapted from Smith et al. (2020).",
+            duration: 60,
+            elements: [
+              {
+                type: "prompt",
+                name: "p_with_notes",
+                notes: "Pilot showed N=32 was adequate.",
+                file: "prompts/q.prompt.md",
+              },
+              { type: "submitButton" },
+            ],
+          },
+        ],
+        exitSequence: [
+          {
+            name: "e_with_notes",
+            notes: "Debrief copy pending IRB approval.",
+            elements: [
+              { type: "prompt", file: "prompts/debrief.prompt.md" },
+              { type: "submitButton" },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  test("authoring schema accepts `notes` on treatments, stages, elements, and intro/exit steps", () => {
+    const result = treatmentFileSchema.safeParse(authoringYaml);
+    if (!result.success) console.error(result.error.issues);
+    expect(result.success).toBe(true);
+  });
+
+  test("resolvedTreatmentSchema strips every `notes` in the output tree", () => {
+    const resolvedInput = authoringYaml.treatments[0];
+    const result = resolvedTreatmentSchema.safeParse(resolvedInput);
+    if (!result.success) console.error(result.error.issues);
+    expect(result.success).toBe(true);
+
+    // Walk the whole parsed object and confirm no `notes` key survived.
+    function findNotesKey(value: unknown, path = "$"): string | null {
+      if (Array.isArray(value)) {
+        for (let i = 0; i < value.length; i++) {
+          const found = findNotesKey(value[i], `${path}[${String(i)}]`);
+          if (found) return found;
+        }
+        return null;
+      }
+      if (value && typeof value === "object") {
+        for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+          if (k === "notes") return `${path}.notes`;
+          const found = findNotesKey(v, `${path}.${k}`);
+          if (found) return found;
+        }
+      }
+      return null;
+    }
+
+    expect(findNotesKey(result.data)).toBe(null);
+  });
+
+  test("`desc` is no longer accepted as a key in authoring schemas (#158)", () => {
+    const withDesc = {
+      treatments: [
+        {
+          name: "t_old",
+          desc: "legacy description field",
+          playerCount: 2,
+          gameStages: [
+            {
+              name: "s",
+              duration: 60,
+              elements: [
+                { type: "prompt", file: "p.prompt.md" },
+                { type: "submitButton" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const result = treatmentFileSchema.safeParse(withDesc);
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -12,7 +12,6 @@
 import { z } from "zod";
 import {
   nameSchema,
-  descriptionSchema,
   durationSchema,
   displayTimeSchema,
   hideTimeSchema,
@@ -73,7 +72,6 @@ const resolvedConditionsSchema = z.array(resolvedConditionSchema).optional();
 const resolvedElementBaseSchema = z.object({
   type: z.string(),
   name: nameSchema.optional(),
-  desc: descriptionSchema.optional(),
   file: z.string().optional(),
   displayTime: displayTimeSchema.optional(),
   hideTime: hideTimeSchema.optional(),
@@ -134,7 +132,6 @@ export type ResolvedElementType = z.infer<typeof resolvedElementSchema>;
 
 export const resolvedStageSchema = z.object({
   name: nameSchema,
-  desc: descriptionSchema.optional(),
   discussion: discussionSchema.optional(),
   duration: durationSchema,
   elements: z.array(resolvedElementSchema).nonempty(),
@@ -147,7 +144,6 @@ export type ResolvedStageType = z.infer<typeof resolvedStageSchema>;
 
 export const resolvedIntroExitStepSchema = z.object({
   name: nameSchema,
-  desc: descriptionSchema.optional(),
   elements: z.array(resolvedElementSchema).nonempty(),
 });
 export type ResolvedIntroExitStepType = z.infer<
@@ -160,12 +156,10 @@ export type ResolvedIntroExitStepType = z.infer<
 
 export const resolvedTreatmentSchema = z.object({
   name: nameSchema,
-  desc: descriptionSchema.optional(),
   playerCount: z.number(),
   groupComposition: z
     .array(
       z.object({
-        desc: descriptionSchema.optional(),
         position: positionSchema,
         title: z.string().max(25).optional(),
         conditions: resolvedConditionsSchema,

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -16,7 +16,7 @@ function isValidRegex(pattern: string): boolean {
   }
 }
 
-// ------------------ Names, descriptions, and files ------------------ //
+// ------------------ Names and files ------------------ //
 
 // Field placeholder pattern: only alphanumeric + underscore.
 // Must match FIELD_PLACEHOLDER_REGEX in templates/fillTemplates.ts
@@ -39,9 +39,6 @@ export const nameSchema = z
       "Name must be alphanumeric, cannot have special characters, with optional template fields in the format ${fieldname}",
   });
 export type NameType = z.infer<typeof nameSchema>;
-
-export const descriptionSchema = z.string();
-export type DescriptionType = z.infer<typeof descriptionSchema>;
 
 // TODO: check that file exists
 export const fileSchema = z.string().optional();
@@ -674,7 +671,6 @@ export type ConditionType = z.infer<typeof conditionSchema>;
 
 export const playerSchema = z
   .object({
-    desc: descriptionSchema.optional(),
     position: positionSchema,
     title: z.string().max(25).optional(),
     conditions: z
@@ -692,7 +688,7 @@ export type PlayerType = z.infer<typeof playerSchema>;
 const elementBaseSchema = z
   .object({
     name: nameSchema.optional(),
-    desc: descriptionSchema.optional(),
+    notes: z.string().optional(),
     file: fileSchema.or(fieldPlaceholderSchema).optional(),
     displayTime: displayTimeSchema.or(fieldPlaceholderSchema).optional(),
     hideTime: hideTimeSchema.or(fieldPlaceholderSchema).optional(),
@@ -1085,7 +1081,7 @@ export const stageSchema = altTemplateContext(
   z
     .object({
       name: nameSchema,
-      desc: descriptionSchema.optional(),
+      notes: z.string().optional(),
       discussion: discussionSchema.optional(),
       duration: durationSchema.or(fieldPlaceholderSchema),
       elements: elementsSchema,
@@ -1146,7 +1142,7 @@ export const introExitStepSchema = altTemplateContext(
   z
     .object({
       name: nameSchema,
-      desc: descriptionSchema.optional(),
+      notes: z.string().optional(),
       elements: elementsSchema,
     })
     .strict(),
@@ -1281,7 +1277,7 @@ export const introSequenceSchema = altTemplateContext(
   z
     .object({
       name: nameSchema,
-      desc: descriptionSchema.optional(),
+      notes: z.string().optional(),
       introSteps: introStepsSchema,
     })
     .strict(),
@@ -1302,7 +1298,6 @@ export const introSequencesSchema = altTemplateContext(
 export const baseTreatmentSchema = z
   .object({
     name: nameSchema,
-    desc: descriptionSchema.optional(),
     notes: z.string().optional(),
     playerCount: z.number(),
     groupComposition: z
@@ -1653,7 +1648,8 @@ export const templateSchema = z
         "other",
       ])
       .optional(),
-    templateDesc: descriptionSchema.optional(),
+    templateDesc: z.string().optional(),
+    notes: z.string().optional(),
     templateContent: z.any(),
   })
   .strict()


### PR DESCRIPTION
Closes #158.

## Summary
Breaking DSL change: `desc` is removed from every authoring and resolved schema and replaced by `notes` on the authoring side only. Researchers can document rationale, citations, and design decisions inline in their treatment YAML; the platform runtime strips `notes` before any data reaches participants (the security boundary).

## What changed

**Authoring schemas** ([`treatment.ts`](packages/stagebook/src/schemas/treatment.ts))
- `desc` removed from `playerSchema`, `elementBaseSchema`, `stageSchema`, `introExitStepSchema`, `introSequenceSchema`, `baseTreatmentSchema`.
- `notes: z.string().optional()` added to `elementBaseSchema`, `stageSchema`, `introExitStepSchema`, `introSequenceSchema`, `templateSchema`. (`baseTreatmentSchema` already had `notes` — I just removed its `desc`.)
- `playerSchema` keeps `title` (user-visible label) but no `notes` — rationale about positions belongs at treatment or stage level.
- `templateDesc` is preserved (distinct template-naming field, not documentation) but inlined as `z.string().optional()`, which lets me delete `descriptionSchema` / `DescriptionType` entirely.

**Resolved schemas** ([`resolved.ts`](packages/stagebook/src/schemas/resolved.ts))
- `desc` stripped from every resolved schema. `notes` is deliberately NOT added; Zod's default strip mode drops `notes` when a treatment is parsed through `resolvedTreatmentSchema`. That's the security boundary.

**Public API** ([`schemas/index.ts`](packages/stagebook/src/schemas/index.ts))
- `descriptionSchema` and `DescriptionType` no longer exported.

**Tests** ([`schemas/resolved.test.ts`](packages/stagebook/src/schemas/resolved.test.ts), new)
- `notes` is accepted at every listed authoring level (treatment, stage, element, intro/exit step).
- `notes` is stripped from the resolved tree (recursive walk confirms no surviving `notes` key).
- Legacy `desc:` at treatment level fails validation.

**Docs**
- [`treatment-files.md`](docs/researcher/treatment-files.md): new "Notes" section with block-scalar example and the viewer-only/strip-at-runtime guarantee; existing example's `desc:` → `notes:`.
- [`conditions.md`](docs/researcher/conditions.md): `groupComposition` example's `desc:` → `title:` (semantic match).
- [`syntax-reference.md`](docs/researcher/syntax-reference.md): element-field list `desc?` → `notes?`.

## Breaking change notice
Treatment files that still use `desc` will now **fail validation**. Rename every `desc:` to `notes:`. There is no migration shim — this is the reason for a minor version bump at the next release (0.6.0).

## Test plan
- [x] `npm test` — 584 stagebook + 178 vscode + 69 viewer all green (+3 new tests for the round-trip).
- [x] `npm run test:ct -w stagebook` — 355 Playwright CT tests pass.
- [x] `npm run lint` clean.
- [x] `npm run format:check` clean.