### PR TITLE
Markdown.ct: add em/table-border/strikethrough coverage (#193)

### DIFF
--- a/packages/stagebook/src/components/form/Markdown.ct.tsx
+++ b/packages/stagebook/src/components/form/Markdown.ct.tsx
@@ -47,6 +47,32 @@ test("renders GFM tables", async ({ mount }) => {
   await expect(component.locator("table")).toBeVisible();
 });
 
+test("table uses collapsed borders and visible cell borders", async ({
+  mount,
+}) => {
+  // Also implicitly verifies the stylesheet is loading — no other test
+  // exercises that failure mode. Tables style via the stylesheet, not
+  // inline, so a dropped rule or unloaded sheet would regress silently.
+  const component = await mount(
+    <Markdown text={"| A | B |\n|---|---|\n| 1 | 2 |"} />,
+  );
+  const borderCollapse = await component
+    .locator("table")
+    .evaluate((el) => getComputedStyle(el).borderCollapse);
+  expect(borderCollapse).toBe("collapse");
+
+  const cellBorderWidth = await component
+    .locator("td")
+    .first()
+    .evaluate((el) => parseFloat(getComputedStyle(el).borderTopWidth));
+  expect(cellBorderWidth).toBeGreaterThan(0);
+});
+
+test("renders GFM strikethrough", async ({ mount }) => {
+  const component = await mount(<Markdown text="~~crossed out~~" />);
+  await expect(component.locator("del")).toContainText("crossed out");
+});
+
 // ---------------------------------------------------------------------------
 // Inline styling — issue #33
 //
@@ -102,6 +128,16 @@ test("strong renders with bold weight (matches browser default)", async ({
     .locator("strong")
     .evaluate((el) => parseInt(getComputedStyle(el).fontWeight, 10));
   expect(weight).toBe(700);
+});
+
+test("em renders with italic style (matches browser default)", async ({
+  mount,
+}) => {
+  const component = await mount(<Markdown text="Some *italic* text" />);
+  const style = await component
+    .locator("em")
+    .evaluate((el) => getComputedStyle(el).fontStyle);
+  expect(style).toBe("italic");
 });
 
 test("ul renders with disc bullets, not none", async ({ mount }) => {


### PR DESCRIPTION
Closes #193.

## Summary
- `em` italic style — symmetric with the existing `strong` bold-weight test.
- Table `border-collapse: collapse` + visible cell-border width — upgrades the existing `toBeVisible`-only table test. Since table styling flows through the stylesheet (not inline), a dropped rule or unloaded sheet would regress silently; this check also implicitly proves the sheet loads.
- GFM strikethrough — `remark-gfm` is already wired up for tables, but nothing asserted the `<del>` output.

## Test plan
- [x] `npx playwright test Markdown.ct.tsx` — 22/22 pass (3 new + 19 existing)
- [x] Full unit suite green locally (643 stagebook + 75 viewer + 189 vscode)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)