### PR TITLE
Timeline + viewer: range UX, wheel pan/pinch, label overlay, StageNav anchoring

### DIFF
--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -162,12 +162,13 @@ export function Viewer({
             </button>
           )}
           <span style={treatmentNameStyle}>{treatment.name}</span>
+          <span style={headerDividerStyle} aria-hidden="true" />
+          <StageNav
+            steps={steps}
+            currentIndex={stageIndex}
+            onSelect={setStageIndex}
+          />
         </div>
-        <StageNav
-          steps={steps}
-          currentIndex={stageIndex}
-          onSelect={setStageIndex}
-        />
         <TimeScrubber
           currentStep={currentStep}
           elapsedTime={store.getElapsedTime(stageIndex)}
@@ -260,6 +261,15 @@ const headerLeftStyle: React.CSSProperties = {
   display: "flex",
   alignItems: "center",
   gap: "0.5rem",
+  flexShrink: 0,
+};
+
+const headerDividerStyle: React.CSSProperties = {
+  width: "1px",
+  height: "1rem",
+  backgroundColor: "#e5e7eb",
+  marginLeft: "0.25rem",
+  marginRight: "0.25rem",
 };
 
 const backButtonStyle: React.CSSProperties = {

--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -2937,6 +2937,11 @@ test("wheel pan: negative deltaX moves viewportStart back toward zero", async ({
   const timeline = component.locator('[data-testid="timeline"]');
   await component.locator('[data-testid="timeline-zoom-in"]').click();
   await component.locator('[data-testid="timeline-zoom-in"]').click();
+  // Wait for the zoom commit to land in the DOM. Without this, on busy CI
+  // the wheel dispatch can race the commit — our handler reads zoomLevel
+  // from a render-time ref, sees the stale value (1), and bails before
+  // panning anything.
+  await expect(timeline).toHaveAttribute("data-zoom-level", "4");
 
   // Pan right first so we have room to pan back.
   await timeline.dispatchEvent("wheel", {
@@ -3002,6 +3007,7 @@ test("wheel pan: vertical-dominant wheel does NOT pan (passes through to page)",
   const timeline = component.locator('[data-testid="timeline"]');
   await component.locator('[data-testid="timeline-zoom-in"]').click();
   await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await expect(timeline).toHaveAttribute("data-zoom-level", "4");
 
   const before = await readViewportStart(timeline);
   // |deltaY| > |deltaX| → vertical-dominant. Should pass through.
@@ -3031,6 +3037,7 @@ test("wheel pan: clamps at viewport start (cannot pan before t=0)", async ({
   const timeline = component.locator('[data-testid="timeline"]');
   await component.locator('[data-testid="timeline-zoom-in"]').click();
   await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await expect(timeline).toHaveAttribute("data-zoom-level", "4");
 
   // Already at viewportStart=0; a leftward swipe must not go negative.
   expect(await readViewportStart(timeline)).toBe(0);
@@ -3059,6 +3066,7 @@ test("wheel pan: clamps at viewport end (cannot pan past duration)", async ({
   const timeline = component.locator('[data-testid="timeline"]');
   await component.locator('[data-testid="timeline-zoom-in"]').click();
   await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await expect(timeline).toHaveAttribute("data-zoom-level", "4");
 
   // Pan all the way right.
   await timeline.dispatchEvent("wheel", {
@@ -3134,6 +3142,7 @@ test("pinch-to-zoom: ctrl+wheel with positive deltaY zooms out", async ({
   // Zoom in via the buttons first so there's room to zoom out.
   await component.locator('[data-testid="timeline-zoom-in"]').click();
   await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await expect(timeline).toHaveAttribute("data-zoom-level", "4");
   const before = await readZoomLevel(timeline);
   expect(before).toBe(4);
 

--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -226,6 +226,94 @@ test("falls back to Track N for extra channels beyond trackLabels", async ({
   await expect(labels.nth(2)).toContainText("Track 2");
 });
 
+// The label is overlaid on the upper-left of each track's waveform, on top
+// of the SelectionOverlay. It must not capture pointer events — otherwise
+// drags that start in the upper-left region would silently fail to create
+// a range. Guards against accidentally dropping `pointer-events: none` on
+// the label in the future.
+test("track-label overlay does not block pointer events on the waveform", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="ranges"
+      selectionType="range"
+      multiSelect={true}
+      mockDuration={60}
+      mockChannelCount={1}
+      trackLabels={["A reasonably wide track label"]}
+    />,
+  );
+  const overlay = component.locator('[data-testid="selection-overlay"]');
+  const label = component.locator('[data-testid="track-label"]').first();
+  const overlayBox = await overlay.boundingBox();
+  const labelBox = await label.boundingBox();
+  if (!overlayBox || !labelBox) throw new Error("missing element");
+
+  // Sanity: label sits inside the overlay's x range. If this weren't true,
+  // the test below wouldn't actually exercise click-through.
+  expect(labelBox.x).toBeGreaterThanOrEqual(overlayBox.x);
+  expect(labelBox.x + labelBox.width).toBeLessThanOrEqual(
+    overlayBox.x + overlayBox.width,
+  );
+
+  // Real mouse drag starting INSIDE the label, ending in the open waveform.
+  // Using page.mouse (not dispatchEvent) so the browser hit-tests through
+  // CSS — this is what proves pointer-events: none is honored.
+  const startX = labelBox.x + labelBox.width / 2;
+  const startY = labelBox.y + labelBox.height / 2;
+  const endX = overlayBox.x + overlayBox.width * 0.7;
+
+  await page.mouse.move(startX, startY);
+  await page.mouse.down();
+  await page.mouse.move(endX, startY);
+  await page.mouse.up();
+
+  await expect(component.locator('[data-testid="range-0"]')).toBeAttached();
+});
+
+test("very long track labels truncate within the waveform width", async ({
+  mount,
+}) => {
+  // Repeat enough that the natural width exceeds even a wide test viewport.
+  const longLabel =
+    "Speaker who has a needlessly long descriptive name ".repeat(20);
+  const component = await mount(
+    <div style={{ width: "400px" }}>
+      <MockTimeline
+        source="player"
+        playerName="player"
+        name="vis"
+        selectionType="range"
+        mockDuration={60}
+        mockChannelCount={1}
+        trackLabels={[longLabel]}
+      />
+    </div>,
+  );
+  const label = component.locator('[data-testid="track-label"]').first();
+
+  // text-overflow: ellipsis kicks in when scrollWidth > clientWidth.
+  const dims = await label.evaluate((el) => ({
+    clientWidth: (el as HTMLElement).clientWidth,
+    scrollWidth: (el as HTMLElement).scrollWidth,
+  }));
+  expect(dims.scrollWidth).toBeGreaterThan(dims.clientWidth);
+
+  // Rendered label must fit within the waveform region (no spilling past
+  // the overlay's right edge, which would mean truncation isn't bounded).
+  const labelBox = await label.boundingBox();
+  const overlay = component.locator('[data-testid="selection-overlay"]');
+  const overlayBox = await overlay.boundingBox();
+  if (!labelBox || !overlayBox) throw new Error("missing element");
+  expect(labelBox.x + labelBox.width).toBeLessThanOrEqual(
+    overlayBox.x + overlayBox.width + 1,
+  );
+});
+
 test("renders canvas for waveform", async ({ mount }) => {
   const component = await mount(
     <MockTimeline
@@ -2780,4 +2868,415 @@ test("playhead time box is draggable (pointerEvents: auto)", async ({
     (el) => getComputedStyle(el).pointerEvents,
   );
   expect(pointerEvents).toBe("auto");
+});
+
+// -- Trackpad gestures: wheel pan and pinch-to-zoom --
+
+/**
+ * Read viewportStart off the timeline element. Lives on the data-attribute
+ * so tests can verify pan/zoom behavior without reaching into React state.
+ */
+async function readViewportStart(
+  timeline: import("@playwright/test").Locator,
+): Promise<number> {
+  const raw = await timeline.getAttribute("data-viewport-start");
+  if (raw === null) throw new Error("data-viewport-start missing");
+  return parseFloat(raw);
+}
+
+async function readZoomLevel(
+  timeline: import("@playwright/test").Locator,
+): Promise<number> {
+  const raw = await timeline.getAttribute("data-zoom-level");
+  if (raw === null) throw new Error("data-zoom-level missing");
+  return parseFloat(raw);
+}
+
+test("wheel pan: horizontal-dominant deltaX advances viewportStart when zoomed", async ({
+  mount,
+}) => {
+  // Two zoom-ins to land at 4×, where there's room to pan in both directions.
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="pan_test"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  expect(await readZoomLevel(timeline)).toBe(4);
+
+  const before = await readViewportStart(timeline);
+  await timeline.dispatchEvent("wheel", {
+    deltaX: 200,
+    deltaY: 0,
+    deltaMode: 0,
+    bubbles: true,
+    cancelable: true,
+  });
+  const after = await readViewportStart(timeline);
+  expect(after).toBeGreaterThan(before);
+});
+
+test("wheel pan: negative deltaX moves viewportStart back toward zero", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="pan_back_test"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+
+  // Pan right first so we have room to pan back.
+  await timeline.dispatchEvent("wheel", {
+    deltaX: 400,
+    deltaY: 0,
+    deltaMode: 0,
+    bubbles: true,
+    cancelable: true,
+  });
+  const mid = await readViewportStart(timeline);
+  expect(mid).toBeGreaterThan(0);
+
+  await timeline.dispatchEvent("wheel", {
+    deltaX: -400,
+    deltaY: 0,
+    deltaMode: 0,
+    bubbles: true,
+    cancelable: true,
+  });
+  const after = await readViewportStart(timeline);
+  expect(after).toBeLessThan(mid);
+});
+
+test("wheel pan: ignored when zoom level is 1 (full duration visible)", async ({
+  mount,
+}) => {
+  // At zoom 1 there's nothing to pan to — wheel should pass through.
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="no_pan_at_1x"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  expect(await readZoomLevel(timeline)).toBe(1);
+  expect(await readViewportStart(timeline)).toBe(0);
+
+  await timeline.dispatchEvent("wheel", {
+    deltaX: 500,
+    deltaY: 0,
+    deltaMode: 0,
+    bubbles: true,
+    cancelable: true,
+  });
+  expect(await readViewportStart(timeline)).toBe(0);
+});
+
+test("wheel pan: vertical-dominant wheel does NOT pan (passes through to page)", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="vertical_passthrough"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+
+  const before = await readViewportStart(timeline);
+  // |deltaY| > |deltaX| → vertical-dominant. Should pass through.
+  await timeline.dispatchEvent("wheel", {
+    deltaX: 10,
+    deltaY: 200,
+    deltaMode: 0,
+    bubbles: true,
+    cancelable: true,
+  });
+  const after = await readViewportStart(timeline);
+  expect(after).toBe(before);
+});
+
+test("wheel pan: clamps at viewport start (cannot pan before t=0)", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="clamp_left"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+
+  // Already at viewportStart=0; a leftward swipe must not go negative.
+  expect(await readViewportStart(timeline)).toBe(0);
+  await timeline.dispatchEvent("wheel", {
+    deltaX: -1000,
+    deltaY: 0,
+    deltaMode: 0,
+    bubbles: true,
+    cancelable: true,
+  });
+  expect(await readViewportStart(timeline)).toBe(0);
+});
+
+test("wheel pan: clamps at viewport end (cannot pan past duration)", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="clamp_right"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+
+  // Pan all the way right.
+  await timeline.dispatchEvent("wheel", {
+    deltaX: 100000,
+    deltaY: 0,
+    deltaMode: 0,
+    bubbles: true,
+    cancelable: true,
+  });
+  const maxStart = await readViewportStart(timeline);
+  // At zoom 4 of 60s, max viewportStart = 60 - 15 = 45.
+  expect(maxStart).toBeCloseTo(45, 5);
+
+  // Another rightward swipe should not move further.
+  await timeline.dispatchEvent("wheel", {
+    deltaX: 1000,
+    deltaY: 0,
+    deltaMode: 0,
+    bubbles: true,
+    cancelable: true,
+  });
+  const stillMax = await readViewportStart(timeline);
+  expect(stillMax).toBe(maxStart);
+});
+
+test("pinch-to-zoom: ctrl+wheel with negative deltaY zooms in", async ({
+  mount,
+}) => {
+  // Chromium reports trackpad pinch as wheel + ctrlKey.
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="pinch_in"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  expect(await readZoomLevel(timeline)).toBe(1);
+
+  const box = await timeline.boundingBox();
+  if (!box) throw new Error("timeline box not found");
+  // Aim the pinch in the middle of the waveform so the focal computation
+  // has somewhere reasonable to anchor.
+  await timeline.dispatchEvent("wheel", {
+    deltaX: 0,
+    deltaY: -200,
+    deltaMode: 0,
+    ctrlKey: true,
+    clientX: box.x + box.width / 2,
+    clientY: box.y + box.height / 2,
+    bubbles: true,
+    cancelable: true,
+  });
+  const after = await readZoomLevel(timeline);
+  expect(after).toBeGreaterThan(1);
+});
+
+test("pinch-to-zoom: ctrl+wheel with positive deltaY zooms out", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="pinch_out"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  // Zoom in via the buttons first so there's room to zoom out.
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  const before = await readZoomLevel(timeline);
+  expect(before).toBe(4);
+
+  const box = await timeline.boundingBox();
+  if (!box) throw new Error("timeline box not found");
+  await timeline.dispatchEvent("wheel", {
+    deltaX: 0,
+    deltaY: 200,
+    deltaMode: 0,
+    ctrlKey: true,
+    clientX: box.x + box.width / 2,
+    clientY: box.y + box.height / 2,
+    bubbles: true,
+    cancelable: true,
+  });
+  const after = await readZoomLevel(timeline);
+  expect(after).toBeLessThan(before);
+});
+
+test("pinch-to-zoom: anchors on cursor — pinching inside the gutter pins viewport at 0", async ({
+  mount,
+}) => {
+  // Cursor over the gutter (where track labels live, before the waveform
+  // starts) → cursorX inside the wheel handler is negative, focalRatio
+  // clamps to 0, so the focal time IS viewportStart and viewportStart
+  // should remain pinned at 0 across the zoom.
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="pinch_focal_left"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  const box = await timeline.boundingBox();
+  if (!box) throw new Error("timeline box not found");
+
+  await timeline.dispatchEvent("wheel", {
+    deltaX: 0,
+    deltaY: -400,
+    deltaMode: 0,
+    ctrlKey: true,
+    // 20px in is well inside the 72px gutter — focalRatio clamps to 0.
+    clientX: box.x + 20,
+    clientY: box.y + box.height / 2,
+    bubbles: true,
+    cancelable: true,
+  });
+  const zoom = await readZoomLevel(timeline);
+  expect(zoom).toBeGreaterThan(1);
+  const vs = await readViewportStart(timeline);
+  expect(vs).toBe(0);
+});
+
+test("pinch-to-zoom: anchors on cursor — pinching at right edge advances viewportStart", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="pinch_focal_right"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  const box = await timeline.boundingBox();
+  if (!box) throw new Error("timeline box not found");
+
+  await timeline.dispatchEvent("wheel", {
+    deltaX: 0,
+    deltaY: -400,
+    deltaMode: 0,
+    ctrlKey: true,
+    clientX: box.x + box.width - 20,
+    clientY: box.y + box.height / 2,
+    bubbles: true,
+    cancelable: true,
+  });
+  const zoom = await readZoomLevel(timeline);
+  expect(zoom).toBeGreaterThan(1);
+  // Cursor at the right edge → focalRatio ≈ 1 → viewport should advance
+  // so the right-edge time stays near the right of the new viewport.
+  const vs = await readViewportStart(timeline);
+  expect(vs).toBeGreaterThan(0);
+});
+
+test("pinch-to-zoom: zoom level is clamped at MAX_ZOOM", async ({ mount }) => {
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="pinch_max"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  const box = await timeline.boundingBox();
+  if (!box) throw new Error("timeline box not found");
+
+  // Massive negative delta — should saturate at MAX_ZOOM (32) and stay there.
+  await timeline.dispatchEvent("wheel", {
+    deltaX: 0,
+    deltaY: -100000,
+    deltaMode: 0,
+    ctrlKey: true,
+    clientX: box.x + box.width / 2,
+    clientY: box.y + box.height / 2,
+    bubbles: true,
+    cancelable: true,
+  });
+  expect(await readZoomLevel(timeline)).toBe(32);
+});
+
+test("pinch-to-zoom: zoom level is clamped at MIN_ZOOM (1)", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="pinch_min"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  // Already at zoom 1 — pinch-out further should not go below 1.
+  const box = await timeline.boundingBox();
+  if (!box) throw new Error("timeline box not found");
+  await timeline.dispatchEvent("wheel", {
+    deltaX: 0,
+    deltaY: 100000,
+    deltaMode: 0,
+    ctrlKey: true,
+    clientX: box.x + box.width / 2,
+    clientY: box.y + box.height / 2,
+    bubbles: true,
+    cancelable: true,
+  });
+  expect(await readZoomLevel(timeline)).toBe(1);
 });

--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -3325,7 +3325,5 @@ test("wheel pan: line-mode (deltaMode=1) deltas are normalized to pixels", async
   // margin without depending on exact render width. expect.poll keeps
   // re-reading the attribute until React commits the post-wheel state
   // (a one-shot read can race the commit on busy CI workers).
-  await expect
-    .poll(() => readViewportStart(timeline))
-    .toBeGreaterThan(0.5);
+  await expect.poll(() => readViewportStart(timeline)).toBeGreaterThan(0.5);
 });

--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -3289,3 +3289,43 @@ test("pinch-to-zoom: zoom level is clamped at MIN_ZOOM (1)", async ({
   });
   expect(await readZoomLevel(timeline)).toBe(1);
 });
+
+test("wheel pan: line-mode (deltaMode=1) deltas are normalized to pixels", async ({
+  mount,
+}) => {
+  // Some mice / browsers report wheel deltas in lines (~16px each) rather
+  // than pixels. The handler must normalize these so a small line count
+  // becomes a meaningful pan — otherwise line-wheel users would barely
+  // move when swiping. Without normalization, deltaX=5 → 5/pxPerSec ≈
+  // 0.06s of pan; with normalization, deltaX=5 lines → ~80px → ~1s of pan.
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="line_mode"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await expect(timeline).toHaveAttribute("data-zoom-level", "4");
+
+  await timeline.dispatchEvent("wheel", {
+    deltaX: 5,
+    deltaY: 0,
+    deltaMode: 1,
+    bubbles: true,
+    cancelable: true,
+  });
+  // 5 lines * 16px ≈ 80px. At zoom 4 / 60s on any reasonable width
+  // (>= 320px waveform), that's >= 0.5s of pan. Without normalization
+  // it would top out at ~0.1s. The 0.5s threshold has comfortable
+  // margin without depending on exact render width. expect.poll keeps
+  // re-reading the attribute until React commits the post-wheel state
+  // (a one-shot read can race the commit on busy CI workers).
+  await expect
+    .poll(() => readViewportStart(timeline))
+    .toBeGreaterThan(0.5);
+});

--- a/packages/stagebook/src/components/elements/Timeline.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.tsx
@@ -25,10 +25,13 @@ import {
   AUTO_SCROLL_THRESHOLD,
   SEEK_JUMP_THRESHOLD,
   clampViewportStart,
+  computeViewportAfterFocalZoom,
+  computeViewportAfterPan,
   computeViewportAfterScroll,
   computeViewportAfterSeek,
   computeViewportAfterZoom,
   isPlayheadPastThreshold,
+  pinchZoom,
   zoomIn as nextZoomIn,
   zoomOut as nextZoomOut,
 } from "./timeline/viewport.js";
@@ -403,6 +406,79 @@ export function Timeline({
     [zoomLevel],
   );
 
+  // Trackpad gestures: ctrl+wheel = pinch-to-zoom centered on the cursor;
+  // horizontal-dominant wheel (two-finger swipe left/right) = pan when
+  // zoomed in. Vertical-dominant wheel passes through to scroll the page.
+  //
+  // Bound natively (not via React's onWheel) with passive: false so we can
+  // call preventDefault on gestures we handle. Refs feed the latest zoom
+  // and viewport into the handler so we don't re-attach on every change.
+  const zoomLevelRef = useRef(zoomLevel);
+  zoomLevelRef.current = zoomLevel;
+  const viewportStartRef = useRef(viewportStart);
+  viewportStartRef.current = viewportStart;
+  useEffect(() => {
+    const el = containerElRef.current;
+    if (!el) return;
+
+    const onWheel = (e: WheelEvent) => {
+      const dur = handleRef.current?.getDuration() ?? 0;
+      if (dur <= 0) return;
+      const rect = el.getBoundingClientRect();
+      const waveformWidth = Math.max(rect.width - GUTTER_WIDTH, 0);
+      if (waveformWidth <= 0) return;
+
+      // Chromium/Safari report trackpad pinch as wheel + ctrlKey, even
+      // without the Control key being physically pressed.
+      if (e.ctrlKey) {
+        e.preventDefault();
+        const currentZoom = zoomLevelRef.current;
+        const newZoom = pinchZoom(currentZoom, e.deltaY);
+        if (newZoom === currentZoom) return;
+        // Anchor the zoom on the time under the cursor so it stays put.
+        const cursorX = e.clientX - rect.left - GUTTER_WIDTH;
+        const focalRatio = Math.max(0, Math.min(1, cursorX / waveformWidth));
+        const visible = dur / currentZoom;
+        const focalTime = viewportStartRef.current + visible * focalRatio;
+        setZoomLevel(newZoom);
+        setViewportStart(
+          computeViewportAfterFocalZoom({
+            newZoom,
+            duration: dur,
+            focalTime,
+            focalRatio,
+          }),
+        );
+        return;
+      }
+
+      // Horizontal pan only when zoomed in (otherwise there's nothing to
+      // pan to) and only when the gesture is unambiguously horizontal —
+      // pure vertical scroll passes through to the page.
+      if (zoomLevelRef.current <= 1) return;
+      if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
+      e.preventDefault();
+      setViewportStart(
+        computeViewportAfterPan({
+          currentViewportStart: viewportStartRef.current,
+          deltaPx: e.deltaX,
+          waveformWidthPx: waveformWidth,
+          duration: dur,
+          zoomLevel: zoomLevelRef.current,
+        }),
+      );
+    };
+
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => {
+      el.removeEventListener("wheel", onWheel);
+    };
+    // Re-run when the playback handle materializes — until then the
+    // timeline div isn't rendered (we show an error fallback) and
+    // containerElRef.current is null, so an initial-mount-only effect
+    // would never bind the listener.
+  }, [handle]);
+
   // Keyboard handler — delegates to keyboardActions.ts for the key-to-action
   // mapping. Returns null when the key should fall through to MediaPlayer.
   const onKeyDown = (e: React.KeyboardEvent) => {
@@ -561,6 +637,7 @@ export function Timeline({
       data-multi-select={multiSelect}
       data-show-waveform={showWaveform}
       data-zoom-level={zoomLevel}
+      data-viewport-start={viewportStart}
       role="region"
       aria-label={`Timeline: ${name}`}
       tabIndex={0}

--- a/packages/stagebook/src/components/elements/Timeline.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.tsx
@@ -31,6 +31,7 @@ import {
   computeViewportAfterSeek,
   computeViewportAfterZoom,
   isPlayheadPastThreshold,
+  normalizeWheelDelta,
   pinchZoom,
   zoomIn as nextZoomIn,
   zoomOut as nextZoomOut,
@@ -428,12 +429,19 @@ export function Timeline({
       const waveformWidth = Math.max(rect.width - GUTTER_WIDTH, 0);
       if (waveformWidth <= 0) return;
 
+      // Normalize deltas to pixels. Trackpads always report PIXEL mode
+      // (0); some mouse wheels and rare browsers report LINE (1) or
+      // PAGE (2). Without this our pan/pinch sensitivity would silently
+      // become wildly off on those input devices.
+      const dx = normalizeWheelDelta(e.deltaX, e.deltaMode);
+      const dy = normalizeWheelDelta(e.deltaY, e.deltaMode);
+
       // Chromium/Safari report trackpad pinch as wheel + ctrlKey, even
       // without the Control key being physically pressed.
       if (e.ctrlKey) {
         e.preventDefault();
         const currentZoom = zoomLevelRef.current;
-        const newZoom = pinchZoom(currentZoom, e.deltaY);
+        const newZoom = pinchZoom(currentZoom, dy);
         if (newZoom === currentZoom) return;
         // Anchor the zoom on the time under the cursor so it stays put.
         const cursorX = e.clientX - rect.left - GUTTER_WIDTH;
@@ -456,12 +464,12 @@ export function Timeline({
       // pan to) and only when the gesture is unambiguously horizontal —
       // pure vertical scroll passes through to the page.
       if (zoomLevelRef.current <= 1) return;
-      if (Math.abs(e.deltaX) <= Math.abs(e.deltaY)) return;
+      if (Math.abs(dx) <= Math.abs(dy)) return;
       e.preventDefault();
       setViewportStart(
         computeViewportAfterPan({
           currentViewportStart: viewportStartRef.current,
-          deltaPx: e.deltaX,
+          deltaPx: dx,
           waveformWidthPx: waveformWidth,
           duration: dur,
           zoomLevel: zoomLevelRef.current,

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -79,6 +79,14 @@ const DRAG_DEAD_ZONE_PX = 4;
  */
 const CLICK_CREATED_RANGE_SEC = 1;
 
+/**
+ * Minimum visual width (in pixels) for a click-created range. For long
+ * videos at low zoom, 1 second can render at <1px, leaving the start and
+ * end handles overlapping with no visible range between them. We expand
+ * the range so the gap between the handles is at least this many pixels.
+ */
+const CLICK_CREATED_RANGE_MIN_PX = 6;
+
 interface DragState {
   startX: number;
   startTime: number;
@@ -102,24 +110,81 @@ function isRangeArray(s: TimelineValue): s is RangeSelection[] {
   return s.length === 0 || "start" in (s[0] as object);
 }
 
+const HANDLE_HIT_WIDTH = 8;
+const HANDLE_TIP_WIDTH = 2;
+
 /**
- * Two faint vertical bars in the middle of a range handle — signals
- * "grabbable" at a glance, echoing the standard OS resize-grip pattern.
- * Sized and positioned relative to the 8px-wide handle parent.
+ * Visual content of a range handle — three vertical sections stacked
+ * top-to-middle-to-bottom. The thin top/bottom tips mark the actual range
+ * boundary (same width as the playhead, so they read as precise endpoints);
+ * the thick middle extends outward from the boundary as a wider grab
+ * affordance, with two grip bars echoing OS resize-grip iconography. The
+ * inner edge of the thick block aligns with the inner edge of the tips.
+ *
+ * The thick middle overflows the parent handle's CSS box outward — pointer
+ * events still bubble up to the handle, so the visible grab area matches
+ * what's clickable. The handle's own 8px-wide box stays centered on the
+ * boundary so existing hit behavior (clicking near the edge to grab)
+ * continues to work.
  */
-function HandleGrip() {
-  const barStyle: React.CSSProperties = {
+function HandleVisual({
+  handle,
+  color,
+}: {
+  handle: "start" | "end";
+  color: string;
+}) {
+  const isStart = handle === "start";
+  // The parent handle's CSS box is 8px wide and centered on the boundary
+  // (left:-4 width:8 for start; right:-4 width:8 for end), so the boundary
+  // sits at the parent's INNER edge — boundary = parent's right edge for
+  // a start handle, parent's left edge for an end handle. We anchor every
+  // visual element's inner edge to that point using `right: 4` (start) or
+  // `left: 4` (end), which both resolve to the boundary in container coords.
+  const innerOffset = HANDLE_HIT_WIDTH / 2;
+  const innerEdge: React.CSSProperties = isStart
+    ? { right: innerOffset }
+    : { left: innerOffset };
+  // Tips: 2px wide, sitting just outside the boundary so their inner edge
+  // marks the actual endpoint of the range.
+  const tipStyle: React.CSSProperties = {
     position: "absolute",
-    top: "35%",
-    bottom: "35%",
+    width: HANDLE_TIP_WIDTH,
+    background: color,
+    pointerEvents: "none",
+    ...innerEdge,
+  };
+  // Thick middle: 8px wide, inner edge at the boundary, extending outward.
+  // The left half overflows the parent handle's box; pointer events still
+  // bubble up to the handle, so clicks on the visible thick area are
+  // captured as handle drags.
+  const thickStyle: React.CSSProperties = {
+    position: "absolute",
+    top: "33%",
+    bottom: "33%",
+    width: HANDLE_HIT_WIDTH,
+    background: color,
+    ...innerEdge,
+  };
+  // Two faint grip bars centered inside the thick block (matches the prior
+  // resize-grip iconography — the visual itself is what's changing, not
+  // the affordance).
+  const gripBar: React.CSSProperties = {
+    position: "absolute",
+    top: "25%",
+    bottom: "25%",
     width: 1,
     background: "rgba(255, 255, 255, 0.75)",
     pointerEvents: "none",
   };
   return (
     <>
-      <div style={{ ...barStyle, left: 2 }} />
-      <div style={{ ...barStyle, right: 2 }} />
+      <div style={{ ...tipStyle, top: 0, height: "33%" }} />
+      <div style={thickStyle}>
+        <div style={{ ...gripBar, left: 2 }} />
+        <div style={{ ...gripBar, right: 2 }} />
+      </div>
+      <div style={{ ...tipStyle, bottom: 0, height: "33%" }} />
     </>
   );
 }
@@ -325,11 +390,23 @@ export function SelectionOverlay({
             if (activeIndex !== null) onDeselect();
             onRequestFocus();
           } else {
+            // Pick a width that's at least CLICK_CREATED_RANGE_SEC AND at
+            // least CLICK_CREATED_RANGE_MIN_PX wide on screen — for long
+            // videos at low zoom 1 second can render sub-pixel, so the
+            // pixel floor keeps the new range visible.
+            const pxPerSec = duration > 0 ? (width * zoomLevel) / duration : 0;
+            const widthSec =
+              pxPerSec > 0
+                ? Math.max(
+                    CLICK_CREATED_RANGE_SEC,
+                    CLICK_CREATED_RANGE_MIN_PX / pxPerSec,
+                  )
+                : CLICK_CREATED_RANGE_SEC;
             let start = time;
-            let end = time + CLICK_CREATED_RANGE_SEC;
+            let end = time + widthSec;
             if (end > duration) {
               end = duration;
-              start = Math.max(0, duration - CLICK_CREATED_RANGE_SEC);
+              start = Math.max(0, duration - widthSec);
             }
             if (end - start > 0) {
               onCreateRange(start, end, track);
@@ -360,6 +437,8 @@ export function SelectionOverlay({
       selectionType,
       activeIndex,
       duration,
+      width,
+      zoomLevel,
       selections,
       multiSelect,
       onCreatePoint,
@@ -524,19 +603,22 @@ export function SelectionOverlay({
             }}
             style={{
               position: "absolute",
-              left: -4,
+              left: -(HANDLE_HIT_WIDTH / 2),
               top: 0,
-              width: 8,
+              width: HANDLE_HIT_WIDTH,
               height: "100%",
-              background:
-                isActive && activeHandle === "start"
-                  ? "rgba(37, 99, 235, 1)"
-                  : "rgba(59, 130, 246, 0.7)",
               cursor: "ew-resize",
               zIndex: startHandleOnTop ? 2 : 1,
             }}
           >
-            <HandleGrip />
+            <HandleVisual
+              handle="start"
+              color={
+                isActive && activeHandle === "start"
+                  ? "rgba(37, 99, 235, 1)"
+                  : "rgba(59, 130, 246, 0.7)"
+              }
+            />
             {hoveredHandle?.index === i &&
               hoveredHandle?.handle === "start" && (
                 <div style={handleTooltipStyle("start")}>
@@ -560,19 +642,22 @@ export function SelectionOverlay({
             }}
             style={{
               position: "absolute",
-              right: -4,
+              right: -(HANDLE_HIT_WIDTH / 2),
               top: 0,
-              width: 8,
+              width: HANDLE_HIT_WIDTH,
               height: "100%",
-              background:
-                isActive && activeHandle === "end"
-                  ? "rgba(37, 99, 235, 1)"
-                  : "rgba(59, 130, 246, 0.7)",
               cursor: "ew-resize",
               zIndex: startHandleOnTop ? 1 : 2,
             }}
           >
-            <HandleGrip />
+            <HandleVisual
+              handle="end"
+              color={
+                isActive && activeHandle === "end"
+                  ? "rgba(37, 99, 235, 1)"
+                  : "rgba(59, 130, 246, 0.7)"
+              }
+            />
             {hoveredHandle?.index === i && hoveredHandle?.handle === "end" && (
               <div style={handleTooltipStyle("end")}>
                 {formatTime(range.end, zoomDecimals(zoomLevel))}

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -136,11 +136,11 @@ function HandleVisual({
 }) {
   const isStart = handle === "start";
   // The parent handle's CSS box is 8px wide and centered on the boundary
-  // (left:-4 width:8 for start; right:-4 width:8 for end), so the boundary
-  // sits at the parent's INNER edge — boundary = parent's right edge for
-  // a start handle, parent's left edge for an end handle. We anchor every
-  // visual element's inner edge to that point using `right: 4` (start) or
-  // `left: 4` (end), which both resolve to the boundary in container coords.
+  // (`left: -4 width: 8` for start, `right: -4 width: 8` for end). So the
+  // boundary sits at the *center* of the parent box — half the box is
+  // outside the range, half is inside. Anchoring a child with `right: 4`
+  // (start) or `left: 4` (end) — i.e., `HANDLE_HIT_WIDTH / 2` from the
+  // outer edge — places that child's inner edge exactly on the boundary.
   const innerOffset = HANDLE_HIT_WIDTH / 2;
   const innerEdge: React.CSSProperties = isStart
     ? { right: innerOffset }

--- a/packages/stagebook/src/components/elements/timeline/TimelineTrack.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineTrack.tsx
@@ -25,11 +25,12 @@ export interface TimelineTrackProps {
   onToggleMute: (nextMuted: boolean) => void;
 }
 
-const GUTTER_WIDTH = 72;
+const GUTTER_WIDTH = 60;
 const MUTE_BUTTON_WIDTH = 22;
 
 /**
- * One row in the timeline: a fixed-width gutter label + a WaveformRenderer.
+ * One row in the timeline: a narrow gutter (mute button) + a WaveformRenderer
+ * with the track label overlaid in its upper-left corner.
  */
 export function TimelineTrack({
   label,
@@ -59,7 +60,7 @@ export function TimelineTrack({
           minWidth: `${String(GUTTER_WIDTH)}px`,
           display: "flex",
           alignItems: "center",
-          paddingRight: "0.5rem",
+          justifyContent: "center",
           borderRight: "1px solid var(--stagebook-border, #e5e7eb)",
         }}
       >
@@ -74,8 +75,6 @@ export function TimelineTrack({
             width: `${String(MUTE_BUTTON_WIDTH)}px`,
             minWidth: `${String(MUTE_BUTTON_WIDTH)}px`,
             height: `${String(MUTE_BUTTON_WIDTH)}px`,
-            marginLeft: "0.25rem",
-            marginRight: "0.25rem",
             padding: 0,
             display: "flex",
             alignItems: "center",
@@ -91,32 +90,41 @@ export function TimelineTrack({
         >
           {muted ? <SpeakerMutedIcon /> : <SpeakerIcon />}
         </button>
-        <div
+      </div>
+      <div style={{ position: "relative" }}>
+        <WaveformRenderer
+          peaks={peaks}
+          peaksVersion={peaksVersion}
+          width={waveformWidth}
+          height={height}
+          startBucket={startBucket}
+          endBucket={endBucket}
+        />
+        <span
           data-testid="track-label"
           style={{
-            flex: 1,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "flex-end",
-            fontSize: "0.79rem",
-            color: "var(--stagebook-text-faint, #9ca3af)",
+            position: "absolute",
+            top: "4px",
+            left: "4px",
+            boxSizing: "border-box",
+            padding: "1px 6px",
+            fontSize: "0.7rem",
+            lineHeight: 1.4,
+            color: "var(--stagebook-text-faint, #6b7280)",
+            background: "rgba(255, 255, 255, 0.85)",
+            border: "1px solid var(--stagebook-border, #e5e7eb)",
+            borderRadius: "0.25rem",
             userSelect: "none",
+            pointerEvents: "none",
+            maxWidth: `${String(Math.max(waveformWidth - 8, 0))}px`,
             overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
           }}
         >
           {label}
-        </div>
+        </span>
       </div>
-      <WaveformRenderer
-        peaks={peaks}
-        peaksVersion={peaksVersion}
-        width={waveformWidth}
-        height={height}
-        startBucket={startBucket}
-        endBucket={endBucket}
-      />
     </div>
   );
 }

--- a/packages/stagebook/src/components/elements/timeline/viewport.test.ts
+++ b/packages/stagebook/src/components/elements/timeline/viewport.test.ts
@@ -7,6 +7,7 @@ import {
   computeViewportAfterPan,
   clampViewportStart,
   isPlayheadPastThreshold,
+  normalizeWheelDelta,
   pinchZoom,
   zoomIn,
   zoomOut,
@@ -361,5 +362,33 @@ describe("computeViewportAfterPan", () => {
       zoomLevel: 2,
     });
     expect(result).toBe(5);
+  });
+});
+
+describe("normalizeWheelDelta", () => {
+  it("passes pixel-mode deltas through unchanged", () => {
+    expect(normalizeWheelDelta(42, 0)).toBe(42);
+    expect(normalizeWheelDelta(-7.5, 0)).toBe(-7.5);
+  });
+
+  it("scales line-mode deltas to pixels", () => {
+    // Mode 1 (DOM_DELTA_LINE): one line ≈ 16px.
+    expect(normalizeWheelDelta(3, 1)).toBe(48);
+    expect(normalizeWheelDelta(-1, 1)).toBe(-16);
+  });
+
+  it("scales page-mode deltas to pixels", () => {
+    // Mode 2 (DOM_DELTA_PAGE): one page ≈ 800px.
+    expect(normalizeWheelDelta(1, 2)).toBe(800);
+    expect(normalizeWheelDelta(-2, 2)).toBe(-1600);
+  });
+
+  it("returns 0 on non-finite delta", () => {
+    expect(normalizeWheelDelta(Number.NaN, 0)).toBe(0);
+    expect(normalizeWheelDelta(Number.POSITIVE_INFINITY, 1)).toBe(0);
+  });
+
+  it("falls through to pass-through for unknown deltaMode", () => {
+    expect(normalizeWheelDelta(5, 99)).toBe(5);
   });
 });

--- a/packages/stagebook/src/components/elements/timeline/viewport.test.ts
+++ b/packages/stagebook/src/components/elements/timeline/viewport.test.ts
@@ -3,11 +3,15 @@ import {
   computeViewportAfterZoom,
   computeViewportAfterScroll,
   computeViewportAfterSeek,
+  computeViewportAfterFocalZoom,
+  computeViewportAfterPan,
   clampViewportStart,
   isPlayheadPastThreshold,
+  pinchZoom,
   zoomIn,
   zoomOut,
   MIN_ZOOM,
+  MAX_ZOOM,
 } from "./viewport.js";
 
 describe("clampViewportStart", () => {
@@ -166,5 +170,196 @@ describe("computeViewportAfterSeek", () => {
     // Playhead at 58, visible 30, snap 0.25 → start = 50.5. Max = 60 - 30 = 30. Clamp to 30.
     const result = computeViewportAfterSeek(58, 30, 60, 0.25);
     expect(result).toBe(30);
+  });
+});
+
+describe("pinchZoom", () => {
+  it("returns the input zoom for deltaY = 0", () => {
+    expect(pinchZoom(2, 0)).toBe(2);
+  });
+
+  it("zooms in for negative deltaY (pinch out / two-finger swipe up)", () => {
+    expect(pinchZoom(2, -100)).toBeGreaterThan(2);
+  });
+
+  it("zooms out for positive deltaY (pinch in / two-finger swipe down)", () => {
+    expect(pinchZoom(4, 100)).toBeLessThan(4);
+  });
+
+  it("compounds multiplicatively across ticks", () => {
+    // Two ticks of -50 should equal one tick of -100 (within float tolerance).
+    const onceLarge = pinchZoom(2, -100);
+    const twiceSmall = pinchZoom(pinchZoom(2, -50), -50);
+    expect(twiceSmall).toBeCloseTo(onceLarge, 5);
+  });
+
+  it("clamps at MIN_ZOOM", () => {
+    expect(pinchZoom(MIN_ZOOM, 1000)).toBe(MIN_ZOOM);
+  });
+
+  it("clamps at MAX_ZOOM", () => {
+    expect(pinchZoom(MAX_ZOOM, -1000)).toBe(MAX_ZOOM);
+  });
+
+  it("clamps at MAX_ZOOM even when the multiplicative factor overflows", () => {
+    // exp(-(-100000) * 0.01) = exp(1000) overflows to Infinity. We rely on
+    // Math.min(MAX_ZOOM, Infinity) === MAX_ZOOM rather than bailing out,
+    // since the user's intent (huge pinch-in) is unambiguously "max zoom."
+    expect(pinchZoom(1, -100000)).toBe(MAX_ZOOM);
+  });
+
+  it("returns input on non-finite deltaY", () => {
+    expect(pinchZoom(2, Number.NaN)).toBe(2);
+    expect(pinchZoom(2, Number.POSITIVE_INFINITY)).toBe(2);
+  });
+});
+
+describe("computeViewportAfterFocalZoom", () => {
+  it("keeps focalTime under focalRatio after zoom", () => {
+    // Focal at 30s, want it to stay at 50% of viewport at zoom 4.
+    // visible = 60/4 = 15, so start = 30 - 15*0.5 = 22.5.
+    const result = computeViewportAfterFocalZoom({
+      newZoom: 4,
+      duration: 60,
+      focalTime: 30,
+      focalRatio: 0.5,
+    });
+    expect(result).toBeCloseTo(22.5, 5);
+  });
+
+  it("anchors to the left edge when focalRatio is 0", () => {
+    // focalTime should remain at the very left of the viewport.
+    const result = computeViewportAfterFocalZoom({
+      newZoom: 4,
+      duration: 60,
+      focalTime: 20,
+      focalRatio: 0,
+    });
+    expect(result).toBeCloseTo(20, 5);
+  });
+
+  it("anchors to the right edge when focalRatio is 1", () => {
+    // visible = 15. start = 45 - 15 = 30.
+    const result = computeViewportAfterFocalZoom({
+      newZoom: 4,
+      duration: 60,
+      focalTime: 45,
+      focalRatio: 1,
+    });
+    expect(result).toBeCloseTo(30, 5);
+  });
+
+  it("clamps to 0 when zooming would push viewport before t=0", () => {
+    // Focal near start, zoom would put start = 5 - 30*0.5 = -10 → clamp 0.
+    const result = computeViewportAfterFocalZoom({
+      newZoom: 2,
+      duration: 60,
+      focalTime: 5,
+      focalRatio: 0.5,
+    });
+    expect(result).toBe(0);
+  });
+
+  it("clamps to max when zooming would push viewport past duration", () => {
+    // Focal near end. visible = 30, max start = 30. Should clamp.
+    const result = computeViewportAfterFocalZoom({
+      newZoom: 2,
+      duration: 60,
+      focalTime: 58,
+      focalRatio: 0.1,
+    });
+    expect(result).toBe(30);
+  });
+
+  it("returns 0 at zoom <= 1 (full duration visible)", () => {
+    expect(
+      computeViewportAfterFocalZoom({
+        newZoom: 1,
+        duration: 60,
+        focalTime: 30,
+        focalRatio: 0.5,
+      }),
+    ).toBe(0);
+  });
+
+  it("returns 0 for non-positive duration", () => {
+    expect(
+      computeViewportAfterFocalZoom({
+        newZoom: 4,
+        duration: 0,
+        focalTime: 30,
+        focalRatio: 0.5,
+      }),
+    ).toBe(0);
+  });
+});
+
+describe("computeViewportAfterPan", () => {
+  it("pans right (forward in time) on positive deltaPx", () => {
+    // 800px shows 30s (zoom 2 of 60s) → 1px = 0.0375s. 100px = 3.75s.
+    const result = computeViewportAfterPan({
+      currentViewportStart: 0,
+      deltaPx: 100,
+      waveformWidthPx: 800,
+      duration: 60,
+      zoomLevel: 2,
+    });
+    expect(result).toBeCloseTo(3.75, 5);
+  });
+
+  it("pans left (back in time) on negative deltaPx", () => {
+    const result = computeViewportAfterPan({
+      currentViewportStart: 10,
+      deltaPx: -100,
+      waveformWidthPx: 800,
+      duration: 60,
+      zoomLevel: 2,
+    });
+    expect(result).toBeCloseTo(6.25, 5);
+  });
+
+  it("clamps at the left edge", () => {
+    const result = computeViewportAfterPan({
+      currentViewportStart: 1,
+      deltaPx: -1000,
+      waveformWidthPx: 800,
+      duration: 60,
+      zoomLevel: 2,
+    });
+    expect(result).toBe(0);
+  });
+
+  it("clamps at the right edge", () => {
+    // max start at zoom 2 = 60 - 30 = 30
+    const result = computeViewportAfterPan({
+      currentViewportStart: 25,
+      deltaPx: 10000,
+      waveformWidthPx: 800,
+      duration: 60,
+      zoomLevel: 2,
+    });
+    expect(result).toBe(30);
+  });
+
+  it("returns currentViewportStart for zero waveform width", () => {
+    const result = computeViewportAfterPan({
+      currentViewportStart: 5,
+      deltaPx: 100,
+      waveformWidthPx: 0,
+      duration: 60,
+      zoomLevel: 2,
+    });
+    expect(result).toBe(5);
+  });
+
+  it("returns currentViewportStart for zero duration", () => {
+    const result = computeViewportAfterPan({
+      currentViewportStart: 5,
+      deltaPx: 100,
+      waveformWidthPx: 800,
+      duration: 0,
+      zoomLevel: 2,
+    });
+    expect(result).toBe(5);
   });
 });

--- a/packages/stagebook/src/components/elements/timeline/viewport.ts
+++ b/packages/stagebook/src/components/elements/timeline/viewport.ts
@@ -136,6 +136,26 @@ export function computeViewportAfterSeek(
  */
 export const PINCH_ZOOM_SENSITIVITY = 0.01;
 
+/** Approximate line height (px) for converting `DOM_DELTA_LINE` deltas. */
+const WHEEL_LINE_PX = 16;
+/** Approximate page height (px) for converting `DOM_DELTA_PAGE` deltas. */
+const WHEEL_PAGE_PX = 800;
+
+/**
+ * Convert a wheel delta to pixels regardless of the event's `deltaMode`.
+ * Trackpads always emit `DOM_DELTA_PIXEL` (0), but some mice and rare
+ * browser configurations emit `DOM_DELTA_LINE` (1) or `DOM_DELTA_PAGE`
+ * (2). Without normalization, our pan/zoom sensitivity is wildly off on
+ * those input devices — a single line tick of `dx=3` would feel like 3
+ * pixels of pan instead of ~48.
+ */
+export function normalizeWheelDelta(delta: number, deltaMode: number): number {
+  if (!Number.isFinite(delta)) return 0;
+  if (deltaMode === 1) return delta * WHEEL_LINE_PX;
+  if (deltaMode === 2) return delta * WHEEL_PAGE_PX;
+  return delta;
+}
+
 /**
  * Apply a single pinch wheel tick to a zoom level. Negative deltaY (pinch
  * out / two-finger swipe up with ctrl) zooms in; positive deltaY zooms out.

--- a/packages/stagebook/src/components/elements/timeline/viewport.ts
+++ b/packages/stagebook/src/components/elements/timeline/viewport.ts
@@ -127,3 +127,80 @@ export function computeViewportAfterSeek(
   const zoomLevel = duration / visibleDuration;
   return clampViewportStart(newStart, duration, zoomLevel);
 }
+
+/**
+ * Sensitivity (per pixel of wheel deltaY) for ctrl+wheel pinch-to-zoom.
+ * Sized so a typical Mac trackpad pinch — which produces deltaY accumulation
+ * of ~50–100 over the gesture — zooms by roughly 1.5–3×, matching the feel
+ * of native browser pinch.
+ */
+export const PINCH_ZOOM_SENSITIVITY = 0.01;
+
+/**
+ * Apply a single pinch wheel tick to a zoom level. Negative deltaY (pinch
+ * out / two-finger swipe up with ctrl) zooms in; positive deltaY zooms out.
+ * Multiplicative so successive ticks compound smoothly. Clamped to
+ * [MIN_ZOOM, MAX_ZOOM].
+ */
+export function pinchZoom(currentZoom: number, deltaY: number): number {
+  if (!Number.isFinite(deltaY)) return currentZoom;
+  const factor = Math.exp(-deltaY * PINCH_ZOOM_SENSITIVITY);
+  const next = currentZoom * factor;
+  // Math.min/max with Infinity behaves correctly: huge negative deltaY
+  // produces +Infinity, which clamps to MAX_ZOOM; huge positive deltaY
+  // produces ~0, which clamps to MIN_ZOOM. NaN can't reach here since
+  // deltaY is finite (Math.exp of a finite number is in [0, +Infinity]).
+  return Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, next));
+}
+
+/**
+ * Compute the new viewport start when zooming around a focal point that
+ * should stay anchored on screen — e.g., during pinch-to-zoom, the time
+ * under the cursor stays under the cursor.
+ *
+ * @param newZoom - Target zoom level (clamped at MIN_ZOOM internally)
+ * @param duration - Total media duration in seconds
+ * @param focalTime - Time (seconds) under the focal point
+ * @param focalRatio - Fraction across the viewport (0 = left, 1 = right)
+ *                     where focalTime should remain after the zoom
+ */
+export function computeViewportAfterFocalZoom(args: {
+  newZoom: number;
+  duration: number;
+  focalTime: number;
+  focalRatio: number;
+}): number {
+  const { newZoom, duration, focalTime, focalRatio } = args;
+  if (newZoom <= 1) return 0;
+  if (duration <= 0) return 0;
+  const newVisible = duration / newZoom;
+  const newStart = focalTime - newVisible * focalRatio;
+  return clampViewportStart(newStart, duration, newZoom);
+}
+
+/**
+ * Compute the new viewport start after a horizontal pan by `deltaPx`
+ * pixels. Positive deltaPx pans the viewport to the right (forward in
+ * time), matching the convention that wheel deltaX is positive when the
+ * user scrolls right.
+ */
+export function computeViewportAfterPan(args: {
+  currentViewportStart: number;
+  deltaPx: number;
+  waveformWidthPx: number;
+  duration: number;
+  zoomLevel: number;
+}): number {
+  const {
+    currentViewportStart,
+    deltaPx,
+    waveformWidthPx,
+    duration,
+    zoomLevel,
+  } = args;
+  if (waveformWidthPx <= 0 || duration <= 0) return currentViewportStart;
+  const visibleDuration = duration / zoomLevel;
+  const secondsPerPx = visibleDuration / waveformWidthPx;
+  const newStart = currentViewportStart + deltaPx * secondsPerPx;
+  return clampViewportStart(newStart, duration, zoomLevel);
+}


### PR DESCRIPTION
## Summary

Consolidates two related streams of timeline/viewer UX work into one PR (originally split as #222 + #223 — #223 can be closed once this merges, since it contains the same commits).

### 1. Timeline range UX (commit `ee9eaef`)
- **Click-created ranges have a 6 px minimum visual width.** Click-without-drag previously created a 1-second range; on long videos at low zoom 1 s renders sub-pixel and the start/end handles overlap. Now `max(1 second, 6 px / pxPerSec)`.
- **Range handles redrawn as thin tip + thick middle + thin tip.** A 2 px tip line (matching the playhead width) marks the boundary in the top and bottom thirds; the 8 px-wide middle (with the existing grip bars) extends *outward* from the boundary, sharing the same inner edge. Hit area unchanged so existing click behavior is preserved.
- **Two-finger horizontal scroll pans; ctrl+wheel pinches to zoom.** Native wheel listener (`passive: false`). `ctrlKey` → pinch-to-zoom anchored on cursor X. `|deltaX| > |deltaY|` and zoomed in → pan. Otherwise pass through (vertical scroll over the timeline scrolls the page).
- Pure helpers in `viewport.ts`: `pinchZoom`, `computeViewportAfterFocalZoom`, `computeViewportAfterPan`. `data-viewport-start` exposed for tests.

### 2. StageNav + track-label overlay (commit `34d4347`)
- **Viewer header: anchor the stage picker to the left.** Previously StageNav drifted between timed and untimed stages depending on whether TimeScrubber rendered as a flex sibling. Moved StageNav into the headerLeft group with a thin divider after the treatment name; `flexShrink: 0` keeps it pinned.
- **Track labels overlay the waveform instead of stealing gutter width.** `GUTTER_WIDTH` 72 → 60 (mute button only); the label sits as `position: absolute` in the upper-left of the waveform with `pointer-events: none` so drags starting in that region still create ranges. CT tests cover both the click-through and the long-label ellipsis truncation.

### 3. CT test stability (commit `e89a961`)
- Five wheel/pinch tests click the zoom-in button then dispatch a wheel event. On busy CI the wheel can fire before React commits the new zoomLevel — our handler reads stale state from a render-time ref and bails. Added `await expect(timeline).toHaveAttribute("data-zoom-level", "4")` between the click and the dispatch so the dispatch is guaranteed to see the committed state. Confirmed stable locally with `--repeat-each=2` (196/196).

## Test plan
- [x] 21 new viewport unit tests (`pinchZoom`, `computeViewportAfterFocalZoom`, `computeViewportAfterPan`)
- [x] 14 new Timeline CT tests (12 wheel/pinch + 2 label overlay)
- [x] Full unit suite: 678/678
- [x] Full CT suite: 402/402, repeated twice = 196/196 on the timeline file
- [ ] CI pipeline green
- [ ] Manual: trackpad two-finger horizontal swipe over a zoomed timeline pans; vertical swipe scrolls the page; ctrl+wheel pinches anchored on cursor

## Notes
- WIP `StateInspector.tsx` work from the parallel session is intentionally NOT in this PR — left stashed locally.
- Closes #223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)