### PR TITLE
Release v0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13682,7 +13682,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.5.1",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Bumps \`stagebook\` to \`0.6.0\`. Release notes below will be reused for the GitHub release after merge.

---

## What's new

### Stage-level conditions (#183)
Treatment files can now declare \`conditions\` on any stage, intro step, or exit step. Mental model: _this stage should be active while these conditions hold._ When any condition fails, stagebook asks the host to advance — either skipping the stage at mount (if the data comes from a prior stage) or ending it mid-stage (if the condition references current-stage data, typically paired with \`comparator: doesNotExist\`). Same code path for both behaviors.

Two optional fields on \`StagebookContext\` to support this:
- \`advanceStage?(): void\` — called by stagebook when conditions fail. Single-participant hosts wrap \`submit()\`; multi-participant hosts submit for every player so dropouts can't hang the stage. Falls back to \`submit()\` with a one-time dev message if unimplemented.
- \`stageId?: string\` — identity key stagebook uses to reset its advance latch between stages.

Local preflight enforces:
- Game-stage conditions must use cross-client positions (\`shared\` / \`all\` / \`any\` / \`percentAgreement\` / numeric index) — per-player positions would desync the stage.
- \`percentAgreement\` requires a numeric comparator (\`isAbove\` / \`isBelow\` / \`isAtLeast\` / \`isAtMost\`) at both stage and element level.

### Cross-stage reference validation (#197)
Every reference site in the DSL now goes through a preflight walker at \`treatmentFileSchema\` level. Two rules:

- **No forward references** (all reference sites: stage/element conditions, \`display.reference\`, trackedLink/qualtrics urlParams, discussion conditions, groupComposition). A reference to data produced by a later stage is rejected with a message naming the offending target. \`groupComposition\` is stricter — it runs before any stage, so only intro-phase or external references are allowed.
- **No always-skip-at-load** (stage-level conditions only). A stage-level condition referencing its own stage's data must have a comparator that's true against \`undefined\` (typically \`doesNotExist\`) — otherwise the stage always skips at mount. The same current-stage reference in an element/display/urlParam is accepted because "wait for data to arrive" is the standard pattern there.

External references (\`urlParams.*\`, \`participantInfo.*\`, \`connectionInfo.*\`, \`browserInfo.*\`) are always valid.

Issues emit zod diagnostics whose \`path\` ends at the specific \`reference\` field, so the VS Code extension underlines the bad reference with a red squiggle — no extension-side changes needed.

### \`asset://\` URI scheme for platform-provided media (#188)
A third way to reference media, alongside relative paths and \`http(s)\` URLs. \`asset://path/to/file\` means _the host resolves this_ — stagebook passes the URI through \`getAssetURL()\` and each platform implements its own resolution (S3 presigned URL, local file server, CDN). \`getReferencedAssets\` excludes \`asset://\` paths so they aren't misclassified as repo files.

Use it for sensitive recordings, large binaries kept out of version control, or swappable per-study assets. Docs in \`treatment-files.md\` include a decision table covering all four reference forms (relative path, full URL, \`asset://\`, \`\${field}\`).

Supersedes #185.

### Preflight: timeline \`source\` must name a sibling mediaPlayer (#189)
A typo like \`source: practiceStoryy\` for a mediaPlayer named \`practiceStory\` previously passed validation cleanly and only surfaced at runtime as a "source player not found" error box. Preflight now validates that every timeline's \`source\` matches a mediaPlayer \`name\` in the same stage, with an error message that names the bad source and lists the available mediaPlayers.

## Bug fixes
- \`urlSchema\` now requires the hierarchical \`scheme://\` form — opaque variants like \`https:example.com\` or \`asset:clip.mp4\` are rejected.
- \`urlSchema\` rejects \`https://\` / \`http://\` with an empty host.
- \`getReferencedAssets\` excludes malformed \`asset:\` forms (any \`asset:\` prefix).
- \`flattenSteps\` propagates \`conditions\` through exit steps (missed in the initial #183 commit, fixed via Copilot review).

## Host integration
Full host-integration contract for stage-level conditions is in [docs/engineer/platform-requirements.md](docs/engineer/platform-requirements.md) — includes the single/multi-participant patterns, the force-submit-for-dropouts recommendation, and the stagebook-vs-host responsibility table.

## Test plan
- [x] Full local suite green: 636 stagebook + 75 viewer + 189 vscode unit tests, 360 Playwright CT.
- [x] Lint + format clean.
- [ ] After merge, tag \`v0.6.0\` and publish the GitHub release — [\`npm-publish.yml\`](.github/workflows/npm-publish.yml) picks up the \`release: published\` event automatically.