### PR TITLE
Markdown: add <hr> and <pre> handlers so rules and fenced code render on any host (#215)

### DIFF
--- a/packages/stagebook/src/components/form/Markdown.ct.tsx
+++ b/packages/stagebook/src/components/form/Markdown.ct.tsx
@@ -358,9 +358,7 @@ test("hr survives a host CSS reset that sets hr { border: 0 }", async ({
 test("fenced code block renders with background, monospace font, and horizontal overflow", async ({
   mount,
 }) => {
-  const component = await mount(
-    <Markdown text={"```js\nconst x = 1;\n```"} />,
-  );
+  const component = await mount(<Markdown text={"```js\nconst x = 1;\n```"} />);
   const styles = await component.locator("pre").evaluate((el) => {
     const cs = getComputedStyle(el);
     return {
@@ -371,9 +369,7 @@ test("fenced code block renders with background, monospace font, and horizontal 
   });
   expect(styles.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
   expect(styles.backgroundColor).not.toBe("transparent");
-  expect(styles.fontFamily.toLowerCase()).toMatch(
-    /mono|menlo|consolas|sfmono/,
-  );
+  expect(styles.fontFamily.toLowerCase()).toMatch(/mono|menlo|consolas|sfmono/);
   expect(styles.overflowX).toBe("auto");
 });
 
@@ -383,9 +379,7 @@ test("fenced code block does not double-wrap background on the inner code", asyn
   // The <pre> carries the chip styling; the inner <code class="language-*">
   // must NOT also apply its own background/padding, or the block looks
   // like a nested box.
-  const component = await mount(
-    <Markdown text={"```js\nconst x = 1;\n```"} />,
-  );
+  const component = await mount(<Markdown text={"```js\nconst x = 1;\n```"} />);
   const innerCodeInline = await component
     .locator("pre > code")
     .evaluate((el) => ({
@@ -409,7 +403,5 @@ test("inline code renders as a styled chip with background and padding", async (
   });
   expect(styles.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
   expect(styles.backgroundColor).not.toBe("transparent");
-  expect(styles.fontFamily.toLowerCase()).toMatch(
-    /mono|menlo|consolas|sfmono/,
-  );
+  expect(styles.fontFamily.toLowerCase()).toMatch(/mono|menlo|consolas|sfmono/);
 });

--- a/packages/stagebook/src/components/form/Markdown.ct.tsx
+++ b/packages/stagebook/src/components/form/Markdown.ct.tsx
@@ -315,3 +315,101 @@ test("CSS variable override changes blockquote background", async ({
     .evaluate((el) => getComputedStyle(el).backgroundColor);
   expect(bg).toBe("rgb(0, 255, 0)");
 });
+
+// ---------------------------------------------------------------------------
+// <hr> and <pre> — issue #215
+//
+// `---` in markdown renders as <hr>, which Tailwind preflight and similar
+// resets collapse with `border: 0`. Fenced code blocks wrap in <pre>; with
+// no handler they render as naked pre-formatted text (no background, no
+// monospace font, no overflow scroll). These tests lock in the inline
+// styling that makes both render portably on any host.
+// ---------------------------------------------------------------------------
+
+test("hr renders with visible top border (survives UA stripping)", async ({
+  mount,
+}) => {
+  const component = await mount(<Markdown text={"above\n\n---\n\nbelow"} />);
+  const borderTopWidth = await component
+    .locator("hr")
+    .evaluate((el) => parseFloat(getComputedStyle(el).borderTopWidth));
+  expect(borderTopWidth).toBeGreaterThan(0);
+});
+
+test("hr survives a host CSS reset that sets hr { border: 0 }", async ({
+  mount,
+}) => {
+  // Mirrors the "inline styles beat a host CSS reset" pattern: Tailwind
+  // preflight ships `hr { border: 0 }` which collapses the default UA
+  // border. Our inline border-top must win on specificity.
+  const resetCSS = `hr { border: 0; }`;
+  const component = await mount(
+    <div>
+      <style dangerouslySetInnerHTML={{ __html: resetCSS }} />
+      <Markdown text={"above\n\n---\n\nbelow"} />
+    </div>,
+  );
+  const borderTopWidth = await component
+    .locator("hr")
+    .evaluate((el) => parseFloat(getComputedStyle(el).borderTopWidth));
+  expect(borderTopWidth).toBeGreaterThan(0);
+});
+
+test("fenced code block renders with background, monospace font, and horizontal overflow", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <Markdown text={"```js\nconst x = 1;\n```"} />,
+  );
+  const styles = await component.locator("pre").evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return {
+      backgroundColor: cs.backgroundColor,
+      fontFamily: cs.fontFamily,
+      overflowX: cs.overflowX,
+    };
+  });
+  expect(styles.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+  expect(styles.backgroundColor).not.toBe("transparent");
+  expect(styles.fontFamily.toLowerCase()).toMatch(
+    /mono|menlo|consolas|sfmono/,
+  );
+  expect(styles.overflowX).toBe("auto");
+});
+
+test("fenced code block does not double-wrap background on the inner code", async ({
+  mount,
+}) => {
+  // The <pre> carries the chip styling; the inner <code class="language-*">
+  // must NOT also apply its own background/padding, or the block looks
+  // like a nested box.
+  const component = await mount(
+    <Markdown text={"```js\nconst x = 1;\n```"} />,
+  );
+  const innerCodeInline = await component
+    .locator("pre > code")
+    .evaluate((el) => ({
+      background: (el as HTMLElement).style.background,
+      padding: (el as HTMLElement).style.padding,
+    }));
+  expect(innerCodeInline.background).toBe("");
+  expect(innerCodeInline.padding).toBe("");
+});
+
+test("inline code renders as a styled chip with background and padding", async ({
+  mount,
+}) => {
+  const component = await mount(<Markdown text="Use `npm test` to run." />);
+  const styles = await component.locator("code").evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return {
+      backgroundColor: cs.backgroundColor,
+      fontFamily: cs.fontFamily,
+    };
+  });
+  expect(styles.backgroundColor).not.toBe("rgba(0, 0, 0, 0)");
+  expect(styles.backgroundColor).not.toBe("transparent");
+  expect(styles.fontFamily.toLowerCase()).toMatch(
+    /mono|menlo|consolas|sfmono/,
+  );
+});

--- a/packages/stagebook/src/components/form/Markdown.tsx
+++ b/packages/stagebook/src/components/form/Markdown.tsx
@@ -110,8 +110,10 @@ const emStyle: React.CSSProperties = {
 };
 
 // Inline code only — `like this`. Fenced code blocks (```...```) get
-// className="language-*" from react-markdown and are passed through
-// untouched (out of scope for issue #33).
+// className="language-*" from react-markdown; the <pre> wrapper receives
+// the block-level chip styling (see preStyle), so the inner <code> is
+// passed through without its own background/padding to avoid a nested
+// box look.
 const inlineCodeStyle: React.CSSProperties = {
   fontFamily:
     "var(--stagebook-code-font, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace)",
@@ -119,6 +121,36 @@ const inlineCodeStyle: React.CSSProperties = {
   background: "var(--stagebook-code-bg, rgba(0,0,0,0.06))",
   padding: "0.1em 0.3em",
   borderRadius: "0.25rem",
+};
+
+// Fenced code block wrapper. react-markdown emits
+// <pre><code class="language-*">...</code></pre>, so the <pre> carries
+// all of the block-level chip styling (background, padding, radius,
+// horizontal scroll). The inner <code> keeps only the font so the block
+// doesn't render as a nested box. Tailwind preflight and similar resets
+// strip the UA <pre> monospace font, so we reassert it here. See #215.
+const preStyle: React.CSSProperties = {
+  background: "var(--stagebook-code-bg, rgba(0,0,0,0.06))",
+  padding: "0.75rem 1rem",
+  borderRadius: "0.375rem",
+  overflowX: "auto",
+  fontFamily:
+    "var(--stagebook-code-font, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace)",
+  lineHeight: 1.4,
+  marginBlock: "0.5em",
+};
+
+// Horizontal rule (`---`). Tailwind preflight ships `hr { border: 0 }`
+// which makes the rule disappear entirely. Inline border-top wins on
+// specificity and restores a visible rule on any host. We zero the other
+// border sides so a future host rule like `hr { border-width: 1px }`
+// doesn't accidentally give us a full box. See #215.
+const hrStyle: React.CSSProperties = {
+  border: 0,
+  borderTopWidth: "1px",
+  borderTopStyle: "solid",
+  borderTopColor: "var(--stagebook-border, #d1d5db)",
+  marginBlock: "1em",
 };
 
 const aStyle: React.CSSProperties = {
@@ -199,8 +231,11 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
           code: ({ node: _node, className, ...props }) => {
             // react-markdown v10 dropped the `inline` prop. Fenced code
             // blocks get className="language-*"; inline code has no
-            // className. Style only inline code; pass fenced blocks
-            // through unchanged (out of scope for issue #33).
+            // className. The inline variant gets the chip styling
+            // (background, padding, radius); the fenced variant's
+            // block-level chip is supplied by the surrounding <pre>
+            // (preStyle) so we don't double-wrap the background/padding
+            // here. See #215.
             const isFenced =
               typeof className === "string" &&
               className.startsWith("language-");
@@ -210,6 +245,10 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
               <code style={inlineCodeStyle} {...props} />
             );
           },
+          pre: ({ node: _node, ...props }) => (
+            <pre style={preStyle} {...props} />
+          ),
+          hr: ({ node: _node, ...props }) => <hr style={hrStyle} {...props} />,
           a: ({ node: _node, ...props }) => <a style={aStyle} {...props} />,
           blockquote: ({ node: _node, ...props }) => (
             <blockquote style={blockquoteStyle} {...props} />


### PR DESCRIPTION
Closes #215.

## Summary
Adds inline-style handlers for `<hr>` and `<pre>` in the Markdown component, matching the pattern #211 established for `<img>`. Horizontal rules and fenced code blocks now render consistently on any host, including Tailwind-preflight hosts that would otherwise strip the rule entirely or leave fenced code naked.

## Changes
- **`hrStyle` + `hr:` handler** — wipes all borders (`border: 0`) then sets only `border-top` with `--stagebook-border`. Wins against Tailwind preflight's `hr { border: 0 }` on specificity.
- **`preStyle` + `pre:` handler** — background + padding + radius + `overflow-x: auto` + monospace font + line-height. Uses existing `--stagebook-code-bg` and `--stagebook-code-font` vars.
- **Refined `code:` handler** — the inline variant keeps the chip styling (background + padding + radius); the fenced variant passes through so the outer `<pre>` owns the block-level chip and we don't double-wrap.

No new CSS variables — everything reuses existing tokens in `styles.css`.

## Test plan
- [x] 5 new Playwright CT tests:
  - `hr` renders with visible top border
  - `hr` survives a host CSS reset that sets `hr { border: 0 }` (the load-bearing test — mirrors the existing "inline styles beat a host CSS reset" pattern)
  - Fenced code block renders with background, monospace font, and `overflow-x: auto`
  - Fenced code block doesn't double-wrap background on the inner `<code>`
  - Inline code still renders as a chip (locks in existing behavior; no prior test)
- [x] `npx playwright test -c playwright-ct.config.ts src/components/form/Markdown.ct.tsx` — 28/28 passed
- [x] Full unit suite green
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)