### PR TITLE
Integration tests for ScrollIndicator + useScrollAwareness via Stage (#203)

### DIFF
--- a/packages/stagebook/src/components/Stage.scroll.ct.tsx
+++ b/packages/stagebook/src/components/Stage.scroll.ct.tsx
@@ -1,0 +1,188 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import type { Locator, Page } from "@playwright/test";
+import { MockStageRenderer } from "./testing/MockStageRenderer";
+import type { StageConfig } from "./Stage";
+
+// Integration tests for the ScrollIndicator + useScrollAwareness wiring in
+// Stage.tsx — the three pieces work as a unit and were previously only
+// covered end-to-end via a cypress spec in the downstream deliberation-lab
+// repo. These tests exercise the four behavioral branches of the hook
+// (indicator on, dismiss via scroll, auto-peek at bottom, no re-fire after
+// dismiss) against the real Stage wrapper.
+
+// Static elements only — prompts load text async via getTextContent, which
+// produces its own DOM mutations after mount and would race with the test's
+// deliberate appendChild calls. Separators + submitButton render
+// synchronously, so the MutationObserver's "first growth is absorbed,
+// subsequent growths trigger indicator logic" sequencing is deterministic.
+const staticStage: StageConfig = {
+  name: "ScrollFixture",
+  duration: 600,
+  elements: [
+    { type: "separator" },
+    { type: "separator" },
+    { type: "submitButton", buttonText: "OK" },
+  ],
+};
+
+// Constrains Stage's scroll container so the test's appended pads overflow
+// visibly. 200px is small enough that a 1000px fixture pad clearly triggers
+// "not at bottom" past the 120px threshold in useScrollAwareness.
+const WRAPPER_STYLE = {
+  height: "200px",
+  display: "flex" as const,
+  flexDirection: "column" as const,
+};
+
+// Prime the hook's init gate and set the starting scroll state. After this
+// call the hook's isInitializedRef is true (so the next growth triggers the
+// real indicator path) and wasAtBottomRef reflects `start` via a dispatched
+// scroll event.
+// Stage's scroll container uses `display: flex; flex-direction: column`.
+// Flex items default to `flex-shrink: 1`, which would crush the pads we
+// append below. `flex: 0 0 auto` + explicit height keeps them at the
+// requested size so scrollHeight actually grows.
+
+// useScrollAwareness schedules its MutationObserver callback via
+// requestAnimationFrame. If a test mutates twice before any rAF fires (which
+// happens under parallel load), both rAF callbacks run after the DOM has
+// already settled — the first one initializes with the final scrollHeight
+// and the second sees no growth, so the indicator never fires. Awaiting two
+// rAFs between mutations guarantees the hook has processed each one.
+async function settleHook(page: Page): Promise<void> {
+  await page.evaluate(
+    () =>
+      new Promise<void>((resolve) => {
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+      }),
+  );
+}
+
+async function primeScrollState(
+  container: Locator,
+  start: "top" | "bottom",
+): Promise<void> {
+  await container.evaluate((el, atBottom) => {
+    const pad = document.createElement("div");
+    pad.style.height = "1000px";
+    pad.style.width = "100%";
+    pad.style.flex = "0 0 auto";
+    pad.setAttribute("data-fixture-pad", "1");
+    el.appendChild(pad);
+    el.scrollTop = atBottom ? el.scrollHeight : 0;
+    el.dispatchEvent(new Event("scroll", { bubbles: true }));
+  }, start === "bottom");
+}
+
+async function growContent(container: Locator, height = 200): Promise<void> {
+  await container.evaluate((el, h) => {
+    const pad = document.createElement("div");
+    pad.style.height = `${h}px`;
+    pad.style.width = "100%";
+    pad.style.flex = "0 0 auto";
+    pad.setAttribute("data-growth-pad", "1");
+    el.appendChild(pad);
+  }, height);
+}
+
+async function scrollToBottom(container: Locator): Promise<void> {
+  await container.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+    el.dispatchEvent(new Event("scroll", { bubbles: true }));
+  });
+}
+
+test("indicator appears when content grows while user is scrolled up", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <div style={WRAPPER_STYLE}>
+      <MockStageRenderer stage={staticStage} />
+    </div>,
+  );
+  const container = component.locator('[data-testid="stageContent"]');
+  await expect(container).toBeVisible();
+
+  await primeScrollState(container, "top");
+  await settleHook(component.page());
+  await growContent(container);
+
+  await expect(
+    component.locator('[data-testid="scroll-indicator"]'),
+  ).toBeVisible();
+});
+
+test("indicator is dismissed when user scrolls to bottom", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <div style={WRAPPER_STYLE}>
+      <MockStageRenderer stage={staticStage} />
+    </div>,
+  );
+  const container = component.locator('[data-testid="stageContent"]');
+
+  await primeScrollState(container, "top");
+  await settleHook(component.page());
+  await growContent(container);
+  await expect(
+    component.locator('[data-testid="scroll-indicator"]'),
+  ).toBeVisible();
+
+  await scrollToBottom(container);
+
+  await expect(
+    component.locator('[data-testid="scroll-indicator"]'),
+  ).toHaveCount(0);
+});
+
+test("no indicator when user is already at bottom — auto-peek path", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <div style={WRAPPER_STYLE}>
+      <MockStageRenderer stage={staticStage} />
+    </div>,
+  );
+  const container = component.locator('[data-testid="stageContent"]');
+
+  await primeScrollState(container, "bottom");
+  await settleHook(component.page());
+  await growContent(container);
+  await settleHook(component.page());
+
+  await expect(
+    component.locator('[data-testid="scroll-indicator"]'),
+  ).toHaveCount(0);
+});
+
+test("dismissed indicator does not re-fire on subsequent mutations at the same scroll position", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <div style={WRAPPER_STYLE}>
+      <MockStageRenderer stage={staticStage} />
+    </div>,
+  );
+  const container = component.locator('[data-testid="stageContent"]');
+
+  await primeScrollState(container, "top");
+  await settleHook(component.page());
+  await growContent(container);
+  await expect(
+    component.locator('[data-testid="scroll-indicator"]'),
+  ).toBeVisible();
+
+  await scrollToBottom(container);
+  await expect(
+    component.locator('[data-testid="scroll-indicator"]'),
+  ).toHaveCount(0);
+
+  // User is still at the bottom — another mutation should take the
+  // auto-peek branch, not show the indicator again.
+  await growContent(container);
+  await settleHook(component.page());
+  await expect(
+    component.locator('[data-testid="scroll-indicator"]'),
+  ).toHaveCount(0);
+});

--- a/packages/stagebook/src/components/Stage.scroll.ct.tsx
+++ b/packages/stagebook/src/components/Stage.scroll.ct.tsx
@@ -178,6 +178,12 @@ test("dismissed indicator does not re-fire on subsequent mutations at the same s
     component.locator('[data-testid="scroll-indicator"]'),
   ).toHaveCount(0);
 
+  // Dismissal removes the ScrollIndicator element from the DOM — that's a
+  // mutation the observer sees, and without a settle between it and the
+  // next growth the two can batch into a single rAF callback that misses
+  // the growth delta. Settle so each mutation is processed on its own.
+  await settleHook(component.page());
+
   // User is still at the bottom — another mutation should take the
   // auto-peek branch, not show the indicator again.
   await growContent(container);


### PR DESCRIPTION
Closes #203.

## Summary
Adds `Stage.scroll.ct.tsx` covering the four behavioral branches of the `useScrollAwareness` + `ScrollIndicator` wiring in `Stage`:
1. Indicator appears when content grows while user is scrolled up.
2. Indicator is dismissed when user scrolls to bottom.
3. No indicator when user is already at bottom (auto-peek path).
4. Dismissal stays dismissed on subsequent mutations at the same scroll position.

Tests exercise the hook via direct `appendChild` in the scroll container rather than routing through time-conditional element appearance. That isolates the scroll-awareness mechanism from the content-loading path and avoids coupling these tests to `TimeConditionalRender`'s internal tick timing.

## Notes on test design
- **Static elements only** (separators + submitButton) — Prompt loads text async via `getTextContent`, which produces its own DOM mutations after mount. Those would race with the test's deliberate appends and make the hook's "first growth is absorbed" init-gate sequencing non-deterministic.
- **`settleHook()` between mutations** — `useScrollAwareness` schedules its MutationObserver callback via `requestAnimationFrame`. Without an explicit 2-frame wait, under parallel load both the init-gate rAF and the indicator-trigger rAF can end up running after the DOM has already settled; the first one initializes with the final `scrollHeight` and the second sees no growth, so the indicator never fires. Verified by running the full CT suite 3× — no flakes.
- **`flex: 0 0 auto` on appended pads** — the Stage scroll container is `display: flex; flex-direction: column`, so default `flex-shrink: 1` would crush appended children and `scrollHeight` wouldn't grow.

## Test plan
- [x] All four new CT tests pass in isolation
- [x] Full CT suite (367 tests) passes, ran 3× consecutively to confirm no flakiness introduced
- [x] Existing unit suite green (643 stagebook + 75 viewer + 189 vscode)

## Downstream cleanup
Once this lands, deliberation-lab can retire `cypress/e2e/15_Scroll_Indicator.js` — nothing platform-specific is involved in the scroll-awareness behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)