### PR TITLE
Release v0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13682,7 +13682,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Bumps \`stagebook\` to \`0.7.0\`. Release notes below will be reused for the GitHub release after merge.

Minor bump (not patch) because a new public export is added (\`stagebook/host-typography\`) — no behavior changes for existing consumers, but the package surface grows.

---

## What's new

### Opt-in \`stagebook/host-typography\` CSS layer (#208)
New optional stylesheet export that host apps can import alongside \`stagebook/styles\` to get a consistent preflight-like baseline on their own bare-tag pages (settings, permissions, attention checks, etc.). Without it, two apps that both embed stagebook end up rendering their non-stagebook pages differently based on whatever reset the host is using — Tailwind preflight, no-preflight, normalize.css, nothing. With it, bare tags get a small, themeable baseline:

- Universal \`box-sizing: border-box\` + \`border: 0 solid\`
- \`img, video { max-width: 100%; height: auto }\`
- Heading type scale driven by \`--stagebook-h{1..6}-size\` variables (30/24/20/18/16/14px)
- \`margin-block: 0\` on \`h*, p, ul, ol\` so host layouts control vertical rhythm
- \`a\` styled from \`--stagebook-link\` + new \`--stagebook-link-hover\`

Strictly host-layer — no class selectors, no \`.stagebook-*\` rules (enforced by a test), no form resets beyond what \`stagebook/styles\` already handles. Not compatible with Tailwind preflight (pick one); applies to any third-party widgets the host renders too.

\`\`\`ts
import \"stagebook/styles\";
import \"stagebook/host-typography\";
\`\`\`

Documented in [docs/engineer/architecture.md](docs/engineer/architecture.md).

## Test plan
- [x] Full local suite green — stagebook (including 6 new host-typography tests) + viewer + vscode unit tests, Playwright CT suite
- [x] Lint + format clean
- [ ] After merge, tag \`v0.7.0\` and publish the GitHub release — [\`npm-publish.yml\`](.github/workflows/npm-publish.yml) picks up the \`release: published\` event automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)