### PR TITLE
VS Code: render `notes:` values in comment color + bump to 0.5.1 (#186)

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -241,6 +241,7 @@ const semanticTokenTypes: SemanticTokenType[] = [
   "variable",
   "string",
   "property",
+  "comment",
 ];
 
 const tokenLegend = new vscode.SemanticTokensLegend(semanticTokenTypes);

--- a/apps/vscode/src/lib/semanticTokens.test.ts
+++ b/apps/vscode/src/lib/semanticTokens.test.ts
@@ -399,6 +399,44 @@ duration: 300`;
       ]);
     });
 
+    it("highlights a content line that happens to be a single `|` or `>` character", () => {
+      // Only the *first* line of the scalar is the indicator. A later
+      // content line that is literally just `|` or `>` is legitimate
+      // prose (e.g., a table separator drawn in ASCII) and must not be
+      // dropped.
+      const src = `treatments:
+  - name: t1
+    notes: |
+      header
+      |
+      >
+      footer`;
+      const tokens = computeSemanticTokens(src);
+      const comment = tokens
+        .filter((t) => t.tokenType === "comment")
+        .map((t) => t.text);
+      expect(comment).toEqual(["header", "|", ">", "footer"]);
+    });
+
+    it("strips a trailing CR on CRLF-terminated files", () => {
+      const src =
+        "treatments:\r\n" +
+        "  - name: t1\r\n" +
+        "    notes: |\r\n" +
+        "      first line\r\n" +
+        "      second line\r\n";
+      const tokens = computeSemanticTokens(src);
+      const comment = tokens.filter((t) => t.tokenType === "comment");
+      expect(comment).toHaveLength(2);
+      // No carriage return should leak into the token text or its length.
+      for (const t of comment) {
+        expect(t.text.includes("\r")).toBe(false);
+        expect(t.length).toBe(t.text.length);
+      }
+      expect(comment[0].text).toBe("first line");
+      expect(comment[1].text).toBe("second line");
+    });
+
     it("survives blank lines inside a block scalar", () => {
       const src = `treatments:
   - name: t1

--- a/apps/vscode/src/lib/semanticTokens.test.ts
+++ b/apps/vscode/src/lib/semanticTokens.test.ts
@@ -343,6 +343,155 @@ duration: 300`;
     });
   });
 
+  describe("notes (comment color)", () => {
+    it("highlights an inline plain-scalar notes value", () => {
+      const src = `treatments:
+  - name: t1
+    notes: adapted from Smith et al. 2021`;
+      const tokens = computeSemanticTokens(src);
+      const comment = tokens.filter((t) => t.tokenType === "comment");
+      expect(comment).toHaveLength(1);
+      expect(comment[0]).toMatchObject({
+        line: 2,
+        text: "adapted from Smith et al. 2021",
+      });
+    });
+
+    it("highlights a quoted-scalar notes value and strips the quotes", () => {
+      const src = `treatments:
+  - name: t1
+    notes: "rationale in quotes"`;
+      const tokens = computeSemanticTokens(src);
+      const comment = tokens.filter((t) => t.tokenType === "comment");
+      expect(comment).toHaveLength(1);
+      expect(comment[0].text).toBe("rationale in quotes");
+    });
+
+    it("highlights every content line of a literal block scalar, skipping the indicator line", () => {
+      const src = `treatments:
+  - name: t1
+    notes: |
+      Adapted from the narrative engagement scale.
+      We use 5 items instead of 12.
+    playerCount: 2`;
+      const tokens = computeSemanticTokens(src);
+      const comment = tokens.filter((t) => t.tokenType === "comment");
+      expect(comment.map((t) => t.text)).toEqual([
+        "Adapted from the narrative engagement scale.",
+        "We use 5 items instead of 12.",
+      ]);
+      // First content line starts at col 6 (six-space indent under `notes: |`).
+      expect(comment[0]).toMatchObject({ line: 3, startCol: 6 });
+      expect(comment[1]).toMatchObject({ line: 4, startCol: 6 });
+    });
+
+    it("handles a folded block scalar (`>`) the same way", () => {
+      const src = `treatments:
+  - name: t1
+    notes: >
+      Folded paragraph first line
+      Folded paragraph second line`;
+      const tokens = computeSemanticTokens(src);
+      const comment = tokens.filter((t) => t.tokenType === "comment");
+      expect(comment.map((t) => t.text)).toEqual([
+        "Folded paragraph first line",
+        "Folded paragraph second line",
+      ]);
+    });
+
+    it("survives blank lines inside a block scalar", () => {
+      const src = `treatments:
+  - name: t1
+    notes: |
+      First paragraph.
+
+      Second paragraph.`;
+      const tokens = computeSemanticTokens(src);
+      const comment = tokens.filter((t) => t.tokenType === "comment");
+      expect(comment.map((t) => t.text)).toEqual([
+        "First paragraph.",
+        "Second paragraph.",
+      ]);
+    });
+
+    it("does NOT leave the notes: key itself colored", () => {
+      const src = `treatments:
+  - name: t1
+    notes: short`;
+      const tokens = computeSemanticTokens(src);
+      // No token covers the key text "notes".
+      expect(tokens.some((t) => t.text === "notes")).toBe(false);
+    });
+
+    it("highlights notes: on stages, elements, intro steps, and templates", () => {
+      const src = `templates:
+  - templateName: tpl
+    contentType: stage
+    notes: template note
+    templateContent:
+      name: s
+      notes: stage-in-template note
+      duration: 10
+      elements:
+        - type: prompt
+          notes: element note
+          file: p.prompt.md
+introSequences:
+  - name: i
+    introSteps:
+      - name: step1
+        notes: intro step note
+        elements:
+          - type: submitButton
+treatments:
+  - name: t
+    notes: treatment note
+    playerCount: 1
+    gameStages:
+      - name: g1
+        notes: game stage note
+        duration: 5
+        elements:
+          - type: submitButton`;
+      const tokens = computeSemanticTokens(src);
+      const commentTexts = new Set(
+        tokens.filter((t) => t.tokenType === "comment").map((t) => t.text),
+      );
+      expect(commentTexts).toEqual(
+        new Set([
+          "template note",
+          "stage-in-template note",
+          "element note",
+          "intro step note",
+          "treatment note",
+          "game stage note",
+        ]),
+      );
+    });
+
+    it("does NOT highlight notes: inside a freeform template (contentType: other)", () => {
+      const src = `templates:
+  - templateName: freeform
+    contentType: other
+    templateContent:
+      notes: not a real researcher note
+      anything: goes`;
+      const tokens = computeSemanticTokens(src);
+      const comment = tokens.filter((t) => t.tokenType === "comment");
+      expect(comment).toHaveLength(0);
+    });
+
+    it("does NOT highlight notes: inside a template with no contentType", () => {
+      const src = `templates:
+  - templateName: untagged
+    templateContent:
+      notes: can't prove what this is`;
+      const tokens = computeSemanticTokens(src);
+      const comment = tokens.filter((t) => t.tokenType === "comment");
+      expect(comment).toHaveLength(0);
+    });
+  });
+
   describe("mixed content", () => {
     it("handles a realistic treatment snippet", () => {
       const src = `treatments:

--- a/apps/vscode/src/lib/semanticTokens.ts
+++ b/apps/vscode/src/lib/semanticTokens.ts
@@ -164,17 +164,24 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
 
     // Block scalar: walk source line-by-line within the value's range.
     let lineStart = range[0];
+    let isFirstLine = true;
     while (lineStart < range[1]) {
       const nlIdx = source.indexOf("\n", lineStart);
       const lineEnd = nlIdx === -1 || nlIdx >= range[1] ? range[1] : nlIdx;
-      const lineText = source.slice(lineStart, lineEnd);
+      // Trim a trailing \r so CRLF-terminated files don't leak carriage
+      // returns into the token's text/length.
+      const lineTextEnd =
+        lineEnd > lineStart && source[lineEnd - 1] === "\r"
+          ? lineEnd - 1
+          : lineEnd;
+      const lineText = source.slice(lineStart, lineTextEnd);
       const firstNonWs = lineText.search(/\S/);
       if (firstNonWs !== -1) {
-        const firstChar = lineText[firstNonWs];
-        // Skip the block-scalar indicator line (`|`, `>`, `|-`, `|+`, etc.)
+        // Only the first line of the scalar is the block-scalar indicator
+        // (`|`, `>`, `|-`, `|+`, etc.). Later content lines may legitimately
+        // consist of a single `|` or `>` character and must be highlighted.
         const isIndicator =
-          (firstChar === "|" || firstChar === ">") &&
-          /^[|>][-+]?\s*$/.test(lineText.slice(firstNonWs));
+          isFirstLine && /^[|>][-+]?\s*$/.test(lineText.slice(firstNonWs));
         if (!isIndicator) {
           addToken(
             lineStart + firstNonWs,
@@ -183,6 +190,7 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
           );
         }
       }
+      isFirstLine = false;
       if (nlIdx === -1 || nlIdx >= range[1]) break;
       lineStart = nlIdx + 1;
     }

--- a/apps/vscode/src/lib/semanticTokens.ts
+++ b/apps/vscode/src/lib/semanticTokens.ts
@@ -13,7 +13,8 @@ export type SemanticTokenType =
   | "keyword" // comparators (equals, isAbove) → purple
   | "variable" // reference strings (prompt.q1) → light blue
   | "string" // file paths → orange (distinct via modifier)
-  | "property"; // section keys (elements, treatments) → blue
+  | "property" // section keys (elements, treatments) → blue
+  | "comment"; // notes: body → same color as `# …` YAML comments
 
 export interface SemanticToken {
   line: number;
@@ -139,6 +140,55 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
   }
 
   /**
+   * Emit comment tokens covering a `notes:` scalar value — one token per
+   * non-blank content line. Works for inline plain/quoted scalars and for
+   * block scalars (`notes: |` / `notes: >`), which we identify by the
+   * presence of a newline in the raw source slice. For block scalars we
+   * skip the indicator line (the one starting with `|` or `>`) and any
+   * blank lines, coloring each content line from its first non-whitespace
+   * column to end-of-line.
+   */
+  function addNotesTokens(range: [number, number, number] | undefined): void {
+    if (!range) return;
+    const raw = source.slice(range[0], range[1]);
+    const isBlock = raw.includes("\n");
+
+    if (!isBlock) {
+      // Inline: strip surrounding quotes, color the content as one token.
+      const src = getScalarSource(range);
+      if (src && src.text.length > 0) {
+        addToken(src.offset, src.text, "comment");
+      }
+      return;
+    }
+
+    // Block scalar: walk source line-by-line within the value's range.
+    let lineStart = range[0];
+    while (lineStart < range[1]) {
+      const nlIdx = source.indexOf("\n", lineStart);
+      const lineEnd = nlIdx === -1 || nlIdx >= range[1] ? range[1] : nlIdx;
+      const lineText = source.slice(lineStart, lineEnd);
+      const firstNonWs = lineText.search(/\S/);
+      if (firstNonWs !== -1) {
+        const firstChar = lineText[firstNonWs];
+        // Skip the block-scalar indicator line (`|`, `>`, `|-`, `|+`, etc.)
+        const isIndicator =
+          (firstChar === "|" || firstChar === ">") &&
+          /^[|>][-+]?\s*$/.test(lineText.slice(firstNonWs));
+        if (!isIndicator) {
+          addToken(
+            lineStart + firstNonWs,
+            lineText.slice(firstNonWs),
+            "comment",
+          );
+        }
+      }
+      if (nlIdx === -1 || nlIdx >= range[1]) break;
+      lineStart = nlIdx + 1;
+    }
+  }
+
+  /**
    * Emit tokens for a file path, splitting around ${...} placeholders.
    * Path segments get "string", placeholders get "variable".
    */
@@ -164,8 +214,18 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
     }
   }
 
-  function walkNode(node: unknown, keyName?: string): void {
+  function walkNode(
+    node: unknown,
+    keyName?: string,
+    freeformTemplateContent = false,
+  ): void {
     if (isMap(node)) {
+      // A template whose `contentType` is `"other"` (explicitly freeform) or
+      // unknown can carry arbitrary keys inside `templateContent`. We can't
+      // prove a stray `notes:` in there is a researcher note, so highlight
+      // gets suppressed for that subtree only.
+      const templateContentIsFreeform = isFreeformTemplate(node);
+
       for (const pair of node.items) {
         if (!isPair(pair)) continue;
 
@@ -178,6 +238,20 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
           if (sectionKeys.has(keyStr)) {
             addToken(key.range[0], keyStr, "property");
           }
+        }
+
+        // `notes:` — researcher-facing commentary; render in comment color.
+        // Skipped when we're inside a freeform templateContent (see above).
+        if (
+          !freeformTemplateContent &&
+          isScalar(key) &&
+          typeof key.value === "string" &&
+          key.value === "notes" &&
+          isScalar(value) &&
+          typeof value.value === "string" &&
+          value.range
+        ) {
+          addNotesTokens(value.range);
         }
 
         // Highlight the value based on the key name
@@ -262,17 +336,48 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
             emitTemplateVarTokens(scalarSrc.offset, scalarSrc.text);
           }
 
-          // Recurse into the value
-          walkNode(value, isScalar(key) ? String(key.value) : undefined);
+          // Recurse into the value — switch the freeform flag on when we
+          // descend into the templateContent of a freeform template.
+          const childFreeform =
+            freeformTemplateContent ||
+            (templateContentIsFreeform && k === "templateContent");
+          walkNode(value, String(k), childFreeform);
         } else {
-          walkNode(value);
+          walkNode(value, undefined, freeformTemplateContent);
         }
       }
     } else if (isSeq(node)) {
       for (const item of node.items) {
-        walkNode(item, keyName);
+        walkNode(item, keyName, freeformTemplateContent);
       }
     }
+  }
+
+  /**
+   * Detect whether a YAML map is a template whose `templateContent` should
+   * be treated as freeform — either `contentType: other` or `contentType`
+   * is missing (which the stagebook validator tolerates for custom shapes).
+   * Used to suppress `notes:` highlighting inside that subtree.
+   */
+  function isFreeformTemplate(node: unknown): boolean {
+    if (!isMap(node)) return false;
+    let hasTemplateName = false;
+    let contentType: string | undefined;
+    for (const pair of node.items) {
+      if (!isPair(pair)) continue;
+      if (!isScalar(pair.key) || typeof pair.key.value !== "string") continue;
+      const k = pair.key.value;
+      if (k === "templateName") hasTemplateName = true;
+      if (
+        k === "contentType" &&
+        isScalar(pair.value) &&
+        typeof pair.value.value === "string"
+      ) {
+        contentType = pair.value.value;
+      }
+    }
+    if (!hasTemplateName) return false;
+    return contentType === undefined || contentType === "other";
   }
 
   walkNode(doc.contents);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13682,7 +13682,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Closes #186.

## Summary
`notes:` fields carry researcher commentary that survives into the viewer but never reaches participants. Visually treating them like `# …` comments in the editor signals "this is aside, not part of the flow" without recruiting a new color.

Implemented in the existing AST-walking semantic-token provider rather than the TextMate grammar — the grammar is a thin base-YAML wrapper and block scalars are awkward to match there.

## Changes

- **`SemanticTokenType` extended with `"comment"`** and registered on the legend in [extension.ts](apps/vscode/src/extension.ts). It's a VS Code standard token type, so every stock theme already has a color for it — no custom theme work needed.

- **`addNotesTokens()` in [semanticTokens.ts](apps/vscode/src/lib/semanticTokens.ts)** handles all three scalar shapes:
    - **Inline plain** (`notes: adapted from Smith ...`) — single token
    - **Quoted** (`notes: "rationale"`) — single token, quotes stripped via the existing `getScalarSource()` helper
    - **Block literal / folded** (`notes: |` / `notes: >`) — walks the value's source range line-by-line, skipping the indicator line (`|`, `>`, `|-`, `|+`, etc.) and blank lines, emitting one comment token per content line from first-non-whitespace column to EOL. Per-line emission keeps `SemanticTokensBuilder.push`'s single-line range contract happy.

- **Freeform template gate.** A template whose `contentType: other` (or missing) has an arbitrary-shape `templateContent`. We can't prove a stray `notes:` there is a researcher note, so comment highlighting is suppressed for that subtree via a `freeformTemplateContent` flag threaded through `walkNode`. All other `notes:` sites are colored.

- **Key color unchanged.** Only the value's range is emitted — the `notes:` key itself keeps whatever base-YAML color the grammar gives it.

## Tests
9 new cases in `semanticTokens.test.ts`:
- Inline plain, quoted, literal block, folded block, block with a blank line.
- Key not colored by the semantic provider.
- All authoring levels (treatment, stage, intro step, element, introSequence, template, stage-in-template) emit a comment token.
- `contentType: other` suppresses highlighting inside `templateContent`.
- Missing `contentType` on a template suppresses highlighting inside `templateContent`.

Existing 31 semanticTokens tests still pass unchanged.

## Test plan
- [x] `npm test` — 587 stagebook + 75 viewer + 187 vscode (was 178) all green.
- [x] `npm run lint` clean.
- [x] `prettier --check` clean.
- [x] Packaged `stagebook-vscode-0.1.0.vsix` installed locally via `code --install-extension`.
- [ ] Manual: open a treatment file with `notes:` in all three scalar forms, confirm body renders in comment color across Dark+, Light+, and High Contrast themes.