### PR TITLE
Release v0.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13682,7 +13682,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Bumps `stagebook` to `0.6.1`. Release notes below will be reused for the GitHub release after merge.

---

## What's new

### Timeline: click-to-add range (#205)
Primary click gesture on the Timeline overlay now **creates a 1-second range at the click position** instead of moving the playhead. Seek-by-click is still available on the media player's own scrubber, so the convention isn't lost — just moved to the element that owns playhead control. Why: novice participants discover timeline functionality in one move rather than having to guess that drag is the right gesture; also unifies point and range creation (you can't drag to create a point) under a single mental model.

Behavioral details:
- **Single-select + existing range → click is a no-op.** Replacing the participant's range on one misclick felt punitive; adjustment happens via the handles instead. Cursor flips from `crosshair` to `default` over empty timeline so the affordance doesn't lie about what a click will do.
- **Multi-select → click appends** a new default-width range.
- **Drag-to-create** is unchanged (still produces arbitrary-width ranges).
- **Point mode** is unchanged.

### Timeline visual polish (#205)
- Range handles widened 6→8px with two faint vertical "grip" bars in the middle, matching the OS resize-grip convention. Obviously grabbable at a glance.
- Subtle grey track-lane band drawn behind each waveform (~90% of track height). Frames the track area even when the waveform is silent or not yet captured. Themed via `--stagebook-waveform-track-bg`.

## Bug fixes

- **Viewer scroll container (#205)**: `<main>` in the Viewer app had `overflow: auto`, so it was the element that actually scrolled when stage content overflowed. Stage's own scroll div sized to content inside `<main>` and never overflowed — so `useScrollAwareness` (added in 0.6.0) saw `scrollHeight == clientHeight`, and the scroll indicator + auto-peek nudge never fired in the Viewer or VS Code preview. Flipped `main` to `overflow: hidden` and let the stage container fill main's height, so Stage's internal div is the scroller (matching how host integrations like deliberation-lab place Stage).

## Test plan
- [x] Full local suite green — stagebook + viewer + vscode unit tests, Playwright CT suite
- [x] Lint + format clean
- [ ] After merge, tag `v0.6.1` and publish the GitHub release — [`npm-publish.yml`](.github/workflows/npm-publish.yml) picks up the `release: published` event automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)