### PR TITLE
Extend reference validation: intro/exit timeline sources + unknown-reference typos

### DIFF
--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -1222,6 +1222,62 @@ test("stage allows multiple timelines pointing at different mediaPlayers", () =>
   expect(result.success).toBe(true);
 });
 
+test("intro/exit step also rejects a timeline whose source doesn't match a sibling mediaPlayer", () => {
+  // Regression: the timeline-source check was originally only wired into
+  // `stageSchema.superRefine` (game stages). Intro and exit steps can
+  // also mix timelines with mediaPlayers (e.g. a practice-annotation
+  // intro step with a sample video), and the same typo footgun applies.
+  const result = introExitStepSchema.safeParse({
+    name: "practice",
+    elements: [
+      {
+        type: "mediaPlayer",
+        url: "asset://recordings/sample.mp4",
+        name: "practiceStory",
+      },
+      {
+        type: "timeline",
+        source: "practiceStoryy", // typo
+        name: "practiceSegment",
+        selectionType: "range",
+      },
+      { type: "submitButton" },
+    ],
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find(
+      (i) =>
+        i.path.join(".") === "elements.1.source" &&
+        i.message.includes("practiceStoryy"),
+    );
+    expect(issue).toBeDefined();
+    expect(issue?.message).toContain('"practiceStory"');
+  }
+});
+
+test("intro/exit step accepts a matching timeline source", () => {
+  const result = introExitStepSchema.safeParse({
+    name: "practice",
+    elements: [
+      {
+        type: "mediaPlayer",
+        url: "asset://recordings/sample.mp4",
+        name: "practiceStory",
+      },
+      {
+        type: "timeline",
+        source: "practiceStory",
+        name: "practiceSegment",
+        selectionType: "range",
+      },
+      { type: "submitButton" },
+    ],
+  });
+  if (!result.success) console.log(result.error.issues);
+  expect(result.success).toBe(true);
+});
+
 test("stage reports one issue per mismatched timeline (not a single aggregated error)", () => {
   const result = stageSchema.safeParse({
     name: "coding",

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -727,6 +727,7 @@ const GAME_STAGE_FORBIDDEN_POSITIONS = new Set([
 function validateTimelineSources(
   elements: Record<string, unknown>[],
   ctx: z.RefinementCtx,
+  containerLabel: "stage" | "step" = "stage",
 ): void {
   // Track total mediaPlayer elements alongside the named set so the
   // error message can distinguish "no mediaPlayers at all" from
@@ -756,19 +757,20 @@ function validateTimelineSources(
     if (mediaPlayerNames.has(source)) return;
     let available: string;
     if (mediaPlayerNames.size > 0) {
-      available = ` Available mediaPlayers in this step: ${[...mediaPlayerNames]
+      available = ` Available mediaPlayers in this ${containerLabel}: ${[
+        ...mediaPlayerNames,
+      ]
         .map((n) => `"${n}"`)
         .join(", ")}.`;
     } else if (totalMediaPlayers > 0) {
-      available =
-        " No mediaPlayer elements in this step have a `name:` field — add one so timelines can reference them.";
+      available = ` No mediaPlayer elements in this ${containerLabel} have a \`name:\` field — add one so timelines can reference them.`;
     } else {
-      available = " No mediaPlayer elements are defined in this step.";
+      available = ` No mediaPlayer elements are defined in this ${containerLabel}.`;
     }
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
       path: ["elements", elementIndex, "source"],
-      message: `Timeline source "${source}" does not match any mediaPlayer.name in this step.${available}`,
+      message: `Timeline source "${source}" does not match any mediaPlayer.name in this ${containerLabel}.${available}`,
     });
   });
 }
@@ -1374,7 +1376,7 @@ export const introExitStepSchema = altTemplateContext(
         // `source` must name a mediaPlayer in the same step. Intro and
         // exit steps can carry timeline+mediaPlayer pairs too (e.g. a
         // practice-annotation intro step).
-        validateTimelineSources(elements, ctx);
+        validateTimelineSources(elements, ctx, "step");
       }
     }),
 );

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -713,6 +713,67 @@ const GAME_STAGE_FORBIDDEN_POSITIONS = new Set([
 ]);
 
 /**
+ * Validate that every `type: "timeline"` element's `source` names a
+ * `type: "mediaPlayer"` element's `name` in the same step (stage, intro
+ * step, or exit step). PlaybackHandles are step-scoped at runtime, so
+ * a cross-step source would fail at render with a "source player not
+ * found" error box — catching it at preflight gives authors immediate
+ * feedback on typos.
+ *
+ * Called from both `stageSchema.superRefine` and
+ * `introExitStepSchema.superRefine` since both step kinds can mix
+ * timelines with mediaPlayers (e.g. a practice-annotation intro step).
+ */
+function validateTimelineSources(
+  elements: Record<string, unknown>[],
+  ctx: z.RefinementCtx,
+): void {
+  // Track total mediaPlayer elements alongside the named set so the
+  // error message can distinguish "no mediaPlayers at all" from
+  // "mediaPlayers exist but all are unnamed."
+  let totalMediaPlayers = 0;
+  const mediaPlayerNames = new Set<string>();
+  for (const element of elements) {
+    if (
+      element &&
+      typeof element === "object" &&
+      element.type === "mediaPlayer"
+    ) {
+      totalMediaPlayers++;
+      if (typeof element.name === "string") {
+        mediaPlayerNames.add(element.name);
+      }
+    }
+  }
+  elements.forEach((element, elementIndex) => {
+    if (!element || typeof element !== "object" || element.type !== "timeline")
+      return;
+    const source = element.source;
+    if (typeof source !== "string") return;
+    // Skip when source is an unresolved `${field}` placeholder — the
+    // referenced name may only be known after template fill.
+    if (containsFieldPlaceholder(source)) return;
+    if (mediaPlayerNames.has(source)) return;
+    let available: string;
+    if (mediaPlayerNames.size > 0) {
+      available = ` Available mediaPlayers in this step: ${[...mediaPlayerNames]
+        .map((n) => `"${n}"`)
+        .join(", ")}.`;
+    } else if (totalMediaPlayers > 0) {
+      available =
+        " No mediaPlayer elements in this step have a `name:` field — add one so timelines can reference them.";
+    } else {
+      available = " No mediaPlayer elements are defined in this step.";
+    }
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["elements", elementIndex, "source"],
+      message: `Timeline source "${source}" does not match any mediaPlayer.name in this step.${available}`,
+    });
+  });
+}
+
+/**
  * Apply cross-cutting rules to a list of conditions (stage-level or
  * element-level). Adds zod issues for each violation found; called from
  * stage/intro-exit superRefines so we can point issue paths at the
@@ -1263,59 +1324,7 @@ export const stageSchema = altTemplateContext(
         });
       }
 
-      // Validate that every timeline's `source` names a mediaPlayer in
-      // the same stage. PlaybackHandles are stage-scoped, so a timeline
-      // whose source doesn't match any mediaPlayer.name here would fail
-      // at runtime with a "source player not found" error. Track total
-      // mediaPlayer elements alongside the named set so the error
-      // message can distinguish "no mediaPlayers at all" from "all
-      // mediaPlayers are unnamed".
-      let totalMediaPlayers = 0;
-      const mediaPlayerNames = new Set<string>();
-      for (const element of elements) {
-        if (
-          element &&
-          typeof element === "object" &&
-          element.type === "mediaPlayer"
-        ) {
-          totalMediaPlayers++;
-          if (typeof element.name === "string") {
-            mediaPlayerNames.add(element.name);
-          }
-        }
-      }
-      elements.forEach((element, elementIndex) => {
-        if (
-          !element ||
-          typeof element !== "object" ||
-          element.type !== "timeline"
-        )
-          return;
-        const source = element.source;
-        if (typeof source !== "string") return;
-        // Skip when source is an unresolved `${field}` placeholder —
-        // the referenced name may only be known after template fill.
-        if (containsFieldPlaceholder(source)) return;
-        if (mediaPlayerNames.has(source)) return;
-        let available: string;
-        if (mediaPlayerNames.size > 0) {
-          available = ` Available mediaPlayers in this stage: ${[
-            ...mediaPlayerNames,
-          ]
-            .map((n) => `"${n}"`)
-            .join(", ")}.`;
-        } else if (totalMediaPlayers > 0) {
-          available =
-            " No mediaPlayer elements in this stage have a `name:` field — add one so timelines can reference them.";
-        } else {
-          available = " No mediaPlayer elements are defined in this stage.";
-        }
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["elements", elementIndex, "source"],
-          message: `Timeline source "${source}" does not match any mediaPlayer.name in this stage.${available}`,
-        });
-      });
+      validateTimelineSources(elements, ctx);
     }),
 );
 export type StageType = z.infer<typeof stageSchema>;
@@ -1350,18 +1359,22 @@ export const introExitStepSchema = altTemplateContext(
         forbidSelfPosition: false,
       });
       if (Array.isArray(data.elements)) {
-        (data.elements as Record<string, unknown>[]).forEach(
-          (element, elementIndex) => {
-            if (element && typeof element === "object") {
-              validateConditionRules(
-                (element as { conditions?: unknown }).conditions,
-                ["elements", elementIndex, "conditions"],
-                ctx,
-                { contextLabel: "Element", forbidSelfPosition: false },
-              );
-            }
-          },
-        );
+        const elements = data.elements as Record<string, unknown>[];
+        elements.forEach((element, elementIndex) => {
+          if (element && typeof element === "object") {
+            validateConditionRules(
+              (element as { conditions?: unknown }).conditions,
+              ["elements", elementIndex, "conditions"],
+              ctx,
+              { contextLabel: "Element", forbidSelfPosition: false },
+            );
+          }
+        });
+        // Same timeline-source validation as game stages: a timeline's
+        // `source` must name a mediaPlayer in the same step. Intro and
+        // exit steps can carry timeline+mediaPlayer pairs too (e.g. a
+        // practice-annotation intro step).
+        validateTimelineSources(elements, ctx);
       }
     }),
 );

--- a/packages/stagebook/src/schemas/validateReferences.test.ts
+++ b/packages/stagebook/src/schemas/validateReferences.test.ts
@@ -594,6 +594,154 @@ describe("Rule 1 — no forward references", () => {
   });
 });
 
+describe("Unknown-reference detection", () => {
+  test("element-level condition referencing a non-existent timeline → rejected as typo", () => {
+    // Regression: a typo like `timeline.storySegment2` for an actual
+    // element named `storySegment` previously passed validation because
+    // the target wasn't in producedAt (so the walker returned early).
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "story",
+          duration: 60,
+          elements: [
+            {
+              type: "mediaPlayer",
+              url: "asset://x.mp4",
+              name: "story",
+            },
+            {
+              type: "timeline",
+              source: "story",
+              name: "storySegment",
+              selectionType: "range",
+            },
+            {
+              type: "submitButton",
+              conditions: [
+                {
+                  reference: "timeline.storySegment2",
+                  comparator: "exists",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    const typo = issues.find(
+      (i) =>
+        i.path.join(".").endsWith("elements.2.conditions.0.reference") &&
+        /doesn't match any timeline element/i.test(i.message),
+    );
+    expect(typo).toBeDefined();
+  });
+
+  test("stage-level condition referencing a non-existent prompt → rejected as typo", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s",
+          duration: 60,
+          conditions: [
+            {
+              reference: "prompt.nonexistent",
+              comparator: "equals",
+              value: "yes",
+              position: "all",
+            },
+          ],
+          elements: [{ type: "submitButton" }],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    const typo = issues.find(
+      (i) =>
+        /doesn't match any prompt element/i.test(i.message) &&
+        i.message.includes("nonexistent"),
+    );
+    expect(typo).toBeDefined();
+  });
+
+  test("reference whose target is produced by a template → accepted", () => {
+    // Templates produce elements via broadcast expansion; the walker
+    // collects their produced keys recursively so references aren't
+    // false-flagged as unknown.
+    const file = {
+      templates: [
+        {
+          templateName: "storyStage",
+          contentType: "stage",
+          templateContent: {
+            name: "templated",
+            duration: 60,
+            elements: [
+              {
+                type: "prompt",
+                name: "templatedPrompt",
+                file: "p.prompt.md",
+              },
+              { type: "submitButton" },
+            ],
+          },
+        },
+      ],
+      introSequences: [
+        {
+          name: "seq",
+          introSteps: [{ name: "a", elements: [{ type: "submitButton" }] }],
+        },
+      ],
+      treatments: [
+        {
+          name: "t",
+          playerCount: 1,
+          gameStages: [
+            {
+              name: "uses",
+              duration: 60,
+              elements: [
+                {
+                  type: "display",
+                  reference: "prompt.templatedPrompt",
+                },
+                { type: "submitButton" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const issues = validateTreatmentFileReferences(file);
+    // No unknown-reference complaint about `prompt.templatedPrompt` —
+    // the walker sees it in the template's content.
+    const unknown = issues.find((i) => i.message.includes("templatedPrompt"));
+    expect(unknown).toBeUndefined();
+  });
+
+  test("external references still skip unknown-reference check", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s",
+          duration: 60,
+          elements: [
+            {
+              type: "display",
+              reference: "urlParams.neverDeclared",
+            },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(issues.length).toBe(0);
+  });
+});
+
 describe("Rule 2 — stage-level always-skip-at-load (current-stage refs only)", () => {
   test("stage-level condition `doesNotExist` on current-stage ref → accepted", () => {
     const file = baseFile({

--- a/packages/stagebook/src/schemas/validateReferences.test.ts
+++ b/packages/stagebook/src/schemas/validateReferences.test.ts
@@ -721,6 +721,33 @@ describe("Unknown-reference detection", () => {
     expect(unknown).toBeUndefined();
   });
 
+  test("discussion.* references are not flagged as unknown (we don't model their storage keys)", () => {
+    // Regression: before the fix, `discussion.anyName.x` would fall
+    // through the walker as "unknown" because no discussion keys live
+    // in producedAt/globalProducedKeys. Leave discussion refs alone.
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s",
+          duration: 60,
+          elements: [
+            {
+              type: "submitButton",
+              conditions: [
+                {
+                  reference: "discussion.someRoom.messages",
+                  comparator: "exists",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    expect(issues.length).toBe(0);
+  });
+
   test("external references still skip unknown-reference check", () => {
     const file = baseFile({
       gameStages: [

--- a/packages/stagebook/src/schemas/validateReferences.ts
+++ b/packages/stagebook/src/schemas/validateReferences.ts
@@ -73,6 +73,7 @@ export function validateTreatmentFileReferences(
 
   const introSequences = toArray(treatmentFile.introSequences);
   const treatments = toArray(treatmentFile.treatments);
+  const templates = toArray(treatmentFile.templates);
 
   // Build the set of keys produced by any game stage or exit step across
   // all treatments. Intro-step references to any of these are forward
@@ -90,6 +91,33 @@ export function validateTreatmentFileReferences(
     }
   }
 
+  // Every key produced *anywhere* in the treatment file — intro + game +
+  // exit, plus whatever templates could produce. Used to catch "unknown
+  // reference" typos (e.g. `timeline.storySegment2` where the actual
+  // element is `storySegment`). We walk template content recursively so
+  // elements produced via template expansion don't false-positive as
+  // unknown.
+  const globalProducedKeys = new Set<string>();
+  for (const seq of introSequences) {
+    if (!isRecord(seq)) continue;
+    for (const step of toArray(seq.introSteps)) {
+      for (const key of collectStepKeys(step)) globalProducedKeys.add(key);
+    }
+  }
+  for (const treatment of treatments) {
+    if (!isRecord(treatment)) continue;
+    for (const stage of toArray(treatment.gameStages)) {
+      for (const key of collectStepKeys(stage)) globalProducedKeys.add(key);
+    }
+    for (const step of toArray(treatment.exitSequence)) {
+      for (const key of collectStepKeys(step)) globalProducedKeys.add(key);
+    }
+  }
+  for (const tmpl of templates) {
+    if (!isRecord(tmpl)) continue;
+    collectKeysFromAny(tmpl.templateContent, globalProducedKeys);
+  }
+
   // Intro sequences: validate each sequence in isolation for within-sequence
   // forward references, cross-phase forward references into game/exit, and
   // stage-level always-skip.
@@ -102,6 +130,7 @@ export function validateTreatmentFileReferences(
       phase: "intro",
       issues,
       laterPhaseKeys,
+      globalProducedKeys,
     });
   });
 
@@ -123,6 +152,7 @@ export function validateTreatmentFileReferences(
       treatmentPath: ["treatments", treatmentIdx],
       introProducedKeys,
       issues,
+      globalProducedKeys,
     });
   });
 
@@ -142,6 +172,7 @@ function validateStepSequence({
   issues,
   priorPhaseKeys,
   laterPhaseKeys,
+  globalProducedKeys,
 }: {
   steps: unknown[];
   sequencePath: (string | number)[];
@@ -152,6 +183,9 @@ function validateStepSequence({
   /** Keys produced by later phases. Any intro-step reference to one of
    *  these is a cross-phase forward reference. */
   laterPhaseKeys?: Set<string>;
+  /** Union of every produced key anywhere in the file (incl. templates).
+   *  Used to flag unknown-reference typos. */
+  globalProducedKeys?: Set<string>;
 }): void {
   // Build producedAt: key → earliest step index that produces it.
   const producedAt = new Map<string, number>();
@@ -172,6 +206,7 @@ function validateStepSequence({
         issues,
         priorPhaseKeys,
         laterPhaseKeys,
+        globalProducedKeys,
         phaseLabel: phase === "intro" ? "intro step" : "exit step",
       });
     }
@@ -183,11 +218,13 @@ function validateTreatment({
   treatmentPath,
   introProducedKeys,
   issues,
+  globalProducedKeys,
 }: {
   treatment: Record<string, unknown>;
   treatmentPath: (string | number)[];
   introProducedKeys: Set<string>;
   issues: ReferenceValidationIssue[];
+  globalProducedKeys?: Set<string>;
 }): void {
   const gameStages = toArray(treatment.gameStages);
   const exitSequence = toArray(treatment.exitSequence);
@@ -243,6 +280,7 @@ function validateTreatment({
         // groupComposition's rule: target must be intro-phase or external.
         // Pass intro keys as the only valid phase.
         allowedProducerRanks: new Set([RANK_INTRO]),
+        globalProducedKeys,
       });
     });
   });
@@ -259,6 +297,7 @@ function validateTreatment({
         producedAt,
         issues,
         phaseLabel: "game stage",
+        globalProducedKeys,
       });
     }
     // Discussion conditions nested under the stage
@@ -285,6 +324,7 @@ function validateTreatment({
           producedAt,
           issues,
           phaseLabel: "game stage",
+          globalProducedKeys,
         });
       });
     }
@@ -302,6 +342,7 @@ function validateTreatment({
         producedAt,
         issues,
         phaseLabel: "exit step",
+        globalProducedKeys,
       });
     }
   });
@@ -410,6 +451,7 @@ function applyRules({
   laterPhaseKeys,
   allowedProducerRanks,
   phaseLabel,
+  globalProducedKeys,
 }: {
   site: RefSite;
   enclosingRank: number;
@@ -427,6 +469,11 @@ function applyRules({
   allowedProducerRanks?: Set<number>;
   /** Context word used in error messages — "game stage", "intro step", … */
   phaseLabel?: string;
+  /** Union of produced keys across every stage + template in the file.
+   *  When a reference's target isn't in this set, the reference is to
+   *  something that doesn't exist anywhere in the treatment — typically
+   *  a typo (e.g. `timeline.storySegment2` vs `timeline.storySegment`). */
+  globalProducedKeys?: Set<string>;
 }): void {
   // Try to parse the reference.
   let referenceKey: string;
@@ -456,6 +503,17 @@ function applyRules({
       issues.push({
         path: site.path,
         message: `Reference "${site.reference}" points at data produced by a later phase (game or exit) than this ${phase}. Forward references across phases are always falsy at runtime — move the reference or reorder the flow.`,
+      });
+      return;
+    }
+    // Unknown reference: the target key isn't produced anywhere in the
+    // treatment (concrete stages or templates). Almost always a typo on
+    // the element name (e.g. `timeline.storySegment2` when the actual
+    // element is `storySegment`).
+    if (globalProducedKeys && !globalProducedKeys.has(referenceKey)) {
+      issues.push({
+        path: site.path,
+        message: `Reference "${site.reference}" doesn't match any ${refType} element in the treatment. Check the name — no element produces the storage key "${referenceKey}".`,
       });
     }
     return;
@@ -514,6 +572,31 @@ function collectStepKeys(step: unknown): Set<string> {
     collectProducedKeys(el, keys);
   }
   return keys;
+}
+
+/** Recursively collect every storage key that appears anywhere under
+ *  `node`. Used for templates, where the `templateContent` can be a bare
+ *  element, a list of elements, a stage-shaped object, etc. We walk all
+ *  sub-values rather than trying to shape-check against `contentType`,
+ *  because template shapes are flexible and we just want "every key that
+ *  could come out of this template."
+ */
+function collectKeysFromAny(node: unknown, acc: Set<string>): void {
+  if (typeof node === "string" && node.endsWith(".prompt.md")) {
+    acc.add(`prompt_${node}`);
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) collectKeysFromAny(item, acc);
+    return;
+  }
+  if (!isRecord(node)) return;
+  // Try as an element first (matches the concrete-walker shape).
+  collectProducedKeys(node, acc);
+  // Then recurse into every sub-value for nested elements.
+  for (const value of Object.values(node)) {
+    collectKeysFromAny(value, acc);
+  }
 }
 
 /** Map an element (or a bare prompt-shorthand path string) to its storage

--- a/packages/stagebook/src/schemas/validateReferences.ts
+++ b/packages/stagebook/src/schemas/validateReferences.ts
@@ -49,7 +49,14 @@ const RANK_GAME_BASE = 1;
 
 /** The types of reference whose target keys are **produced by a stage**. A
  *  reference of any other type (urlParams, participantInfo, …) is external
- *  and always valid regardless of position. */
+ *  and always valid regardless of position.
+ *
+ *  Note: `discussion` references aren't in this set because stagebook
+ *  doesn't model discussion storage keys — their shape depends on the
+ *  host's runtime conventions (Tajriba attributes, chat transcript
+ *  layout, …). We leave `discussion.*` refs alone rather than risk a
+ *  false-positive "doesn't match any discussion element" on valid
+ *  references. Forward-ref and unknown-ref checks both skip them. */
 const STAGE_PRODUCED_REF_TYPES = new Set([
   "prompt",
   "survey",
@@ -57,7 +64,6 @@ const STAGE_PRODUCED_REF_TYPES = new Set([
   "qualtrics",
   "timeline",
   "trackedLink",
-  "discussion",
 ]);
 
 /**
@@ -580,22 +586,39 @@ function collectStepKeys(step: unknown): Set<string> {
  *  sub-values rather than trying to shape-check against `contentType`,
  *  because template shapes are flexible and we just want "every key that
  *  could come out of this template."
+ *
+ *  Bare `*.prompt.md` strings are only treated as produced keys when
+ *  they appear as prompt-shorthand entries inside an `elements` array.
+ *  Treating every matching string as a produced key would
+ *  over-approximate — e.g. an explicit `{ type: prompt, name: foo,
+ *  file: "p.prompt.md" }` element would add *both* `prompt_foo` (real
+ *  key) and `prompt_p.prompt.md` (bogus) — and mask real typos.
  */
-function collectKeysFromAny(node: unknown, acc: Set<string>): void {
-  if (typeof node === "string" && node.endsWith(".prompt.md")) {
-    acc.add(`prompt_${node}`);
+function collectKeysFromAny(
+  node: unknown,
+  acc: Set<string>,
+  allowPromptShorthand = false,
+): void {
+  if (typeof node === "string") {
+    if (allowPromptShorthand && node.endsWith(".prompt.md")) {
+      acc.add(`prompt_${node}`);
+    }
     return;
   }
   if (Array.isArray(node)) {
-    for (const item of node) collectKeysFromAny(item, acc);
+    for (const item of node) {
+      collectKeysFromAny(item, acc, allowPromptShorthand);
+    }
     return;
   }
   if (!isRecord(node)) return;
   // Try as an element first (matches the concrete-walker shape).
   collectProducedKeys(node, acc);
-  // Then recurse into every sub-value for nested elements.
-  for (const value of Object.values(node)) {
-    collectKeysFromAny(value, acc);
+  // Recurse into every sub-value. Only `elements` arrays carry
+  // prompt-shorthand strings — any other string field (e.g. `file:
+  // "…prompt.md"`) is not a shorthand and shouldn't be counted.
+  for (const [key, value] of Object.entries(node)) {
+    collectKeysFromAny(value, acc, key === "elements");
   }
 }
 


### PR DESCRIPTION
Two preflight gaps filled, reported by the same user during manual testing of the 0.5.1 extension.

## 1. Timeline source check now also applies to intro/exit steps
The timeline-source preflight check from #189 was wired only into \`stageSchema.superRefine\` (game stages). Intro and exit steps can also mix timelines with mediaPlayers — for example, a practice-annotation intro step with a sample video — so the same typo footgun applied there with no preflight error.

- Extracted the collect-mediaPlayer-names-then-walk-timelines logic into a shared \`validateTimelineSources\` helper in [treatment.ts](packages/stagebook/src/schemas/treatment.ts).
- Call the helper from both \`stageSchema.superRefine\` and \`introExitStepSchema.superRefine\`.
- Messages updated from "in this stage" to "in this step" since the function now runs in both contexts.
- 2 new regression tests (intro/exit step rejects typo'd source; accepts matching source).

## 2. Reference walker now rejects unknown-reference typos
Follow-up to #197. The walker previously returned early when a reference's target storage key wasn't produced anywhere — rationale: "it's either a typo (other tooling) or produced by external state we can't model." But for stage-producing reference types (prompt, survey, submitButton, qualtrics, timeline, trackedLink, discussion), a target that doesn't exist anywhere in the treatment really is a bug.

Triggered by a user whose condition had \`reference: timeline.storySegment2\` for a timeline named \`storySegment\` (trailing 2) — no preflight complaint, just silent undefined at runtime.

- New \`globalProducedKeys\` set built in [validateReferences.ts](packages/stagebook/src/schemas/validateReferences.ts) containing every key produced across intro + game + exit stages AND every key any top-level template could produce.
- New \`collectKeysFromAny\` helper recurses through template content regardless of \`contentType\` shape — so a templated stage, a templated element, or a templated elements list all yield their keys.
- When a reference target is a stage-producing type AND isn't in any of \`producedAt\` / \`laterPhaseKeys\` / \`globalProducedKeys\`, emit: _"Reference X doesn't match any <type> element in the treatment. Check the name — no element produces the storage key \\"X\\"."_ External refs (urlParams, etc.) are unchanged — they never hit the stage-produced branch.
- 4 new regression tests (element-level + stage-level typo detection; template-produced target accepted; external \`urlParams.*\` still skipped).

Verified against the reporter's file — the \`timeline.storySegment2\` typo is the only issue reported.

## Test plan
- [x] \`npm test\` — 642 stagebook (was 638) + 75 viewer + 189 vscode all green.
- [x] \`npm run lint\` + \`format:check\` clean.

Intended to bundle into 0.6.0 alongside #183/#188/#189/#197 — the v0.6.0 tag hasn't been cut yet.