### PR TITLE
Stage-level conditions: skip-at-load and early termination (#183)

### DIFF
--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -138,6 +138,7 @@ export function Viewer({
     duration: currentStep.duration,
     elements: currentStep.elements,
     discussion: currentStep.discussion,
+    conditions: currentStep.conditions,
   };
 
   return (

--- a/apps/viewer/src/lib/context.ts
+++ b/apps/viewer/src/lib/context.ts
@@ -64,6 +64,18 @@ export function createViewerContext(
       onSubmit();
     },
 
+    // Single-participant preview: stage-level conditions (#183) end the
+    // stage by the same mechanism a submit button does. No cross-client
+    // coordination to do — just advance.
+    advanceStage(): void {
+      onSubmit();
+    },
+
+    // Opaque per-stage identity (just the index, which is unique per
+    // flattened step). Lets the StageConditionGate's latch reset cleanly
+    // when the stage changes.
+    stageId: `stage-${String(stageIndex)}`,
+
     getAssetURL,
     getTextContent,
     contentVersion,

--- a/apps/viewer/src/lib/steps.ts
+++ b/apps/viewer/src/lib/steps.ts
@@ -87,6 +87,7 @@ export function flattenSteps(
         name: step.name,
         elements: step.elements,
         notes: step.notes,
+        conditions: step.conditions,
       });
     }
   }

--- a/apps/viewer/src/lib/steps.ts
+++ b/apps/viewer/src/lib/steps.ts
@@ -1,4 +1,4 @@
-import type { ElementType, DiscussionType } from "stagebook";
+import type { ElementType, DiscussionType, ConditionType } from "stagebook";
 
 export type Phase = "intro" | "game" | "exit";
 
@@ -11,11 +11,18 @@ export interface ViewerStep {
   discussion?: DiscussionType;
   /** Researcher-facing notes on the stage (never shown to participants). */
   notes?: string;
+  /** Stage-level conditions (#183). Evaluated by StageConditionGate. */
+  conditions?: ConditionType[];
 }
 
 interface IntroSequence {
   name: string;
-  introSteps: { name: string; notes?: string; elements: ElementType[] }[];
+  introSteps: {
+    name: string;
+    notes?: string;
+    conditions?: ConditionType[];
+    elements: ElementType[];
+  }[];
 }
 
 interface Treatment {
@@ -24,11 +31,17 @@ interface Treatment {
   gameStages: {
     name: string;
     notes?: string;
+    conditions?: ConditionType[];
     duration?: number;
     elements: ElementType[];
     discussion?: DiscussionType;
   }[];
-  exitSequence?: { name: string; notes?: string; elements: ElementType[] }[];
+  exitSequence?: {
+    name: string;
+    notes?: string;
+    conditions?: ConditionType[];
+    elements: ElementType[];
+  }[];
 }
 
 /**
@@ -49,6 +62,7 @@ export function flattenSteps(
       name: step.name,
       elements: step.elements,
       notes: step.notes,
+      conditions: step.conditions,
     });
   }
 
@@ -61,6 +75,7 @@ export function flattenSteps(
       duration: stage.duration,
       discussion: stage.discussion,
       notes: stage.notes,
+      conditions: stage.conditions,
     });
   }
 

--- a/docs/engineer/platform-requirements.md
+++ b/docs/engineer/platform-requirements.md
@@ -194,6 +194,55 @@ When a participant disconnects during a game stage:
 - On reconnection, the participant resumes at the current stage with the correct elapsed time
 - If a video element was playing, it should resume at the correct position
 
+### Stage-level Conditions (#183)
+
+Treatment files may declare `conditions` on a stage, intro step, or exit step. When any condition evaluates to false, stagebook asks the host to advance the stage via two optional context fields:
+
+- **`advanceStage?(): void`** — called when stagebook decides the stage should end (either at mount for skip-at-load, or mid-stage for early termination).
+- **`stageId?: string`** — opaque per-stage identifier. Stagebook uses it to reset its internal advance latch cleanly when the stage changes, so hosts that reuse the provider across stages don't need to key-remount.
+
+Both are optional. If `advanceStage` is missing, stagebook falls back to `submit()` and logs a one-time dev-mode warning.
+
+#### Single-participant hosts
+
+`advanceStage` is a thin wrapper over whatever you do for submit:
+
+```ts
+advanceStage: () => submit(),
+```
+
+`stageId` can be omitted — stagebook uses the conditions array identity as a fallback key.
+
+#### Multi-participant hosts
+
+Two responsibilities that only the host can handle:
+
+1. **Submit for every player, not just self.** A dropout whose client never fires the advance call would otherwise hang the stage until the duration timer expires. Recommended:
+
+    ```ts
+    advanceStage: () => {
+      const target = currentStageId;
+      players.forEach((p) => {
+        if (p.stage?.id === target && !p.stage.get("submit")) {
+          p.stage.set("submit", true);
+        }
+      });
+    }
+    ```
+
+2. **Ensure condition data is hydrated consistently across clients before the provider mounts.** Stagebook evaluates conditions from `context.get()` results; if client A sees the data and client B doesn't, they'll make different advance decisions. Hosts with staged-attribute stores (e.g., Tajriba) should gate the `<StagebookProvider>` mount on full hydration and show a host-level loading UI during transitions.
+
+#### What stagebook handles vs. what the host handles
+
+| | Stagebook | Host |
+|---|---|---|
+| Evaluating conditions | ✅ | |
+| Latching so `advanceStage` fires once per stage | ✅ | |
+| Submitting for every player | | ✅ |
+| Cross-client stage-ID coordination during advance | | ✅ |
+| Force-submit for disconnected players | | ✅ |
+| Hydration sentinel / atomic store snapshot | | ✅ |
+
 ---
 
 ## 3. Group Formation (required for multiplayer)

--- a/docs/researcher/conditions.md
+++ b/docs/researcher/conditions.md
@@ -274,3 +274,85 @@ groupComposition:
 ```
 
 **Note:** Group assignment conditions can only use the participant's own responses — no `position` modifier is available.
+
+## Stage-level conditions
+
+Any stage, intro step, or exit step can carry its own `conditions` array. Think of it as: _this stage should be active while these conditions hold._ When any condition is false, stagebook asks the host to advance — either skipping the stage at load (if the data comes from an earlier stage) or ending it early (if it comes from the current stage).
+
+Same condition syntax, same comparators, same position modifier as element-level conditions.
+
+### Skip a stage based on prior data
+
+Round 2 only runs if the group voted to continue after round 1:
+
+```yaml
+gameStages:
+  - name: round1_vote
+    duration: 60
+    elements:
+      - type: survey
+        surveyName: continueVote
+        name: continueVote
+
+  - name: round2
+    duration: 300
+    conditions:
+      - reference: survey.continueVote.result.keepGoing
+        comparator: equals
+        value: "yes"
+        position: all
+    elements:
+      - type: prompt
+        file: round2.prompt.md
+      - type: submitButton
+```
+
+### End a stage early (early termination)
+
+Condition authored so it's `true` while no one has submitted, flips to `false` as soon as anyone does:
+
+```yaml
+gameStages:
+  - name: speed_round
+    duration: 120
+    conditions:
+      - reference: submitButton.speedSubmit
+        comparator: doesNotExist
+        position: all
+    elements:
+      - type: submitButton
+        name: speedSubmit
+```
+
+### Position rules
+
+Game-stage conditions must evaluate **identically on every client** or the stage desyncs (one participant skips while the other renders). Stagebook rejects per-player positions at preflight for game stages:
+
+| Context | Default / `player` | `shared` / `all` / `any` / `percentAgreement` / index |
+|---|---|---|
+| Game stages | ❌ rejected at preflight | ✅ |
+| Intro / exit steps | ✅ | ✅ |
+
+Intro and exit steps run per-participant, so any position is fine there — including the default.
+
+### `percentAgreement` needs a numeric comparator
+
+`percentAgreement` aggregates all players' values and compares the *percentage of agreement* against a threshold. Preflight now enforces that the comparator is one of `isAbove`, `isBelow`, `isAtLeast`, `isAtMost` — the ones that actually compare numbers.
+
+```yaml
+# At least 60% of the group agreed on some value
+conditions:
+  - reference: survey.vote.result.choice
+    comparator: isAtLeast
+    value: 60
+    position: percentAgreement
+```
+
+### Host requirements
+
+Stage-level conditions rely on two fields on `StagebookContext`:
+
+- `advanceStage()` — called by stagebook when conditions fail. Hosts implement the advancement policy. Single-participant hosts wrap `submit()`; multi-participant hosts submit for every player (so dropouts can't hang the stage).
+- `stageId` — opaque per-stage identifier. Lets stagebook reset its internal latch cleanly between stages without a key-remount by the host.
+
+See [platform-requirements.md](../engineer/platform-requirements.md) for the full host-integration checklist.

--- a/packages/stagebook/src/components/Stage.tsx
+++ b/packages/stagebook/src/components/Stage.tsx
@@ -6,6 +6,7 @@ import { TimeConditionalRender } from "./conditions/TimeConditionalRender.js";
 import { PositionConditionalRender } from "./conditions/PositionConditionalRender.js";
 import { ConditionsConditionalRender } from "./conditions/ConditionsConditionalRender.js";
 import { SubmissionConditionalRender } from "./conditions/SubmissionConditionalRender.js";
+import { StageConditionGate } from "./conditions/StageConditionGate.js";
 import { ScrollIndicator } from "./scroll/ScrollIndicator.js";
 import { useScrollAwareness } from "./scroll/useScrollAwareness.js";
 import { PlaybackProvider } from "./playback/PlaybackProvider.js";
@@ -32,6 +33,14 @@ export interface StageConfig {
   duration?: number;
   elements: ElementConfig[];
   discussion?: DiscussionType;
+  /**
+   * Stage-level conditions (#183). When any condition evaluates to
+   * false at mount the stage is skipped; when a condition flips to
+   * false after mount the stage ends early. Stagebook asks the host
+   * to advance via `StagebookContext.advanceStage` (falling back to
+   * `submit`).
+   */
+  conditions?: Condition[];
 }
 
 export interface StageProps {
@@ -214,64 +223,68 @@ export function Stage({ stage, onSubmit }: StageProps) {
     );
 
     return (
-      <PlaybackProvider>
-        <SubmissionConditionalRender
-          isSubmitted={isSubmitted}
-          playerCount={playerCount}
-        >
-          {discussionConditions && discussionConditions.length > 0 ? (
-            <ConditionsConditionalRender
-              conditions={discussionConditions}
-              resolve={resolve}
-              fallback={
-                <div
-                  data-testid="stageContent"
-                  style={{
-                    display: "flex",
-                    height: "100%",
-                    width: "100%",
-                    flexDirection: "column",
-                    paddingBottom: "0.5rem",
-                    overflow: "auto",
-                  }}
-                >
-                  {elementsColumn}
-                </div>
-              }
-            >
-              {discussionPage}
-            </ConditionsConditionalRender>
-          ) : (
-            discussionPage
-          )}
-        </SubmissionConditionalRender>
-      </PlaybackProvider>
+      <StageConditionGate conditions={stage.conditions}>
+        <PlaybackProvider>
+          <SubmissionConditionalRender
+            isSubmitted={isSubmitted}
+            playerCount={playerCount}
+          >
+            {discussionConditions && discussionConditions.length > 0 ? (
+              <ConditionsConditionalRender
+                conditions={discussionConditions}
+                resolve={resolve}
+                fallback={
+                  <div
+                    data-testid="stageContent"
+                    style={{
+                      display: "flex",
+                      height: "100%",
+                      width: "100%",
+                      flexDirection: "column",
+                      paddingBottom: "0.5rem",
+                      overflow: "auto",
+                    }}
+                  >
+                    {elementsColumn}
+                  </div>
+                }
+              >
+                {discussionPage}
+              </ConditionsConditionalRender>
+            ) : (
+              discussionPage
+            )}
+          </SubmissionConditionalRender>
+        </PlaybackProvider>
+      </StageConditionGate>
     );
   }
 
   // Single-column layout: elements only
   return (
-    <PlaybackProvider>
-      <SubmissionConditionalRender
-        isSubmitted={isSubmitted}
-        playerCount={playerCount}
-      >
-        <div
-          ref={singleColumnRef}
-          data-testid="stageContent"
-          style={{
-            display: "flex",
-            height: "100%",
-            width: "100%",
-            flexDirection: "column",
-            paddingBottom: "0.5rem",
-            overflow: "auto",
-          }}
+    <StageConditionGate conditions={stage.conditions}>
+      <PlaybackProvider>
+        <SubmissionConditionalRender
+          isSubmitted={isSubmitted}
+          playerCount={playerCount}
         >
-          {elementsColumn}
-          <ScrollIndicator visible={showSingleColumnScrollIndicator} />
-        </div>
-      </SubmissionConditionalRender>
-    </PlaybackProvider>
+          <div
+            ref={singleColumnRef}
+            data-testid="stageContent"
+            style={{
+              display: "flex",
+              height: "100%",
+              width: "100%",
+              flexDirection: "column",
+              paddingBottom: "0.5rem",
+              overflow: "auto",
+            }}
+          >
+            {elementsColumn}
+            <ScrollIndicator visible={showSingleColumnScrollIndicator} />
+          </div>
+        </SubmissionConditionalRender>
+      </PlaybackProvider>
+    </StageConditionGate>
   );
 }

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -44,11 +44,15 @@ export interface StagebookContext {
 
   /**
    * Opaque host-provided identifier for the current stage instance.
-   * Stagebook captures it at condition-evaluation time and no-ops the
-   * `advanceStage` call if the id has changed by the time the effect
-   * fires (guards against racing against host-driven navigation).
-   * Optional — single-participant hosts can omit; the mount-lifecycle
-   * guarantee is sufficient there.
+   * Stagebook uses it as the identity key for `StageConditionGate`'s
+   * advance latch: when `stageId` changes the latch resets, so a host
+   * that reuses the provider across stages doesn't need to key-remount
+   * the subtree between stages. Hosts that already remount per stage,
+   * or that never change stage mid-mount, can omit it — the conditions
+   * array reference is used as a fallback identity. Cross-client
+   * staleness checks (e.g. "is this advance still for the stage we
+   * thought it was?") belong inside the host's `advanceStage`
+   * implementation, not here.
    */
   stageId?: string;
 

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -29,6 +29,29 @@ export interface StagebookContext {
   // Advance to next step
   submit(): void;
 
+  /**
+   * Called by stagebook when stage-level conditions (#183) evaluate to
+   * false and the stage should end — either at mount (skip-at-load) or
+   * mid-stage (early termination). Hosts implement the advancement
+   * policy: single-participant hosts typically wrap `submit()`;
+   * multi-participant hosts submit for every player so dropouts don't
+   * hang the stage. Distinct from `submit()` so the host can
+   * differentiate "this player finished" from "the stage should end
+   * for everyone." Optional — when absent, stagebook falls back to
+   * `submit()` and logs a dev-mode warning.
+   */
+  advanceStage?: () => void;
+
+  /**
+   * Opaque host-provided identifier for the current stage instance.
+   * Stagebook captures it at condition-evaluation time and no-ops the
+   * `advanceStage` call if the id has changed by the time the effect
+   * fires (guards against racing against host-driven navigation).
+   * Optional — single-participant hosts can omit; the mount-lifecycle
+   * guarantee is sufficient there.
+   */
+  stageId?: string;
+
   // Content resolution — platform handles fetching, caching, retries
   getAssetURL(path: string): string;
   getTextContent(path: string): Promise<string>;

--- a/packages/stagebook/src/components/conditions/StageConditionGate.ct.tsx
+++ b/packages/stagebook/src/components/conditions/StageConditionGate.ct.tsx
@@ -1,0 +1,150 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { MockStageRenderer } from "../testing/MockStageRenderer";
+
+// A minimal stage with one element — submitButton is an advancement
+// element and keeps the stage schema-valid in both passing and failing
+// condition cases.
+const elements = [{ type: "submitButton" as const }];
+
+test.describe("StageConditionGate (#183)", () => {
+  test("renders stage body when all conditions pass", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <MockStageRenderer
+        stage={{
+          name: "r2",
+          duration: 60,
+          conditions: [
+            {
+              reference: "survey.continueVote.result.keepGoing",
+              comparator: "equals",
+              value: "yes",
+              position: "all",
+            },
+          ],
+          elements,
+        }}
+        stateValues={{
+          "survey.continueVote.result.keepGoing": "yes",
+        }}
+      />,
+    );
+    await expect(page.locator('[data-testid="stageContent"]')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="stage-condition-gate"]'),
+    ).not.toBeVisible();
+  });
+
+  test("shows the advancing state when a stage-level condition fails", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <MockStageRenderer
+        stage={{
+          name: "r2",
+          duration: 60,
+          conditions: [
+            {
+              reference: "survey.continueVote.result.keepGoing",
+              comparator: "equals",
+              value: "yes",
+              position: "all",
+            },
+          ],
+          elements,
+        }}
+        stateValues={{
+          "survey.continueVote.result.keepGoing": "no",
+        }}
+      />,
+    );
+    const gate = page.locator('[data-testid="stage-condition-gate"]');
+    await expect(gate).toBeVisible();
+    await expect(gate).toHaveAttribute("data-state", "advancing");
+    // Stage body should not be rendered.
+    await expect(
+      page.locator('[data-testid="stageContent"]'),
+    ).not.toBeVisible();
+  });
+
+  test("shows the advancing state when the referenced data is absent (skip-at-load)", async ({
+    mount,
+    page,
+  }) => {
+    // `equals "yes"` evaluates false against undefined data — classic
+    // skip-at-load pattern when the prior-stage value was never set.
+    await mount(
+      <MockStageRenderer
+        stage={{
+          name: "r2",
+          duration: 60,
+          conditions: [
+            {
+              reference: "survey.continueVote.result.keepGoing",
+              comparator: "equals",
+              value: "yes",
+              position: "all",
+            },
+          ],
+          elements,
+        }}
+        // no stateValues — references are undefined
+      />,
+    );
+    await expect(
+      page.locator('[data-testid="stage-condition-gate"]'),
+    ).toBeVisible();
+  });
+
+  test("renders stage body when early-termination condition holds (data not yet present)", async ({
+    mount,
+    page,
+  }) => {
+    // Early-termination pattern: condition is true while the referenced
+    // value is undefined; flips to false once data arrives.
+    await mount(
+      <MockStageRenderer
+        stage={{
+          name: "speed_round",
+          duration: 60,
+          conditions: [
+            {
+              reference: "submitButton.speedSubmit",
+              comparator: "doesNotExist",
+              position: "all",
+            },
+          ],
+          elements: [{ type: "submitButton" as const, name: "speedSubmit" }],
+        }}
+        // no stateValues — submitButton.speedSubmit is undefined →
+        // doesNotExist is true → stage renders.
+      />,
+    );
+    await expect(page.locator('[data-testid="stageContent"]')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="stage-condition-gate"]'),
+    ).not.toBeVisible();
+  });
+
+  test("no gate overhead when stage has no conditions", async ({
+    mount,
+    page,
+  }) => {
+    await mount(
+      <MockStageRenderer
+        stage={{
+          name: "plain",
+          duration: 60,
+          elements,
+        }}
+      />,
+    );
+    await expect(page.locator('[data-testid="stageContent"]')).toBeVisible();
+    await expect(
+      page.locator('[data-testid="stage-condition-gate"]'),
+    ).not.toBeAttached();
+  });
+});

--- a/packages/stagebook/src/components/conditions/StageConditionGate.tsx
+++ b/packages/stagebook/src/components/conditions/StageConditionGate.tsx
@@ -1,0 +1,97 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import React, { useEffect, useRef } from "react";
+import { useStagebookContext } from "../StagebookProvider.js";
+import { evaluateConditions } from "../../utils/evaluateConditions.js";
+import { Loading } from "../form/Loading.js";
+import type { Condition } from "./ConditionsConditionalRender.js";
+
+export interface StageConditionGateProps {
+  /**
+   * Stage-level conditions from the treatment DSL (#183). When all
+   * conditions evaluate to `true`, children render normally. When any
+   * condition is `false`, stagebook asks the host to advance the stage
+   * via `context.advanceStage` (falling back to `submit`).
+   */
+  conditions?: Condition[];
+  children: React.ReactNode;
+}
+
+/**
+ * Wraps a stage's render body and evaluates stage-level conditions.
+ *
+ * Two behaviors, same code path:
+ * - **Skip at load.** Conditions reference data produced in *prior*
+ *   stages. Evaluated on mount; if false, stagebook immediately asks
+ *   the host to advance. Stage body never renders.
+ * - **Early termination.** Conditions reference data in the *current*
+ *   stage, authored so they evaluate to `true` when the value is
+ *   `undefined` (typically `comparator: doesNotExist`). Stage renders
+ *   normally; when a value arrives that flips a condition to false,
+ *   stagebook asks the host to advance.
+ *
+ * Advance is fired at most once per stage:
+ * - A latch ref prevents double-fire within a stage.
+ * - The latch auto-resets when the stage identity changes (via
+ *   `stageId` if the host supplies one, or the conditions array
+ *   reference otherwise) so the next stage starts clean — hosts that
+ *   reuse the provider across stages don't need to key-remount.
+ */
+export function StageConditionGate({
+  conditions,
+  children,
+}: StageConditionGateProps) {
+  const { resolve, advanceStage, submit, stageId } = useStagebookContext();
+
+  // Reset the advance latch whenever the stage changes. Tracks
+  // `stageId` when the host supplies one (authoritative identity),
+  // otherwise falls back to the conditions array reference (changes
+  // each time the stage config changes in a well-behaved host).
+  const stageKey = stageId ?? conditions;
+  const lastStageKeyRef = useRef<unknown>(null);
+  const advanceFiredRef = useRef(false);
+  if (lastStageKeyRef.current !== stageKey) {
+    lastStageKeyRef.current = stageKey;
+    advanceFiredRef.current = false;
+  }
+
+  const hasConditions = !!conditions && conditions.length > 0;
+  const allMet = hasConditions ? evaluateConditions(conditions, resolve) : true;
+
+  useEffect(() => {
+    if (!hasConditions) return;
+    if (allMet) return;
+    if (advanceFiredRef.current) return;
+    advanceFiredRef.current = true;
+
+    if (advanceStage) {
+      advanceStage();
+    } else {
+      warnFallbackOnce();
+      submit();
+    }
+  }, [hasConditions, allMet, advanceStage, submit, stageId]);
+
+  if (!hasConditions || allMet) return <>{children}</>;
+
+  return (
+    <div
+      data-testid="stage-condition-gate"
+      data-state="advancing"
+      style={{ textAlign: "center" }}
+    >
+      <Loading />
+    </div>
+  );
+}
+
+let warned = false;
+function warnFallbackOnce(): void {
+  if (warned) return;
+  warned = true;
+  console.warn(
+    "[stagebook] StagebookContext.advanceStage is not implemented; " +
+      "falling back to submit() for stage-level condition advancement. " +
+      "Multi-participant hosts should implement advanceStage to submit " +
+      "for every player so dropouts don't hang the stage. See #183.",
+  );
+}

--- a/packages/stagebook/src/components/conditions/StageConditionGate.tsx
+++ b/packages/stagebook/src/components/conditions/StageConditionGate.tsx
@@ -69,7 +69,12 @@ export function StageConditionGate({
       warnFallbackOnce();
       submit();
     }
-  }, [hasConditions, allMet, advanceStage, submit, stageId]);
+    // `stageKey` in deps: without it, two consecutive stages that both
+    // fail conditions wouldn't re-fire the effect, because `allMet`
+    // stays `false` across the transition and no other dep changes.
+    // The in-render latch reset covers the latch, but the effect also
+    // needs to be woken up for the new stage.
+  }, [hasConditions, allMet, advanceStage, submit, stageKey]);
 
   if (!hasConditions || allMet) return <>{children}</>;
 
@@ -88,7 +93,12 @@ let warned = false;
 function warnFallbackOnce(): void {
   if (warned) return;
   warned = true;
-  console.warn(
+  // `console.debug` rather than `console.warn`: the fallback is a
+  // legitimate choice for single-participant hosts that don't need
+  // cross-client advancement, and we don't want to spam those hosts'
+  // production logs. Browsers hide `.debug` by default but surface it
+  // at the Verbose log level for hosts investigating stage behavior.
+  console.debug(
     "[stagebook] StagebookContext.advanceStage is not implemented; " +
       "falling back to submit() for stage-level condition advancement. " +
       "Multi-participant hosts should implement advanceStage to submit " +

--- a/packages/stagebook/src/components/conditions/index.ts
+++ b/packages/stagebook/src/components/conditions/index.ts
@@ -15,3 +15,7 @@ export {
   SubmissionConditionalRender,
   type SubmissionConditionalRenderProps,
 } from "./SubmissionConditionalRender.js";
+export {
+  StageConditionGate,
+  type StageConditionGateProps,
+} from "./StageConditionGate.js";

--- a/packages/stagebook/src/components/testing/MockStageRenderer.tsx
+++ b/packages/stagebook/src/components/testing/MockStageRenderer.tsx
@@ -21,6 +21,14 @@ export interface MockStageRendererProps {
   elapsedTime?: number;
   /** Key-value map of DSL reference string → extracted value (e.g., "prompt.answer" → "yes") */
   stateValues?: Record<string, unknown>;
+  /**
+   * Host advancement hook for stage-level conditions (#183). Default
+   * is a no-op so existing tests aren't affected; tests that want to
+   * verify stage-gate advancement can pass a mock to inspect.
+   */
+  advanceStage?: () => void;
+  /** Opaque stage id — for the gate's latch-reset logic. */
+  stageId?: string;
 }
 
 /** Wrap a value at a nested path, e.g. wrapAtPath("yes", ["value"]) → { value: "yes" } */
@@ -55,6 +63,8 @@ export function MockStageRenderer({
   isSubmitted = false,
   elapsedTime = 0,
   stateValues = {},
+  advanceStage,
+  stageId,
 }: MockStageRendererProps) {
   const flatValues = buildFlatValues(stateValues);
 
@@ -66,6 +76,8 @@ export function MockStageRenderer({
     save: () => {},
     getElapsedTime: () => elapsedTime,
     submit: () => {},
+    advanceStage,
+    stageId,
     getAssetURL: (path: string) => `https://mock-cdn.test/${path}`,
     getTextContent: (path: string) =>
       Promise.resolve(

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -6,6 +6,7 @@ import {
   discussionSchema,
   elementsSchema,
   elementSchema,
+  introExitStepSchema,
   introStepsSchema,
   exitStepsSchema,
   mediaPlayerSchema,
@@ -1247,4 +1248,173 @@ test("stage reports one issue per mismatched timeline (not a single aggregated e
     expect(paths).toContain("elements.1.source");
     expect(paths).toContain("elements.2.source");
   }
+});
+
+// ----------- Stage-level conditions (#183) -----------
+
+test("stageSchema accepts stage-level conditions with a cross-client position", () => {
+  const result = stageSchema.safeParse({
+    name: "r2",
+    duration: 120,
+    conditions: [
+      {
+        reference: "survey.continueVote.responses.keepGoing",
+        comparator: "equals",
+        value: "yes",
+        position: "all",
+      },
+    ],
+    elements: [{ type: "submitButton" }],
+  });
+  if (!result.success) console.log(result.error.issues);
+  expect(result.success).toBe(true);
+});
+
+test("stageSchema rejects stage-level conditions with default position (implicit player)", () => {
+  const result = stageSchema.safeParse({
+    name: "r2",
+    duration: 120,
+    conditions: [
+      {
+        reference: "prompt.vote",
+        comparator: "equals",
+        value: "yes",
+        // no position → defaults to per-player, would desync
+      },
+    ],
+    elements: [{ type: "submitButton" }],
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find(
+      (i) => i.path.join(".") === "conditions.0.position",
+    );
+    expect(issue?.message).toMatch(/cross-client position/);
+  }
+});
+
+test("stageSchema rejects stage-level conditions with explicit position: player", () => {
+  const result = stageSchema.safeParse({
+    name: "r2",
+    duration: 120,
+    conditions: [
+      {
+        reference: "prompt.vote",
+        comparator: "equals",
+        value: "yes",
+        position: "player",
+      },
+    ],
+    elements: [{ type: "submitButton" }],
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find(
+      (i) => i.path.join(".") === "conditions.0.position",
+    );
+    expect(issue).toBeDefined();
+  }
+});
+
+test("introExitStepSchema allows stage-level conditions with any position, including default", () => {
+  const result = introExitStepSchema.safeParse({
+    name: "optional_info",
+    conditions: [
+      // Intro/exit is per-participant — default (player) position is fine
+      {
+        reference: "urlParams.showOptionalInfo",
+        comparator: "equals",
+        value: "true",
+      },
+    ],
+    elements: [{ type: "submitButton" }],
+  });
+  if (!result.success) console.log(result.error.issues);
+  expect(result.success).toBe(true);
+});
+
+test("stageSchema rejects percentAgreement with a non-numeric comparator", () => {
+  const result = stageSchema.safeParse({
+    name: "r2",
+    duration: 120,
+    conditions: [
+      {
+        reference: "survey.continueVote.responses.keepGoing",
+        comparator: "equals",
+        value: "yes",
+        position: "percentAgreement",
+      },
+    ],
+    elements: [{ type: "submitButton" }],
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find(
+      (i) => i.path.join(".") === "conditions.0.comparator",
+    );
+    expect(issue?.message).toMatch(/percentAgreement.*numeric comparator/);
+  }
+});
+
+test("stageSchema accepts percentAgreement with isAtLeast and a numeric threshold", () => {
+  const result = stageSchema.safeParse({
+    name: "r2",
+    duration: 120,
+    conditions: [
+      {
+        reference: "survey.vote.result.normPosition",
+        comparator: "isAtLeast",
+        value: 50,
+        position: "percentAgreement",
+      },
+    ],
+    elements: [{ type: "submitButton" }],
+  });
+  if (!result.success) console.log(result.error.issues);
+  expect(result.success).toBe(true);
+});
+
+test("stageSchema still rejects element-level percentAgreement with a non-numeric comparator", () => {
+  const result = stageSchema.safeParse({
+    name: "r2",
+    duration: 120,
+    elements: [
+      {
+        type: "prompt",
+        file: "p.prompt.md",
+        conditions: [
+          {
+            reference: "survey.vote.result.x",
+            comparator: "equals",
+            value: "yes",
+            position: "percentAgreement",
+          },
+        ],
+      },
+      { type: "submitButton" },
+    ],
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find(
+      (i) => i.path.join(".") === "elements.0.conditions.0.comparator",
+    );
+    expect(issue).toBeDefined();
+  }
+});
+
+test("introExitStepSchema rejects percentAgreement with a non-numeric comparator", () => {
+  const result = introExitStepSchema.safeParse({
+    name: "debrief",
+    conditions: [
+      {
+        reference: "survey.feedback.result.x",
+        comparator: "equals",
+        value: "yes",
+        position: "percentAgreement",
+      },
+    ],
+    elements: [{ type: "submitButton" }],
+  });
+  expect(result.success).toBe(false);
 });

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -692,6 +692,84 @@ export const conditionSchema = altTemplateContext(
   ]),
 );
 
+// Comparators that compare numeric magnitudes — the only ones that make
+// sense with `position: percentAgreement`, where the referenced value is
+// the *percentage of agreement* rather than the raw response.
+const PERCENT_AGREEMENT_NUMERIC_COMPARATORS = new Set([
+  "isAbove",
+  "isBelow",
+  "isAtLeast",
+  "isAtMost",
+]);
+
+// Positions that are forbidden on game-stage-level conditions because
+// they would evaluate to a different result on each participant's client
+// — causing one participant to skip a stage while the other renders it.
+// Intro/exit steps are per-participant and have no such constraint.
+const GAME_STAGE_FORBIDDEN_POSITIONS = new Set([
+  "player",
+  "self", // not in the schema today but guard against future additions
+]);
+
+/**
+ * Apply cross-cutting rules to a list of conditions (stage-level or
+ * element-level). Adds zod issues for each violation found; called from
+ * stage/intro-exit superRefines so we can point issue paths at the
+ * condition's actual location in the parent object.
+ */
+function validateConditionRules(
+  conditions: unknown,
+  pathPrefix: (string | number)[],
+  ctx: z.RefinementCtx,
+  options: { contextLabel: string; forbidSelfPosition: boolean },
+): void {
+  if (!Array.isArray(conditions)) return;
+  conditions.forEach((rawCondition: unknown, idx: number) => {
+    if (!rawCondition || typeof rawCondition !== "object") return;
+    const c = rawCondition as {
+      position?: unknown;
+      comparator?: unknown;
+      value?: unknown;
+    };
+
+    // `percentAgreement` aggregates the referenced values and compares
+    // the agreement percentage against `value`. Non-numeric comparators
+    // (equals, includes, matches, …) silently produce wrong results.
+    if (
+      c.position === "percentAgreement" &&
+      typeof c.comparator === "string" &&
+      !PERCENT_AGREEMENT_NUMERIC_COMPARATORS.has(c.comparator)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [...pathPrefix, idx, "comparator"],
+        message: `position: percentAgreement requires a numeric comparator (isAbove, isBelow, isAtLeast, isAtMost) — got "${c.comparator}". The comparator is applied to the percentage of agreement, not the raw response.`,
+      });
+    }
+
+    // Game-stage conditions must evaluate identically on every client or
+    // they'll desync (one player skips, the other renders). The default
+    // position is "player", which reads this participant's own data — so
+    // we reject both missing and explicitly "player".
+    if (
+      options.forbidSelfPosition &&
+      (c.position === undefined ||
+        (typeof c.position === "string" &&
+          GAME_STAGE_FORBIDDEN_POSITIONS.has(c.position)))
+    ) {
+      const shown =
+        c.position === undefined
+          ? "(default: player)"
+          : `"${String(c.position)}"`;
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [...pathPrefix, idx, "position"],
+        message: `${options.contextLabel} conditions must use a cross-client position (shared, all, any, percentAgreement, or a numeric index) — got ${shown}. Per-player positions would let one participant skip the stage while the other renders it.`,
+      });
+    }
+  });
+}
+
 export const conditionsSchema = altTemplateContext(
   z
     .array(conditionSchema, {
@@ -1119,6 +1197,7 @@ export const stageSchema = altTemplateContext(
     .object({
       name: nameSchema,
       notes: z.string().optional(),
+      conditions: conditionsSchema.optional(),
       discussion: discussionSchema.optional(),
       duration: durationSchema.or(fieldPlaceholderSchema),
       elements: elementsSchema,
@@ -1134,8 +1213,29 @@ export const stageSchema = altTemplateContext(
         });
       }
 
+      // Stage-level conditions (#183): forbid per-player positions on
+      // game stages (would desync), validate percentAgreement threshold.
+      validateConditionRules(data.conditions, ["conditions"], ctx, {
+        contextLabel: "Game-stage",
+        forbidSelfPosition: true,
+      });
+
       if (!Array.isArray(data.elements)) return;
       const elements = data.elements as Record<string, unknown>[];
+
+      // Element-level conditions in game stages: elements render per
+      // player, so per-player positions are fine here. Only the
+      // percentAgreement-needs-numeric-comparator rule applies.
+      elements.forEach((element, elementIndex) => {
+        if (element && typeof element === "object") {
+          validateConditionRules(
+            (element as { conditions?: unknown }).conditions,
+            ["elements", elementIndex, "conditions"],
+            ctx,
+            { contextLabel: "Element", forbidSelfPosition: false },
+          );
+        }
+      });
 
       // Validate element time bounds against stage duration
       const duration = data.duration;
@@ -1235,9 +1335,34 @@ export const introExitStepSchema = altTemplateContext(
     .object({
       name: nameSchema,
       notes: z.string().optional(),
+      conditions: conditionsSchema.optional(),
       elements: elementsSchema,
     })
-    .strict(),
+    .strict()
+    .superRefine((data, ctx) => {
+      // Intro/exit steps are per-participant, so per-player positions
+      // are fine here — no desync concern. Just enforce the
+      // percentAgreement-needs-numeric-comparator rule on step-level
+      // and element-level conditions.
+      validateConditionRules(data.conditions, ["conditions"], ctx, {
+        contextLabel: "Intro/exit step",
+        forbidSelfPosition: false,
+      });
+      if (Array.isArray(data.elements)) {
+        (data.elements as Record<string, unknown>[]).forEach(
+          (element, elementIndex) => {
+            if (element && typeof element === "object") {
+              validateConditionRules(
+                (element as { conditions?: unknown }).conditions,
+                ["elements", elementIndex, "conditions"],
+                ctx,
+                { contextLabel: "Element", forbidSelfPosition: false },
+              );
+            }
+          },
+        );
+      }
+    }),
 );
 // Todo: add a superrefine that checks that no conditions have position values
 // and that no elements have showToPositions or hideFromPositions

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -1364,8 +1364,13 @@ export const introExitStepSchema = altTemplateContext(
       }
     }),
 );
-// Todo: add a superrefine that checks that no conditions have position values
-// and that no elements have showToPositions or hideFromPositions
+// Intro/exit step conditions intentionally allow any `position` value —
+// these steps are per-participant, so per-player positions don't desync.
+// The superRefine above still enforces the `percentAgreement → numeric
+// comparator` rule. The original TODO about position-value restriction
+// was superseded by #183; if we later want to forbid `showToPositions` /
+// `hideFromPositions` on intro/exit elements (they render for one
+// participant so those fields are no-ops), it belongs here.
 export type IntroExitStepType = z.infer<typeof introExitStepSchema>;
 
 export const introExitStepsBaseSchema = altTemplateContext(


### PR DESCRIPTION
Closes #183. Follow-up tracked in #194.

## Summary
Treatment files can now declare `conditions` on any stage, intro step, or exit step. When any condition is false, stagebook asks the host to advance — either **skip at load** (data comes from a prior stage) or **end mid-stage** (data from the current stage, typically paired with `comparator: doesNotExist`). Same code path for both behaviors; the difference is just where the data lives.

```yaml
# Skip round 2 unless everyone voted to continue
gameStages:
  - name: round2
    duration: 300
    conditions:
      - reference: survey.continueVote.result.keepGoing
        comparator: equals
        value: "yes"
        position: all
    elements: [...]
```

```yaml
# End a stage as soon as any player submits
gameStages:
  - name: speed_round
    duration: 120
    conditions:
      - reference: submitButton.speedSubmit
        comparator: doesNotExist
        position: all
    elements:
      - type: submitButton
        name: speedSubmit
```

## Changes

**Schema** — [`stageSchema`](packages/stagebook/src/schemas/treatment.ts) and `introExitStepSchema` now accept `conditions: conditionsSchema.optional()`.

**Preflight (local rules this PR)**
- **Game-stage position restriction.** Game stages must use cross-client positions (`shared`, `all`, `any`, `percentAgreement`, numeric index). Per-player positions (default / explicit `player`) would evaluate differently per client and desync the stage — rejected at preflight. Intro/exit steps are per-participant and permit any position.
- **`percentAgreement` requires a numeric comparator.** The comparator is applied to the *percentage of agreement*, so only `isAbove`/`isBelow`/`isAtLeast`/`isAtMost` make sense. Enforced at stage-level AND element-level (closes the existing gap noted in the issue).
- Cross-stage rules (forward-reference rejection, current-stage always-falsy) deferred to #194 — they need a full stage-ordering walker and are cleaner to ship separately.

**Context** — two optional fields on `StagebookContext`:
- `advanceStage?(): void` — called when stagebook decides the stage should end. Single-participant hosts wrap `submit()`; multi-participant hosts submit for every player (so dropouts don't hang the stage). Fallback: `submit()` + one-time dev warning.
- `stageId?: string` — opaque per-stage identifier. Lets stagebook auto-reset the internal advance latch between stages without key-remounts by the host.

**Runtime** — new [`StageConditionGate`](packages/stagebook/src/components/conditions/StageConditionGate.tsx) component. Uses the existing `evaluateConditions` helper (same three-valued `compare()`, same undefined-is-falsy semantics as element conditions). Fires `advanceStage` at most once per stage via a `useRef` latch that auto-resets when stage identity changes. Renders a `data-testid="stage-condition-gate"` `data-state="advancing"` overlay while the host transitions. Wired into both branches of `Stage.tsx`; zero overhead when `stage.conditions` is absent or empty.

**Viewer integration** — [`createViewerContext`](apps/viewer/src/lib/context.ts) passes `advanceStage` as a pass-through to `submit` and `stageId` as `stage-${stageIndex}`. [`flattenSteps`](apps/viewer/src/lib/steps.ts) and `ViewerStep` carry `conditions` through intro/game/exit sources.

**Docs**
- [`conditions.md`](docs/researcher/conditions.md): new "Stage-level conditions" section with skip + early-termination examples, the position-rules table, and the `percentAgreement` numeric-comparator rule.
- [`platform-requirements.md`](docs/engineer/platform-requirements.md): new subsection with single/multi-participant integration patterns and a stagebook-vs-host responsibility table.

## Tests
- Unit (8 new) — game-stage position rule, intro/exit any-position acceptance, `percentAgreement` across stage/element/intro levels.
- CT (5 new, [StageConditionGate.ct.tsx](packages/stagebook/src/components/conditions/StageConditionGate.ct.tsx)) — body renders when conditions pass; advancing state when they fail; skip-at-load for absent data; early-termination pattern; no gate overhead without conditions.

## Test plan
- [x] `npm test` — 615 stagebook (was 607) + 75 viewer + 187 vscode all green.
- [x] `npm run test:ct -w stagebook` — 360 CT pass (was 355).
- [x] `npm run lint` + `format:check` clean.
- [x] Viewer builds cleanly.