### PR TITLE
Study overview page + researcher notes panel (#159, #160)

### DIFF
--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import type { TreatmentFileType } from "stagebook";
 import { loadTreatmentFromUrl } from "./lib/loader";
 import {
@@ -44,11 +44,21 @@ type AppState =
 export function App() {
   const [state, setState] = useState<AppState>({ phase: "landing" });
 
+  // Monotonic token — incremented on every load request so a slower README
+  // fetch from an earlier click can't overwrite state set by a later one.
+  const loadSeqRef = useRef(0);
+
   const enterTreatment = useCallback(
-    async (treatmentFile: TreatmentFileType, contentFns: ContentFns) => {
+    async (
+      treatmentFile: TreatmentFileType,
+      contentFns: ContentFns,
+      seq: number,
+    ) => {
       const readmeContent = await contentFns
         .getTextContent("README.md")
         .catch(() => null);
+      // A newer load started while we were awaiting README — drop this one.
+      if (seq !== loadSeqRef.current) return;
 
       const needsPicker =
         treatmentFile.introSequences.length > 1 ||
@@ -76,11 +86,18 @@ export function App() {
 
   const handleLoad = useCallback(
     async (url: string) => {
+      const seq = ++loadSeqRef.current;
       setState({ phase: "loading", url });
       try {
         const { treatmentFile, rawBaseUrl } = await loadTreatmentFromUrl(url);
-        await enterTreatment(treatmentFile, createUrlContentFns(rawBaseUrl));
+        if (seq !== loadSeqRef.current) return;
+        await enterTreatment(
+          treatmentFile,
+          createUrlContentFns(rawBaseUrl),
+          seq,
+        );
       } catch (err) {
+        if (seq !== loadSeqRef.current) return;
         const validationIssues =
           err instanceof TreatmentValidationError ? err.issues : undefined;
         setState({
@@ -96,10 +113,16 @@ export function App() {
 
   const handleLoadExample = useCallback(
     async (entry: ExampleEntry) => {
+      const seq = ++loadSeqRef.current;
       try {
         const treatmentFile = parseTreatmentYaml(entry.yaml);
-        await enterTreatment(treatmentFile, createExampleContentFns(entry));
+        await enterTreatment(
+          treatmentFile,
+          createExampleContentFns(entry),
+          seq,
+        );
       } catch (err) {
+        if (seq !== loadSeqRef.current) return;
         const validationIssues =
           err instanceof TreatmentValidationError ? err.issues : undefined;
         setState({

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -13,7 +13,7 @@ import {
   type ExampleEntry,
 } from "./lib/exampleCatalog";
 import { LandingPage } from "./components/LandingPage";
-import { TreatmentPicker } from "./components/TreatmentPicker";
+import { OverviewPage } from "./components/OverviewPage";
 import { PreviewHost } from "./components/PreviewHost";
 
 type ContentFns = ReturnType<typeof createUrlContentFns>;
@@ -22,9 +22,10 @@ type AppState =
   | { phase: "landing" }
   | { phase: "loading"; url: string }
   | {
-      phase: "selecting";
+      phase: "overview";
       treatmentFile: TreatmentFileType;
       contentFns: ContentFns;
+      readmeContent: string | null;
     }
   | {
       phase: "viewing";
@@ -44,13 +45,22 @@ export function App() {
   const [state, setState] = useState<AppState>({ phase: "landing" });
 
   const enterTreatment = useCallback(
-    (treatmentFile: TreatmentFileType, contentFns: ContentFns) => {
+    async (treatmentFile: TreatmentFileType, contentFns: ContentFns) => {
+      const readmeContent = await contentFns
+        .getTextContent("README.md")
+        .catch(() => null);
+
       const needsPicker =
         treatmentFile.introSequences.length > 1 ||
         treatmentFile.treatments.length > 1;
 
-      if (needsPicker) {
-        setState({ phase: "selecting", treatmentFile, contentFns });
+      if (needsPicker || readmeContent !== null) {
+        setState({
+          phase: "overview",
+          treatmentFile,
+          contentFns,
+          readmeContent,
+        });
       } else {
         setState({
           phase: "viewing",
@@ -69,7 +79,7 @@ export function App() {
       setState({ phase: "loading", url });
       try {
         const { treatmentFile, rawBaseUrl } = await loadTreatmentFromUrl(url);
-        enterTreatment(treatmentFile, createUrlContentFns(rawBaseUrl));
+        await enterTreatment(treatmentFile, createUrlContentFns(rawBaseUrl));
       } catch (err) {
         const validationIssues =
           err instanceof TreatmentValidationError ? err.issues : undefined;
@@ -85,10 +95,10 @@ export function App() {
   );
 
   const handleLoadExample = useCallback(
-    (entry: ExampleEntry) => {
+    async (entry: ExampleEntry) => {
       try {
         const treatmentFile = parseTreatmentYaml(entry.yaml);
-        enterTreatment(treatmentFile, createExampleContentFns(entry));
+        await enterTreatment(treatmentFile, createExampleContentFns(entry));
       } catch (err) {
         const validationIssues =
           err instanceof TreatmentValidationError ? err.issues : undefined;
@@ -134,11 +144,13 @@ export function App() {
         />
       );
 
-    case "selecting": {
-      const { treatmentFile, contentFns } = state;
+    case "overview": {
+      const { treatmentFile, contentFns, readmeContent } = state;
       return (
-        <TreatmentPicker
+        <OverviewPage
           treatmentFile={treatmentFile}
+          readmeContent={readmeContent}
+          onBack={() => setState({ phase: "landing" })}
           onSelect={(introIndex, treatmentIndex) => {
             setState({
               phase: "viewing",

--- a/apps/viewer/src/components/NotesIconsOverlay.tsx
+++ b/apps/viewer/src/components/NotesIconsOverlay.tsx
@@ -1,10 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type RefObject,
-} from "react";
+import { useCallback, useEffect, useState, type RefObject } from "react";
 import type { ViewerStep } from "../lib/steps";
 import { noteAnchorId } from "./StateInspector";
 
@@ -37,7 +31,6 @@ export function NotesIconsOverlay({
   currentStep,
 }: NotesIconsOverlayProps) {
   const [positions, setPositions] = useState<IconPos[]>([]);
-  const observerRef = useRef<ResizeObserver | null>(null);
 
   const recompute = useCallback(() => {
     const container = containerRef.current;
@@ -69,20 +62,27 @@ export function NotesIconsOverlay({
     const container = containerRef.current;
     if (!container) return;
     // Recompute once after layout settles, then whenever the container
-    // resizes or its subtree mutates. Layout shifts from prompt-markdown
-    // loading or stage nav don't fire window.resize, so we need both
-    // ResizeObserver and MutationObserver.
+    // resizes, its subtree mutates, the window resizes, or any internal
+    // scroll container scrolls (Stage uses `[data-testid="stageContent"]`
+    // with `overflow: auto` for long content). Scroll events don't bubble,
+    // so we listen in the capture phase on the container — this catches
+    // scrolls on any current or future descendant without having to
+    // re-resolve the scroller set on DOM churn.
     const ro = new ResizeObserver(recompute);
     ro.observe(container);
-    observerRef.current = ro;
     const mo = new MutationObserver(recompute);
     mo.observe(container, { childList: true, subtree: true });
     window.addEventListener("resize", recompute);
+    container.addEventListener("scroll", recompute, {
+      capture: true,
+      passive: true,
+    });
     const raf = requestAnimationFrame(recompute);
     return () => {
       ro.disconnect();
       mo.disconnect();
       window.removeEventListener("resize", recompute);
+      container.removeEventListener("scroll", recompute, true);
       cancelAnimationFrame(raf);
     };
   }, [recompute, containerRef]);

--- a/apps/viewer/src/components/NotesIconsOverlay.tsx
+++ b/apps/viewer/src/components/NotesIconsOverlay.tsx
@@ -1,0 +1,161 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type RefObject,
+} from "react";
+import type { ViewerStep } from "../lib/steps";
+import { noteAnchorId } from "./StateInspector";
+
+export interface NotesIconsOverlayProps {
+  /** Container whose DOM children include the rendered `<Stage>`. */
+  containerRef: RefObject<HTMLElement | null>;
+  currentStep: ViewerStep;
+}
+
+interface IconPos {
+  key: string;
+  type: string;
+  name: string | undefined;
+  top: number;
+  left: number;
+}
+
+/**
+ * Viewer-only overlay that drops a small ℹ icon onto every rendered
+ * element whose `notes` field is set. Clicking the icon scrolls the
+ * matching note in the StateInspector sidebar into view and briefly
+ * highlights it.
+ *
+ * Implementation uses `data-testid="element-{type}-{name}"` (added by
+ * `packages/stagebook/src/components/Stage.tsx`) to locate element
+ * wrappers — no library changes required.
+ */
+export function NotesIconsOverlay({
+  containerRef,
+  currentStep,
+}: NotesIconsOverlayProps) {
+  const [positions, setPositions] = useState<IconPos[]>([]);
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  const recompute = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const containerRect = container.getBoundingClientRect();
+    const next: IconPos[] = [];
+    for (const el of currentStep.elements) {
+      const typed = el as { type: string; name?: string; notes?: string };
+      if (!typed.notes) continue;
+      const selector = `[data-testid="element-${typed.type}${typed.name ? `-${typed.name}` : ""}"]`;
+      const node = container.querySelector(selector);
+      if (!(node instanceof HTMLElement)) continue;
+      const r = node.getBoundingClientRect();
+      next.push({
+        key: `${typed.type}-${typed.name ?? "anon"}-${String(next.length)}`,
+        type: typed.type,
+        name: typed.name,
+        // Anchor the icon in the lower-right of the element rect,
+        // relative to the overlay's coordinate system (same as the
+        // container since the overlay is inset:0 within it).
+        top: r.bottom - containerRect.top - 20,
+        left: r.right - containerRect.left - 20,
+      });
+    }
+    setPositions(next);
+  }, [containerRef, currentStep]);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    // Recompute once after layout settles, then whenever the container
+    // resizes or its subtree mutates. Layout shifts from prompt-markdown
+    // loading or stage nav don't fire window.resize, so we need both
+    // ResizeObserver and MutationObserver.
+    const ro = new ResizeObserver(recompute);
+    ro.observe(container);
+    observerRef.current = ro;
+    const mo = new MutationObserver(recompute);
+    mo.observe(container, { childList: true, subtree: true });
+    window.addEventListener("resize", recompute);
+    const raf = requestAnimationFrame(recompute);
+    return () => {
+      ro.disconnect();
+      mo.disconnect();
+      window.removeEventListener("resize", recompute);
+      cancelAnimationFrame(raf);
+    };
+  }, [recompute, containerRef]);
+
+  const handleClick = (type: string, name: string | undefined) => {
+    const id = noteAnchorId(type, name);
+    const target = document.getElementById(id);
+    if (!target) return;
+    target.scrollIntoView({ behavior: "smooth", block: "center" });
+    // Brief flash so the reader can find the just-scrolled note.
+    const prev = target.style.backgroundColor;
+    target.style.backgroundColor = "#fef3c7";
+    window.setTimeout(() => {
+      target.style.backgroundColor = prev;
+    }, 900);
+  };
+
+  return (
+    <div
+      data-testid="notes-icons-overlay"
+      style={overlayStyle}
+      aria-hidden={false}
+    >
+      {positions.map((pos) => (
+        <button
+          key={pos.key}
+          type="button"
+          onClick={() => handleClick(pos.type, pos.name)}
+          title="Has researcher notes — click to jump to the sidebar note"
+          aria-label={`Open note for ${pos.name ?? pos.type}`}
+          data-testid={`notes-icon-${pos.type}${pos.name ? `-${pos.name}` : ""}`}
+          style={{
+            ...iconButtonStyle,
+            top: `${String(pos.top)}px`,
+            left: `${String(pos.left)}px`,
+          }}
+        >
+          <span style={iconGlyphStyle}>i</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: "absolute",
+  inset: 0,
+  pointerEvents: "none",
+  // Keep icons above rendered stage content but below modal UI.
+  zIndex: 10,
+};
+
+const iconButtonStyle: React.CSSProperties = {
+  position: "absolute",
+  width: "1.5rem",
+  height: "1.5rem",
+  padding: 0,
+  borderRadius: "9999px",
+  border: "1px solid #fbbf24",
+  backgroundColor: "#fde68a",
+  color: "#92400e",
+  cursor: "pointer",
+  pointerEvents: "auto",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  boxShadow: "0 1px 2px rgba(0, 0, 0, 0.08)",
+};
+
+const iconGlyphStyle: React.CSSProperties = {
+  fontFamily: "'Times New Roman', Georgia, serif",
+  fontStyle: "italic",
+  fontWeight: 700,
+  fontSize: "0.875rem",
+  lineHeight: 1,
+};

--- a/apps/viewer/src/components/OverviewPage.tsx
+++ b/apps/viewer/src/components/OverviewPage.tsx
@@ -1,0 +1,272 @@
+import { useState } from "react";
+import type { TreatmentFileType } from "stagebook";
+import { Markdown } from "stagebook/components";
+
+export interface OverviewPageProps {
+  treatmentFile: TreatmentFileType;
+  /** README content, or null if no README was found. */
+  readmeContent: string | null;
+  onSelect: (introIndex: number, treatmentIndex: number) => void;
+  onBack?: () => void;
+}
+
+/**
+ * Study overview page. Renders the sibling `README.md` (left column) and
+ * the treatment picker (right column) on wide screens; stacks vertically
+ * on narrow ones. When there is no README, collapses to a single-column
+ * picker. See #159.
+ */
+export function OverviewPage({
+  treatmentFile,
+  readmeContent,
+  onSelect,
+  onBack,
+}: OverviewPageProps) {
+  const { introSequences, treatments } = treatmentFile;
+  const multipleIntros = introSequences.length > 1;
+  const multipleTreatments = treatments.length > 1;
+
+  const [selectedIntro, setSelectedIntro] = useState(0);
+  const [selectedTreatment, setSelectedTreatment] = useState(0);
+
+  const hasReadme = readmeContent !== null;
+
+  return (
+    <div style={containerStyle}>
+      {onBack && (
+        <button aria-label="Back" onClick={onBack} style={backButtonStyle}>
+          &larr; Back
+        </button>
+      )}
+      <div style={{ ...layoutStyle, ...(hasReadme ? {} : oneColLayoutStyle) }}>
+        {hasReadme && (
+          <section style={readmeColStyle} data-testid="overview-readme">
+            <Markdown text={readmeContent} />
+          </section>
+        )}
+        <section
+          style={pickerColStyle}
+          data-testid="overview-picker"
+          aria-label="Select a configuration"
+        >
+          <h1 style={titleStyle}>
+            {multipleTreatments || multipleIntros
+              ? "Select a configuration"
+              : "Ready to view"}
+          </h1>
+
+          {multipleTreatments && (
+            <fieldset style={fieldsetStyle}>
+              <legend style={legendStyle}>Treatments</legend>
+              <div style={listStyle}>
+                {treatments.map(
+                  (
+                    t: {
+                      name: string;
+                      playerCount: number;
+                      gameStages: unknown[];
+                    },
+                    i: number,
+                  ) => (
+                    <label
+                      key={t.name}
+                      style={optionStyle(i === selectedTreatment)}
+                    >
+                      <input
+                        type="radio"
+                        name="treatment"
+                        checked={i === selectedTreatment}
+                        onChange={() => setSelectedTreatment(i)}
+                        style={radioStyle}
+                      />
+                      <span style={optionBodyStyle}>
+                        <span style={optionNameStyle}>{t.name}</span>
+                        <span style={optionDetailStyle}>
+                          {t.playerCount} player
+                          {t.playerCount !== 1 ? "s" : ""},{" "}
+                          {t.gameStages.length} stage
+                          {t.gameStages.length !== 1 ? "s" : ""}
+                        </span>
+                      </span>
+                    </label>
+                  ),
+                )}
+              </div>
+            </fieldset>
+          )}
+
+          {multipleIntros && (
+            <fieldset style={fieldsetStyle}>
+              <legend style={legendStyle}>Intro sequence</legend>
+              <div style={listStyle}>
+                {introSequences.map(
+                  (
+                    intro: { name: string; introSteps: unknown[] },
+                    i: number,
+                  ) => (
+                    <label
+                      key={intro.name}
+                      style={optionStyle(i === selectedIntro)}
+                    >
+                      <input
+                        type="radio"
+                        name="intro"
+                        checked={i === selectedIntro}
+                        onChange={() => setSelectedIntro(i)}
+                        style={radioStyle}
+                      />
+                      <span style={optionBodyStyle}>
+                        <span style={optionNameStyle}>{intro.name}</span>
+                        <span style={optionDetailStyle}>
+                          {intro.introSteps.length} step
+                          {intro.introSteps.length !== 1 ? "s" : ""}
+                        </span>
+                      </span>
+                    </label>
+                  ),
+                )}
+              </div>
+            </fieldset>
+          )}
+
+          <button
+            onClick={() => onSelect(selectedIntro, selectedTreatment)}
+            style={viewButtonStyle}
+            data-testid="overview-view-button"
+          >
+            View &rarr;
+          </button>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+// --- Styles ---
+
+const containerStyle: React.CSSProperties = {
+  minHeight: "100vh",
+  backgroundColor: "#f9fafb",
+  padding: "2rem",
+  boxSizing: "border-box",
+};
+
+const layoutStyle: React.CSSProperties = {
+  maxWidth: "72rem",
+  margin: "0 auto",
+  display: "flex",
+  gap: "2rem",
+  flexWrap: "wrap",
+  alignItems: "flex-start",
+};
+
+const oneColLayoutStyle: React.CSSProperties = {
+  maxWidth: "32rem",
+  justifyContent: "center",
+};
+
+const readmeColStyle: React.CSSProperties = {
+  flex: "2 1 24rem",
+  minWidth: 0,
+  padding: "1.5rem",
+  backgroundColor: "white",
+  borderRadius: "0.5rem",
+  border: "1px solid #e5e7eb",
+};
+
+const pickerColStyle: React.CSSProperties = {
+  flex: "1 1 20rem",
+  minWidth: 0,
+  padding: "1.5rem",
+  backgroundColor: "white",
+  borderRadius: "0.5rem",
+  border: "1px solid #e5e7eb",
+  display: "flex",
+  flexDirection: "column",
+  gap: "1rem",
+};
+
+const titleStyle: React.CSSProperties = {
+  fontSize: "1.25rem",
+  fontWeight: 700,
+  color: "#1f2937",
+  margin: 0,
+};
+
+const fieldsetStyle: React.CSSProperties = {
+  border: "none",
+  margin: 0,
+  padding: 0,
+};
+
+const legendStyle: React.CSSProperties = {
+  fontSize: "0.8125rem",
+  fontWeight: 600,
+  color: "#374151",
+  marginBottom: "0.5rem",
+  padding: 0,
+};
+
+const listStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.375rem",
+};
+
+const optionStyle = (active: boolean): React.CSSProperties => ({
+  display: "flex",
+  alignItems: "flex-start",
+  gap: "0.625rem",
+  padding: "0.625rem 0.75rem",
+  borderRadius: "0.375rem",
+  border: active ? "1px solid #3b82f6" : "1px solid #e5e7eb",
+  backgroundColor: active ? "#eff6ff" : "white",
+  cursor: "pointer",
+});
+
+const radioStyle: React.CSSProperties = {
+  marginTop: "0.1875rem",
+  cursor: "pointer",
+};
+
+const optionBodyStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.125rem",
+};
+
+const optionNameStyle: React.CSSProperties = {
+  fontWeight: 500,
+  color: "#1f2937",
+  fontSize: "0.875rem",
+};
+
+const optionDetailStyle: React.CSSProperties = {
+  color: "#6b7280",
+  fontSize: "0.75rem",
+};
+
+const viewButtonStyle: React.CSSProperties = {
+  marginTop: "auto",
+  alignSelf: "stretch",
+  padding: "0.625rem 1rem",
+  borderRadius: "0.375rem",
+  border: "none",
+  backgroundColor: "#3b82f6",
+  color: "white",
+  cursor: "pointer",
+  fontSize: "0.875rem",
+  fontWeight: 500,
+};
+
+const backButtonStyle: React.CSSProperties = {
+  position: "absolute",
+  top: "1rem",
+  left: "1rem",
+  background: "none",
+  border: "none",
+  color: "#6b7280",
+  cursor: "pointer",
+  fontSize: "0.875rem",
+  padding: "0.25rem 0.5rem",
+};

--- a/apps/viewer/src/components/StateInspector.tsx
+++ b/apps/viewer/src/components/StateInspector.tsx
@@ -1,8 +1,17 @@
 import { useState } from "react";
 import { getReferenceKeyAndPath, getNestedValueByPath } from "stagebook";
+import { Markdown } from "stagebook/components";
 import { ViewerStateStore } from "../lib/store";
 import { extractStageReferences } from "../lib/references";
 import type { ViewerStep } from "../lib/steps";
+
+/** DOM id used to scroll a specific element's note into view. */
+export function noteAnchorId(
+  elementType: string,
+  elementName?: string,
+): string {
+  return `note-${elementType}${elementName ? `-${elementName}` : ""}`;
+}
 
 interface StateInspectorProps {
   store: ViewerStateStore;
@@ -66,6 +75,9 @@ export function StateInspector({
         <p style={emptyStyle}>No external references on this stage.</p>
       )}
 
+      {/* Researcher notes (never shown to participants) */}
+      <NotesSection currentStep={currentStep} />
+
       {/* All state expansion */}
       <button onClick={() => setShowAll(!showAll)} style={expandButtonStyle}>
         {showAll ? "▾ Hide all state" : "▸ Show all state"}
@@ -79,6 +91,56 @@ export function StateInspector({
         />
       )}
     </div>
+  );
+}
+
+interface ElementNote {
+  type: string;
+  name?: string;
+  notes: string;
+}
+
+function NotesSection({ currentStep }: { currentStep: ViewerStep }) {
+  const stageNote = currentStep.notes;
+  const elementNotes: ElementNote[] = [];
+  for (const el of currentStep.elements) {
+    const e = el as { type: string; name?: string; notes?: string };
+    if (e.notes) {
+      elementNotes.push({ type: e.type, name: e.name, notes: e.notes });
+    }
+  }
+
+  if (!stageNote && elementNotes.length === 0) return null;
+
+  return (
+    <>
+      <div style={{ ...sectionHeaderStyle, marginTop: "1rem" }}>Notes</div>
+      <div style={notesStackStyle}>
+        {stageNote && (
+          <div style={noteItemStyle}>
+            <div style={noteLabelStyle}>Stage: {currentStep.name}</div>
+            <div style={noteBodyStyle}>
+              <Markdown text={stageNote} />
+            </div>
+          </div>
+        )}
+        {elementNotes.map((n, i) => (
+          <div
+            id={noteAnchorId(n.type, n.name)}
+            key={`${n.type}-${n.name ?? "anon"}-${i}`}
+            style={noteItemStyle}
+          >
+            <div style={noteLabelStyle}>
+              Element: {n.name ?? "(unnamed)"}{" "}
+              <span style={noteTypeStyle}>({n.type})</span>
+            </div>
+            <div style={noteBodyStyle}>
+              <Markdown text={n.notes} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
   );
 }
 
@@ -314,4 +376,40 @@ const allStateValueStyle: React.CSSProperties = {
   color: "#6b7280",
   marginTop: "0.125rem",
   wordBreak: "break-all" as const,
+};
+
+const notesStackStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+  marginTop: "0.25rem",
+};
+
+const noteItemStyle: React.CSSProperties = {
+  padding: "0.5rem 0.625rem",
+  backgroundColor: "#fffbeb",
+  border: "1px solid #fde68a",
+  borderRadius: "0.375rem",
+  fontSize: "0.75rem",
+  color: "#374151",
+  scrollMarginTop: "1rem",
+  transition: "background-color 300ms ease-out",
+};
+
+const noteLabelStyle: React.CSSProperties = {
+  fontSize: "0.6875rem",
+  fontWeight: 600,
+  color: "#92400e",
+  marginBottom: "0.25rem",
+};
+
+const noteTypeStyle: React.CSSProperties = {
+  fontWeight: 400,
+  color: "#b45309",
+  fontFamily: "monospace",
+};
+
+const noteBodyStyle: React.CSSProperties = {
+  color: "#374151",
+  lineHeight: 1.45,
 };

--- a/apps/viewer/src/components/StateInspector.tsx
+++ b/apps/viewer/src/components/StateInspector.tsx
@@ -5,12 +5,19 @@ import { ViewerStateStore } from "../lib/store";
 import { extractStageReferences } from "../lib/references";
 import type { ViewerStep } from "../lib/steps";
 
-/** DOM id used to scroll a specific element's note into view. */
+/**
+ * DOM id used to scroll a specific element's note into view. Encodes the
+ * type and name so characters like spaces (which nameSchema permits in
+ * some contexts) don't produce invalid HTML ids.
+ */
 export function noteAnchorId(
   elementType: string,
   elementName?: string,
 ): string {
-  return `note-${elementType}${elementName ? `-${elementName}` : ""}`;
+  const type = encodeURIComponent(elementType);
+  const name =
+    elementName === undefined ? "" : `-${encodeURIComponent(elementName)}`;
+  return `note-${type}${name}`;
 }
 
 interface StateInspectorProps {

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -1,5 +1,6 @@
 import {
   useEffect,
+  useRef,
   useState,
   useMemo,
   useCallback,
@@ -13,6 +14,7 @@ import { createViewerContext } from "../lib/context";
 import { StageNav } from "./StageNav";
 import { StateInspector } from "./StateInspector";
 import { TimeScrubber } from "./TimeScrubber";
+import { NotesIconsOverlay } from "./NotesIconsOverlay";
 import { createSkeletonRenderers } from "./SkeletonPlaceholder";
 
 export interface ViewerProps {
@@ -65,6 +67,7 @@ export function Viewer({
   const [stageIndex, setStageIndex] = useState(0);
   const [position, setPosition] = useState(0);
   const [store] = useState(() => new ViewerStateStore());
+  const stageContainerRef = useRef<HTMLDivElement | null>(null);
 
   // Clamp stageIndex if the treatment was edited to have fewer stages
   // (e.g. researcher deleted a stage while the preview was open). Without
@@ -217,9 +220,15 @@ export function Viewer({
               </button>
             </div>
           ) : (
-            <StagebookProvider value={ctx}>
-              <Stage stage={stageConfig} onSubmit={handleSubmit} />
-            </StagebookProvider>
+            <div ref={stageContainerRef} style={stageContainerStyle}>
+              <StagebookProvider value={ctx}>
+                <Stage stage={stageConfig} onSubmit={handleSubmit} />
+              </StagebookProvider>
+              <NotesIconsOverlay
+                containerRef={stageContainerRef}
+                currentStep={currentStep}
+              />
+            </div>
           )}
         </main>
       </div>
@@ -316,6 +325,12 @@ const mainStyle: React.CSSProperties = {
   padding: "1.5rem",
   display: "flex",
   justifyContent: "center",
+};
+
+const stageContainerStyle: React.CSSProperties = {
+  position: "relative",
+  width: "100%",
+  alignSelf: "flex-start",
 };
 
 const submittedOverlayStyle: React.CSSProperties = {

--- a/apps/viewer/src/lib/exampleCatalog.test.ts
+++ b/apps/viewer/src/lib/exampleCatalog.test.ts
@@ -72,6 +72,19 @@ describe("buildCatalog", () => {
     expect(entry.readme).toContain("Overview text.");
   });
 
+  it("does NOT mix README.md into the `prompts` field", () => {
+    const [entry] = buildCatalog(
+      { "/root/examples/demo/foo.treatments.yaml": SAMPLE_YAML },
+      {
+        "/root/examples/demo/README.md": "# Demo",
+        "/root/examples/demo/prompts/x.prompt.md":
+          "---\ntype: noResponse\n---\nbody\n---\n",
+      },
+    );
+    expect(Object.keys(entry.prompts)).toEqual(["prompts/x.prompt.md"]);
+    expect(entry.prompts["README.md"]).toBeUndefined();
+  });
+
   it("leaves `readme` undefined when no README.md is bundled", () => {
     const [entry] = buildCatalog(
       { "/root/examples/demo/foo.treatments.yaml": SAMPLE_YAML },

--- a/apps/viewer/src/lib/exampleCatalog.test.ts
+++ b/apps/viewer/src/lib/exampleCatalog.test.ts
@@ -60,6 +60,26 @@ describe("buildCatalog", () => {
     expect(entry.prompts["prompts/x.prompt.md"]).toContain("noResponse");
   });
 
+  it("picks up the example's sibling README.md into the `readme` field", () => {
+    const [entry] = buildCatalog(
+      { "/root/examples/demo/foo.treatments.yaml": SAMPLE_YAML },
+      {
+        "/root/examples/demo/README.md": "# Demo study\n\nOverview text.",
+        "/root/examples/other/README.md": "ignored",
+      },
+    );
+    expect(entry.readme).toContain("Demo study");
+    expect(entry.readme).toContain("Overview text.");
+  });
+
+  it("leaves `readme` undefined when no README.md is bundled", () => {
+    const [entry] = buildCatalog(
+      { "/root/examples/demo/foo.treatments.yaml": SAMPLE_YAML },
+      {},
+    );
+    expect(entry.readme).toBeUndefined();
+  });
+
   it("falls back to the id when the treatment has no notes", () => {
     const yaml = SAMPLE_YAML.replace(
       "    notes: |\n      A **Markdown** note describing the treatment.\n",
@@ -94,6 +114,26 @@ describe("createExampleContentFns", () => {
     );
     const fns = createExampleContentFns(entry);
     await expect(fns.getTextContent("prompts/missing.md")).rejects.toThrow(
+      /No bundled content/,
+    );
+  });
+
+  it("serves README.md via getTextContent when bundled", async () => {
+    const [entry] = buildCatalog(
+      { "/root/examples/demo/foo.treatments.yaml": SAMPLE_YAML },
+      { "/root/examples/demo/README.md": "# Demo" },
+    );
+    const fns = createExampleContentFns(entry);
+    await expect(fns.getTextContent("README.md")).resolves.toBe("# Demo");
+  });
+
+  it("rejects getTextContent for README.md when not bundled", async () => {
+    const [entry] = buildCatalog(
+      { "/root/examples/demo/foo.treatments.yaml": SAMPLE_YAML },
+      {},
+    );
+    const fns = createExampleContentFns(entry);
+    await expect(fns.getTextContent("README.md")).rejects.toThrow(
       /No bundled content/,
     );
   });

--- a/apps/viewer/src/lib/exampleCatalog.ts
+++ b/apps/viewer/src/lib/exampleCatalog.ts
@@ -13,6 +13,8 @@ export interface ExampleEntry {
   /** Content of every `*.prompt.md` in the example, keyed by path
    *  relative to the example directory (e.g. `"prompts/consent.prompt.md"`). */
   prompts: Record<string, string>;
+  /** README.md content, if present in the example directory. */
+  readme?: string;
 }
 
 /**
@@ -61,6 +63,7 @@ function buildEntry(
     notes: firstTreatment?.notes,
     yaml,
     prompts,
+    readme: textByPath[`${exampleDir}README.md`],
   };
 }
 
@@ -73,11 +76,10 @@ const yamlByPath = import.meta.glob(
   { query: "?raw", import: "default", eager: true },
 ) as Record<string, string>;
 
-const textByPath = import.meta.glob("../../../../examples/**/*.prompt.md", {
-  query: "?raw",
-  import: "default",
-  eager: true,
-}) as Record<string, string>;
+const textByPath = import.meta.glob(
+  ["../../../../examples/**/*.prompt.md", "../../../../examples/*/README.md"],
+  { query: "?raw", import: "default", eager: true },
+) as Record<string, string>;
 
 export const exampleCatalog: ExampleEntry[] = buildCatalog(
   yamlByPath,
@@ -91,6 +93,12 @@ export const exampleCatalog: ExampleEntry[] = buildCatalog(
 export function createExampleContentFns(entry: ExampleEntry) {
   return {
     getTextContent(path: string): Promise<string> {
+      // README is bundled separately from prompts but served via the same
+      // getTextContent channel so App.tsx can fetch it without knowing
+      // whether the source is an example or a URL.
+      if (path === "README.md" && entry.readme !== undefined) {
+        return Promise.resolve(entry.readme);
+      }
       const content = entry.prompts[path];
       if (content === undefined) {
         return Promise.reject(

--- a/apps/viewer/src/lib/exampleCatalog.ts
+++ b/apps/viewer/src/lib/exampleCatalog.ts
@@ -50,9 +50,11 @@ function buildEntry(
     | { name: string; notes?: string }
     | undefined;
 
+  // `textByPath` globs both `*.prompt.md` and `README.md`; only the
+  // prompt files belong in `prompts`. README is a separate field.
   const prompts: Record<string, string> = {};
   for (const [p, content] of Object.entries(textByPath)) {
-    if (p.startsWith(exampleDir)) {
+    if (p.startsWith(exampleDir) && p.endsWith(".prompt.md")) {
       prompts[p.substring(exampleDir.length)] = content;
     }
   }

--- a/apps/viewer/src/lib/steps.test.ts
+++ b/apps/viewer/src/lib/steps.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { flattenSteps, type ViewerStep } from "./steps";
+import { flattenSteps } from "./steps";
 
 describe("flattenSteps", () => {
   const introSequence = {
@@ -107,6 +107,38 @@ describe("flattenSteps", () => {
   it("assigns sequential indices", () => {
     const steps = flattenSteps(introSequence, treatment);
     expect(steps.map((s) => s.index)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("carries notes through on intro steps, game stages, and exit steps", () => {
+    const introWithNotes = {
+      ...introSequence,
+      introSteps: [
+        { ...introSequence.introSteps[0], notes: "Intro step rationale" },
+        introSequence.introSteps[1],
+      ],
+    };
+    const treatmentWithNotes = {
+      ...treatment,
+      gameStages: [
+        { ...treatment.gameStages[0], notes: "Stage rationale" },
+        treatment.gameStages[1],
+      ],
+      exitSequence: [
+        { ...treatment.exitSequence[0], notes: "Debrief rationale" },
+      ],
+    };
+    const steps = flattenSteps(introWithNotes, treatmentWithNotes);
+    expect(steps.find((s) => s.name === "consent")?.notes).toBe(
+      "Intro step rationale",
+    );
+    expect(steps.find((s) => s.name === "round1")?.notes).toBe(
+      "Stage rationale",
+    );
+    expect(steps.find((s) => s.name === "debrief")?.notes).toBe(
+      "Debrief rationale",
+    );
+    // Unannotated steps have no notes.
+    expect(steps.find((s) => s.name === "round2")?.notes).toBeUndefined();
   });
 
   it("carries discussion through on game stages", () => {

--- a/apps/viewer/src/lib/steps.ts
+++ b/apps/viewer/src/lib/steps.ts
@@ -9,11 +9,13 @@ export interface ViewerStep {
   elements: ElementType[];
   duration?: number;
   discussion?: DiscussionType;
+  /** Researcher-facing notes on the stage (never shown to participants). */
+  notes?: string;
 }
 
 interface IntroSequence {
   name: string;
-  introSteps: { name: string; elements: ElementType[] }[];
+  introSteps: { name: string; notes?: string; elements: ElementType[] }[];
 }
 
 interface Treatment {
@@ -21,11 +23,12 @@ interface Treatment {
   playerCount: number;
   gameStages: {
     name: string;
+    notes?: string;
     duration?: number;
     elements: ElementType[];
     discussion?: DiscussionType;
   }[];
-  exitSequence?: { name: string; elements: ElementType[] }[];
+  exitSequence?: { name: string; notes?: string; elements: ElementType[] }[];
 }
 
 /**
@@ -45,6 +48,7 @@ export function flattenSteps(
       phase: "intro",
       name: step.name,
       elements: step.elements,
+      notes: step.notes,
     });
   }
 
@@ -56,6 +60,7 @@ export function flattenSteps(
       elements: stage.elements,
       duration: stage.duration,
       discussion: stage.discussion,
+      notes: stage.notes,
     });
   }
 
@@ -66,6 +71,7 @@ export function flattenSteps(
         phase: "exit",
         name: step.name,
         elements: step.elements,
+        notes: step.notes,
       });
     }
   }


### PR DESCRIPTION
Closes #159, #160.

Implemented together because they share the `notes` / treatment-file plumbing (both are sub-issues of #136).

## #159 — Study overview page

- New `overview` phase in [App.tsx](apps/viewer/src/App.tsx) replaces the old `selecting` phase.
- On treatment load, fetches a sibling `README.md` via the existing content-fn bridge (URL fetch for remote treatments, bundled raw import for example treatments).
- Overview is shown when the README exists **OR** when there's more than one intro/treatment. With no README and only one of each, the fast-path straight to `viewing` is preserved.
- New [OverviewPage.tsx](apps/viewer/src/components/OverviewPage.tsx) renders README (left) + picker (right) in a two-column flex layout that wraps on narrow screens. README uses stagebook's `Markdown` component. Picker always has an explicit "View →" button (even single-treatment).
- `stagebook-viewer/preview` (PreviewHost) is unchanged — the VS Code webview still skips the overview, per #159 "out of scope: VS Code extension README support."

## #160 — Researcher notes in the viewer

- `notes` on the current stage and its elements render in the `StateInspector` sidebar under a new "Notes" section, using stagebook's `Markdown`. Section is omitted when no notes exist on the current stage.
- New viewer-only [NotesIconsOverlay.tsx](apps/viewer/src/components/NotesIconsOverlay.tsx) drops a colored `i` icon in the lower-right of every element wrapper whose `notes` field is set. It locates wrappers via the existing `data-testid="element-{type}-{name}"` attribute — **no stagebook library changes**, per the issue constraint.
- Positions recompute via ResizeObserver + MutationObserver so layout shifts (prompt-markdown loading, stage navigation, resize) keep icons aligned.
- Clicking an icon `scrollIntoView`'s the matching note in the sidebar and briefly highlights it. Anchor ids are produced by a shared `noteAnchorId(type, name)` so overlay + sidebar agree on targets.

## Supporting changes

- `ViewerStep.notes` + propagation in `flattenSteps` so intro steps, game stages, and exit steps all carry their notes.
- `exampleCatalog`: `import.meta.glob` now picks up `README.md` alongside `*.prompt.md`; `createExampleContentFns` serves README via the same `getTextContent` channel so `App.tsx` fetches `"README.md"` uniformly for bundled examples and URL-loaded treatments.

## Tests

- `flattenSteps` propagates `notes` at every step type.
- `buildCatalog` picks up a sibling `README.md` into `entry.readme`; absent when not bundled.
- `createExampleContentFns` resolves `README.md` when bundled and rejects with the standard "No bundled content" error otherwise.

## Test plan
- [x] `npm test` — 587 stagebook + 74 viewer + 178 vscode all green (+5 new tests).
- [x] `npm run build -w stagebook-viewer` succeeds.
- [x] `npm run lint` clean.
- [x] `npx prettier --check` clean.
- [ ] Manual: `npm run dev -w stagebook-viewer` → load the annotated-walkthrough example (no README yet), confirm overview page shows picker-only and flow still works. Add a `notes:` to a stage/element and confirm the sidebar renders it with an info-icon overlay that scrolls on click. (Left as a user-facing smoke test; no sample README shipped in this PR.)