### PR TITLE
Markdown: inline table/th/td styles so tables render on any host (#214)

### DIFF
--- a/packages/stagebook/src/components/form/Markdown.ct.tsx
+++ b/packages/stagebook/src/components/form/Markdown.ct.tsx
@@ -64,9 +64,6 @@ test("renders GFM tables", async ({ mount }) => {
 test("table uses collapsed borders and visible cell borders", async ({
   mount,
 }) => {
-  // Also implicitly verifies the stylesheet is loading — no other test
-  // exercises that failure mode. Tables style via the stylesheet, not
-  // inline, so a dropped rule or unloaded sheet would regress silently.
   const component = await mount(
     <Markdown text={"| A | B |\n|---|---|\n| 1 | 2 |"} />,
   );
@@ -80,6 +77,92 @@ test("table uses collapsed borders and visible cell borders", async ({
     .first()
     .evaluate((el) => parseFloat(getComputedStyle(el).borderTopWidth));
   expect(cellBorderWidth).toBeGreaterThan(0);
+});
+
+// ---------------------------------------------------------------------------
+// Inline table styling — issue #214
+//
+// Tables were historically styled via styles.css, which loses on hosts that
+// don't import the stylesheet. These tests assert the styles are now INLINE
+// (read el.style.*, not getComputedStyle) so a dropped rule or unloaded
+// sheet can't regress table rendering.
+// ---------------------------------------------------------------------------
+
+test("table has inline border-collapse: collapse", async ({ mount }) => {
+  const component = await mount(
+    <Markdown text={"| A | B |\n|---|---|\n| 1 | 2 |"} />,
+  );
+  const borderCollapse = await component
+    .locator("table")
+    .evaluate((el) => (el as HTMLElement).style.borderCollapse);
+  expect(borderCollapse).toBe("collapse");
+});
+
+test("td has inline border", async ({ mount }) => {
+  const component = await mount(
+    <Markdown text={"| A | B |\n|---|---|\n| 1 | 2 |"} />,
+  );
+  const borderStyle = await component
+    .locator("td")
+    .first()
+    .evaluate((el) => (el as HTMLElement).style.border);
+  // style.border is a shorthand; inline value should be non-empty
+  expect(borderStyle.length).toBeGreaterThan(0);
+});
+
+test("th has inline background and border", async ({ mount }) => {
+  const component = await mount(
+    <Markdown text={"| A | B |\n|---|---|\n| 1 | 2 |"} />,
+  );
+  const { border, background } = await component
+    .locator("th")
+    .first()
+    .evaluate((el) => ({
+      border: (el as HTMLElement).style.border,
+      background: (el as HTMLElement).style.backgroundColor,
+    }));
+  expect(border.length).toBeGreaterThan(0);
+  expect(background.length).toBeGreaterThan(0);
+});
+
+test("table inline styles survive an aggressive host CSS reset (issue #214)", async ({
+  mount,
+}) => {
+  // Mirrors the "inline styles beat a host CSS reset" pattern for tables.
+  // A Tailwind-style preflight routinely zeroes table borders and
+  // collapses cell padding. Inline styles win on specificity without
+  // !important.
+  const resetCSS = `
+    table { border-collapse: separate; border-spacing: 2px; }
+    th, td { border: 0; padding: 0; background: transparent; }
+    th { font-weight: 400; }
+  `;
+  const component = await mount(
+    <div>
+      <style dangerouslySetInnerHTML={{ __html: resetCSS }} />
+      <Markdown text={"| A | B |\n|---|---|\n| 1 | 2 |"} />
+    </div>,
+  );
+
+  // Table still collapses borders
+  const borderCollapse = await component
+    .locator("table")
+    .evaluate((el) => getComputedStyle(el).borderCollapse);
+  expect(borderCollapse).toBe("collapse");
+
+  // td still has a visible border
+  const borderWidth = await component
+    .locator("td")
+    .first()
+    .evaluate((el) => parseFloat(getComputedStyle(el).borderTopWidth));
+  expect(borderWidth).toBeGreaterThan(0);
+
+  // td still has padding
+  const padding = await component
+    .locator("td")
+    .first()
+    .evaluate((el) => parseFloat(getComputedStyle(el).paddingTop));
+  expect(padding).toBeGreaterThan(0);
 });
 
 test("renders GFM strikethrough", async ({ mount }) => {

--- a/packages/stagebook/src/components/form/Markdown.tsx
+++ b/packages/stagebook/src/components/form/Markdown.tsx
@@ -144,6 +144,34 @@ const imgStyle: React.CSSProperties = {
   height: "auto",
 };
 
+// GFM tables. Inlined (per issue #214) so tables render with borders and
+// padding even on hosts that don't import styles.css. thead / tbody / tr
+// have no handlers here — browser defaults are acceptable once the table
+// itself has border-collapse and the cells have borders + padding.
+const tableStyle: React.CSSProperties = {
+  borderCollapse: "collapse",
+  margin: "1rem 0",
+  width: "100%",
+  maxWidth: "var(--stagebook-prompt-max-width, 36rem)",
+};
+
+const tableCellBase: React.CSSProperties = {
+  border: "1px solid var(--stagebook-border, #d1d5db)",
+  padding: "0.5rem 0.75rem",
+  textAlign: "left",
+  fontSize: "0.875rem",
+  color: "#4a5568",
+};
+
+const thStyle: React.CSSProperties = {
+  ...tableCellBase,
+  backgroundColor: "var(--stagebook-bg-muted, #f9fafb)",
+  fontWeight: 500,
+  color: "#1a202c",
+};
+
+const tdStyle: React.CSSProperties = tableCellBase;
+
 export function Markdown({ text, resolveURL }: MarkdownProps) {
   let displayText = text;
 
@@ -222,6 +250,17 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
           // hasn't opted in. See issue #211.
           img: ({ node: _node, ...props }) => (
             <img style={imgStyle} {...props} alt={props.alt ?? ""} />
+          ),
+          // GFM tables (issue #214). Only table / th / td need handlers —
+          // thead / tbody / tr use browser defaults.
+          table: ({ node: _node, ...props }) => (
+            <table style={tableStyle} {...props} />
+          ),
+          th: ({ node: _node, ...props }) => (
+            <th style={thStyle} {...props} />
+          ),
+          td: ({ node: _node, ...props }) => (
+            <td style={tdStyle} {...props} />
           ),
         }}
       >

--- a/packages/stagebook/src/components/form/Markdown.tsx
+++ b/packages/stagebook/src/components/form/Markdown.tsx
@@ -160,14 +160,14 @@ const tableCellBase: React.CSSProperties = {
   padding: "0.5rem 0.75rem",
   textAlign: "left",
   fontSize: "0.875rem",
-  color: "#4a5568",
+  color: "var(--stagebook-table-text, #4a5568)",
 };
 
 const thStyle: React.CSSProperties = {
   ...tableCellBase,
   backgroundColor: "var(--stagebook-bg-muted, #f9fafb)",
   fontWeight: 500,
-  color: "#1a202c",
+  color: "var(--stagebook-table-header-text, #1a202c)",
 };
 
 const tdStyle: React.CSSProperties = tableCellBase;
@@ -256,12 +256,8 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
           table: ({ node: _node, ...props }) => (
             <table style={tableStyle} {...props} />
           ),
-          th: ({ node: _node, ...props }) => (
-            <th style={thStyle} {...props} />
-          ),
-          td: ({ node: _node, ...props }) => (
-            <td style={tdStyle} {...props} />
-          ),
+          th: ({ node: _node, ...props }) => <th style={thStyle} {...props} />,
+          td: ({ node: _node, ...props }) => <td style={tdStyle} {...props} />,
         }}
       >
         {displayText}

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -16,7 +16,6 @@
  * - Inter font
  * - Stagebook CSS custom properties at :root (default values)
  * - Form input resets
- * - GFM table styles (out of scope for inline styling — see issue #33)
  *
  * Customizing typography / colors: override the --stagebook-* variables on
  * any parent element (or :root). For example, to scale headings down on
@@ -262,36 +261,6 @@ input[type="number"] {
 }
 
 /*
- * GFM tables (rendered by react-markdown).
- *
- * Intentionally NOT inlined into Markdown.tsx like headings/lists/etc.
- * The table style surface is large (table + th + td + collapse behavior
- * + cell borders) and inlining would roughly double Markdown.tsx. As a
- * result: hosts that import this stylesheet get nice tables; hosts that
- * don't get browser-default unstyled tables (functional but ugly).
- *
- * If a researcher needs portable table styling on a non-stylesheet host,
- * follow the pattern in Markdown.tsx and add table/thead/tbody/tr/th/td
- * entries to the components map. See issue #33.
+ * GFM tables are styled inline in src/components/form/Markdown.tsx
+ * (table / th / td handlers in the components map). See issue #214.
  */
-table {
-  border-collapse: collapse;
-  margin: 1rem 0;
-  width: 100%;
-  max-width: var(--stagebook-prompt-max-width, 36rem);
-}
-
-th,
-td {
-  border: 1px solid var(--stagebook-border, #d1d5db);
-  padding: 0.5rem 0.75rem;
-  text-align: left;
-  font-size: 0.875rem;
-  color: #4a5568;
-}
-
-th {
-  background-color: var(--stagebook-bg-muted, #f9fafb);
-  font-weight: 500;
-  color: #1a202c;
-}

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -127,6 +127,10 @@
   --stagebook-code-font:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 
+  /* Markdown GFM tables (used by the Markdown component, issue #214) */
+  --stagebook-table-text: #4a5568;
+  --stagebook-table-header-text: #1a202c;
+
   /* Blockquote (used by Display element and markdown blockquotes) */
   --stagebook-blockquote-border: #d1d5db;
   --stagebook-blockquote-bg: #f9fafb;

--- a/packages/stagebook/src/styles.test.ts
+++ b/packages/stagebook/src/styles.test.ts
@@ -105,16 +105,51 @@ describe("styles.css uses theme variables for hardcoded values (#116)", () => {
   // Table styles moved from styles.css to Markdown.tsx (issue #214). The
   // tokenization guarantee from #116 still holds — it's just asserted
   // against the component source now, since that's the source of truth.
+  //
+  // We assert two things per token:
+  // 1. The token name appears in a real reference context (inside a `var(...)`
+  //    call or a CSSProperties key), not just in a prose comment. We reuse
+  //    extractReferenced() for that — same helper as the coverage test above.
+  // 2. The full `var(--name, fallback)` string appears verbatim, which pins
+  //    the fallback value too so it can't silently drift.
+  // The two checks together guarantee the token is referenced AND the
+  // documented fallback matches.
   const markdownSrc = readFileSync(
     join(componentsDir, "form", "Markdown.tsx"),
     "utf8",
   );
+  const markdownReferenced = extractReferenced(markdownSrc);
 
   it.each([
-    ["var(--stagebook-border, #d1d5db)", "table cell border"],
-    ["var(--stagebook-prompt-max-width, 36rem)", "table max-width"],
-    ["var(--stagebook-bg-muted, #f9fafb)", "table header background"],
-  ])("Markdown.tsx references %s (%s)", (needle) => {
+    [
+      "--stagebook-border",
+      "var(--stagebook-border, #d1d5db)",
+      "table cell border",
+    ],
+    [
+      "--stagebook-prompt-max-width",
+      "var(--stagebook-prompt-max-width, 36rem)",
+      "table max-width",
+    ],
+    [
+      "--stagebook-bg-muted",
+      "var(--stagebook-bg-muted, #f9fafb)",
+      "table header background",
+    ],
+    [
+      "--stagebook-table-text",
+      "var(--stagebook-table-text, #4a5568)",
+      "table cell text color",
+    ],
+    [
+      "--stagebook-table-header-text",
+      "var(--stagebook-table-header-text, #1a202c)",
+      "table header text color",
+    ],
+  ])("Markdown.tsx references %s via %s (%s)", (name, needle) => {
+    // Real reference (not just a comment mention).
+    expect(markdownReferenced.has(name)).toBe(true);
+    // Verbatim var() call with the documented fallback.
     expect(markdownSrc).toContain(needle);
   });
 

--- a/packages/stagebook/src/styles.test.ts
+++ b/packages/stagebook/src/styles.test.ts
@@ -95,13 +95,27 @@ describe("styles.css uses theme variables for hardcoded values (#116)", () => {
   });
 
   it.each([
-    ["var(--stagebook-border, #d1d5db)", "form/table border"],
+    ["var(--stagebook-border, #d1d5db)", "form border"],
     ["var(--stagebook-text, #1f2937)", "form text color"],
     ["var(--stagebook-surface, #fff)", "form control background"],
-    ["var(--stagebook-prompt-max-width, 36rem)", "table max-width"],
-    ["var(--stagebook-bg-muted, #f9fafb)", "table header background"],
   ])("references %s (%s)", (needle) => {
     expect(css).toContain(needle);
+  });
+
+  // Table styles moved from styles.css to Markdown.tsx (issue #214). The
+  // tokenization guarantee from #116 still holds — it's just asserted
+  // against the component source now, since that's the source of truth.
+  const markdownSrc = readFileSync(
+    join(componentsDir, "form", "Markdown.tsx"),
+    "utf8",
+  );
+
+  it.each([
+    ["var(--stagebook-border, #d1d5db)", "table cell border"],
+    ["var(--stagebook-prompt-max-width, 36rem)", "table max-width"],
+    ["var(--stagebook-bg-muted, #f9fafb)", "table header background"],
+  ])("Markdown.tsx references %s (%s)", (needle) => {
+    expect(markdownSrc).toContain(needle);
   });
 
   it("derives focus ring border-color from --stagebook-primary", () => {


### PR DESCRIPTION
Closes #214.

## Summary
Ports the GFM-table rules from `styles.css` into inline handlers on `Markdown.tsx`, matching the pattern #211 established for `<img>` and #215 establishes for `<hr>` / `<pre>`. Tables now render with borders, padding, and `max-width` constraints on any host — even ones that don't import `stagebook/styles`.

## Changes
- **New handlers + style constants** in `Markdown.tsx`: `table:`, `th:`, `td:`. Style constants (`tableStyle`, `tableCellBase`, `thStyle`, `tdStyle`) sit with the other `*Style` declarations. Values mirror the old `styles.css` rules exactly.
- **No `thead` / `tbody` / `tr` handlers** — those tags had no rules in `styles.css` either, so browser defaults have always been in play. Empty handlers would be noise. The existing `renders GFM tables` CT test is still green, confirming.
- **`styles.css`**: removed the ported `table`, `th`, `td` rules and the "Intentionally NOT inlined" comment block (the rationale no longer applies). Updated the file-header bullet list to drop the stale table-styles mention.
- **`styles.test.ts`**: relocated the `#116` token-reference assertions for `--stagebook-prompt-max-width` and `--stagebook-bg-muted` into a parallel `Markdown.tsx references` block, since `Markdown.tsx` is now the source of truth for those tokens. Preserves the guarantee that table styling never regresses to bare literals.

## Test plan
- [x] 4 new Playwright CT tests — three assert `element.style.*` inline values (proving the styles are inline, not cascade-derived), one wraps the Markdown in an aggressive host CSS reset that targets `table`/`th`/`td` without `!important` and confirms inline still wins.
- [x] Existing `renders GFM tables` + `table uses collapsed borders and visible cell borders` tests still pass (the latter via `getComputedStyle`, complementary to the new inline-style assertions).
- [x] `npm test` from repo root green
- [x] `npx playwright test -c playwright-ct.config.ts` from `packages/stagebook/` green
- [x] Lint clean

## Related
- #211 / #212 (`<img>` precedent)
- #215 / #216 (`<hr>` + `<pre>` — concurrent)
- #213 (radio + checkbox — next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)