### PR TITLE
Markdown: constrain img with inline max-width: 100% (#211)

### DIFF
--- a/packages/stagebook/src/components/form/Markdown.ct.tsx
+++ b/packages/stagebook/src/components/form/Markdown.ct.tsx
@@ -28,6 +28,20 @@ test("passes through relative image paths without resolveURL", async ({
   );
 });
 
+test("img renders with inline max-width: 100% and height: auto so it can't overflow the prompt (issue #211)", async ({
+  mount,
+}) => {
+  const component = await mount(<Markdown text="![photo](images/test.png)" />);
+  const { maxWidth, height } = await component
+    .locator("img")
+    .evaluate((el) => ({
+      maxWidth: (el as HTMLElement).style.maxWidth,
+      height: (el as HTMLElement).style.height,
+    }));
+  expect(maxWidth).toBe("100%");
+  expect(height).toBe("auto");
+});
+
 test("renders headings", async ({ mount }) => {
   const component = await mount(<Markdown text="## Section Title" />);
   await expect(component.locator("h2")).toContainText("Section Title");

--- a/packages/stagebook/src/components/form/Markdown.tsx
+++ b/packages/stagebook/src/components/form/Markdown.tsx
@@ -139,6 +139,11 @@ const blockquoteStyle: React.CSSProperties = {
   background: "var(--stagebook-blockquote-bg, #f9fafb)",
 };
 
+const imgStyle: React.CSSProperties = {
+  maxWidth: "100%",
+  height: "auto",
+};
+
 export function Markdown({ text, resolveURL }: MarkdownProps) {
   let displayText = text;
 
@@ -208,6 +213,15 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
           a: ({ node: _node, ...props }) => <a style={aStyle} {...props} />,
           blockquote: ({ node: _node, ...props }) => (
             <blockquote style={blockquoteStyle} {...props} />
+          ),
+          // Inline max-width keeps markdown-embedded images inside the
+          // prompt container on any host, regardless of what reset the
+          // host chose. host-typography provides the same rule for the
+          // host's own bare-tag pages; this override ensures stagebook's
+          // own rendered content is self-constraining even when the host
+          // hasn't opted in. See issue #211.
+          img: ({ node: _node, ...props }) => (
+            <img style={imgStyle} {...props} alt={props.alt ?? ""} />
           ),
         }}
       >


### PR DESCRIPTION
Closes #211.

## What

Adds an `img` override in the Markdown component's `components` prop, matching the inline-style pattern used for every other rendered element:

```tsx
img: ({ node: _node, ...props }) => (
  <img style={imgStyle} {...props} alt={props.alt ?? ""} />
),
```

where \`imgStyle\` is \`{ maxWidth: "100%", height: "auto" }\`.

## Why

Images embedded in a markdown prompt (\`![alt](path)\`) were falling through to react-markdown's default renderer, which emits a bare \`<img>\` with no inline styles. On hosts without a bare-tag img reset — Tailwind preflight, \`stagebook/host-typography\`, normalize.css, whatever — an image wider than \`--stagebook-prompt-max-width\` (default 36rem) would render at its natural resolution and overflow the prompt container.

This breaks stagebook's documented contract that components \"render correctly on any host without extra CSS.\" Every other HTML element in the component list is already inline-styled to make this guarantee hold; \`img\` was the one gap.

## Test

New Markdown.ct test asserts the rendered img has inline \`maxWidth: \"100%\"\` and \`height: \"auto\"\`. Ran via \`npm run test:ct\`; 23/23 pass.

## Out of scope

Noted in the issue: h5, h6, hr, and table-family elements (\`table\`, \`thead\`, \`tbody\`, \`tr\`, \`td\`, \`th\`) also use react-markdown defaults. Not fixing them here because none of them produce the overflow symptom that surfaced in the field; worth a sweep in a later pass if the contract ends up stated more formally (e.g. \"every HTML element react-markdown might emit is inline-styled\").

## Context

Surfaced during the deliberation-lab parity test on Railway ([deliberation-lab/manager#13](https://github.com/deliberation-lab/manager/pull/13)). Discussion of why \`host-typography\` (#208) is not the right layer for this in the issue thread.