### PR TITLE
Viewer: clear all state + per-reference clear buttons

### DIFF
--- a/apps/viewer/src/components/StateInspector.tsx
+++ b/apps/viewer/src/components/StateInspector.tsx
@@ -5,6 +5,19 @@ import { ViewerStateStore } from "../lib/store";
 import { extractStageReferences } from "../lib/references";
 import type { ViewerStep } from "../lib/steps";
 
+// Mirrors the read-side guard in stagebook/utils/reference.ts. The viewer
+// writes through these paths, so traversing into prototype slots would let
+// a crafted reference mutate Object.prototype. Defence in depth.
+const DISALLOWED_PATH_SEGMENTS = new Set([
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+function hasUnsafeSegment(path: string[]): boolean {
+  return path.some((seg) => DISALLOWED_PATH_SEGMENTS.has(seg));
+}
+
 /**
  * DOM id used to scroll a specific element's note into view. Encodes the
  * type and name so characters like spaces (which nameSchema permits in
@@ -215,6 +228,23 @@ function ReferenceEditor({
     );
   }
 
+  const unsafe = hasUnsafeSegment(path);
+
+  if (unsafe) {
+    return (
+      <div style={refGroupStyle}>
+        <label style={refLabelStyle}>{reference}</label>
+        <input
+          type="text"
+          value=""
+          disabled
+          placeholder="(unsafe path segment)"
+          style={{ ...refInputStyle, opacity: 0.5 }}
+        />
+      </div>
+    );
+  }
+
   const rawValues = store.lookup(referenceKey, position);
   const values = rawValues
     .map((v) => getNestedValueByPath(v, path))
@@ -228,7 +258,8 @@ function ReferenceEditor({
       store.set(position, referenceKey, newValue, stageIndex);
     } else {
       // Nested path (e.g., prompt → path=["value"]) — preserve existing
-      // object structure and write the value at the correct path
+      // object structure and write the value at the correct path. Use
+      // Object.hasOwn to avoid traversing inherited properties.
       const existing = store.get(position, referenceKey)?.value;
       const obj =
         existing && typeof existing === "object" && !Array.isArray(existing)
@@ -237,7 +268,8 @@ function ReferenceEditor({
       let cursor: Record<string, unknown> = obj;
       for (let i = 0; i < path.length - 1; i++) {
         const seg = path[i];
-        if (typeof cursor[seg] !== "object" || cursor[seg] === null) {
+        const child = Object.hasOwn(cursor, seg) ? cursor[seg] : undefined;
+        if (typeof child !== "object" || child === null) {
           cursor[seg] = {};
         }
         cursor = cursor[seg] as Record<string, unknown>;
@@ -300,6 +332,9 @@ function ReferenceEditor({
  * Returns a new object with the leaf at `path` removed, pruning any
  * parent objects that become empty as a result. Returns `undefined` if
  * the entire root would become empty (signal to delete the entry).
+ *
+ * Defensive: rejects prototype-polluting segments and uses own-property
+ * checks so callers can't reach into Object.prototype via crafted paths.
  */
 function deletePath(
   obj: Record<string, unknown>,
@@ -307,7 +342,8 @@ function deletePath(
 ): Record<string, unknown> | undefined {
   if (path.length === 0) return undefined;
   const [head, ...rest] = path;
-  if (!(head in obj)) return obj;
+  if (DISALLOWED_PATH_SEGMENTS.has(head)) return obj;
+  if (!Object.hasOwn(obj, head)) return obj;
   const next = { ...obj };
   if (rest.length === 0) {
     delete next[head];

--- a/apps/viewer/src/components/StateInspector.tsx
+++ b/apps/viewer/src/components/StateInspector.tsx
@@ -36,6 +36,7 @@ export function StateInspector({
   playerCount,
 }: StateInspectorProps) {
   const [showAll, setShowAll] = useState(false);
+  const [confirmingClearAll, setConfirmingClearAll] = useState(false);
 
   const references = extractStageReferences(
     currentStep.elements as Record<string, unknown>[],
@@ -90,22 +91,37 @@ export function StateInspector({
         <button onClick={() => setShowAll(!showAll)} style={expandButtonStyle}>
           {showAll ? "▾ Hide all state" : "▸ Show all state"}
         </button>
-        <button
-          type="button"
-          onClick={() => {
-            if (
-              window.confirm(
-                "Clear all stored state (responses, submitted flags, elapsed time)?",
-              )
-            ) {
-              store.clearAll();
-            }
-          }}
-          style={clearAllButtonStyle}
-          title="Wipe all stored state in the viewer"
-        >
-          Clear all state
-        </button>
+        {confirmingClearAll ? (
+          <div style={clearAllConfirmGroupStyle}>
+            <button
+              type="button"
+              onClick={() => {
+                store.clearAll();
+                setConfirmingClearAll(false);
+              }}
+              style={clearAllConfirmButtonStyle}
+              title="Wipe all stored state"
+            >
+              Confirm clear
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmingClearAll(false)}
+              style={clearAllCancelButtonStyle}
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setConfirmingClearAll(true)}
+            style={clearAllButtonStyle}
+            title="Wipe all stored state in the viewer"
+          >
+            Clear all state
+          </button>
+        )}
       </div>
 
       {showAll && (
@@ -425,28 +441,24 @@ const refInputStyle: React.CSSProperties = {
   fontSize: "0.8125rem",
 };
 
-const refClearButtonStyle: React.CSSProperties = {
-  padding: "0 0.5rem",
-  border: "1px solid #d1d5db",
-  borderRadius: "0.25rem",
-  background: "white",
-  color: "#6b7280",
-  fontSize: "1rem",
+const refClearButtonBaseStyle: React.CSSProperties = {
+  padding: "0 0.375rem",
+  border: "none",
+  background: "transparent",
+  fontSize: "0.875rem",
   lineHeight: 1,
+};
+
+const refClearButtonStyle: React.CSSProperties = {
+  ...refClearButtonBaseStyle,
+  color: "#9ca3af",
   cursor: "pointer",
 };
 
 const refClearButtonDisabledStyle: React.CSSProperties = {
-  ...{
-    padding: "0 0.5rem",
-    border: "1px solid #e5e7eb",
-    borderRadius: "0.25rem",
-    background: "#f9fafb",
-    color: "#d1d5db",
-    fontSize: "1rem",
-    lineHeight: 1,
-  },
-  cursor: "not-allowed",
+  ...refClearButtonBaseStyle,
+  color: "transparent",
+  cursor: "default",
 };
 
 const emptyStyle: React.CSSProperties = {
@@ -478,6 +490,32 @@ const clearAllButtonStyle: React.CSSProperties = {
   border: "1px solid #e5e7eb",
   borderRadius: "0.25rem",
   color: "#b91c1c",
+  fontSize: "0.75rem",
+  cursor: "pointer",
+  padding: "0.25rem 0.5rem",
+};
+
+const clearAllConfirmGroupStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: "0.25rem",
+};
+
+const clearAllConfirmButtonStyle: React.CSSProperties = {
+  background: "#b91c1c",
+  border: "1px solid #b91c1c",
+  borderRadius: "0.25rem",
+  color: "white",
+  fontSize: "0.75rem",
+  cursor: "pointer",
+  padding: "0.25rem 0.5rem",
+};
+
+const clearAllCancelButtonStyle: React.CSSProperties = {
+  background: "white",
+  border: "1px solid #e5e7eb",
+  borderRadius: "0.25rem",
+  color: "#6b7280",
   fontSize: "0.75rem",
   cursor: "pointer",
   padding: "0.25rem 0.5rem",

--- a/apps/viewer/src/components/StateInspector.tsx
+++ b/apps/viewer/src/components/StateInspector.tsx
@@ -85,10 +85,28 @@ export function StateInspector({
       {/* Researcher notes (never shown to participants) */}
       <NotesSection currentStep={currentStep} />
 
-      {/* All state expansion */}
-      <button onClick={() => setShowAll(!showAll)} style={expandButtonStyle}>
-        {showAll ? "▾ Hide all state" : "▸ Show all state"}
-      </button>
+      {/* All state expansion + clear */}
+      <div style={allStateActionsStyle}>
+        <button onClick={() => setShowAll(!showAll)} style={expandButtonStyle}>
+          {showAll ? "▾ Hide all state" : "▸ Show all state"}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            if (
+              window.confirm(
+                "Clear all stored state (responses, submitted flags, elapsed time)?",
+              )
+            ) {
+              store.clearAll();
+            }
+          }}
+          style={clearAllButtonStyle}
+          title="Wipe all stored state in the viewer"
+        >
+          Clear all state
+        </button>
+      </div>
 
       {showAll && (
         <AllState
@@ -186,6 +204,7 @@ function ReferenceEditor({
     .map((v) => getNestedValueByPath(v, path))
     .filter((v) => v !== undefined);
   const currentValue = values[0] !== undefined ? String(values[0]) : "";
+  const isSet = values.length > 0;
 
   const handleChange = (newValue: string) => {
     if (path.length === 0) {
@@ -212,18 +231,85 @@ function ReferenceEditor({
     }
   };
 
+  const handleClear = () => {
+    if (path.length === 0) {
+      store.delete(position, referenceKey);
+      return;
+    }
+    const existing = store.get(position, referenceKey)?.value;
+    if (!existing || typeof existing !== "object" || Array.isArray(existing)) {
+      // Nothing to prune at this path — drop the whole entry so `exists` fails
+      store.delete(position, referenceKey);
+      return;
+    }
+    const root = deletePath(existing as Record<string, unknown>, path);
+    if (root === undefined) {
+      store.delete(position, referenceKey);
+    } else {
+      store.set(position, referenceKey, root, stageIndex);
+    }
+  };
+
   return (
     <div style={refGroupStyle}>
       <label style={refLabelStyle}>{reference}</label>
-      <input
-        type="text"
-        value={currentValue}
-        onChange={(e) => handleChange(e.target.value)}
-        placeholder="(not set)"
-        style={refInputStyle}
-      />
+      <div style={refInputRowStyle}>
+        <input
+          type="text"
+          value={currentValue}
+          onChange={(e) => handleChange(e.target.value)}
+          placeholder="(not set)"
+          style={refInputStyle}
+        />
+        <button
+          type="button"
+          onClick={handleClear}
+          disabled={!isSet}
+          aria-label={`Clear ${reference}`}
+          title={
+            isSet
+              ? "Remove this value entirely (so exists checks fail)"
+              : "Not set"
+          }
+          style={isSet ? refClearButtonStyle : refClearButtonDisabledStyle}
+        >
+          ×
+        </button>
+      </div>
     </div>
   );
+}
+
+/**
+ * Returns a new object with the leaf at `path` removed, pruning any
+ * parent objects that become empty as a result. Returns `undefined` if
+ * the entire root would become empty (signal to delete the entry).
+ */
+function deletePath(
+  obj: Record<string, unknown>,
+  path: string[],
+): Record<string, unknown> | undefined {
+  if (path.length === 0) return undefined;
+  const [head, ...rest] = path;
+  if (!(head in obj)) return obj;
+  const next = { ...obj };
+  if (rest.length === 0) {
+    delete next[head];
+  } else {
+    const child = next[head];
+    if (child && typeof child === "object" && !Array.isArray(child)) {
+      const pruned = deletePath(child as Record<string, unknown>, rest);
+      if (pruned === undefined) {
+        delete next[head];
+      } else {
+        next[head] = pruned;
+      }
+    } else {
+      // Path goes through a non-object — nothing to prune, leave as-is
+      return obj;
+    }
+  }
+  return Object.keys(next).length === 0 ? undefined : next;
 }
 
 function AllState({
@@ -324,17 +410,57 @@ const refLabelStyle: React.CSSProperties = {
   fontFamily: "monospace",
 };
 
+const refInputRowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "stretch",
+  gap: "0.25rem",
+};
+
 const refInputStyle: React.CSSProperties = {
+  flex: 1,
+  minWidth: 0,
   padding: "0.25rem 0.375rem",
   border: "1px solid #d1d5db",
   borderRadius: "0.25rem",
   fontSize: "0.8125rem",
 };
 
+const refClearButtonStyle: React.CSSProperties = {
+  padding: "0 0.5rem",
+  border: "1px solid #d1d5db",
+  borderRadius: "0.25rem",
+  background: "white",
+  color: "#6b7280",
+  fontSize: "1rem",
+  lineHeight: 1,
+  cursor: "pointer",
+};
+
+const refClearButtonDisabledStyle: React.CSSProperties = {
+  ...{
+    padding: "0 0.5rem",
+    border: "1px solid #e5e7eb",
+    borderRadius: "0.25rem",
+    background: "#f9fafb",
+    color: "#d1d5db",
+    fontSize: "1rem",
+    lineHeight: 1,
+  },
+  cursor: "not-allowed",
+};
+
 const emptyStyle: React.CSSProperties = {
   fontSize: "0.75rem",
   color: "#9ca3af",
   marginTop: "0.5rem",
+};
+
+const allStateActionsStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "0.5rem",
+  marginTop: "1rem",
 };
 
 const expandButtonStyle: React.CSSProperties = {
@@ -345,7 +471,16 @@ const expandButtonStyle: React.CSSProperties = {
   cursor: "pointer",
   textAlign: "left" as const,
   padding: "0.25rem 0",
-  marginTop: "1rem",
+};
+
+const clearAllButtonStyle: React.CSSProperties = {
+  background: "none",
+  border: "1px solid #e5e7eb",
+  borderRadius: "0.25rem",
+  color: "#b91c1c",
+  fontSize: "0.75rem",
+  cursor: "pointer",
+  padding: "0.25rem 0.5rem",
 };
 
 const allStateStyle: React.CSSProperties = {

--- a/apps/viewer/src/lib/store.test.ts
+++ b/apps/viewer/src/lib/store.test.ts
@@ -106,6 +106,74 @@ describe("ViewerStateStore", () => {
     });
   });
 
+  describe("delete", () => {
+    it("removes a player-scoped entry so lookup returns []", () => {
+      const store = new ViewerStateStore();
+      store.save("prompt_q1", { value: "yes" }, "player", 0, 0);
+      store.delete(0, "prompt_q1");
+      expect(store.lookup("prompt_q1", 0)).toEqual([]);
+      expect(store.get(0, "prompt_q1")).toBeUndefined();
+    });
+
+    it("removes a shared entry", () => {
+      const store = new ViewerStateStore();
+      store.save("prompt_q1", { value: "yes" }, "shared", 0, 0);
+      store.delete("shared", "prompt_q1");
+      expect(store.lookup("prompt_q1", "shared")).toEqual([]);
+    });
+
+    it("prunes the position bucket when its last entry is removed", () => {
+      const store = new ViewerStateStore();
+      store.save("prompt_q1", { value: "a" }, "player", 0, 0);
+      store.save("prompt_q2", { value: "b" }, "player", 1, 0);
+      store.delete(0, "prompt_q1");
+      const all = store.getAll();
+      expect(all).toHaveLength(1);
+      expect(all[0]?.positionKey).toBe(1);
+    });
+
+    it("is a no-op for missing keys (and does not notify)", () => {
+      const store = new ViewerStateStore();
+      const calls: unknown[] = [];
+      store.onChange(() => calls.push("changed"));
+      store.delete(0, "prompt_missing");
+      expect(calls).toEqual([]);
+    });
+
+    it("notifies listeners on successful delete", () => {
+      const store = new ViewerStateStore();
+      store.save("prompt_q1", { value: "yes" }, "player", 0, 0);
+      const calls: unknown[] = [];
+      store.onChange(() => calls.push("changed"));
+      store.delete(0, "prompt_q1");
+      expect(calls).toEqual(["changed"]);
+    });
+  });
+
+  describe("clearAll", () => {
+    it("wipes all data, submitted flags, and elapsed time", () => {
+      const store = new ViewerStateStore();
+      store.save("prompt_q1", { value: "a" }, "player", 0, 0);
+      store.save("prompt_q2", { value: "b" }, "shared", 0, 1);
+      store.setSubmitted(0, true);
+      store.setElapsedTime(0, 30);
+
+      store.clearAll();
+
+      expect(store.getAll()).toEqual([]);
+      expect(store.getSubmitted(0)).toBe(false);
+      expect(store.getElapsedTime(0)).toBe(0);
+    });
+
+    it("notifies listeners", () => {
+      const store = new ViewerStateStore();
+      const calls: unknown[] = [];
+      store.onChange(() => calls.push("changed"));
+      store.clearAll();
+      expect(calls).toEqual(["changed"]);
+    });
+  });
+
   describe("onChange", () => {
     it("notifies listeners on save", () => {
       const store = new ViewerStateStore();

--- a/apps/viewer/src/lib/store.ts
+++ b/apps/viewer/src/lib/store.ts
@@ -53,6 +53,30 @@ export class ViewerStateStore {
     return this.data.get(positionKey)?.get(storeKey);
   }
 
+  /**
+   * Remove a single entry. Prunes the position bucket if it becomes empty
+   * so getAll() doesn't surface ghost positions. After deletion, lookup()
+   * returns [] for the key — matching the "never set" case, so condition
+   * checks like `exists` correctly fail.
+   */
+  delete(positionKey: PositionKey, storeKey: string): void {
+    const bucket = this.data.get(positionKey);
+    if (!bucket) return;
+    if (!bucket.delete(storeKey)) return;
+    if (bucket.size === 0) {
+      this.data.delete(positionKey);
+    }
+    this.notify();
+  }
+
+  /** Wipe all stored values, submitted flags, and elapsed time. */
+  clearAll(): void {
+    this.data.clear();
+    this.submitted.clear();
+    this.elapsed.clear();
+    this.notify();
+  }
+
   /** Return all entries across all positions. */
   getAll(): StoreRecord[] {
     const records: StoreRecord[] = [];


### PR DESCRIPTION
## Summary
- Adds a **Clear all state** button next to "Show all state" in the viewer's StateInspector sidebar — wipes responses, submitted flags, and elapsed time after a `confirm()` dialog.
- Adds a per-reference **×** button on each entry under "Referenced state" — deletes the entry entirely (instead of saving an empty string), so condition checks like `exists` correctly fail.
- `ViewerStateStore` gains `delete(positionKey, storeKey)` (with bucket pruning so empty positions don't linger) and `clearAll()`.

The per-reference clear treats nested paths properly: it removes the leaf, prunes empty parent objects on the way up, and drops the whole entry if the root becomes empty.

Participant-facing form elements (TextArea, etc.) still save `""` when emptied — that's a library-level behavior change deferred to a separate issue.

## Test plan
- [x] 7 new vitest tests for `delete()` and `clearAll()` (bucket pruning, no-op on missing key, listener notification, full wipe)
- [x] All viewer tests pass (82/82)
- [x] Viewer build/typecheck clean
- [x] Prettier clean on changed files
- [ ] Manual: empty a reference via × → condition referencing `exists` flips to false
- [ ] Manual: Clear all state → all stored values, submitted flags, elapsed time wiped

🤖 Generated with [Claude Code](https://claude.com/claude-code)