### PR TITLE
Pin StageNav and overlay track labels on the waveform

### DIFF
--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -162,12 +162,13 @@ export function Viewer({
             </button>
           )}
           <span style={treatmentNameStyle}>{treatment.name}</span>
+          <span style={headerDividerStyle} aria-hidden="true" />
+          <StageNav
+            steps={steps}
+            currentIndex={stageIndex}
+            onSelect={setStageIndex}
+          />
         </div>
-        <StageNav
-          steps={steps}
-          currentIndex={stageIndex}
-          onSelect={setStageIndex}
-        />
         <TimeScrubber
           currentStep={currentStep}
           elapsedTime={store.getElapsedTime(stageIndex)}
@@ -260,6 +261,15 @@ const headerLeftStyle: React.CSSProperties = {
   display: "flex",
   alignItems: "center",
   gap: "0.5rem",
+  flexShrink: 0,
+};
+
+const headerDividerStyle: React.CSSProperties = {
+  width: "1px",
+  height: "1rem",
+  backgroundColor: "#e5e7eb",
+  marginLeft: "0.25rem",
+  marginRight: "0.25rem",
 };
 
 const backButtonStyle: React.CSSProperties = {

--- a/packages/stagebook/src/components/elements/timeline/TimelineTrack.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineTrack.tsx
@@ -25,11 +25,12 @@ export interface TimelineTrackProps {
   onToggleMute: (nextMuted: boolean) => void;
 }
 
-const GUTTER_WIDTH = 72;
+const GUTTER_WIDTH = 60;
 const MUTE_BUTTON_WIDTH = 22;
 
 /**
- * One row in the timeline: a fixed-width gutter label + a WaveformRenderer.
+ * One row in the timeline: a narrow gutter (mute button) + a WaveformRenderer
+ * with the track label overlaid in its upper-left corner.
  */
 export function TimelineTrack({
   label,
@@ -59,7 +60,7 @@ export function TimelineTrack({
           minWidth: `${String(GUTTER_WIDTH)}px`,
           display: "flex",
           alignItems: "center",
-          paddingRight: "0.5rem",
+          justifyContent: "center",
           borderRight: "1px solid var(--stagebook-border, #e5e7eb)",
         }}
       >
@@ -74,8 +75,6 @@ export function TimelineTrack({
             width: `${String(MUTE_BUTTON_WIDTH)}px`,
             minWidth: `${String(MUTE_BUTTON_WIDTH)}px`,
             height: `${String(MUTE_BUTTON_WIDTH)}px`,
-            marginLeft: "0.25rem",
-            marginRight: "0.25rem",
             padding: 0,
             display: "flex",
             alignItems: "center",
@@ -91,32 +90,41 @@ export function TimelineTrack({
         >
           {muted ? <SpeakerMutedIcon /> : <SpeakerIcon />}
         </button>
-        <div
+      </div>
+      <div style={{ position: "relative" }}>
+        <WaveformRenderer
+          peaks={peaks}
+          peaksVersion={peaksVersion}
+          width={waveformWidth}
+          height={height}
+          startBucket={startBucket}
+          endBucket={endBucket}
+        />
+        <span
           data-testid="track-label"
           style={{
-            flex: 1,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "flex-end",
-            fontSize: "0.79rem",
-            color: "var(--stagebook-text-faint, #9ca3af)",
+            position: "absolute",
+            top: "4px",
+            left: "4px",
+            boxSizing: "border-box",
+            padding: "1px 6px",
+            fontSize: "0.7rem",
+            lineHeight: 1.4,
+            color: "var(--stagebook-text-faint, #6b7280)",
+            background: "rgba(255, 255, 255, 0.85)",
+            border: "1px solid var(--stagebook-border, #e5e7eb)",
+            borderRadius: "0.25rem",
             userSelect: "none",
+            pointerEvents: "none",
+            maxWidth: `${String(Math.max(waveformWidth - 8, 0))}px`,
             overflow: "hidden",
             textOverflow: "ellipsis",
             whiteSpace: "nowrap",
           }}
         >
           {label}
-        </div>
+        </span>
       </div>
-      <WaveformRenderer
-        peaks={peaks}
-        peaksVersion={peaksVersion}
-        width={waveformWidth}
-        height={height}
-        startBucket={startBucket}
-        endBucket={endBucket}
-      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Two unrelated UI fixes — the only thread between them is "things shouldn't move or get cut off in cramped headers."

**1. Viewer header: pin the stage picker to the left.** Previously `StageNav` sat as a flex sibling of `TimeScrubber`. When the current stage had no timer the scrubber returned `null`, leaving three flex children that `justify-content: space-between` distributed evenly — so the picker visually centered. When a timed stage rendered the scrubber, its `flex: 1` consumed the middle and pushed the picker to the left. Clicking through stages quickly meant chasing the dropdown.

   `StageNav` now lives inside the `headerLeft` group with a thin divider after the treatment name. Same place across timed and untimed stages. `flexShrink: 0` on the left group keeps the scrubber from squeezing it on narrow viewports.

**2. Timeline: overlay the track label on the waveform.** Gutter was 72px to fit "Track 0" alongside the mute button, but the label was right-aligned with `overflow: hidden` — when text was wider than the cell, the **left** side clipped. Result: "ack 0" instead of an ellipsis. Custom labels like "Interviewer" hit the same path.

   Gutter shrinks to 60px (mute button only, still wide enough for the zoom controls in the header). Label moves to a small white-backed pill in the upper-left of each waveform: `pointer-events: none` so it doesn't block selection drags or playhead seeks; `box-sizing: border-box` and `max-width` tied to the waveform so it can't spill past the right edge. The mute button's `aria-label` still includes the full track name for screen readers.

## Stacking

This PR is **stacked on #222**. The two new Component Tests
- `track-label overlay does not block pointer events on the waveform`
- `very long track labels truncate within the waveform width`

were inadvertently committed to #222's branch (we were sharing a worktree). #222's CT job is currently failing because of those tests — the implementation lives here. Merging this PR after #222 unblocks both.

## Test plan

- [ ] Component tests pass locally and in CI (`npm run test:ct -w stagebook`)
- [ ] Manual: open viewer, switch between timed and untimed stages — picker stays put
- [ ] Manual: load a treatment with multi-channel audio — labels visible, mute still works, no clipping
- [ ] Manual: drag a selection starting from the upper-left of a waveform (under the label) — drag still creates a range

🤖 Generated with [Claude Code](https://claude.com/claude-code)