### PR TITLE
Release v0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13396,7 +13396,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Bump `stagebook` to **0.8.0**.

## Changes since 0.7.1

### Library (`stagebook`)
- **Timeline range UX (#222)** — precise range handles, min-width clicks, two-finger pan + pinch zoom, click-to-add ranges, grip affordances, cursor hints, and stage-nav/track-label pinning during scroll.
- **Diagnostics (#221, #123)** — unrecognized-key errors now suggest the closest valid key and list the full set of valid keys at that location.

### Viewer / VS Code preview (#224)
- **Clear all state** button in the StateInspector sidebar (inline two-step confirm — VS Code webviews block native `confirm()`).
- **Per-reference × clear** that fully removes the entry rather than saving an empty string, so `exists` condition checks correctly fail.
- `ViewerStateStore` gains `delete()` and `clearAll()` methods (with bucket pruning).
- Defensive guards against prototype-polluting reference paths in the writer paths (mirroring the read-side guard in `utils/reference.ts`).

### Repo
- Pin local Node to 24 via `.nvmrc` (#220).

## Bump rationale
Two additive library features (#221, #222), no breaking changes — **minor** bump from 0.7.1 → 0.8.0.

## Test plan
- [x] CI green on the contributing PRs (#221, #222, #224)
- [ ] CI passes on this release branch
- [ ] After merge: tag and publish to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)