### PR TITLE
Migrate annotated-walkthrough to showcase notes + README (#184)

### DIFF
--- a/examples/annotated-walkthrough/README.md
+++ b/examples/annotated-walkthrough/README.md
@@ -1,0 +1,37 @@
+# Annotated walkthrough
+
+A self-contained pedagogical example that tours Stagebook's treatment-file syntax. The study itself is a two-person text discussion: each participant writes an initial position on a topic, discusses it with a partner, then reflects after seeing the partner's original response.
+
+Two treatments are generated from a single template by broadcasting over a list of topics — you'll see them side-by-side in the treatment picker.
+
+## What this example demonstrates
+
+| Feature                                                              | Where it lives                                                         |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| **Templates** with `${fieldName}` placeholders                       | `templates:` → `studyTreatment`                                        |
+| **Broadcast** expansion (one template → N treatments)                | `treatments:` → `broadcast: { d0: [...] }`                             |
+| **Intro / game / exit** sequences                                    | `introSequences`, `gameStages`, `exitSequence`                         |
+| **Timed elements** (`displayTime`, `hideTime`)                       | Stage 1 (`*_initial`)                                                  |
+| **Position-based visibility** (`showToPositions`)                    | Stage 3 (`*_reflection`) display elements                              |
+| **`groupComposition`** (matching participants by condition)          | `studyTreatment.groupComposition`                                      |
+| **Conditional rendering** on elements                                | Stage 3 consensus prompt                                               |
+| **`display` elements** (one player's response shown to another)      | Stage 3                                                                |
+| **Platform-coupled elements** (`survey`, `discussion`, `sharedNotepad`, `qualtrics`) | Intro `Personality`, Stage 2, exit `Exit Survey` |
+
+The platform-coupled elements render as skeleton placeholders in the viewer — they require a live multi-participant session on a host that implements the corresponding slot.
+
+## How to read the file
+
+Open `walkthrough.treatments.yaml` in the viewer (or any editor) and scan top-to-bottom. Each stage, element, and template carries a `notes:` field explaining what it's demonstrating — the viewer surfaces these in the sidebar, and elements with notes get a small info-icon overlay you can click to focus that note.
+
+The `notes:` fields are researcher documentation, not participant-facing content. Participant-facing copy lives in the `prompts/` directory as individual `*.prompt.md` files.
+
+## Running it
+
+Load this directory from the viewer's landing page (file picker → point at `walkthrough.treatments.yaml`) or run the dev viewer from the stagebook repo root:
+
+```
+npm run dev -w stagebook-viewer
+```
+
+Then click the "annotated-walkthrough" card. You can step through intro → game → exit from the sidebar, and switch between the two broadcast-generated treatments (`remote work policies`, `the four-day work week`) from the treatment picker.

--- a/examples/annotated-walkthrough/README.md
+++ b/examples/annotated-walkthrough/README.md
@@ -28,10 +28,10 @@ The `notes:` fields are researcher documentation, not participant-facing content
 
 ## Running it
 
-Load this directory from the viewer's landing page (file picker → point at `walkthrough.treatments.yaml`) or run the dev viewer from the stagebook repo root:
+From the viewer's landing page you can either click the **annotated-walkthrough** example card, or paste a GitHub URL to this repo's `walkthrough.treatments.yaml` into the URL input and press Load. To run the dev viewer locally:
 
 ```
 npm run dev -w stagebook-viewer
 ```
 
-Then click the "annotated-walkthrough" card. You can step through intro → game → exit from the sidebar, and switch between the two broadcast-generated treatments (`remote work policies`, `the four-day work week`) from the treatment picker.
+Once loaded, step through intro → game → exit from the sidebar, and switch between the two broadcast-generated treatments (`remote work policies`, `the four-day work week`) from the treatment picker.

--- a/examples/annotated-walkthrough/README.md
+++ b/examples/annotated-walkthrough/README.md
@@ -16,9 +16,10 @@ Two treatments are generated from a single template by broadcasting over a list 
 | **`groupComposition`** (matching participants by condition)          | `studyTreatment.groupComposition`                                      |
 | **Conditional rendering** on elements                                | Stage 3 consensus prompt                                               |
 | **`display` elements** (one player's response shown to another)      | Stage 3                                                                |
-| **Platform-coupled elements** (`survey`, `discussion`, `sharedNotepad`, `qualtrics`) | Intro `Personality`, Stage 2, exit `Exit Survey` |
+| **Platform-coupled elements** (`survey`, `discussion`, `sharedNotepad`) | Intro `Personality`, Stage 2                                           |
+| **`qualtrics` element** (real iframe to an external survey)          | exit `Exit Survey`                                                     |
 
-The platform-coupled elements render as skeleton placeholders in the viewer — they require a live multi-participant session on a host that implements the corresponding slot.
+The platform-coupled elements render as skeleton placeholders in the viewer — they require a host that implements the corresponding `render*` slot. The `qualtrics` element is different: stagebook renders it directly as an iframe to the configured URL, so the viewer will attempt to load `example.qualtrics.com` (which will fail, since that's a placeholder URL) rather than showing a skeleton.
 
 ## How to read the file
 

--- a/examples/annotated-walkthrough/walkthrough.treatments.yaml
+++ b/examples/annotated-walkthrough/walkthrough.treatments.yaml
@@ -1,66 +1,36 @@
-# =====================================================================
-# Annotated walkthrough — a Stagebook syntax tour
-# =====================================================================
-#
-# This treatment file is a self-contained pedagogical example. Each
-# block is annotated with what it demonstrates; together they cover
-# the syntax features you need to write a real study:
-#
-#   - templates (with broadcast expansion)
-#   - intro / game / exit sequences
-#   - timed elements (displayTime, hideTime)
-#   - position-based visibility (showToPositions, groupComposition)
-#   - conditions (on elements and on group assignment)
-#   - display elements (showing one player's response to another)
-#   - platform-coupled elements (survey, discussion, sharedNotepad,
-#     qualtrics) — these render as skeleton placeholders in the viewer
-#
-# The study itself is a two-person text discussion. Each participant
-# writes an initial position, discusses it with a partner, then
-# reflects after seeing the partner's original response.
-# Two treatments are generated from one template by broadcasting over
-# a list of discussion topics.
-# ---------------------------------------------------------------------
+# Annotated walkthrough — a Stagebook syntax tour.
+# See README.md for the big-picture overview. The `notes:` fields below
+# describe each stage/element/template and are surfaced in the viewer
+# sidebar; short inline comments flag syntax particulars.
 
-
-# --- TEMPLATES -------------------------------------------------------
-#
-# Templates are reusable blocks of YAML. Define a structure once, then
-# instantiate it with different field values via `template:` + `fields:`
-# (single use) or `template:` + `broadcast:` (cartesian expansion).
-# Placeholders use the `${fieldName}` syntax and are substituted at
-# expansion time. `contentType` tells the validator which schema to
-# apply to `templateContent`.
 templates:
   - templateName: studyTreatment
     contentType: treatment
     templateDesc: One run of the study, parameterised by topic.
+    notes: |
+      Templates are reusable blocks of YAML — define a structure once,
+      then instantiate it with different field values via `template:` +
+      `fields:` (single use) or `template:` + `broadcast:` (cartesian
+      expansion, used here under `treatments:`). Placeholders use the
+      `${fieldName}` syntax and are substituted at expansion time.
+      `contentType: treatment` tells the validator which schema to apply
+      to `templateContent`.
     templateContent:
-      # `${topic}` and `${topicLabel}` come from the broadcast axis
-      # below. After expansion `${topic}` becomes e.g. "remote_work"
-      # and `${topicLabel}` becomes "remote work policies".
+      # `${topic}` and `${topicLabel}` come from the broadcast axis at
+      # the bottom of the file. After expansion `${topic}` becomes e.g.
+      # "remote_work" and `${topicLabel}` becomes "remote work policies".
       name: Annotated walkthrough - ${topicLabel}
-      # `notes` carries free-text, Markdown documentation for the
-      # researcher (rationale, citations, design notes). The viewer
-      # surfaces it — here it powers the treatment card on the
-      # landing page.
-      notes: |
-        A two-person text discussion about ${topicLabel}, annotated as
-        a syntax tour. Demonstrates templates (with broadcast), timed
-        stages, position-based visibility, group composition by
-        condition, display elements, conditional rendering, and the
-        platform-coupled elements (`survey`, `discussion`,
-        `sharedNotepad`, `qualtrics`) that surface as skeleton
-        placeholders in the viewer.
+      notes: A two-person text discussion about ${topicLabel}, annotated as a syntax tour.
       playerCount: 2
 
       # `groupComposition` matches participants to numbered positions
-      # using conditions on data captured during the intro. Here we
-      # use an absolute cutoff on the familiarity slider: scores >= 50
-      # are eligible for position 0 ("Familiar"), scores < 50 are
-      # eligible for position 1 ("Newcomer"). A group only forms when
-      # one participant matches each side of the cutoff — this is the
-      # intentional cost of threshold-based composition.
+      # using conditions on data captured during the intro. (Player-level
+      # blocks don't carry `notes:`, so the explanatory commentary for
+      # this block lives here as a YAML comment.) Absolute cutoff on the
+      # familiarity slider: scores ≥ 50 → position 0 ("Familiar"); scores
+      # < 50 → position 1 ("Newcomer"). A group only forms when one
+      # participant matches each side of the cutoff — the intentional
+      # cost of threshold-based composition.
       groupComposition:
         - position: 0
           title: Familiar
@@ -76,34 +46,46 @@ templates:
               value: 50
 
       gameStages:
-        # ----- Stage 1: Initial position (timed reveal) ------------
-        # Demonstrates `displayTime` / `hideTime`: instructions are
-        # visible for the first 10 seconds, then swapped for the
-        # actual prompt. The submit button only appears after the
-        # prompt is visible to discourage skipping the read.
         - name: ${topic}_initial
           duration: 90
+          notes: |
+            Demonstrates timed reveal with `displayTime` / `hideTime`.
+            Instructions are visible for the first 10 seconds, then
+            swapped for the actual prompt. The submit button only
+            appears after the prompt is visible to discourage skipping
+            the read.
           elements:
             - type: prompt
               file: prompts/initial_intro.prompt.md
               hideTime: 10
-            # `name:` makes this response addressable as
-            # `prompt.${topic}_initial` in later references.
+              notes: |
+                Visible for 0–10s via `hideTime: 10`. Acts as a short
+                orientation screen before the real prompt appears.
             - type: prompt
+              # `name:` makes this response addressable as
+              # `prompt.${topic}_initial` in later references.
               name: ${topic}_initial
               file: prompts/topic_${topic}.prompt.md
               displayTime: 10
+              notes: |
+                Visible from 10s onward via `displayTime: 10`. Named so
+                Stage 3's `display` elements can reference
+                `prompt.${topic}_initial`.
             - type: timer
             - type: submitButton
               buttonText: Submit my position
               displayTime: 10
+              notes: Hidden for the first 10s so participants read the orientation before they can advance.
 
-        # ----- Stage 2: Discussion (platform-coupled) --------------
-        # The `discussion` block adds a synchronised chat panel. The
-        # viewer renders this as a skeleton placeholder — it requires
-        # a live multi-participant session.
         - name: ${topic}_discussion
           duration: 300
+          notes: |
+            Platform-coupled stage. The `discussion` block adds a
+            synchronised chat panel; `sharedNotepad` adds a
+            collaborative editor. Both are slots the host platform
+            implements — they render as skeleton placeholders in the
+            viewer because they require a live multi-participant
+            session.
           discussion:
             chatType: text
             showNickname: true
@@ -112,36 +94,36 @@ templates:
           elements:
             - type: prompt
               file: prompts/discussion_guide.prompt.md
-            # `sharedNotepad` is platform-coupled (collaborative editor).
-            # Skeleton in the viewer.
             - type: sharedNotepad
               name: ${topic}_notes
+              notes: Platform-coupled collaborative editor. Renders as a skeleton placeholder in the viewer.
             - type: timer
             - type: submitButton
               buttonText: End discussion
-              # Hide the submit button during the first minute so
-              # participants engage before bailing out.
               displayTime: 60
+              notes: Hidden for the first 60s so participants engage before they can bail out.
 
-        # ----- Stage 3: Reflection (positions + display + condition)
-        # Each participant sees the *other* participant's initial
-        # response. `showToPositions` restricts which seat receives
-        # the element; `position:` on a `display` selects whose
-        # response to read. The conditional prompt only appears once
-        # both participants have responded to the post-survey.
         - name: ${topic}_reflection
           duration: 120
+          notes: |
+            Demonstrates positions + `display` elements + conditional
+            rendering. Each participant sees the *other* participant's
+            initial response; `showToPositions` restricts which seat
+            receives the element and `position:` on a `display` selects
+            whose response to read. The consensus prompt only appears
+            once both participants have answered the "changed mind"
+            question.
           elements:
-            # Show position 1's initial response to position 0
             - type: display
               reference: prompt.${topic}_initial
               position: 1
               showToPositions: [0]
-            # Show position 0's initial response to position 1
+              notes: Shows position 1's initial response to position 0.
             - type: display
               reference: prompt.${topic}_initial
               position: 0
               showToPositions: [1]
+              notes: Shows position 0's initial response to position 1.
 
             - type: separator
               style: thick
@@ -154,13 +136,6 @@ templates:
               name: ${topic}_changed
               file: prompts/post_changed.prompt.md
 
-            # Conditional element: only appears once *both* players
-            # have answered the "changed mind" question. We check each
-            # position explicitly because the resolver filters out
-            # undefined values before comparison — `position: all`
-            # with `exists` would fire as soon as a single player
-            # responded. Conditions AND together, so this prompt only
-            # becomes visible when both references are defined.
             - type: prompt
               file: prompts/post_consensus.prompt.md
               conditions:
@@ -170,72 +145,75 @@ templates:
                 - reference: prompt.${topic}_changed
                   position: 1
                   comparator: exists
+              notes: |
+                Conditional element — only appears once *both* players
+                have answered the "changed mind" question. We check each
+                position explicitly because the resolver filters out
+                undefined values before comparison: `position: all` with
+                `exists` would fire as soon as a single player
+                responded. Conditions AND together, so this prompt only
+                becomes visible when both references are defined.
 
             - type: submitButton
 
-      # ----- Exit sequence (per-treatment, solo) -------------------
       exitSequence:
         - name: Debrief
+          notes: Per-treatment, solo exit step. Runs after the game stages but before any treatment-wide exit survey.
           elements:
             - type: prompt
               name: ${topic}_feedback
               file: prompts/exit_feedback.prompt.md
             - type: submitButton
-        # Exit step that auto-submits when the embedded survey
-        # completes — `qualtrics` is platform-coupled (skeleton in
-        # the viewer). No submitButton needed because Qualtrics
-        # advancement is handled by the iframe completion event.
         - name: Exit Survey
+          notes: Auto-submits when the embedded Qualtrics survey signals completion — no `submitButton` needed because advancement is handled by the iframe completion event.
           elements:
             - type: qualtrics
               name: exit_qualtrics
               url: https://example.qualtrics.com/jfe/form/SV_example
 
-
-# --- INTRO SEQUENCES -------------------------------------------------
-#
-# Intro steps run solo, before participants are matched. They cannot
-# use `position`, `showToPositions`, or `hideFromPositions`. Every
-# intro/exit step needs an "advancement element" — a submitButton, a
-# survey, a qualtrics, or a mediaPlayer with `submitOnComplete: true`.
 introSequences:
   - name: onboarding
+    notes: |
+      Intro steps run solo, before participants are matched. They
+      cannot use `position`, `showToPositions`, or `hideFromPositions`.
+      Every intro/exit step needs an "advancement element" — a
+      `submitButton`, a `survey`, a `qualtrics`, or a `mediaPlayer`
+      with `submitOnComplete: true`.
     introSteps:
-      # `noResponse` prompt — informational text, no input collected.
       - name: Consent
         elements:
           - type: prompt
             file: prompts/consent.prompt.md
+            notes: Informational `noResponse` prompt — text only, no input collected.
           - type: submitButton
             buttonText: I consent
 
-      # The `name:` field on this slider is what makes it addressable
-      # by `groupComposition` above as `prompt.familiarity`.
       - name: Familiarity
         elements:
           - type: prompt
+            # `name:` here is what makes this slider addressable by
+            # `groupComposition` above as `prompt.familiarity`.
             name: familiarity
             file: prompts/familiarity.prompt.md
+            notes: |
+              The `name: familiarity` here is the reference target
+              `groupComposition` uses (`prompt.familiarity`) to split
+              participants into positions.
           - type: submitButton
 
-      # `survey` is platform-coupled — it renders an external survey
-      # component (here the Ten-Item Personality Inventory). The
-      # viewer shows a skeleton placeholder.
       - name: Personality
         elements:
           - type: survey
             surveyName: TIPI
             name: pre_TIPI
+            notes: Platform-coupled survey element — the host platform renders the Ten-Item Personality Inventory. Skeleton placeholder in the viewer.
 
 
-# --- TREATMENTS ------------------------------------------------------
-#
-# Two treatments are generated from a single template by broadcasting
-# over a list of topics. The viewer will offer them side-by-side in
-# the treatment picker. Each broadcast row supplies a different value
-# for `${topic}` and `${topicLabel}`, which fan out through every
-# `${topic}` placeholder inside `studyTreatment` (stage names, prompt
-# file paths, reference strings, etc.).
+# Two treatments are generated from one template by broadcasting over
+# the `d0` axis below. The viewer offers them side-by-side in the
+# treatment picker; each row supplies a different value for `${topic}`
+# and `${topicLabel}`, which fan out through every `${topic}`
+# placeholder inside `studyTreatment`.
 treatments:
   - template: studyTreatment
     broadcast:

--- a/examples/annotated-walkthrough/walkthrough.treatments.yaml
+++ b/examples/annotated-walkthrough/walkthrough.treatments.yaml
@@ -23,14 +23,16 @@ templates:
       notes: A two-person text discussion about ${topicLabel}, annotated as a syntax tour.
       playerCount: 2
 
-      # `groupComposition` matches participants to numbered positions
-      # using conditions on data captured during the intro. (Player-level
-      # blocks don't carry `notes:`, so the explanatory commentary for
-      # this block lives here as a YAML comment.) Absolute cutoff on the
+      # `groupComposition` defines per-position eligibility conditions
+      # on data captured during the intro. (Player-level blocks don't
+      # carry `notes:`, so the explanatory commentary for this block
+      # lives here as a YAML comment.) Absolute cutoff on the
       # familiarity slider: scores ≥ 50 → position 0 ("Familiar"); scores
-      # < 50 → position 1 ("Newcomer"). A group only forms when one
-      # participant matches each side of the cutoff — the intentional
-      # cost of threshold-based composition.
+      # < 50 → position 1 ("Newcomer"). Stagebook defines the contract;
+      # matching happens in the host's lobby. Hosts that enforce strict
+      # threshold matching will fail to form a group when both
+      # participants fall on the same side of the cutoff — the
+      # intentional cost of threshold-based composition there.
       groupComposition:
         - position: 0
           title: Familiar
@@ -165,7 +167,13 @@ templates:
               file: prompts/exit_feedback.prompt.md
             - type: submitButton
         - name: Exit Survey
-          notes: Auto-submits when the embedded Qualtrics survey signals completion — no `submitButton` needed because advancement is handled by the iframe completion event.
+          notes: |
+            Stagebook renders `qualtrics` directly as an iframe (not via
+            a host slot, unlike `survey` / `discussion` /
+            `sharedNotepad`). The step auto-submits when the iframe
+            posts its end-of-survey message — no `submitButton` needed.
+            In the viewer the placeholder URL below won't load; swap in
+            a real Qualtrics form URL to test the flow.
           elements:
             - type: qualtrics
               name: exit_qualtrics

--- a/examples/annotated-walkthrough/walkthrough.treatments.yaml
+++ b/examples/annotated-walkthrough/walkthrough.treatments.yaml
@@ -10,7 +10,7 @@ templates:
     notes: |
       Templates are reusable blocks of YAML — define a structure once,
       then instantiate it with different field values via `template:` +
-      `fields:` (single use) or `template:` + `broadcast:` (cartesian
+      `fields:` (single use) or `template:` + `broadcast:` (Cartesian
       expansion, used here under `treatments:`). Placeholders use the
       `${fieldName}` syntax and are substituted at expansion time.
       `contentType: treatment` tells the validator which schema to apply


### PR DESCRIPTION
Closes #184. Follow-up to #182.

## Summary
Uses the annotated-walkthrough example as the demo surface for the new `notes:` field and per-example `README.md` rendering shipped in #182. Since it's the first example users land on, exercising these features here makes them discoverable without a separate tutorial.

## Changes
- **New**: `examples/annotated-walkthrough/README.md` — big-picture tour (what the study is, which syntax features it demonstrates and where, how to read the file, how to run it). Replaces the 20+ line top-of-file YAML comment block.
- **YAML comments → `notes:` fields** wherever a block described a specific stage / element / template. All three stages (`*_initial`, `*_discussion`, `*_reflection`), element-level notes on the timed elements + the `sharedNotepad` + the `display` elements + the conditional consensus prompt, intro-sequence note + element notes on consent / familiarity / TIPI, step notes on both exit steps. Template-level note on `studyTreatment` explains templates + broadcast syntax.
- **Treatment-level `notes:`** shrunk from a multi-line tour to a one-sentence caption (the README is the tour now). Kept truthy so the landing-page card and the `exampleCatalog` test's `notes` assertion both stay happy.
- **`groupComposition`** block kept as YAML comment — player-level entries don't carry `notes:` per #158 scope.
- **Short inline comments retained** where they flag syntax particulars next to one line they modify (placeholder origin, why a specific `name:` matters for a downstream reference).

## Test plan
- [x] Full unit suite green (649 stagebook + 75 viewer + 189 vscode = 913)
- [x] `examples.test.ts` still parses + expands + validates the rewritten YAML
- [x] `exampleCatalog.test.ts` still finds the walkthrough with a truthy `notes` field
- [ ] **Screenshots**: I can't capture screenshots from the CLI. The acceptance criteria mention (a) overview page showing the README, (b) viewer sidebar showing notes, (c) element with an info-icon overlay, (d) sidebar after clicking the icon — please verify these by loading the example locally before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)