### PR TITLE
Add asset:// URI scheme for platform-provided media (#188, supersedes #185)

### DIFF
--- a/docs/researcher/treatment-files.md
+++ b/docs/researcher/treatment-files.md
@@ -158,6 +158,69 @@ treatments:
 
 Positions must be unique and cover 0 through `playerCount - 1`.
 
+## Media and asset references
+
+Elements that point at media (`mediaPlayer.url`, `image.file`, `audio.file`, `prompt.file`, `mediaPlayer.captionsFile`) accept three reference forms. Pick based on who owns the asset.
+
+### 1. Relative path — bundled with the treatment
+
+```yaml
+- type: mediaPlayer
+  url: shared/training.mp4
+```
+
+The file lives in the treatment's own directory (or a sibling directory like `shared/`) and ships to the platform alongside the YAML. Use this for public, stable assets that are appropriate to commit to the repo.
+
+### 2. Full URL — hosted at a fixed, public endpoint
+
+```yaml
+- type: mediaPlayer
+  url: https://youtu.be/QC8iQqtG0hg
+```
+
+`http://` or `https://`. The browser fetches the URL directly; the platform doesn't rewrite it. Use this for CDN links, YouTube embeds, or any asset whose public URL won't change.
+
+### 3. `asset://` — platform-provided
+
+```yaml
+- type: mediaPlayer
+  # Video is sensitive and can't live in the repo. Each platform
+  # supplies the URL at task time (S3 presigned URL, local file server,
+  # CDN — implementation is host-specific).
+  url: asset://group_recordings/session_001.mp4
+```
+
+`asset://path/to/file` means *the platform will resolve this*. Stagebook passes the URI through `getAssetURL()`, and each host (annotator, viewer, VS Code extension) implements its own resolution strategy. `asset://` references are explicitly excluded from `getReferencedAssets()` — they aren't repo files.
+
+Use `asset://` for:
+
+- **Sensitive media** — recordings, identifiable audio, or anything that shouldn't sit in version control.
+- **Large binaries** — files that would bloat the repo or exceed git/LFS limits.
+- **Host-specific storage** — an S3 bucket you own, a Box folder, a local dev server's asset directory.
+- **Swappability** — swap the underlying file without editing the treatment.
+
+### `${field}` placeholders — per-task variable media
+
+Distinct from `asset://`: use a field when the asset *varies from task to task*.
+
+```yaml
+- type: mediaPlayer
+  # Each participant gets a different recording (their partner's
+  # previous-round video). Filled in from the task CSV / API call.
+  url: ${partnerVideoUrl}
+```
+
+The task definition supplies the value at creation time. The value itself can be any of the three forms above (relative path, full URL, or `asset://`).
+
+### Choosing between the three
+
+| Asset is the same every task? | Asset is in the repo? | Reference form |
+|---|---|---|
+| yes | yes | relative path |
+| yes | no — public URL | full URL |
+| yes | no — host storage | `asset://…` |
+| no (varies per task) | — | `${fieldName}` |
+
 ## Naming Rules
 
 Names (for stages, elements, treatments, etc.) must be:

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -552,6 +552,19 @@ test("urlSchema rejects non-URL strings", () => {
   expect(urlSchema.safeParse("").success).toBe(false);
 });
 
+test("urlSchema rejects opaque-scheme URLs without //", () => {
+  // `new URL()` accepts these, but downstream consumers expect the
+  // hierarchical `scheme://` form.
+  expect(urlSchema.safeParse("https:example.com").success).toBe(false);
+  expect(urlSchema.safeParse("http:foo").success).toBe(false);
+  expect(urlSchema.safeParse("asset:clip.mp4").success).toBe(false);
+});
+
+test("urlSchema rejects http(s):// with an empty host", () => {
+  expect(urlSchema.safeParse("https://").success).toBe(false);
+  expect(urlSchema.safeParse("http://").success).toBe(false);
+});
+
 test("mediaPlayer: full config with all fields", () => {
   const result = mediaPlayerSchema.safeParse({
     type: "mediaPlayer",

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -13,6 +13,7 @@ import {
   timelineSchema,
   promptSchema,
   treatmentFileSchema,
+  urlSchema,
 } from "./treatment.js";
 
 // ----------- Reference Schema ------------
@@ -502,6 +503,53 @@ test("mediaPlayer: relative path url is valid", () => {
   });
   if (!result.success) console.log(result.error.message);
   expect(result.success).toBe(true);
+});
+
+test("mediaPlayer: asset:// url is valid (platform-provided)", () => {
+  // mediaPlayer.url is z.string() (accepts relative paths too), so any
+  // string passes here — the real schema-level gate on `asset://` lives
+  // in `urlSchema` and is covered below.
+  const result = mediaPlayerSchema.safeParse({
+    type: "mediaPlayer",
+    url: "asset://group_recordings/training_video.mp4",
+  });
+  if (!result.success) console.log(result.error.message);
+  expect(result.success).toBe(true);
+});
+
+// --- urlSchema (used by qualtrics.url and trackedLink.url, #188) ---
+
+test("urlSchema accepts https://", () => {
+  expect(urlSchema.safeParse("https://example.com/foo").success).toBe(true);
+});
+
+test("urlSchema accepts http://", () => {
+  expect(urlSchema.safeParse("http://example.com/foo").success).toBe(true);
+});
+
+test("urlSchema accepts asset:// with a host and path", () => {
+  expect(
+    urlSchema.safeParse("asset://group_recordings/training.mp4").success,
+  ).toBe(true);
+});
+
+test("urlSchema accepts case-insensitive asset scheme", () => {
+  expect(urlSchema.safeParse("ASSET://clip.mp4").success).toBe(true);
+});
+
+test("urlSchema rejects bare `asset://` with no host or path", () => {
+  expect(urlSchema.safeParse("asset://").success).toBe(false);
+});
+
+test("urlSchema rejects ftp:// and other non-allowed protocols", () => {
+  expect(urlSchema.safeParse("ftp://example.com/clip.mp4").success).toBe(false);
+  expect(urlSchema.safeParse("javascript:alert(1)").success).toBe(false);
+  expect(urlSchema.safeParse("file:///etc/passwd").success).toBe(false);
+});
+
+test("urlSchema rejects non-URL strings", () => {
+  expect(urlSchema.safeParse("not a url").success).toBe(false);
+  expect(urlSchema.safeParse("").success).toBe(false);
 });
 
 test("mediaPlayer: full config with all fields", () => {

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -72,17 +72,25 @@ export type FileType = z.infer<typeof fileSchema>;
 // Callers that walk treatment trees for repo-local assets (e.g.
 // `getReferencedAssets`) should exclude both `http(s)://` and
 // `asset://` — neither is a local file.
+// Require the hierarchical `scheme://` form. `new URL()` alone accepts
+// opaque-scheme variants like `https:example.com` or `asset:clip.mp4`
+// (no `//`), which parse but aren't what we mean — downstream code
+// (e.g. the Qualtrics iframe, the `asset://` exclusion in
+// `getReferencedAssets`) expects a real hierarchical URL.
+const HIERARCHICAL_URL_RE = /^(?:https?|asset):\/\//i;
+
 export const urlSchema = z.string().refine(
   (url) => {
+    if (!HIERARCHICAL_URL_RE.test(url)) return false;
     try {
       const parsed = new URL(url);
       if (parsed.protocol === "http:" || parsed.protocol === "https:") {
-        return true;
+        // Reject `https://` with no host.
+        return parsed.host.length > 0;
       }
       if (parsed.protocol === "asset:") {
-        // `asset://foo/bar` → pathname is `/bar`, host is `foo`. Require
-        // the URL to carry *some* location after the scheme so we don't
-        // silently accept a bare `asset://`.
+        // Require the URL to carry *some* location after the scheme so
+        // we don't silently accept a bare `asset://`.
         return parsed.host.length > 0 || parsed.pathname.length > 1;
       }
       return false;
@@ -91,7 +99,8 @@ export const urlSchema = z.string().refine(
     }
   },
   {
-    message: "URL must use http, https, or asset:// (platform-provided media)",
+    message:
+      "URL must use http://, https://, or asset:// (platform-provided media) with a non-empty host/path",
   },
 );
 export type UrlType = z.infer<typeof urlSchema>;

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -64,20 +64,36 @@ export const promptFilePathSchema = z
 
 export type FileType = z.infer<typeof fileSchema>;
 
-export const urlSchema = z
-  .string()
-  .url()
-  .refine(
-    (url) => {
-      try {
-        const parsed = new URL(url);
-        return ["http:", "https:"].includes(parsed.protocol);
-      } catch {
-        return false;
+// Three accepted URL forms in treatment files:
+// - `http://…` / `https://…`  — fetched directly by the browser
+// - `asset://path/…`          — platform-provided; resolved by the
+//   host's `getAssetURL()` (e.g. S3 presigned URL, local file server).
+//   See #188.
+// Callers that walk treatment trees for repo-local assets (e.g.
+// `getReferencedAssets`) should exclude both `http(s)://` and
+// `asset://` — neither is a local file.
+export const urlSchema = z.string().refine(
+  (url) => {
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+        return true;
       }
-    },
-    { message: "URL must use http or https protocol" },
-  );
+      if (parsed.protocol === "asset:") {
+        // `asset://foo/bar` → pathname is `/bar`, host is `foo`. Require
+        // the URL to carry *some* location after the scheme so we don't
+        // silently accept a bare `asset://`.
+        return parsed.host.length > 0 || parsed.pathname.length > 1;
+      }
+      return false;
+    } catch {
+      return false;
+    }
+  },
+  {
+    message: "URL must use http, https, or asset:// (platform-provided media)",
+  },
+);
 export type UrlType = z.infer<typeof urlSchema>;
 
 // stage duration:

--- a/packages/stagebook/src/utils/referencedAssets.test.ts
+++ b/packages/stagebook/src/utils/referencedAssets.test.ts
@@ -178,6 +178,16 @@ describe("getReferencedAssets — exclusions", () => {
     expect(getReferencedAssets(tree)).toEqual([]);
   });
 
+  test("excludes malformed opaque `asset:` form too (no //)", () => {
+    // Guard against an `asset:clip.mp4` slipping through as a "local
+    // file" when `urlSchema` would have rejected it upstream.
+    const tree = treatmentWithElements([
+      { type: "mediaPlayer", url: "asset:clip.mp4" },
+      { type: "image", file: "asset:diagram.png" },
+    ]);
+    expect(getReferencedAssets(tree)).toEqual([]);
+  });
+
   test("excludes empty string paths", () => {
     const tree = treatmentWithElements([
       { type: "image", file: "" },

--- a/packages/stagebook/src/utils/referencedAssets.test.ts
+++ b/packages/stagebook/src/utils/referencedAssets.test.ts
@@ -158,6 +158,26 @@ describe("getReferencedAssets — exclusions", () => {
     expect(getReferencedAssets(tree)).toEqual([]);
   });
 
+  test("excludes asset:// platform-provided references (#188)", () => {
+    const tree = treatmentWithElements([
+      {
+        type: "mediaPlayer",
+        url: "asset://group_recordings/training_video.mp4",
+      },
+      { type: "image", file: "asset://diagrams/flow.png" },
+      { type: "audio", file: "asset://stings/intro.mp3" },
+    ]);
+    expect(getReferencedAssets(tree)).toEqual([]);
+  });
+
+  test("is case-insensitive on the asset:// scheme", () => {
+    const tree = treatmentWithElements([
+      { type: "mediaPlayer", url: "ASSET://clip.mp4" },
+      { type: "mediaPlayer", url: "Asset://clip.mp4" },
+    ]);
+    expect(getReferencedAssets(tree)).toEqual([]);
+  });
+
   test("excludes empty string paths", () => {
     const tree = treatmentWithElements([
       { type: "image", file: "" },

--- a/packages/stagebook/src/utils/referencedAssets.ts
+++ b/packages/stagebook/src/utils/referencedAssets.ts
@@ -25,8 +25,10 @@ const PLACEHOLDER_PATTERN = /\$\{[^}]*\}/;
 const FULL_URL_PATTERN = /^(?:https?:)?\/\//i;
 // Platform-provided assets (see #188) live outside the repo — the host
 // resolves them via `getAssetURL()`, so they aren't collectable as local
-// files for bundling/manifest purposes.
-const ASSET_URI_PATTERN = /^asset:\/\//i;
+// files for bundling/manifest purposes. Match the whole `asset:` scheme
+// (not just the `asset://` form) so a malformed opaque variant like
+// `asset:clip.mp4` isn't silently misclassified as a local file path.
+const ASSET_URI_PATTERN = /^asset:/i;
 
 export interface ReferencedAsset {
   /** The raw path as it appears in the treatment YAML. */

--- a/packages/stagebook/src/utils/referencedAssets.ts
+++ b/packages/stagebook/src/utils/referencedAssets.ts
@@ -23,6 +23,10 @@ const PROMPT_SHORTHAND_SUFFIX = ".prompt.md";
 
 const PLACEHOLDER_PATTERN = /\$\{[^}]*\}/;
 const FULL_URL_PATTERN = /^(?:https?:)?\/\//i;
+// Platform-provided assets (see #188) live outside the repo — the host
+// resolves them via `getAssetURL()`, so they aren't collectable as local
+// files for bundling/manifest purposes.
+const ASSET_URI_PATTERN = /^asset:\/\//i;
 
 export interface ReferencedAsset {
   /** The raw path as it appears in the treatment YAML. */
@@ -44,6 +48,7 @@ function isCollectableLocalPath(value: unknown): value is string {
   if (value.length === 0) return false;
   if (PLACEHOLDER_PATTERN.test(value)) return false;
   if (FULL_URL_PATTERN.test(value)) return false;
+  if (ASSET_URI_PATTERN.test(value)) return false;
   return true;
 }
 
@@ -58,9 +63,10 @@ function isCollectableLocalPath(value: unknown): value is string {
  * yields `[]`.
  *
  * Excludes template-placeholder paths (`${…}`), full URLs (`http://…`,
- * `https://…`, `//…`), and empty strings. Order is stable tree-walk order
- * (outer-to-inner, then insertion order within each object), with
- * field-declaration order from the table above within a single element.
+ * `https://…`, `//…`), `asset://…` platform-provided references (#188),
+ * and empty strings. Order is stable tree-walk order (outer-to-inner,
+ * then insertion order within each object), with field-declaration order
+ * from the table above within a single element.
  */
 export function getReferencedAssets(treatmentFile: unknown): ReferencedAsset[] {
   const results: ReferencedAsset[] = [];


### PR DESCRIPTION
Closes #188. Supersedes #185 — the docs update covers both.

## Summary
Treatment files now have a first-class way to reference media that the platform resolves from its own storage (S3 presigned URL, local file server, CDN, etc.). Researchers write:

```yaml
- type: mediaPlayer
  url: asset://group_recordings/session_001.mp4
```

and the host's `getAssetURL()` resolves the URI. Stagebook never fetches or bundles these references.

## Library changes

- **`urlSchema`** ([treatment.ts](packages/stagebook/src/schemas/treatment.ts)) now accepts `asset:` in addition to `http:` and `https:`. Bare `asset://` with no host or path is rejected so typos fail loudly. Used by `qualtrics.url` and `trackedLink.url`.
    - `mediaPlayer.url` is already `z.string()` to permit relative paths, so `asset://` values there pass trivially — the new test documents the end-to-end intent.
- **`getReferencedAssets()`** ([referencedAssets.ts](packages/stagebook/src/utils/referencedAssets.ts)) excludes `asset://` alongside `http(s)://` — neither is a repo file, so manifest freezes and file-existence checks skip them.
- **No change needed** in `Element.tsx` or `Markdown.tsx`: both already route non-http URLs through `getAssetURL()`, and Markdown's anti-`javascript:` guard stays intact because a host's `getAssetURL('asset://…')` returns a real http(s) URL.

## Docs
Updated [treatment-files.md](docs/researcher/treatment-files.md) with a new "Media and asset references" section covering all three reference forms — relative path, full URL, `asset://` — plus `${field}` for per-task variation. Includes a decision table:

| Asset is the same every task? | Asset is in the repo? | Reference form |
|---|---|---|
| yes | yes | relative path |
| yes | no — public URL | full URL |
| yes | no — host storage | `asset://…` |
| no (varies per task) | — | `${fieldName}` |

## Why supersede #185
#185 proposed "use fields for platform-provided fixed media" as a pattern. That conflated two concerns: fixed media from host storage (now `asset://`) and per-task variable media (still `${field}`). The doc update separates them and folds #185's guidance in.

## Tests (10 new)
- `urlSchema` accepts http/https/asset, rejects ftp/javascript/file/empty/non-URL strings, rejects bare `asset://`, case-insensitive on the asset scheme.
- `getReferencedAssets` excludes `asset://` on `url` and `file` fields across mediaPlayer/image/audio, case-insensitive on the scheme.

## Test plan
- [x] `npm test` — 604 stagebook (was 594) + 75 viewer + 187 vscode all green.
- [x] `npm run lint` clean.
- [x] `npm run format:check` clean.

Will close #185 as superseded after this lands.