### PR TITLE
Add opt-in stagebook/host-typography CSS layer (#206)

### DIFF
--- a/docs/engineer/architecture.md
+++ b/docs/engineer/architecture.md
@@ -120,3 +120,18 @@ Stagebook ships a default stylesheet (`stagebook/styles`) with CSS custom proper
 ```
 
 Component layout (padding, flex, positioning) uses inline styles and is not overridable — this ensures consistent experiment rendering. Only visual theming (colors, borders) is customizable.
+
+### Opt-in host typography (`stagebook/host-typography`)
+
+Stagebook components render correctly on any host without extra CSS, but the *host's* own bare-tag pages (settings, permissions, attention checks, etc.) inherit whatever reset the host has (Tailwind preflight, no-preflight, normalize.css, nothing). That's how two apps using stagebook end up with noticeably different `<h1>` / `<img>` / `<a>` rendering on pages that don't use stagebook components.
+
+`stagebook/host-typography` is an opt-in stylesheet that provides a small preflight-like baseline on **bare tags only**: universal `box-sizing: border-box`, `img/video { max-width: 100% }`, a heading type scale, zero `margin-block` on `p/ul/ol/h*`, and `a` styled from `--stagebook-link`. No class selectors — nothing that targets stagebook's own components.
+
+Import it alongside `stagebook/styles`:
+
+```ts
+import "stagebook/styles";
+import "stagebook/host-typography";
+```
+
+Trade-offs: not compatible with Tailwind preflight (pick one), and the reset applies to third-party widgets the host renders too. Hosts that need to preserve third-party rendering should either not import this globally or scope it to their own UI tree via their own wrapper class.

--- a/docs/engineer/architecture.md
+++ b/docs/engineer/architecture.md
@@ -125,7 +125,7 @@ Component layout (padding, flex, positioning) uses inline styles and is not over
 
 Stagebook components render correctly on any host without extra CSS, but the *host's* own bare-tag pages (settings, permissions, attention checks, etc.) inherit whatever reset the host has (Tailwind preflight, no-preflight, normalize.css, nothing). That's how two apps using stagebook end up with noticeably different `<h1>` / `<img>` / `<a>` rendering on pages that don't use stagebook components.
 
-`stagebook/host-typography` is an opt-in stylesheet that provides a small preflight-like baseline on **bare tags only**: universal `box-sizing: border-box`, `img/video { max-width: 100% }`, a heading type scale, zero `margin-block` on `p/ul/ol/h*`, and `a` styled from `--stagebook-link`. No class selectors — nothing that targets stagebook's own components.
+`stagebook/host-typography` is an opt-in stylesheet that provides a small preflight-like baseline on **bare tags only**: a universal box-model reset of `box-sizing: border-box` and `border: 0 solid`, `img/video { max-width: 100% }`, a heading type scale, zero `margin-block` on `p/ul/ol/h*`, and `a` styled from `--stagebook-link`. No class selectors — nothing that targets stagebook's own components.
 
 Import it alongside `stagebook/styles`:
 

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -18,6 +18,7 @@
       }
     },
     "./styles": "./src/styles.css",
+    "./host-typography": "./src/host-typography.css",
     "./components": {
       "import": {
         "types": "./dist/components/index.d.ts",
@@ -31,7 +32,8 @@
   },
   "files": [
     "dist",
-    "src/styles.css"
+    "src/styles.css",
+    "src/host-typography.css"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/stagebook/src/host-typography.css
+++ b/packages/stagebook/src/host-typography.css
@@ -1,0 +1,146 @@
+/*
+ * stagebook/host-typography
+ *
+ * OPT-IN typography + box-model baseline for host apps that want consistent
+ * cross-host rendering on their own bare tags. Import alongside
+ * `stagebook/styles`:
+ *
+ *   import "stagebook/styles";
+ *   import "stagebook/host-typography";
+ *
+ * Why this exists: stagebook components ship inline styles and render
+ * correctly on any host without extra CSS. But the *host's* own pages
+ * (settings, permissions, attention checks, report forms, etc.) use bare
+ * tags like <h1>, <img>, <a>, <p>, and those inherit the host's CSS reset
+ * decisions — Tailwind preflight, no-preflight, normalize.css, bootstrap
+ * reboot, or nothing at all. Two apps that embed stagebook can then render
+ * "sibling" pages inconsistently even though they share the same library.
+ *
+ * This stylesheet targets ONLY bare tags (no class selectors, no
+ * `.stagebook-*` rules, no form resets beyond what styles.css already
+ * handles). It's a host-layer preflight, not a component stylesheet.
+ *
+ * Scope and trade-offs:
+ * - NOT compatible with Tailwind preflight — pick one. Hosts that already
+ *   use Tailwind preflight get sensible defaults without this layer.
+ * - Overrides bare-tag browser defaults everywhere in the host app,
+ *   including inside any third-party widgets the host renders (e.g.
+ *   `survey-react`). Hosts that need to preserve browser defaults for a
+ *   specific subtree should not import this globally — or scope it via
+ *   their own wrapper (this file deliberately doesn't define one).
+ * - NOT a stylesheet for stagebook's own components. Those already ship
+ *   inline styles and aren't affected by this layer.
+ *
+ * Customize by overriding the --stagebook-* variables at :root or on any
+ * ancestor element — same pattern as stagebook/styles.
+ */
+
+/* ------------------------------------------------------------------ */
+/* Typography scale                                                     */
+/* ------------------------------------------------------------------ */
+
+:root {
+  --stagebook-h1-size: 1.875rem; /* 30px */
+  --stagebook-h2-size: 1.5rem; /* 24px */
+  --stagebook-h3-size: 1.25rem; /* 20px */
+  --stagebook-h4-size: 1.125rem; /* 18px */
+  --stagebook-h5-size: 1rem; /* 16px */
+  --stagebook-h6-size: 0.875rem; /* 14px */
+  --stagebook-body-size: 1rem;
+  --stagebook-body-line-height: 1.5;
+  --stagebook-heading-weight: 600;
+  --stagebook-link-hover: #1d4ed8;
+  /* --stagebook-link is declared in stagebook/styles. Usages below carry a
+     literal fallback so this file is still usable if imported alone. */
+}
+
+/* ------------------------------------------------------------------ */
+/* Box model — universal border-box + safe border-default so                 */
+/* utility-style `border-t` / `border-b` rules from downstream code          */
+/* (if any) render as expected without an explicit border-style.            */
+/* ------------------------------------------------------------------ */
+
+*,
+::before,
+::after {
+  box-sizing: border-box;
+  border: 0 solid;
+}
+
+/* ------------------------------------------------------------------ */
+/* Media — never overflow the container at natural resolution                */
+/* ------------------------------------------------------------------ */
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}
+
+/* ------------------------------------------------------------------ */
+/* Headings — reset margin-block so host layouts control spacing, and        */
+/* restore a usable type scale regardless of what the host's reset does.    */
+/* ------------------------------------------------------------------ */
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-weight: var(--stagebook-heading-weight, 600);
+  margin-block: 0;
+}
+
+h1 {
+  font-size: var(--stagebook-h1-size, 1.875rem);
+}
+h2 {
+  font-size: var(--stagebook-h2-size, 1.5rem);
+}
+h3 {
+  font-size: var(--stagebook-h3-size, 1.25rem);
+}
+h4 {
+  font-size: var(--stagebook-h4-size, 1.125rem);
+}
+h5 {
+  font-size: var(--stagebook-h5-size, 1rem);
+}
+h6 {
+  font-size: var(--stagebook-h6-size, 0.875rem);
+}
+
+/* ------------------------------------------------------------------ */
+/* Body text                                                            */
+/* ------------------------------------------------------------------ */
+
+body {
+  font-size: var(--stagebook-body-size, 1rem);
+  line-height: var(--stagebook-body-line-height, 1.5);
+}
+
+/* ------------------------------------------------------------------ */
+/* Paragraphs and lists — zero margin-block so host layouts control          */
+/* vertical rhythm. Hosts that want classic browser spacing can set          */
+/* their own `margin-block` rule after importing this file.                 */
+/* ------------------------------------------------------------------ */
+
+p,
+ul,
+ol {
+  margin-block: 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* Links                                                                */
+/* ------------------------------------------------------------------ */
+
+a {
+  color: var(--stagebook-link, #2563eb);
+  text-decoration: underline;
+}
+
+a:hover {
+  color: var(--stagebook-link-hover, #1d4ed8);
+}

--- a/packages/stagebook/src/host-typography.test.ts
+++ b/packages/stagebook/src/host-typography.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const cssPath = join(here, "host-typography.css");
+
+describe("host-typography.css", () => {
+  const css = readFileSync(cssPath, "utf8");
+  // Strip comments so documented override examples or JSDoc-style prose
+  // can't accidentally satisfy the assertions below.
+  const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, "");
+
+  it("declares the typography-scale custom properties", () => {
+    for (const name of [
+      "--stagebook-h1-size",
+      "--stagebook-h2-size",
+      "--stagebook-h3-size",
+      "--stagebook-h4-size",
+      "--stagebook-body-size",
+      "--stagebook-body-line-height",
+      "--stagebook-heading-weight",
+      "--stagebook-link-hover",
+    ]) {
+      expect(cssWithoutComments).toMatch(new RegExp(`${name}\\s*:`));
+    }
+  });
+
+  it("applies the box-sizing reset to universal selectors", () => {
+    // Pins the exact shape the issue prescribed — don't silently degrade to
+    // a class-scoped reset which would break the contract.
+    expect(cssWithoutComments).toMatch(
+      /\*\s*,\s*::before\s*,\s*::after\s*{[^}]*box-sizing:\s*border-box/,
+    );
+  });
+
+  it("applies the media max-width rule to bare img/video tags", () => {
+    expect(cssWithoutComments).toMatch(
+      /\bimg\s*,\s*video\s*{[^}]*max-width:\s*100%/,
+    );
+  });
+
+  it("sets heading font-sizes from variables", () => {
+    expect(cssWithoutComments).toMatch(
+      /\bh1\s*{[^}]*font-size:\s*var\(--stagebook-h1-size/,
+    );
+    expect(cssWithoutComments).toMatch(
+      /\bh2\s*{[^}]*font-size:\s*var\(--stagebook-h2-size/,
+    );
+    expect(cssWithoutComments).toMatch(
+      /\bh3\s*{[^}]*font-size:\s*var\(--stagebook-h3-size/,
+    );
+    expect(cssWithoutComments).toMatch(
+      /\bh4\s*{[^}]*font-size:\s*var\(--stagebook-h4-size/,
+    );
+  });
+
+  it("styles bare <a> with stagebook-link and hover variants", () => {
+    expect(cssWithoutComments).toMatch(
+      /\ba\s*{[^}]*color:\s*var\(--stagebook-link[^)]*\)/,
+    );
+    expect(cssWithoutComments).toMatch(
+      /\ba:hover\s*{[^}]*color:\s*var\(--stagebook-link-hover/,
+    );
+  });
+
+  it("has no class selectors (the 'no .stagebook-* rules' contract)", () => {
+    // The file must target bare tags only. Class selectors would put
+    // styling on stagebook's own components and defeat the "host-only"
+    // contract documented in the header.
+    const ruleSelectors = [
+      ...cssWithoutComments.matchAll(/([^{}]+){/g),
+    ].flatMap((m) =>
+      m[1]
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean),
+    );
+    const classSelectors = ruleSelectors.filter((s) => s.includes("."));
+    expect(classSelectors).toEqual([]);
+  });
+});

--- a/packages/stagebook/src/host-typography.test.ts
+++ b/packages/stagebook/src/host-typography.test.ts
@@ -18,6 +18,8 @@ describe("host-typography.css", () => {
       "--stagebook-h2-size",
       "--stagebook-h3-size",
       "--stagebook-h4-size",
+      "--stagebook-h5-size",
+      "--stagebook-h6-size",
       "--stagebook-body-size",
       "--stagebook-body-line-height",
       "--stagebook-heading-weight",
@@ -42,18 +44,13 @@ describe("host-typography.css", () => {
   });
 
   it("sets heading font-sizes from variables", () => {
-    expect(cssWithoutComments).toMatch(
-      /\bh1\s*{[^}]*font-size:\s*var\(--stagebook-h1-size/,
-    );
-    expect(cssWithoutComments).toMatch(
-      /\bh2\s*{[^}]*font-size:\s*var\(--stagebook-h2-size/,
-    );
-    expect(cssWithoutComments).toMatch(
-      /\bh3\s*{[^}]*font-size:\s*var\(--stagebook-h3-size/,
-    );
-    expect(cssWithoutComments).toMatch(
-      /\bh4\s*{[^}]*font-size:\s*var\(--stagebook-h4-size/,
-    );
+    for (const n of [1, 2, 3, 4, 5, 6]) {
+      expect(cssWithoutComments).toMatch(
+        new RegExp(
+          `\\bh${n}\\s*{[^}]*font-size:\\s*var\\(--stagebook-h${n}-size`,
+        ),
+      );
+    }
   });
 
   it("styles bare <a> with stagebook-link and hover variants", () => {
@@ -77,7 +74,13 @@ describe("host-typography.css", () => {
         .map((s) => s.trim())
         .filter(Boolean),
     );
-    const classSelectors = ruleSelectors.filter((s) => s.includes("."));
+    // Real class selectors only: a literal `.` followed by an identifier.
+    // Raw `includes(".")` would false-positive on attribute selectors like
+    // `[href*=".pdf"]` if any were ever added.
+    const classSelectorPattern = /\.[A-Za-z_-][\w-]*/;
+    const classSelectors = ruleSelectors.filter((s) =>
+      classSelectorPattern.test(s),
+    );
     expect(classSelectors).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #206.

## Summary
New opt-in stylesheet export `stagebook/host-typography` that provides a preflight-like baseline for **host apps' bare-tag pages** (settings, permissions, attention checks, etc.) so two apps embedding stagebook render those pages consistently.

Rendering of stagebook's own components is unaffected — they already ship inline styles.

## Usage
```ts
import \"stagebook/styles\";
import \"stagebook/host-typography\";
```

## Contents
- Universal `box-sizing: border-box` + `border: 0 solid`
- `img, video { max-width: 100%; height: auto }`
- Heading type scale driven by `--stagebook-h{1..6}-size` variables (30/24/20/18/16/14px)
- `margin-block: 0` on `h*, p, ul, ol` so host layouts control vertical rhythm
- `a` styled from `--stagebook-link` + new `--stagebook-link-hover`

## Deliberate non-goals
- **No class selectors, no `.stagebook-*` rules** — enforced by a test. This is a host-layer preflight, not a component stylesheet.
- **No form resets** — `stagebook/styles` already handles those.
- **Not compatible with Tailwind preflight** — hosts pick one. Documented in the file header and `docs/engineer/architecture.md`.
- **Applies to third-party widgets the host renders** — hosts that need to preserve third-party rendering should either not import this globally or scope it via their own wrapper (this file deliberately doesn't define one).

## Package surface
- New file: `packages/stagebook/src/host-typography.css`
- New export: `\"./host-typography\": \"./src/host-typography.css\"`
- Added to `files` in package.json so it ships in the npm package.

## Test plan
- [x] New vitest suite (6 tests) — verifies the typography-scale variables are declared, the universal box-sizing rule exists in the prescribed shape, img/video max-width applies, heading sizes map to their variables, `a` uses `--stagebook-link` + `--stagebook-link-hover`, and there are no class selectors (contract pin).
- [x] Full unit suite green (649 stagebook + 75 viewer + 189 vscode)
- [x] CT suite unaffected (didn't re-run — no component source changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)