### PR TITLE
Preflight: reject forward references across the treatment DSL (#197)

### DIFF
--- a/docs/researcher/conditions.md
+++ b/docs/researcher/conditions.md
@@ -356,3 +356,41 @@ Stage-level conditions rely on two fields on `StagebookContext`:
 - `stageId` — opaque per-stage identifier. Lets stagebook reset its internal latch cleanly between stages without a key-remount by the host.
 
 See [platform-requirements.md](../engineer/platform-requirements.md) for the full host-integration checklist.
+
+## Preflight reference validation
+
+References (in conditions, `display.reference`, `trackedLink` / `qualtrics` `urlParams`, discussion conditions, and `groupComposition` conditions) are checked at preflight. Two rules, the second of which is stage-condition-specific:
+
+### No forward references — everywhere
+
+A reference must point at data produced by an earlier or the current stage in the flow:
+
+```
+introSteps → gameStages → exitSequence
+```
+
+Referencing a stage that hasn't run yet is rejected. External references (`urlParams.*`, `participantInfo.*`, `connectionInfo.*`, `browserInfo.*`) are always valid — they come from the platform, not a stage.
+
+`groupComposition` is stricter: it runs before the game starts, so its conditions can only reference intro-phase or external data. Referencing game or exit data from `groupComposition` is rejected.
+
+### No always-skip-at-load — stage-level conditions only
+
+A stage-level condition that references its *own* stage's data (early-termination pattern) must be authored so `compare(undefined, comparator, value) === true` — otherwise the stage evaluates false at mount and always skips itself, which is almost always a forgotten `doesNotExist`.
+
+OK:
+```yaml
+conditions:
+  - reference: submitButton.speedSubmit
+    comparator: doesNotExist   # true against undefined → stage renders
+    position: all
+```
+
+Rejected at preflight:
+```yaml
+conditions:
+  - reference: submitButton.speedSubmit
+    comparator: exists         # false against undefined → always skips
+    position: all
+```
+
+This rule only applies to stage-level conditions. Element-level conditions, `display.reference`, `urlParams`, and discussion conditions all have "wait for data to arrive" semantics where false-at-load is the standard pattern (e.g., a submit button that appears only after the prompt is answered).

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument */
 import { z } from "zod";
 import type { ZodIssue } from "zod";
+import { validateTreatmentFileReferences } from "./validateReferences.js";
 
 // TODO: used by regex validation in conditionMatchesSchema — wire up or remove
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -1953,12 +1954,25 @@ export function matchContentType(contentType: string) {
 export type TemplateType = z.infer<typeof templateSchema>;
 
 // ------------------ Treatment File ------------------ //
-export const treatmentFileSchema = z.object({
-  templates: z
-    .array(templateSchema)
-    .min(1, "Templates cannot be empty")
-    .optional(),
-  introSequences: introSequencesSchema,
-  treatments: treatmentsSchema,
-});
+export const treatmentFileSchema = z
+  .object({
+    templates: z
+      .array(templateSchema)
+      .min(1, "Templates cannot be empty")
+      .optional(),
+    introSequences: introSequencesSchema,
+    treatments: treatmentsSchema,
+  })
+  .superRefine((data, ctx) => {
+    // Cross-stage reference validation (#197): forward-reference rejection
+    // + stage-level always-skip-at-load detection. Walker lives in its
+    // own module to keep this file focused.
+    for (const issue of validateTreatmentFileReferences(data)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: issue.path,
+        message: issue.message,
+      });
+    }
+  });
 export type TreatmentFileType = z.infer<typeof treatmentFileSchema>;

--- a/packages/stagebook/src/schemas/validateReferences.test.ts
+++ b/packages/stagebook/src/schemas/validateReferences.test.ts
@@ -396,6 +396,114 @@ describe("Rule 1 — no forward references", () => {
     expect(issues.length).toBe(0);
   });
 
+  test("intro-step condition referencing game-stage data → rejected (cross-phase forward)", () => {
+    // Intro always runs before game, so a reference FROM intro TO game is
+    // always falsy at runtime. Caught via the laterPhaseKeys set.
+    const file = baseFile({
+      introSteps: [
+        {
+          name: "welcome",
+          conditions: [
+            {
+              reference: "prompt.gameAnswer",
+              comparator: "equals",
+              value: "yes",
+            },
+          ],
+          elements: [{ type: "submitButton" }],
+        },
+      ],
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          elements: [
+            { type: "prompt", name: "gameAnswer", file: "g.prompt.md" },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    const hit = issues.find(
+      (i) =>
+        i.path.join(".") ===
+          "introSequences.0.introSteps.0.conditions.0.reference" &&
+        /later phase/i.test(i.message),
+    );
+    expect(hit).toBeDefined();
+  });
+
+  test("intro-step display.reference targeting game-stage data → rejected", () => {
+    const file = baseFile({
+      introSteps: [
+        {
+          name: "welcome",
+          elements: [
+            { type: "display", reference: "prompt.gameAnswer" },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          elements: [
+            { type: "prompt", name: "gameAnswer", file: "g.prompt.md" },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    const hit = issues.find(
+      (i) =>
+        i.path.join(".") ===
+          "introSequences.0.introSteps.0.elements.0.reference" &&
+        /later phase/i.test(i.message),
+    );
+    expect(hit).toBeDefined();
+  });
+
+  test("survey produces a storage key from surveyName when name is absent", () => {
+    // Element.tsx derives the storage key as
+    // `survey_${element.name ?? element.surveyName}`. The walker has to
+    // match, otherwise forward references to `survey.<surveyName>` slip
+    // through when authors omit the optional `name`.
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          elements: [
+            {
+              type: "display",
+              reference: "survey.MySurvey.result.answer",
+            },
+            { type: "submitButton" },
+          ],
+        },
+        {
+          name: "s2",
+          duration: 60,
+          elements: [
+            // no `name:` — storage key derives from surveyName
+            { type: "survey", surveyName: "MySurvey" },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    const hit = issues.find(
+      (i) =>
+        i.path.join(".") === "treatments.0.gameStages.0.elements.0.reference" &&
+        /later/i.test(i.message),
+    );
+    expect(hit).toBeDefined();
+  });
+
   test("external references (urlParams.x, participantInfo.x) accepted at every site", () => {
     const file = baseFile({
       gameStages: [

--- a/packages/stagebook/src/schemas/validateReferences.test.ts
+++ b/packages/stagebook/src/schemas/validateReferences.test.ts
@@ -1,0 +1,692 @@
+import { describe, expect, test } from "vitest";
+import { treatmentFileSchema } from "./treatment.js";
+import { validateTreatmentFileReferences } from "./validateReferences.js";
+
+// Helpers — build minimal-valid treatment files with targeted modifications.
+// We use the full treatmentFileSchema in some tests to confirm that issues
+// surface through the schema's superRefine (i.e. they'd cause red squiggles
+// in the VS Code extension), and call the walker directly in others to
+// avoid noise from other schema rules.
+
+interface StageConfig {
+  name: string;
+  duration?: number;
+  conditions?: Record<string, unknown>[];
+  elements: Record<string, unknown>[];
+}
+
+function baseFile(opts: {
+  introSteps?: StageConfig[];
+  gameStages?: StageConfig[];
+  exitSequence?: StageConfig[];
+  groupComposition?: Record<string, unknown>[];
+}): Record<string, unknown> {
+  return {
+    introSequences: [
+      {
+        name: "seq",
+        introSteps: opts.introSteps ?? [
+          { name: "welcome", elements: [{ type: "submitButton" }] },
+        ],
+      },
+    ],
+    treatments: [
+      {
+        name: "t",
+        playerCount: 2,
+        gameStages: opts.gameStages ?? [
+          {
+            name: "s1",
+            duration: 60,
+            elements: [{ type: "submitButton" }],
+          },
+        ],
+        ...(opts.exitSequence ? { exitSequence: opts.exitSequence } : {}),
+        ...(opts.groupComposition
+          ? { groupComposition: opts.groupComposition }
+          : {}),
+      },
+    ],
+  };
+}
+
+function pickForwardRefIssue(
+  issues: { path: (string | number)[]; message: string }[],
+  pathSuffix: string,
+) {
+  return issues.find(
+    (i) => i.path.join(".").endsWith(pathSuffix) && /later/i.test(i.message),
+  );
+}
+
+function pickAlwaysSkipIssue(
+  issues: { path: (string | number)[]; message: string }[],
+  pathSuffix: string,
+) {
+  return issues.find(
+    (i) =>
+      i.path.join(".").endsWith(pathSuffix) &&
+      /always skip the stage at load/i.test(i.message),
+  );
+}
+
+describe("Rule 1 — no forward references", () => {
+  test("stage-level condition referencing a future stage → rejected", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          conditions: [
+            {
+              reference: "prompt.laterAnswer",
+              comparator: "equals",
+              value: "yes",
+              position: "all",
+            },
+          ],
+          elements: [{ type: "submitButton" }],
+        },
+        {
+          name: "s2",
+          duration: 60,
+          elements: [
+            {
+              type: "prompt",
+              name: "laterAnswer",
+              file: "p.prompt.md",
+            },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(
+      pickForwardRefIssue(
+        issues,
+        "treatments.0.gameStages.0.conditions.0.reference",
+      ),
+    ).toBeDefined();
+  });
+
+  test("element-level condition referencing a future stage → rejected", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          elements: [
+            {
+              type: "submitButton",
+              conditions: [
+                {
+                  reference: "prompt.laterAnswer",
+                  comparator: "equals",
+                  value: "yes",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: "s2",
+          duration: 60,
+          elements: [
+            {
+              type: "prompt",
+              name: "laterAnswer",
+              file: "p.prompt.md",
+            },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(
+      pickForwardRefIssue(
+        issues,
+        "treatments.0.gameStages.0.elements.0.conditions.0.reference",
+      ),
+    ).toBeDefined();
+  });
+
+  test("display element.reference pointing at a later stage → rejected", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          elements: [
+            { type: "display", reference: "prompt.laterAnswer" },
+            { type: "submitButton" },
+          ],
+        },
+        {
+          name: "s2",
+          duration: 60,
+          elements: [
+            {
+              type: "prompt",
+              name: "laterAnswer",
+              file: "p.prompt.md",
+            },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(
+      pickForwardRefIssue(
+        issues,
+        "treatments.0.gameStages.0.elements.0.reference",
+      ),
+    ).toBeDefined();
+  });
+
+  test("trackedLink urlParams[i].reference pointing at a later stage → rejected", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          elements: [
+            {
+              type: "trackedLink",
+              name: "signup",
+              url: "https://example.org",
+              displayText: "Go",
+              urlParams: [{ key: "answer", reference: "prompt.laterAnswer" }],
+            },
+          ],
+        },
+        {
+          name: "s2",
+          duration: 60,
+          elements: [
+            {
+              type: "prompt",
+              name: "laterAnswer",
+              file: "p.prompt.md",
+            },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(
+      pickForwardRefIssue(
+        issues,
+        "treatments.0.gameStages.0.elements.0.urlParams.0.reference",
+      ),
+    ).toBeDefined();
+  });
+
+  test("qualtrics urlParams[i].reference pointing at a later stage → rejected", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          elements: [
+            {
+              type: "qualtrics",
+              url: "https://upenn.qualtrics.com/jfe/form/SV_x",
+              urlParams: [{ key: "x", reference: "prompt.laterAnswer" }],
+            },
+          ],
+        },
+        {
+          name: "s2",
+          duration: 60,
+          elements: [
+            {
+              type: "prompt",
+              name: "laterAnswer",
+              file: "p.prompt.md",
+            },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(
+      pickForwardRefIssue(
+        issues,
+        "treatments.0.gameStages.0.elements.0.urlParams.0.reference",
+      ),
+    ).toBeDefined();
+  });
+
+  test("discussion.conditions[i].reference pointing at a later stage → rejected", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          discussion: {
+            chatType: "text",
+            showNickname: true,
+            showTitle: false,
+            conditions: [
+              {
+                reference: "prompt.laterAnswer",
+                comparator: "equals",
+                value: "yes",
+                position: "all",
+              },
+            ],
+          },
+          elements: [{ type: "submitButton" }],
+        },
+        {
+          name: "s2",
+          duration: 60,
+          elements: [
+            {
+              type: "prompt",
+              name: "laterAnswer",
+              file: "p.prompt.md",
+            },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    } as never);
+    const issues = validateTreatmentFileReferences(file);
+    expect(
+      pickForwardRefIssue(
+        issues,
+        "treatments.0.gameStages.0.discussion.conditions.0.reference",
+      ),
+    ).toBeDefined();
+  });
+
+  test("groupComposition condition referencing game-stage data → rejected (stricter)", () => {
+    const file = baseFile({
+      groupComposition: [
+        {
+          position: 0,
+          title: "Confederate",
+          conditions: [
+            {
+              reference: "prompt.gameStageAnswer",
+              comparator: "equals",
+              value: "yes",
+            },
+          ],
+        },
+        {
+          position: 1,
+          title: "Participant",
+          conditions: [
+            {
+              reference: "prompt.gameStageAnswer",
+              comparator: "doesNotEqual",
+              value: "yes",
+            },
+          ],
+        },
+      ],
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          elements: [
+            {
+              type: "prompt",
+              name: "gameStageAnswer",
+              file: "q.prompt.md",
+            },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    const hits = issues.filter((i) => /groupComposition/i.test(i.message));
+    expect(hits.length).toBe(2);
+  });
+
+  test("groupComposition condition referencing intro data → accepted", () => {
+    const file = baseFile({
+      introSteps: [
+        {
+          name: "survey_step",
+          elements: [
+            {
+              type: "prompt",
+              name: "partyAffiliation",
+              file: "pa.prompt.md",
+            },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+      groupComposition: [
+        {
+          position: 0,
+          title: "D",
+          conditions: [
+            {
+              reference: "prompt.partyAffiliation",
+              comparator: "equals",
+              value: "democrat",
+            },
+          ],
+        },
+        {
+          position: 1,
+          title: "R",
+          conditions: [
+            {
+              reference: "prompt.partyAffiliation",
+              comparator: "equals",
+              value: "republican",
+            },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(issues.length).toBe(0);
+  });
+
+  test("external references (urlParams.x, participantInfo.x) accepted at every site", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          conditions: [
+            {
+              reference: "urlParams.cohort",
+              comparator: "equals",
+              value: "a",
+              position: "all",
+            },
+          ],
+          elements: [
+            {
+              type: "display",
+              reference: "participantInfo.playerId",
+            },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(issues.length).toBe(0);
+  });
+
+  test("earlier-stage reference accepted", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          elements: [
+            { type: "prompt", name: "early", file: "e.prompt.md" },
+            { type: "submitButton" },
+          ],
+        },
+        {
+          name: "s2",
+          duration: 60,
+          conditions: [
+            {
+              reference: "prompt.early",
+              comparator: "equals",
+              value: "yes",
+              position: "all",
+            },
+          ],
+          elements: [{ type: "submitButton" }],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(issues.length).toBe(0);
+  });
+
+  test("exit-stage reference to game-stage data accepted", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          elements: [
+            { type: "prompt", name: "main", file: "m.prompt.md" },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+      exitSequence: [
+        {
+          name: "debrief",
+          conditions: [
+            {
+              reference: "prompt.main",
+              comparator: "equals",
+              value: "yes",
+              position: "all",
+            },
+          ],
+          elements: [{ type: "submitButton" }],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(issues.length).toBe(0);
+  });
+});
+
+describe("Rule 2 — stage-level always-skip-at-load (current-stage refs only)", () => {
+  test("stage-level condition `doesNotExist` on current-stage ref → accepted", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "speed_round",
+          duration: 60,
+          conditions: [
+            {
+              reference: "submitButton.speedSubmit",
+              comparator: "doesNotExist",
+              position: "all",
+            },
+          ],
+          elements: [{ type: "submitButton", name: "speedSubmit" }],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(issues.length).toBe(0);
+  });
+
+  test("stage-level condition `exists` on current-stage ref → rejected (always skip)", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "gated",
+          duration: 60,
+          conditions: [
+            {
+              reference: "submitButton.s",
+              comparator: "exists",
+              position: "all",
+            },
+          ],
+          elements: [{ type: "submitButton", name: "s" }],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(
+      pickAlwaysSkipIssue(
+        issues,
+        "treatments.0.gameStages.0.conditions.0.reference",
+      ),
+    ).toBeDefined();
+  });
+
+  test("stage-level condition `equals` on current-stage ref → rejected", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "gated",
+          duration: 60,
+          conditions: [
+            {
+              reference: "prompt.currentAnswer",
+              comparator: "equals",
+              value: "yes",
+              position: "all",
+            },
+          ],
+          elements: [
+            {
+              type: "prompt",
+              name: "currentAnswer",
+              file: "c.prompt.md",
+            },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(
+      pickAlwaysSkipIssue(
+        issues,
+        "treatments.0.gameStages.0.conditions.0.reference",
+      ),
+    ).toBeDefined();
+  });
+
+  test("element-level condition `equals` on current-stage ref → accepted (gating pattern)", () => {
+    // Submit button appears only after the prompt is answered — the
+    // exact pattern the always-skip rule must NOT reject at element level.
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s",
+          duration: 60,
+          elements: [
+            {
+              type: "prompt",
+              name: "currentAnswer",
+              file: "c.prompt.md",
+            },
+            {
+              type: "submitButton",
+              conditions: [
+                {
+                  reference: "prompt.currentAnswer",
+                  comparator: "equals",
+                  value: "yes",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(issues.length).toBe(0);
+  });
+
+  test("display.reference to current-stage data → accepted (shows when data arrives)", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s",
+          duration: 60,
+          elements: [
+            {
+              type: "prompt",
+              name: "currentAnswer",
+              file: "c.prompt.md",
+            },
+            { type: "display", reference: "prompt.currentAnswer" },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(issues.length).toBe(0);
+  });
+
+  test("urlParams with current-stage reference → accepted", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s",
+          duration: 60,
+          elements: [
+            {
+              type: "prompt",
+              name: "currentAnswer",
+              file: "c.prompt.md",
+            },
+            {
+              type: "trackedLink",
+              name: "link",
+              url: "https://example.org",
+              displayText: "Go",
+              urlParams: [{ key: "a", reference: "prompt.currentAnswer" }],
+            },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(issues.length).toBe(0);
+  });
+});
+
+describe("treatmentFileSchema surfaces walker issues via superRefine (red-squiggle path)", () => {
+  test("forward reference produces a zod issue whose path targets the reference", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          conditions: [
+            {
+              reference: "prompt.later",
+              comparator: "equals",
+              value: "yes",
+              position: "all",
+            },
+          ],
+          elements: [{ type: "submitButton" }],
+        },
+        {
+          name: "s2",
+          duration: 60,
+          elements: [
+            { type: "prompt", name: "later", file: "p.prompt.md" },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const result = treatmentFileSchema.safeParse(file);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const hit = result.error.issues.find(
+        (i) =>
+          i.path.join(".") ===
+            "treatments.0.gameStages.0.conditions.0.reference" &&
+          /later/i.test(i.message),
+      );
+      expect(hit).toBeDefined();
+    }
+  });
+});

--- a/packages/stagebook/src/schemas/validateReferences.ts
+++ b/packages/stagebook/src/schemas/validateReferences.ts
@@ -71,9 +71,28 @@ export function validateTreatmentFileReferences(
   const issues: ReferenceValidationIssue[] = [];
   if (!isRecord(treatmentFile)) return issues;
 
-  // Intro sequences: validate each sequence in isolation for within-sequence
-  // forward references and stage-level always-skip.
   const introSequences = toArray(treatmentFile.introSequences);
+  const treatments = toArray(treatmentFile.treatments);
+
+  // Build the set of keys produced by any game stage or exit step across
+  // all treatments. Intro-step references to any of these are forward
+  // references (intro always runs before game/exit). Passed to
+  // validateStepSequence so intro validation catches the cross-phase case
+  // even though intros don't otherwise know about game/exit data.
+  const laterPhaseKeys = new Set<string>();
+  for (const treatment of treatments) {
+    if (!isRecord(treatment)) continue;
+    for (const stage of toArray(treatment.gameStages)) {
+      for (const key of collectStepKeys(stage)) laterPhaseKeys.add(key);
+    }
+    for (const step of toArray(treatment.exitSequence)) {
+      for (const key of collectStepKeys(step)) laterPhaseKeys.add(key);
+    }
+  }
+
+  // Intro sequences: validate each sequence in isolation for within-sequence
+  // forward references, cross-phase forward references into game/exit, and
+  // stage-level always-skip.
   introSequences.forEach((seq, seqIdx) => {
     if (!isRecord(seq)) return;
     const steps = toArray(seq.introSteps);
@@ -82,6 +101,7 @@ export function validateTreatmentFileReferences(
       sequencePath: ["introSequences", seqIdx, "introSteps"],
       phase: "intro",
       issues,
+      laterPhaseKeys,
     });
   });
 
@@ -96,7 +116,6 @@ export function validateTreatmentFileReferences(
   }
 
   // Each treatment has its own game/exit rank space.
-  const treatments = toArray(treatmentFile.treatments);
   treatments.forEach((treatment, treatmentIdx) => {
     if (!isRecord(treatment)) return;
     validateTreatment({
@@ -122,6 +141,7 @@ function validateStepSequence({
   phase,
   issues,
   priorPhaseKeys,
+  laterPhaseKeys,
 }: {
   steps: unknown[];
   sequencePath: (string | number)[];
@@ -129,6 +149,9 @@ function validateStepSequence({
   issues: ReferenceValidationIssue[];
   /** Keys produced by earlier phases (for exit sequences: intro + game). */
   priorPhaseKeys?: Set<string>;
+  /** Keys produced by later phases. Any intro-step reference to one of
+   *  these is a cross-phase forward reference. */
+  laterPhaseKeys?: Set<string>;
 }): void {
   // Build producedAt: key → earliest step index that produces it.
   const producedAt = new Map<string, number>();
@@ -148,6 +171,7 @@ function validateStepSequence({
         producedAt,
         issues,
         priorPhaseKeys,
+        laterPhaseKeys,
         phaseLabel: phase === "intro" ? "intro step" : "exit step",
       });
     }
@@ -383,6 +407,7 @@ function applyRules({
   producedAt,
   issues,
   priorPhaseKeys,
+  laterPhaseKeys,
   allowedProducerRanks,
   phaseLabel,
 }: {
@@ -393,6 +418,9 @@ function applyRules({
   /** For exit-phase walkers: keys produced by earlier phases that aren't
    *  in the exit-local producedAt map. */
   priorPhaseKeys?: Set<string>;
+  /** For intro-phase walkers: keys produced by later phases. Any target in
+   *  this set is a cross-phase forward reference. */
+  laterPhaseKeys?: Set<string>;
   /** For groupComposition: a whitelist of producer ranks that the target
    *  key must live in. Anything else (or a non-whitelisted stage-produced
    *  target) is rejected. */
@@ -420,7 +448,18 @@ function applyRules({
   const producerRank =
     producedAt.get(referenceKey) ??
     (priorPhaseKeys?.has(referenceKey) ? RANK_INTRO : undefined);
-  if (producerRank === undefined) return;
+  if (producerRank === undefined) {
+    // Cross-phase forward reference: intro-step site referencing a key
+    // produced by any later phase (game / exit) across treatments.
+    if (laterPhaseKeys?.has(referenceKey)) {
+      const phase = phaseLabel ?? "stage";
+      issues.push({
+        path: site.path,
+        message: `Reference "${site.reference}" points at data produced by a later phase (game or exit) than this ${phase}. Forward references across phases are always falsy at runtime — move the reference or reorder the flow.`,
+      });
+    }
+    return;
+  }
 
   // groupComposition: target must be in the allowed-rank whitelist.
   if (allowedProducerRanks && !allowedProducerRanks.has(producerRank)) {
@@ -493,14 +532,29 @@ function collectProducedKeys(element: unknown, acc: Set<string>): void {
   if (!isRecord(element)) return;
   const type = element.type;
   const name = element.name;
-  if (typeof type !== "string" || typeof name !== "string") return;
+  if (typeof type !== "string") return;
+  // Survey elements fall back to `surveyName` when `name` is absent —
+  // mirrors the runtime storage-key derivation in Element.tsx:
+  // `survey_${element.name ?? element.surveyName}`. Without this fallback,
+  // a reference to `survey.<surveyName>` (common when authors omit `name`)
+  // would silently escape the forward-ref check.
+  if (type === "survey") {
+    const keyName =
+      typeof name === "string"
+        ? name
+        : typeof element.surveyName === "string"
+          ? element.surveyName
+          : undefined;
+    if (keyName !== undefined) acc.add(`survey_${keyName}`);
+    return;
+  }
   if (
-    type === "prompt" ||
-    type === "survey" ||
-    type === "submitButton" ||
-    type === "qualtrics" ||
-    type === "timeline" ||
-    type === "trackedLink"
+    typeof name === "string" &&
+    (type === "prompt" ||
+      type === "submitButton" ||
+      type === "qualtrics" ||
+      type === "timeline" ||
+      type === "trackedLink")
   ) {
     acc.add(`${type}_${name}`);
   }

--- a/packages/stagebook/src/schemas/validateReferences.ts
+++ b/packages/stagebook/src/schemas/validateReferences.ts
@@ -1,0 +1,526 @@
+/**
+ * Cross-stage reference validation for treatment files (#197).
+ *
+ * Two rules:
+ * 1. **No forward references** — applies to every reference site. A reference
+ *    whose target storage key is produced by a *later* stage in the flow is
+ *    rejected. External references (urlParams, participantInfo, …) are
+ *    always valid.
+ * 2. **No always-skip-at-load** — stage-level conditions only. A stage-level
+ *    condition whose reference points at the *current* stage's data and
+ *    whose `compare(undefined, comparator, value)` is not strictly `true`
+ *    will always skip the stage at mount. Rejected with a suggestion to
+ *    rethink the comparator (usually a forgotten `doesNotExist`).
+ *
+ * Only stage-level conditions get Rule 2 because element-level, display,
+ * urlParam, discussion, and groupComposition references all have a
+ * well-defined "wait for data" semantics: element not rendered, display
+ * empty, urlParam omitted, discussion hidden, no player match. None of
+ * those are fatal the way a stage-level always-skip is.
+ */
+
+import { getReferenceKeyAndPath } from "../utils/reference.js";
+import { compare, type Comparator } from "../utils/compare.js";
+
+/** Structured issue emitted by the walker. Translated to zod issues by the
+ *  caller. `path` is relative to the top-level treatment file. */
+export interface ReferenceValidationIssue {
+  path: (string | number)[];
+  message: string;
+}
+
+/** Discriminator for which rules apply at a given reference site. */
+type ReferenceKind =
+  | "stageCondition"
+  | "elementCondition"
+  | "displayReference"
+  | "urlParam"
+  | "discussionCondition"
+  | "groupComposition";
+
+/** Ranks for the linear "who runs first" order within a single treatment.
+ *  groupComposition < intro < gameStage[0] < … < gameStage[n] < exit[0] …
+ *  Intro is collapsed to a single rank because intro sequences are
+ *  interchangeable (a treatment can pair with any of them at runtime).
+ *  Within-intro-sequence ordering is validated separately per sequence. */
+const RANK_GROUP_COMPOSITION = -1;
+const RANK_INTRO = 0;
+const RANK_GAME_BASE = 1;
+
+/** The types of reference whose target keys are **produced by a stage**. A
+ *  reference of any other type (urlParams, participantInfo, …) is external
+ *  and always valid regardless of position. */
+const STAGE_PRODUCED_REF_TYPES = new Set([
+  "prompt",
+  "survey",
+  "submitButton",
+  "qualtrics",
+  "timeline",
+  "trackedLink",
+  "discussion",
+]);
+
+/**
+ * Main entrypoint — given a parsed treatment-file tree, walks every reference
+ * site and returns validation issues. Accepts `unknown` because the walker
+ * runs pre-validation (zod `superRefine`'s input is partially-valid).
+ */
+export function validateTreatmentFileReferences(
+  treatmentFile: unknown,
+): ReferenceValidationIssue[] {
+  const issues: ReferenceValidationIssue[] = [];
+  if (!isRecord(treatmentFile)) return issues;
+
+  // Intro sequences: validate each sequence in isolation for within-sequence
+  // forward references and stage-level always-skip.
+  const introSequences = toArray(treatmentFile.introSequences);
+  introSequences.forEach((seq, seqIdx) => {
+    if (!isRecord(seq)) return;
+    const steps = toArray(seq.introSteps);
+    validateStepSequence({
+      steps,
+      sequencePath: ["introSequences", seqIdx, "introSteps"],
+      phase: "intro",
+      issues,
+    });
+  });
+
+  // Intro-phase produced keys — merged across every intro sequence. Game
+  // stages and exit steps are allowed to reference any intro-phase key.
+  const introProducedKeys = new Set<string>();
+  for (const seq of introSequences) {
+    if (!isRecord(seq)) continue;
+    for (const step of toArray(seq.introSteps)) {
+      collectProducedKeys(step, introProducedKeys);
+    }
+  }
+
+  // Each treatment has its own game/exit rank space.
+  const treatments = toArray(treatmentFile.treatments);
+  treatments.forEach((treatment, treatmentIdx) => {
+    if (!isRecord(treatment)) return;
+    validateTreatment({
+      treatment,
+      treatmentPath: ["treatments", treatmentIdx],
+      introProducedKeys,
+      issues,
+    });
+  });
+
+  return issues;
+}
+
+// ---------------------------------------------------------------------------
+// Per-sequence (intro or exit) and per-treatment walkers
+// ---------------------------------------------------------------------------
+
+/** Validate a linear sequence of steps (intro sequence). Each step has its
+ *  own rank within the sequence; later steps can reference earlier steps. */
+function validateStepSequence({
+  steps,
+  sequencePath,
+  phase,
+  issues,
+  priorPhaseKeys,
+}: {
+  steps: unknown[];
+  sequencePath: (string | number)[];
+  phase: "intro" | "exit";
+  issues: ReferenceValidationIssue[];
+  /** Keys produced by earlier phases (for exit sequences: intro + game). */
+  priorPhaseKeys?: Set<string>;
+}): void {
+  // Build producedAt: key → earliest step index that produces it.
+  const producedAt = new Map<string, number>();
+  steps.forEach((step, stepIdx) => {
+    for (const key of collectStepKeys(step)) {
+      if (!producedAt.has(key)) producedAt.set(key, stepIdx);
+    }
+  });
+
+  steps.forEach((step, stepIdx) => {
+    if (!isRecord(step)) return;
+    const sites = enumerateStepSites(step, [...sequencePath, stepIdx]);
+    for (const site of sites) {
+      applyRules({
+        site,
+        enclosingRank: stepIdx,
+        producedAt,
+        issues,
+        priorPhaseKeys,
+        phaseLabel: phase === "intro" ? "intro step" : "exit step",
+      });
+    }
+  });
+}
+
+function validateTreatment({
+  treatment,
+  treatmentPath,
+  introProducedKeys,
+  issues,
+}: {
+  treatment: Record<string, unknown>;
+  treatmentPath: (string | number)[];
+  introProducedKeys: Set<string>;
+  issues: ReferenceValidationIssue[];
+}): void {
+  const gameStages = toArray(treatment.gameStages);
+  const exitSequence = toArray(treatment.exitSequence);
+
+  // Per-treatment ranks: game stages 1..K, exit entries K+1…. Intro sits
+  // at a single virtual rank (RANK_INTRO) before game stages; its produced
+  // keys are in `introProducedKeys` and treated as "always earlier."
+  const producedAt = new Map<string, number>();
+  // Pre-seed intro keys at RANK_INTRO so forward comparisons always place
+  // them before any game/exit rank.
+  for (const key of introProducedKeys) {
+    if (!producedAt.has(key)) producedAt.set(key, RANK_INTRO);
+  }
+  gameStages.forEach((stage, idx) => {
+    for (const key of collectStepKeys(stage)) {
+      if (!producedAt.has(key)) producedAt.set(key, RANK_GAME_BASE + idx);
+    }
+  });
+  exitSequence.forEach((step, idx) => {
+    for (const key of collectStepKeys(step)) {
+      if (!producedAt.has(key))
+        producedAt.set(key, RANK_GAME_BASE + gameStages.length + idx);
+    }
+  });
+
+  // groupComposition runs before any stage — can only reference intro +
+  // external.
+  const groupComposition = toArray(treatment.groupComposition);
+  groupComposition.forEach((player, playerIdx) => {
+    if (!isRecord(player)) return;
+    const conditions = toArray(player.conditions);
+    conditions.forEach((cond, condIdx) => {
+      if (!isRecord(cond)) return;
+      const ref = cond.reference;
+      if (typeof ref !== "string") return;
+      const site = {
+        reference: ref,
+        kind: "groupComposition" as const,
+        path: [
+          ...treatmentPath,
+          "groupComposition",
+          playerIdx,
+          "conditions",
+          condIdx,
+          "reference",
+        ],
+      };
+      applyRules({
+        site,
+        enclosingRank: RANK_GROUP_COMPOSITION,
+        producedAt,
+        issues,
+        // groupComposition's rule: target must be intro-phase or external.
+        // Pass intro keys as the only valid phase.
+        allowedProducerRanks: new Set([RANK_INTRO]),
+      });
+    });
+  });
+
+  // Game stages
+  gameStages.forEach((stage, stageIdx) => {
+    if (!isRecord(stage)) return;
+    const rank = RANK_GAME_BASE + stageIdx;
+    const stagePath = [...treatmentPath, "gameStages", stageIdx];
+    for (const site of enumerateStepSites(stage, stagePath)) {
+      applyRules({
+        site,
+        enclosingRank: rank,
+        producedAt,
+        issues,
+        phaseLabel: "game stage",
+      });
+    }
+    // Discussion conditions nested under the stage
+    const discussion = stage.discussion;
+    if (isRecord(discussion)) {
+      const discConds = toArray(discussion.conditions);
+      discConds.forEach((cond, condIdx) => {
+        if (!isRecord(cond)) return;
+        const ref = cond.reference;
+        if (typeof ref !== "string") return;
+        applyRules({
+          site: {
+            reference: ref,
+            kind: "discussionCondition",
+            path: [
+              ...stagePath,
+              "discussion",
+              "conditions",
+              condIdx,
+              "reference",
+            ],
+          },
+          enclosingRank: rank,
+          producedAt,
+          issues,
+          phaseLabel: "game stage",
+        });
+      });
+    }
+  });
+
+  // Exit sequence
+  exitSequence.forEach((step, stepIdx) => {
+    if (!isRecord(step)) return;
+    const rank = RANK_GAME_BASE + gameStages.length + stepIdx;
+    const stepPath = [...treatmentPath, "exitSequence", stepIdx];
+    for (const site of enumerateStepSites(step, stepPath)) {
+      applyRules({
+        site,
+        enclosingRank: rank,
+        producedAt,
+        issues,
+        phaseLabel: "exit step",
+      });
+    }
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Reference-site enumeration
+// ---------------------------------------------------------------------------
+
+interface RefSite {
+  reference: string;
+  kind: ReferenceKind;
+  path: (string | number)[];
+  /** Stage-level conditions only: needed for Rule 2 simulation. */
+  comparator?: string;
+  value?: unknown;
+}
+
+/** Enumerate every reference site inside a single step/stage:
+ *  stage-level conditions + every element's conditions + display refs +
+ *  urlParam refs. Discussion conditions are handled separately at the
+ *  stage walker (they live on `stage.discussion.conditions`, not on an
+ *  element).
+ */
+function enumerateStepSites(
+  step: unknown,
+  stepPath: (string | number)[],
+): RefSite[] {
+  const sites: RefSite[] = [];
+  if (!isRecord(step)) return sites;
+
+  // Stage-level conditions
+  const stepConditions = toArray(step.conditions);
+  stepConditions.forEach((cond, condIdx) => {
+    if (!isRecord(cond)) return;
+    const ref = cond.reference;
+    if (typeof ref !== "string") return;
+    sites.push({
+      reference: ref,
+      kind: "stageCondition",
+      path: [...stepPath, "conditions", condIdx, "reference"],
+      comparator:
+        typeof cond.comparator === "string" ? cond.comparator : undefined,
+      value: cond.value,
+    });
+  });
+
+  // Element-level sites
+  const elements = toArray(step.elements);
+  elements.forEach((element, elemIdx) => {
+    if (!isRecord(element)) return;
+    const elemPath = [...stepPath, "elements", elemIdx];
+    const elemType = element.type;
+
+    // conditions on any element
+    const elemConditions = toArray(element.conditions);
+    elemConditions.forEach((cond, condIdx) => {
+      if (!isRecord(cond)) return;
+      const ref = cond.reference;
+      if (typeof ref !== "string") return;
+      sites.push({
+        reference: ref,
+        kind: "elementCondition",
+        path: [...elemPath, "conditions", condIdx, "reference"],
+      });
+    });
+
+    // display element: its own top-level `reference` field
+    if (elemType === "display" && typeof element.reference === "string") {
+      sites.push({
+        reference: element.reference,
+        kind: "displayReference",
+        path: [...elemPath, "reference"],
+      });
+    }
+
+    // trackedLink / qualtrics: each urlParams entry can carry a reference
+    if (elemType === "trackedLink" || elemType === "qualtrics") {
+      const urlParams = toArray(element.urlParams);
+      urlParams.forEach((param, paramIdx) => {
+        if (!isRecord(param)) return;
+        const ref = param.reference;
+        if (typeof ref !== "string") return;
+        sites.push({
+          reference: ref,
+          kind: "urlParam",
+          path: [...elemPath, "urlParams", paramIdx, "reference"],
+        });
+      });
+    }
+  });
+
+  return sites;
+}
+
+// ---------------------------------------------------------------------------
+// Rule application
+// ---------------------------------------------------------------------------
+
+function applyRules({
+  site,
+  enclosingRank,
+  producedAt,
+  issues,
+  priorPhaseKeys,
+  allowedProducerRanks,
+  phaseLabel,
+}: {
+  site: RefSite;
+  enclosingRank: number;
+  producedAt: Map<string, number>;
+  issues: ReferenceValidationIssue[];
+  /** For exit-phase walkers: keys produced by earlier phases that aren't
+   *  in the exit-local producedAt map. */
+  priorPhaseKeys?: Set<string>;
+  /** For groupComposition: a whitelist of producer ranks that the target
+   *  key must live in. Anything else (or a non-whitelisted stage-produced
+   *  target) is rejected. */
+  allowedProducerRanks?: Set<number>;
+  /** Context word used in error messages — "game stage", "intro step", … */
+  phaseLabel?: string;
+}): void {
+  // Try to parse the reference.
+  let referenceKey: string;
+  try {
+    ({ referenceKey } = getReferenceKeyAndPath(site.reference));
+  } catch {
+    // Malformed references are a different class of error — not our job.
+    return;
+  }
+
+  // Determine the reference's "type" (first segment). External types
+  // always validate; stage-produced types go through the producer check.
+  const refType = site.reference.split(".")[0];
+  if (!STAGE_PRODUCED_REF_TYPES.has(refType)) return;
+
+  // Look up the producer rank. If the key isn't produced anywhere in the
+  // treatment (and not in the prior-phase keys), skip — it's either a
+  // typo (other tooling) or produced by external state we can't model.
+  const producerRank =
+    producedAt.get(referenceKey) ??
+    (priorPhaseKeys?.has(referenceKey) ? RANK_INTRO : undefined);
+  if (producerRank === undefined) return;
+
+  // groupComposition: target must be in the allowed-rank whitelist.
+  if (allowedProducerRanks && !allowedProducerRanks.has(producerRank)) {
+    issues.push({
+      path: site.path,
+      message: `groupComposition condition references "${site.reference}", which is produced by a game or exit stage. groupComposition is evaluated before any stage runs — it can only reference intro-phase data or external values (urlParams, participantInfo, …).`,
+    });
+    return;
+  }
+
+  // Rule 1 — forward reference. Reject if the producer is in a later stage.
+  if (producerRank > enclosingRank) {
+    const phase = phaseLabel ?? "stage";
+    issues.push({
+      path: site.path,
+      message: `Reference "${site.reference}" points at data produced by a later ${phase} (rank ${String(producerRank)}) than the one this condition/reference belongs to (rank ${String(enclosingRank)}). Forward references are always falsy at runtime — reorder the stages or move the reference.`,
+    });
+    return;
+  }
+
+  // Rule 2 — stage-level "always-skip at load". Only applies to
+  // stageCondition sites whose reference points at the *current* stage.
+  if (
+    site.kind === "stageCondition" &&
+    producerRank === enclosingRank &&
+    site.comparator !== undefined
+  ) {
+    const result = compare(
+      undefined,
+      site.comparator as Comparator,
+      site.value,
+    );
+    if (result !== true) {
+      issues.push({
+        path: site.path,
+        message: `Stage-level condition on "${site.reference}" will always skip the stage at load. This references the current stage's data, which is undefined at mount, and compare(undefined, "${site.comparator}", …) is not true. Did you mean \`comparator: doesNotExist\` (the usual pattern for ending a stage once a value arrives)?`,
+      });
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Produced-key collection
+// ---------------------------------------------------------------------------
+
+/** Collect every storage key produced by the elements inside a single step
+ *  (stage or intro/exit step). */
+function collectStepKeys(step: unknown): Set<string> {
+  const keys = new Set<string>();
+  if (!isRecord(step)) return keys;
+  for (const el of toArray(step.elements)) {
+    collectProducedKeys(el, keys);
+  }
+  return keys;
+}
+
+/** Map an element (or a bare prompt-shorthand path string) to its storage
+ *  key (or keys) and add them to `acc`. The key conventions mirror
+ *  `getReferenceKeyAndPath` so lookups line up.
+ */
+function collectProducedKeys(element: unknown, acc: Set<string>): void {
+  // Prompt-shorthand: a bare "*.prompt.md" string inside `elements` stands
+  // in for `{ type: "prompt", file: <str>, name: <str> }`. Without a name
+  // it still produces `prompt_<str>` since the shorthand auto-names from
+  // the path.
+  if (typeof element === "string" && element.endsWith(".prompt.md")) {
+    acc.add(`prompt_${element}`);
+    return;
+  }
+  if (!isRecord(element)) return;
+  const type = element.type;
+  const name = element.name;
+  if (typeof type !== "string" || typeof name !== "string") return;
+  if (
+    type === "prompt" ||
+    type === "survey" ||
+    type === "submitButton" ||
+    type === "qualtrics" ||
+    type === "timeline" ||
+    type === "trackedLink"
+  ) {
+    acc.add(`${type}_${name}`);
+  }
+  // "discussion" references use the discussion's own name as the storage
+  // key (per getReferenceKeyAndPath's `discussion` branch). We don't
+  // currently track discussion names as produced keys at this level —
+  // discussions are a stage-level construct and their metrics come from
+  // runtime, not from a tracked element. Skipping is safe because
+  // references to discussion keys fall through to the "target not in
+  // producedAt" branch (no false positives) and runtime handles them.
+}
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function toArray(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}


### PR DESCRIPTION
Closes #197. Intended to bundle with #196 for 0.6.0 — stage-level conditions (#183) shouldn't ship without the guardrails that prevent the common footguns.

## Summary
Every reference in a treatment file now goes through a preflight walker that enforces two rules. The VS Code extension picks these up for free (zod issue paths end at the `"reference"` field → the existing path→range mapper underlines the specific reference with a red squiggle).

### Rule 1 — no forward references (everywhere)
A reference whose target storage key is produced by a later stage is rejected. Applies to every reference site in the DSL:

| Site | Covered |
|---|---|
| Stage-level `conditions[i].reference` | ✅ |
| Element-level `conditions[i].reference` | ✅ |
| `display.reference` | ✅ |
| `trackedLink.urlParams[i].reference` | ✅ |
| `qualtrics.urlParams[i].reference` | ✅ |
| `discussion.conditions[i].reference` | ✅ |
| `groupComposition[i].conditions[i].reference` | ✅ (stricter — intro-only) |

External references (`urlParams.*`, `participantInfo.*`, `connectionInfo.*`, `browserInfo.*`) are always valid.

### Rule 2 — no always-skip-at-load (stage-level conditions only)
A stage-level condition whose reference points at its *own* stage's data and whose `compare(undefined, comparator, value) !== true` will always skip at mount — almost always a forgotten `doesNotExist`. Rejected at preflight. This rule is scoped to stage-level conditions because element-level, display, urlParam, discussion, and groupComposition references all have well-defined "wait for data to arrive" semantics where false-at-load is the intended pattern.

## Where the squiggles show up
Issue paths end at the specific `reference` field — e.g. `["treatments", 0, "gameStages", 1, "conditions", 0, "reference"]` — so the VS Code extension's validation pipeline ([lib/validateTreatment.ts](apps/vscode/src/lib/validateTreatment.ts)) resolves each to the exact source range and emits a diagnostic. No extension-side changes needed.

## Implementation
New module [schemas/validateReferences.ts](packages/stagebook/src/schemas/validateReferences.ts) keeps the walker out of `treatment.ts`. Stage ordering uses a simple linear rank per treatment (groupComposition → intro → game → exit), with intro phase collapsed to a single rank across sequences (intro sequences are runtime-interchangeable). Within-sequence intro ordering validated per sequence separately so `intro[3] → intro[5]` is still caught.

## Tests
18 new cases covering:
- Every reference site rejecting forward refs.
- `groupComposition` stricter rule + its intro-accepts case.
- External references accepted everywhere.
- Earlier-stage and exit→game references accepted.
- Rule 2: `doesNotExist` current-stage accepted; `exists`/`equals` current-stage rejected; element / display / urlParam current-stage references accepted (gated-render pattern).
- Integration check: the zod superRefine surfaces an issue at the reference path (red-squiggle proof).

## Docs
New "Preflight reference validation" section in [conditions.md](docs/researcher/conditions.md) with both rules, their scopes, and OK/rejected examples.

## Test plan
- [x] `npm test` — 633 stagebook (was 615) + 75 viewer + 189 vscode (unchanged) all green.
- [x] `npm run lint` + `format:check` clean.