### PR TITLE
Timeline: click-to-add range + grip affordance + cursor hints

### DIFF
--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -322,7 +322,12 @@ const sidebarStyle: React.CSSProperties = {
 
 const mainStyle: React.CSSProperties = {
   flex: 1,
-  overflow: "auto",
+  // overflow: hidden (not auto) so Stage's own scroll container is the
+  // element that actually scrolls. This is what lets useScrollAwareness
+  // inside Stage see scroll events and content growth — when main was
+  // the scroller, Stage's internal div never overflowed and the scroll
+  // indicator / auto-peek nudge never fired.
+  overflow: "hidden",
   padding: "1.5rem",
   display: "flex",
   justifyContent: "center",
@@ -331,7 +336,9 @@ const mainStyle: React.CSSProperties = {
 const stageContainerStyle: React.CSSProperties = {
   position: "relative",
   width: "100%",
-  alignSelf: "flex-start",
+  // Fill main's height so Stage's height: 100% scroll container resolves
+  // to a concrete size and actually overflows when content exceeds it.
+  height: "100%",
 };
 
 const submittedOverlayStyle: React.CSSProperties = {

--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -412,9 +412,14 @@ test("range mode: click-and-drag creates a range", async ({ mount }) => {
   expect(value[0]?.end).toBeCloseTo(30, 0);
 });
 
-test("range mode: pure click (no drag) does not create a range", async ({
+test("range mode: pure click (no drag) creates a min-width range at the click", async ({
   mount,
 }) => {
+  // Previously clicks moved the playhead; now they create a 1-second range
+  // starting at the click so novice participants get immediate visible
+  // feedback ("I made a thing I can tune") without needing to discover the
+  // drag gesture. See the follow-up test below for the single-select
+  // protection rule.
   const component = await mount(
     <MockTimeline
       source="player"
@@ -429,7 +434,7 @@ test("range mode: pure click (no drag) does not create a range", async ({
   const box = await overlay.boundingBox();
   if (!box) throw new Error("overlay not found");
 
-  // Click without movement
+  // Click at 50% without movement (30s into a 60s timeline)
   await overlay.dispatchEvent("pointerdown", {
     clientX: box.x + box.width * 0.5,
     clientY: box.y + box.height * 0.5,
@@ -447,12 +452,26 @@ test("range mode: pure click (no drag) does not create a range", async ({
     isPrimary: true,
   });
 
-  await expect(component.locator('[data-testid="range-0"]')).not.toBeAttached();
+  const range = component.locator('[data-testid="range-0"]');
+  await expect(range).toBeAttached();
+
+  const saves = await readSaveLog(component);
+  const value = saves[saves.length - 1]?.value as {
+    start: number;
+    end: number;
+  }[];
+  expect(value).toHaveLength(1);
+  // Click at 30s → range [30, 31] (1s default width)
+  expect(value[0]?.start).toBeCloseTo(30, 0);
+  expect(value[0]?.end).toBeCloseTo(31, 0);
 });
 
-test("range mode: dead zone — small movement is treated as a click", async ({
+test("range mode: dead zone — small movement is treated as a click and creates a default range", async ({
   mount,
 }) => {
+  // Small movements under the drag dead-zone fall into the click path,
+  // which now creates a default-width range (not a zero-width range from
+  // the tiny drag).
   const component = await mount(
     <MockTimeline
       source="player"
@@ -493,7 +512,169 @@ test("range mode: dead zone — small movement is treated as a click", async ({
     isPrimary: true,
   });
 
-  await expect(component.locator('[data-testid="range-0"]')).not.toBeAttached();
+  const range = component.locator('[data-testid="range-0"]');
+  await expect(range).toBeAttached();
+
+  const saves = await readSaveLog(component);
+  const value = saves[saves.length - 1]?.value as {
+    start: number;
+    end: number;
+  }[];
+  expect(value).toHaveLength(1);
+  // Click at 30s → range [30, 31]
+  expect(value[0]?.end - value[0]?.start).toBeCloseTo(1, 2);
+});
+
+test("range mode single-select: click on empty timeline preserves existing range", async ({
+  mount,
+}) => {
+  // In single-select mode clicking empty space must NOT replace the
+  // user's existing range — that would feel punitive. Adjustment happens
+  // via the handles instead. (Dragging still creates a new range, which
+  // the reducer replaces — tested below.)
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="ranges"
+      selectionType="range"
+      multiSelect={false}
+      mockDuration={60}
+    />,
+  );
+  const overlay = component.locator('[data-testid="selection-overlay"]');
+  const box = await overlay.boundingBox();
+  if (!box) throw new Error("overlay not found");
+
+  // Drag-create a first range at 20%-30% so single-select has something to
+  // protect.
+  await overlay.dispatchEvent("pointerdown", {
+    clientX: box.x + box.width * 0.2,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+  await overlay.dispatchEvent("pointermove", {
+    clientX: box.x + box.width * 0.3,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+  await overlay.dispatchEvent("pointerup", {
+    clientX: box.x + box.width * 0.3,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+  await expect(component.locator('[data-testid="range-0"]')).toBeAttached();
+
+  const savesBefore = await readSaveLog(component);
+  const before = savesBefore[savesBefore.length - 1]?.value as {
+    start: number;
+    end: number;
+  }[];
+
+  // Pure click at 70% (far from the existing range) — should be ignored.
+  await overlay.dispatchEvent("pointerdown", {
+    clientX: box.x + box.width * 0.7,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 2,
+    isPrimary: true,
+  });
+  await overlay.dispatchEvent("pointerup", {
+    clientX: box.x + box.width * 0.7,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 2,
+    isPrimary: true,
+  });
+
+  // Still exactly one range, and it's the original.
+  await expect(component.locator('[data-testid="range-0"]')).toBeAttached();
+  await expect(component.locator('[data-testid="range-1"]')).not.toBeAttached();
+
+  const savesAfter = await readSaveLog(component);
+  const after = savesAfter[savesAfter.length - 1]?.value as {
+    start: number;
+    end: number;
+  }[];
+  expect(after).toHaveLength(1);
+  expect(after[0]?.start).toBeCloseTo(before[0]?.start, 2);
+  expect(after[0]?.end).toBeCloseTo(before[0]?.end, 2);
+});
+
+test("range mode multi-select: click adds a second range next to existing", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="ranges"
+      selectionType="range"
+      multiSelect={true}
+      mockDuration={60}
+    />,
+  );
+  const overlay = component.locator('[data-testid="selection-overlay"]');
+  const box = await overlay.boundingBox();
+  if (!box) throw new Error("overlay not found");
+
+  // Drag to create first range at 10%-25%
+  await overlay.dispatchEvent("pointerdown", {
+    clientX: box.x + box.width * 0.1,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+  await overlay.dispatchEvent("pointermove", {
+    clientX: box.x + box.width * 0.25,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+  await overlay.dispatchEvent("pointerup", {
+    clientX: box.x + box.width * 0.25,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+  await expect(component.locator('[data-testid="range-0"]')).toBeAttached();
+
+  // Click at 60% — should add a second range.
+  await overlay.dispatchEvent("pointerdown", {
+    clientX: box.x + box.width * 0.6,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 2,
+    isPrimary: true,
+  });
+  await overlay.dispatchEvent("pointerup", {
+    clientX: box.x + box.width * 0.6,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 2,
+    isPrimary: true,
+  });
+
+  await expect(component.locator('[data-testid="range-1"]')).toBeAttached();
 });
 
 test("range mode: multiSelect false — new range replaces existing", async ({

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -71,6 +71,14 @@ export interface SelectionOverlayProps {
 
 const DRAG_DEAD_ZONE_PX = 4;
 
+/**
+ * Width of a range created by a click (no drag) in seconds. Long enough to
+ * be visually distinct as a range rather than a line, short enough that
+ * handles don't overlap for quick tuning. Matches ARROW_STEP in
+ * keyboardActions so click-then-arrow feels consistent.
+ */
+const CLICK_CREATED_RANGE_SEC = 1;
+
 interface DragState {
   startX: number;
   startTime: number;
@@ -92,6 +100,28 @@ interface DragState {
 
 function isRangeArray(s: TimelineValue): s is RangeSelection[] {
   return s.length === 0 || "start" in (s[0] as object);
+}
+
+/**
+ * Two faint vertical bars in the middle of a range handle — signals
+ * "grabbable" at a glance, echoing the standard OS resize-grip pattern.
+ * Sized and positioned relative to the 8px-wide handle parent.
+ */
+function HandleGrip() {
+  const barStyle: React.CSSProperties = {
+    position: "absolute",
+    top: "35%",
+    bottom: "35%",
+    width: 1,
+    background: "rgba(255, 255, 255, 0.75)",
+    pointerEvents: "none",
+  };
+  return (
+    <>
+      <div style={{ ...barStyle, left: 2 }} />
+      <div style={{ ...barStyle, right: 2 }} />
+    </>
+  );
 }
 
 /**
@@ -274,14 +304,34 @@ export function SelectionOverlay({
           // arrow keys adjust the handle rather than scrubbing the playhead.
           onRequestFocus();
         } else if (selectionType === "point") {
+          // Point mode: click anywhere creates a point. The reducer
+          // enforces multiSelect (replacing an existing point in single
+          // mode, appending otherwise), so this one path covers both.
           onCreatePoint(time, track);
           onSeek(time);
           onRequestFocus();
         } else {
-          if (activeIndex !== null) {
-            onDeselect();
+          // Range mode: click creates a default-width range starting at
+          // the click, EXCEPT in single-select mode when a range already
+          // exists — there we preserve the existing work (adjustment
+          // happens via handles). Seek is left to the media player's own
+          // scrubber; click-to-add is the primary gesture on the timeline.
+          const hasExistingRange =
+            isRangeArray(selections) && selections.length > 0;
+          if (!multiSelect && hasExistingRange) {
+            if (activeIndex !== null) onDeselect();
+          } else {
+            let start = time;
+            let end = time + CLICK_CREATED_RANGE_SEC;
+            if (end > duration) {
+              end = duration;
+              start = Math.max(0, duration - CLICK_CREATED_RANGE_SEC);
+            }
+            if (end - start > 0) {
+              onCreateRange(start, end, track);
+              onRequestFocus();
+            }
           }
-          onSeek(time);
         }
       } else if (drag.mode === "create-range") {
         const start = Math.min(drag.startTime, time);
@@ -305,6 +355,9 @@ export function SelectionOverlay({
       eventToTime,
       selectionType,
       activeIndex,
+      duration,
+      selections,
+      multiSelect,
       onCreatePoint,
       onSeek,
       onDeselect,
@@ -467,9 +520,9 @@ export function SelectionOverlay({
             }}
             style={{
               position: "absolute",
-              left: -3,
+              left: -4,
               top: 0,
-              width: 6,
+              width: 8,
               height: "100%",
               background:
                 isActive && activeHandle === "start"
@@ -479,6 +532,7 @@ export function SelectionOverlay({
               zIndex: startHandleOnTop ? 2 : 1,
             }}
           >
+            <HandleGrip />
             {hoveredHandle?.index === i &&
               hoveredHandle?.handle === "start" && (
                 <div style={handleTooltipStyle("start")}>
@@ -502,9 +556,9 @@ export function SelectionOverlay({
             }}
             style={{
               position: "absolute",
-              right: -3,
+              right: -4,
               top: 0,
-              width: 6,
+              width: 8,
               height: "100%",
               background:
                 isActive && activeHandle === "end"
@@ -514,6 +568,7 @@ export function SelectionOverlay({
               zIndex: startHandleOnTop ? 1 : 2,
             }}
           >
+            <HandleGrip />
             {hoveredHandle?.index === i && hoveredHandle?.handle === "end" && (
               <div style={handleTooltipStyle("end")}>
                 {formatTime(range.end, zoomDecimals(zoomLevel))}
@@ -663,7 +718,17 @@ export function SelectionOverlay({
       style={{
         position: "absolute",
         inset: 0,
-        cursor: "crosshair",
+        // Crosshair signals "click adds a selection here." In single-select
+        // range mode once a range exists, clicking empty space is a no-op
+        // (we preserve the existing range) — switch to the default cursor
+        // so the affordance doesn't lie about what a click will do.
+        cursor:
+          selectionType === "range" &&
+          !multiSelect &&
+          isRangeArray(selections) &&
+          selections.length > 0
+            ? "default"
+            : "crosshair",
         pointerEvents: "auto",
       }}
     >

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -319,7 +319,11 @@ export function SelectionOverlay({
           const hasExistingRange =
             isRangeArray(selections) && selections.length > 0;
           if (!multiSelect && hasExistingRange) {
+            // No range creation here, but still request focus so arrow /
+            // Delete / Ctrl-Z keep working after the click (Timeline's
+            // container is what owns the keyboard listeners).
             if (activeIndex !== null) onDeselect();
+            onRequestFocus();
           } else {
             let start = time;
             let end = time + CLICK_CREATED_RANGE_SEC;

--- a/packages/stagebook/src/components/elements/timeline/WaveformRenderer.tsx
+++ b/packages/stagebook/src/components/elements/timeline/WaveformRenderer.tsx
@@ -50,14 +50,23 @@ export function WaveformRenderer({
 
     ctx.clearRect(0, 0, width, height);
 
+    // Track-lane background band — covers ~90% of the vertical space, giving
+    // a visible "this is the track area" frame even when the waveform is
+    // silent or not yet captured. Themed via --stagebook-waveform-track-bg.
+    const computed = getComputedStyle(canvas);
+    const trackBg =
+      computed.getPropertyValue("--stagebook-waveform-track-bg").trim() ||
+      "rgba(128, 128, 128, 0.15)";
+    ctx.fillStyle = trackBg;
+    ctx.fillRect(0, height * 0.05, width, height * 0.9);
+
     if (!peaks || endBucket <= startBucket) return;
 
     const visibleBuckets = endBucket - startBucket;
     const midY = height / 2;
 
     ctx.fillStyle =
-      getComputedStyle(canvas).getPropertyValue("--stagebook-waveform-color") ||
-      "#6b7280";
+      computed.getPropertyValue("--stagebook-waveform-color") || "#6b7280";
 
     // Two render paths:
     //   buckets <= width  → one bar per bucket (existing behavior, faithful

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -103,6 +103,9 @@
 
   /* Timeline waveform bars */
   --stagebook-waveform-color: #6b7280;
+  /* Track-lane background behind the waveform — subtle so the waveform
+     remains visually dominant, but enough to frame the track area. */
+  --stagebook-waveform-track-bg: rgba(128, 128, 128, 0.15);
 
   /* Loading spinner */
   --stagebook-spinner-track: #e5e7eb;


### PR DESCRIPTION
## Summary
Timeline UX polish + a Viewer scroll fix that unblocks the scroll-awareness feature from #203 in the preview. Bundle is tight — all four commits are related to timeline/preview interaction.

## Behavior changes

### Range-mode click (main change)
- Click on empty timeline (no drag) now creates a 1-second range at the click position. Gives immediate visible feedback ("I made a thing I can tune") without requiring drag discovery.
- **Single-select + existing range → click is a no-op.** Replacing a participant's range on one misclick felt punitive; adjustment happens via handles instead. Cursor flips from `crosshair` to `default` over the empty timeline so the affordance doesn't lie about what a click will do.
- **Multi-select → click appends** a new default-width range next to the existing ones.
- Drag-to-create is unchanged (still produces arbitrary-width ranges).
- Click on an existing range body still selects it (unchanged).
- Handle drag to resize is unchanged.

### Point mode
Unchanged — click creates a point, reducer enforces single vs multi.

## Visual changes
- Range handles widened 6→8px with two faint vertical "grip" bars in the middle, matching the OS resize-grip convention. Obviously grabbable at a glance.
- Subtle grey track-lane band drawn behind each waveform (~90% of track height). Gives the eye a clear "this is the track area" frame even when the waveform is silent or not yet captured. Themed via `--stagebook-waveform-track-bg`.

## Bug fix
- **Viewer scroll container**: `<main>` in the Viewer app had `overflow: auto`, so it was the element that actually scrolled when stage content overflowed. Stage's own scroll div sized to content inside `<main>` and never overflowed — so `useScrollAwareness` saw scrollHeight == clientHeight, and the scroll indicator + auto-peek nudge never fired in the Viewer or VS Code preview. Flipped `main` to `overflow: hidden` and let the stage container fill main's height, so Stage's internal div is the scroller (matching how host integrations like deliberation-lab place Stage).

## Why click-to-add over keep-click-to-seek
1. The media player has its own click-to-seek scrubber, so the convention isn't lost — just moved to the element that owns playhead control.
2. Unifies point and range creation under one gesture (you can't drag to create a point).
3. Novice participants discover timeline functionality in one move rather than needing to try drag.

The single-select collision (what does a click on an already-selected timeline do?) was resolved by making click a no-op when it'd otherwise destroy existing work — an asymmetric rule that's individually intuitive in each sub-case.

## Test plan
- [x] Unit suite green (643 tests, now 644 with the styles test catching the new CSS var)
- [x] CT suite green (369 tests) — includes 2 rewritten and 3 new tests for the new click paths
- [x] New tests cover: click creates min-width range, dead-zone movement still creates range, single-select protection, multi-select append

🤖 Generated with [Claude Code](https://claude.com/claude-code)