### PR TITLE
Release v0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13682,7 +13682,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Bumps \`stagebook\` to \`0.7.1\`. Release notes below will be reused for the GitHub release after merge.

Patch bump — no behavior change for existing consumers. The four PRs below defensively move bare-tag styling from \`styles.css\` into inline styles on the components themselves, closing a contract gap for new consumers on hosts that don't import \`stagebook/styles\` (Tailwind-preflight hosts, reset-free hosts, etc.). Anyone who imports \`stagebook/styles\` gets identical rendering.

---

## Bug fixes — \"works without extra CSS on any host\" contract

Post-#211 sweep. The \`<img>\` fix in 0.7.0 (via #212) was the first case; the audit found several more bare-tag styles that lived in \`styles.css\` and broke the same contract when the stylesheet wasn't loaded.

- **Radio + checkbox inputs (#213, PR #218).** \`RadioGroup\` and \`CheckboxGroup\` previously relied entirely on \`styles.css\` selector rules for appearance-reset, checked-state primary fill + SVG check/dot, and focus ring. On Tailwind-preflight hosts (which ship \`appearance: none\` for inputs) with our stylesheet not loaded (or loaded after), the checked state rendered empty. All three now ship inline: base + checked + focus (the latter via a single \`focusedKey\` state per group since only one input can hold keyboard focus at a time). GFM task-list checkboxes in Markdown get the same inline base + checked (no focus ring since they're disabled).
- **Markdown tables (#214, PR #217).** \`table\` / \`th\` / \`td\` handlers added to the Markdown \`components\` map. Existing \`styles.css\` rules retired. Two new CSS vars for cell/header text colors so the previously-hardcoded \`#4a5568\` / \`#1a202c\` are tunable.
- **Markdown \`<hr>\` + \`<pre>\` (#215, PR #216).** \`<hr>\` now has inline \`border-top\` that survives Tailwind preflight's \`hr { border: 0 }\`. Fenced code blocks now render with inline background, padding, monospace font, and \`overflow-x: auto\` on the wrapping \`<pre>\` (the inner \`<code>\` is no longer double-wrapped).

## Accessibility fix
- **RadioGroup now sets shared \`name\`** on each radio input (scoped to the group's \`id\`) so browser arrow-key navigation between options works and assistive tech recognizes the group. Pre-existing oversight, noticed during #213 review.

## Test plan
- [x] Full local suite green — 652 stagebook + 75 viewer + 189 vscode unit tests, Playwright CT suite
- [x] Lint + format clean
- [ ] After merge, tag \`v0.7.1\` and publish the GitHub release — [\`npm-publish.yml\`](.github/workflows/npm-publish.yml) picks up the \`release: published\` event automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)