### PR TITLE
Validate timeline.source names a sibling mediaPlayer at authoring time

### DIFF
--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -1093,6 +1093,30 @@ test("stage rejects a timeline when no mediaPlayer exists in the stage", () => {
   }
 });
 
+test("stage with an unnamed mediaPlayer distinguishes 'none named' from 'none at all'", () => {
+  const result = stageSchema.safeParse({
+    name: "coding",
+    duration: 60,
+    elements: [
+      { type: "mediaPlayer", url: "v.mp4" }, // no name
+      {
+        type: "timeline",
+        source: "missing",
+        name: "segments",
+        selectionType: "range",
+      },
+    ],
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find(
+      (i) => i.path.join(".") === "elements.1.source",
+    );
+    expect(issue?.message).toContain("`name:` field");
+    expect(issue?.message).not.toContain("No mediaPlayer elements are defined");
+  }
+});
+
 test("stage skips source validation when source is a ${field} placeholder", () => {
   const result = stageSchema.safeParse({
     name: "coding",

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -9,6 +9,7 @@ import {
   introStepsSchema,
   exitStepsSchema,
   mediaPlayerSchema,
+  stageSchema,
   timelineSchema,
   promptSchema,
   treatmentFileSchema,
@@ -1021,4 +1022,144 @@ test("elementsSchema accepts timeline alongside mediaPlayer", () => {
   ]);
   if (!result.success) console.log(result.error.message);
   expect(result.success).toBe(true);
+});
+
+// ----------- Stage: timeline.source must name a mediaPlayer in the same stage -----------
+
+test("stage accepts a timeline whose source matches a sibling mediaPlayer.name", () => {
+  const result = stageSchema.safeParse({
+    name: "coding",
+    duration: 60,
+    elements: [
+      { type: "mediaPlayer", url: "v.mp4", name: "interview" },
+      {
+        type: "timeline",
+        source: "interview",
+        name: "segments",
+        selectionType: "range",
+      },
+    ],
+  });
+  if (!result.success) console.log(result.error.issues);
+  expect(result.success).toBe(true);
+});
+
+test("stage rejects a timeline whose source doesn't match any mediaPlayer.name", () => {
+  const result = stageSchema.safeParse({
+    name: "coding",
+    duration: 60,
+    elements: [
+      { type: "mediaPlayer", url: "v.mp4", name: "interview" },
+      {
+        type: "timeline",
+        source: "typo_video",
+        name: "segments",
+        selectionType: "range",
+      },
+    ],
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find(
+      (i) =>
+        i.path.join(".") === "elements.1.source" &&
+        i.message.includes("typo_video"),
+    );
+    expect(issue).toBeDefined();
+    expect(issue?.message).toContain('"interview"');
+  }
+});
+
+test("stage rejects a timeline when no mediaPlayer exists in the stage", () => {
+  const result = stageSchema.safeParse({
+    name: "coding",
+    duration: 60,
+    elements: [
+      {
+        type: "timeline",
+        source: "missing",
+        name: "segments",
+        selectionType: "range",
+      },
+      { type: "submitButton" },
+    ],
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find(
+      (i) => i.path.join(".") === "elements.0.source",
+    );
+    expect(issue?.message).toContain("No mediaPlayer elements");
+  }
+});
+
+test("stage skips source validation when source is a ${field} placeholder", () => {
+  const result = stageSchema.safeParse({
+    name: "coding",
+    duration: 60,
+    elements: [
+      { type: "mediaPlayer", url: "v.mp4", name: "interview" },
+      {
+        type: "timeline",
+        source: "${playerName}",
+        name: "segments",
+        selectionType: "range",
+      },
+    ],
+  });
+  if (!result.success) console.log(result.error.issues);
+  expect(result.success).toBe(true);
+});
+
+test("stage allows multiple timelines pointing at different mediaPlayers", () => {
+  const result = stageSchema.safeParse({
+    name: "review",
+    duration: 120,
+    elements: [
+      { type: "mediaPlayer", url: "a.mp4", name: "clip_a" },
+      { type: "mediaPlayer", url: "b.mp4", name: "clip_b" },
+      {
+        type: "timeline",
+        source: "clip_a",
+        name: "clip_a_segments",
+        selectionType: "range",
+      },
+      {
+        type: "timeline",
+        source: "clip_b",
+        name: "clip_b_segments",
+        selectionType: "range",
+      },
+    ],
+  });
+  if (!result.success) console.log(result.error.issues);
+  expect(result.success).toBe(true);
+});
+
+test("stage reports one issue per mismatched timeline (not a single aggregated error)", () => {
+  const result = stageSchema.safeParse({
+    name: "coding",
+    duration: 60,
+    elements: [
+      { type: "mediaPlayer", url: "v.mp4", name: "interview" },
+      {
+        type: "timeline",
+        source: "bogus_a",
+        name: "seg_a",
+        selectionType: "range",
+      },
+      {
+        type: "timeline",
+        source: "bogus_b",
+        name: "seg_b",
+        selectionType: "range",
+      },
+    ],
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const paths = result.error.issues.map((i) => i.path.join("."));
+    expect(paths).toContain("elements.1.source");
+    expect(paths).toContain("elements.2.source");
+  }
 });

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -1097,12 +1097,13 @@ export const stageSchema = altTemplateContext(
         });
       }
 
+      if (!Array.isArray(data.elements)) return;
+      const elements = data.elements as Record<string, unknown>[];
+
       // Validate element time bounds against stage duration
       const duration = data.duration;
-      if (typeof duration !== "number" || !Array.isArray(data.elements)) return;
-
-      data.elements.forEach(
-        (element: Record<string, unknown>, elementIndex: number) => {
+      if (typeof duration === "number") {
+        elements.forEach((element, elementIndex) => {
           if (!element || typeof element !== "object") return;
 
           const timeFields = [
@@ -1117,12 +1118,53 @@ export const stageSchema = altTemplateContext(
               ctx.addIssue({
                 code: z.ZodIssueCode.custom,
                 path: ["elements", elementIndex, field],
-                message: `${field} (${value}) exceeds stage duration (${duration}) for element "${String(element.name || element.type)}"`,
+                message: `${field} (${value}) exceeds stage duration (${duration}) for element "${String(element.name ?? element.type)}"`,
               });
             }
           }
-        },
-      );
+        });
+      }
+
+      // Validate that every timeline's `source` names a mediaPlayer in
+      // the same stage. PlaybackHandles are stage-scoped, so a timeline
+      // whose source doesn't match any mediaPlayer.name here would fail
+      // at runtime with a "source player not found" error.
+      const mediaPlayerNames = new Set<string>();
+      for (const element of elements) {
+        if (
+          element &&
+          typeof element === "object" &&
+          element.type === "mediaPlayer" &&
+          typeof element.name === "string"
+        ) {
+          mediaPlayerNames.add(element.name);
+        }
+      }
+      elements.forEach((element, elementIndex) => {
+        if (
+          !element ||
+          typeof element !== "object" ||
+          element.type !== "timeline"
+        )
+          return;
+        const source = element.source;
+        if (typeof source !== "string") return;
+        // Skip when source is an unresolved `${field}` placeholder —
+        // the referenced name may only be known after template fill.
+        if (/\$\{[a-zA-Z0-9_]+\}/.test(source)) return;
+        if (mediaPlayerNames.has(source)) return;
+        const available =
+          mediaPlayerNames.size > 0
+            ? ` Available mediaPlayers in this stage: ${[...mediaPlayerNames]
+                .map((n) => `"${n}"`)
+                .join(", ")}.`
+            : " No mediaPlayer elements are defined in this stage.";
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["elements", elementIndex, "source"],
+          message: `Timeline source "${source}" does not match any mediaPlayer.name in this stage.${available}`,
+        });
+      });
     }),
 );
 export type StageType = z.infer<typeof stageSchema>;

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -20,10 +20,22 @@ function isValidRegex(pattern: string): boolean {
 
 // Field placeholder pattern: only alphanumeric + underscore.
 // Must match FIELD_PLACEHOLDER_REGEX in templates/fillTemplates.ts
-const fieldPlaceholderSchema = z.string().regex(/\$\{[a-zA-Z0-9_]+\}/, {
+const FIELD_PLACEHOLDER_PATTERN = /\$\{[a-zA-Z0-9_]+\}/;
+
+const fieldPlaceholderSchema = z.string().regex(FIELD_PLACEHOLDER_PATTERN, {
   message:
     "Field placeholder must be in the format `${fieldKey}` (alphanumeric and underscores only)",
 });
+
+/**
+ * True if `value` contains any `${field}` placeholder. Used by cross-field
+ * refinements that should skip validation until templates are filled.
+ * Keeps placeholder detection colocated with `fieldPlaceholderSchema` so
+ * future rule changes apply consistently.
+ */
+function containsFieldPlaceholder(value: string): boolean {
+  return FIELD_PLACEHOLDER_PATTERN.test(value);
+}
 
 // Names should have properties:
 // max length: 64 characters
@@ -1128,16 +1140,22 @@ export const stageSchema = altTemplateContext(
       // Validate that every timeline's `source` names a mediaPlayer in
       // the same stage. PlaybackHandles are stage-scoped, so a timeline
       // whose source doesn't match any mediaPlayer.name here would fail
-      // at runtime with a "source player not found" error.
+      // at runtime with a "source player not found" error. Track total
+      // mediaPlayer elements alongside the named set so the error
+      // message can distinguish "no mediaPlayers at all" from "all
+      // mediaPlayers are unnamed".
+      let totalMediaPlayers = 0;
       const mediaPlayerNames = new Set<string>();
       for (const element of elements) {
         if (
           element &&
           typeof element === "object" &&
-          element.type === "mediaPlayer" &&
-          typeof element.name === "string"
+          element.type === "mediaPlayer"
         ) {
-          mediaPlayerNames.add(element.name);
+          totalMediaPlayers++;
+          if (typeof element.name === "string") {
+            mediaPlayerNames.add(element.name);
+          }
         }
       }
       elements.forEach((element, elementIndex) => {
@@ -1151,14 +1169,21 @@ export const stageSchema = altTemplateContext(
         if (typeof source !== "string") return;
         // Skip when source is an unresolved `${field}` placeholder —
         // the referenced name may only be known after template fill.
-        if (/\$\{[a-zA-Z0-9_]+\}/.test(source)) return;
+        if (containsFieldPlaceholder(source)) return;
         if (mediaPlayerNames.has(source)) return;
-        const available =
-          mediaPlayerNames.size > 0
-            ? ` Available mediaPlayers in this stage: ${[...mediaPlayerNames]
-                .map((n) => `"${n}"`)
-                .join(", ")}.`
-            : " No mediaPlayer elements are defined in this stage.";
+        let available: string;
+        if (mediaPlayerNames.size > 0) {
+          available = ` Available mediaPlayers in this stage: ${[
+            ...mediaPlayerNames,
+          ]
+            .map((n) => `"${n}"`)
+            .join(", ")}.`;
+        } else if (totalMediaPlayers > 0) {
+          available =
+            " No mediaPlayer elements in this stage have a `name:` field — add one so timelines can reference them.";
+        } else {
+          available = " No mediaPlayer elements are defined in this stage.";
+        }
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["elements", elementIndex, "source"],


### PR DESCRIPTION
## Summary
Catches timeline-source typos during treatment-file validation instead of letting them slip through to the runtime error box. Researchers see the issue at preflight, with a message that names the bad source and the available mediaPlayers in the same stage.

## What changed
In [treatment.ts](packages/stagebook/src/schemas/treatment.ts) `stageSchema.superRefine`:
1. Walk `data.elements` once, collecting every `element.name` whose `type === "mediaPlayer"` into a `Set<string>`.
2. For every `type: "timeline"` element, if `source` is a concrete string, require it's in the set. Mismatches add a zod issue on `elements[i].source`:
    - *"Timeline source \"typo_video\" does not match any mediaPlayer.name in this stage. Available mediaPlayers in this stage: \"interview\"."*
    - When no mediaPlayers exist: *"… No mediaPlayer elements are defined in this stage."*
3. Skip when `source` is an unresolved `${field}` placeholder — the referenced name may only be known after template fill. This mirrors the pattern mediaPlayer's `startAt`/`stopAt` cross-check already uses.
4. Also split the existing duration-bound check so a stage whose `duration` is a placeholder still gets timeline-source validation (previously the early-return at the top bypassed everything).

Stage-scoped, not cross-stage — `PlaybackHandle` is stage-local, so a runtime lookup couldn't resolve a cross-stage source either.

## Tests (6 new)
- matching source → valid
- mismatched source → one issue on `elements[i].source` naming the bad source and listing the available mediaPlayer
- timeline + no mediaPlayer → issue message says "No mediaPlayer elements"
- `source: ${playerName}` → skipped, stage validates
- two mediaPlayers + two timelines, each pointing at its own → valid
- two mismatched timelines → two issues, one per timeline path

## Test plan
- [x] `npm test` — 593 stagebook (was 587) + 75 viewer + 187 vscode all green.
- [x] `npm run lint` clean.
- [x] `npm run format:check` clean.