### PR TITLE
release v0.8.1: timeline polish + ruler scrubbing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13396,7 +13396,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -2870,6 +2870,258 @@ test("playhead time box is draggable (pointerEvents: auto)", async ({
   expect(pointerEvents).toBe("auto");
 });
 
+test("playhead drag does not auto-scroll the viewport (zoomed in)", async ({
+  mount,
+  page,
+}) => {
+  // Without onDragStart suppressing it, the auto-scroll effect chases the
+  // cursor: drag into the past-90% zone → effect scrolls right → cursor
+  // is still in past-90% of the new viewport → effect scrolls again →
+  // viewportStart runs all the way to its max. With the fix in place,
+  // viewportStart should not change during OR after the drag.
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="playhead_no_autoscroll"
+      selectionType="range"
+      mockDuration={60}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await expect(timeline).toHaveAttribute("data-zoom-level", "4");
+  expect(await readViewportStart(timeline)).toBe(0);
+
+  const timeBox = component
+    .locator('[data-testid="playhead"]')
+    .locator("div")
+    .first();
+  const timeBoxBox = await timeBox.boundingBox();
+  const tlBox = await timeline.boundingBox();
+  if (!timeBoxBox || !tlBox) throw new Error("element not found");
+
+  // Real mouse drag from the time box across to ~95% of the timeline —
+  // well into the past-90% zone where auto-scroll would normally fire.
+  await page.mouse.move(
+    timeBoxBox.x + timeBoxBox.width / 2,
+    timeBoxBox.y + timeBoxBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    tlBox.x + tlBox.width * 0.95,
+    timeBoxBox.y + timeBoxBox.height / 2,
+  );
+  await page.mouse.up();
+
+  // viewportStart must stay at 0 — both during the drag (auto-scroll
+  // suppressed) and after (lastPlayheadRef reset prevents the post-drag
+  // RAF tick from interpreting the drag delta as a "jump"). Poll a short
+  // window to catch the race deterministically.
+  for (let i = 0; i < 5; i++) {
+    expect(await readViewportStart(timeline)).toBe(0);
+    await page.waitForTimeout(50);
+  }
+});
+
+test("playhead drag is clamped to the visible viewport (left edge)", async ({
+  mount,
+  page,
+}) => {
+  // When zoomed in with a non-zero viewportStart, dragging the cursor past
+  // the left edge of the waveform must not send the playhead to t=0
+  // (off-screen). It should clamp at viewportStart so the playhead stays
+  // visible at the left edge.
+  // mockCurrentTime=10 keeps the playhead inside the viewport after we
+  // pan a bit, so it's still rendered (off-screen playheads bail out of
+  // render entirely and the locator can't find them).
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="playhead_clamp_left"
+      selectionType="range"
+      mockDuration={60}
+      mockCurrentTime={10}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await expect(timeline).toHaveAttribute("data-zoom-level", "4");
+
+  // Pan right so viewportStart > 0 but the playhead at t=10 stays visible.
+  await timeline.dispatchEvent("wheel", {
+    deltaX: 400,
+    deltaY: 0,
+    deltaMode: 0,
+    bubbles: true,
+    cancelable: true,
+  });
+  await expect.poll(() => readViewportStart(timeline)).toBeGreaterThan(0);
+  const vs = await readViewportStart(timeline);
+
+  const playhead = component.locator('[data-testid="playhead"]');
+  const timeBox = playhead.locator("div").first();
+  const timeBoxBox = await timeBox.boundingBox();
+  const tlBox = await timeline.boundingBox();
+  if (!timeBoxBox || !tlBox) throw new Error("element not found");
+
+  // Real mouse drag from the time box, far to the LEFT past the timeline.
+  await page.mouse.move(
+    timeBoxBox.x + timeBoxBox.width / 2,
+    timeBoxBox.y + timeBoxBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(tlBox.x - 200, tlBox.y + 10);
+  await page.mouse.up();
+
+  // After clamping, the playhead's container `left` is `timeToPixel
+  // (viewportStart, ...) === 0`. Poll until the seek+commit has settled.
+  await expect
+    .poll(async () =>
+      playhead.evaluate(
+        (el) => parseFloat((el as HTMLElement).style.left) || 0,
+      ),
+    )
+    .toBeLessThan(2);
+  // viewportStart should also be unchanged by the drag.
+  expect(await readViewportStart(timeline)).toBe(vs);
+});
+
+test("clicking the time ruler seeks the playhead", async ({ mount, page }) => {
+  // Standard NLE convention: a click on the ruler moves the playhead to
+  // that time. Previously the ruler was inert. Uses real mouse events so
+  // the pointercapture / event-routing matches real browser behavior.
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="ruler_click"
+      selectionType="range"
+      mockDuration={60}
+      mockCurrentTime={0}
+    />,
+  );
+  const ruler = component.locator('[data-testid="time-ruler"]');
+  const playhead = component.locator('[data-testid="playhead"]');
+  await expect(playhead).toBeAttached();
+
+  const rulerBox = await ruler.boundingBox();
+  if (!rulerBox) throw new Error("ruler not found");
+
+  // Click ~50% of the ruler. With duration=60 zoom=1, that lands near 30s
+  // and playhead's `left` should land near rulerBox.width / 2.
+  await page.mouse.click(
+    rulerBox.x + rulerBox.width * 0.5,
+    rulerBox.y + rulerBox.height / 2,
+  );
+
+  await expect
+    .poll(async () =>
+      playhead.evaluate(
+        (el) => parseFloat((el as HTMLElement).style.left) || 0,
+      ),
+    )
+    .toBeGreaterThan(rulerBox.width * 0.4);
+});
+
+test("ruler drag scrubs the playhead", async ({ mount, page }) => {
+  // Pointer-down + move + up on the ruler should continuously update the
+  // playhead time, like dragging the time box does. Uses real mouse events
+  // (not dispatchEvent) so pointer capture / move routing matches real
+  // browser behavior — synthetic events flake under parallel test load.
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="ruler_drag"
+      selectionType="range"
+      mockDuration={60}
+      mockCurrentTime={0}
+    />,
+  );
+  const ruler = component.locator('[data-testid="time-ruler"]');
+  const playhead = component.locator('[data-testid="playhead"]');
+  const rulerBox = await ruler.boundingBox();
+  if (!rulerBox) throw new Error("ruler not found");
+
+  // Down at 25%, move to 75%, then up.
+  await page.mouse.move(
+    rulerBox.x + rulerBox.width * 0.25,
+    rulerBox.y + rulerBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    rulerBox.x + rulerBox.width * 0.75,
+    rulerBox.y + rulerBox.height / 2,
+  );
+  await page.mouse.up();
+
+  await expect
+    .poll(async () =>
+      playhead.evaluate(
+        (el) => parseFloat((el as HTMLElement).style.left) || 0,
+      ),
+    )
+    .toBeGreaterThan(rulerBox.width * 0.6);
+});
+
+test("ruler drag does not auto-scroll the viewport (zoomed in)", async ({
+  mount,
+}) => {
+  // Same auto-scroll-suppression invariant as the time-box drag, but
+  // entered through the ruler instead of the playhead head.
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="ruler_no_autoscroll"
+      selectionType="range"
+      mockDuration={60}
+      mockCurrentTime={0}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await component.locator('[data-testid="timeline-zoom-in"]').click();
+  await expect(timeline).toHaveAttribute("data-zoom-level", "4");
+  expect(await readViewportStart(timeline)).toBe(0);
+
+  const ruler = component.locator('[data-testid="time-ruler"]');
+  const rulerBox = await ruler.boundingBox();
+  if (!rulerBox) throw new Error("ruler not found");
+
+  // Click + drag to ~95% of the ruler — well into the past-90% zone.
+  await ruler.dispatchEvent("pointerdown", {
+    clientX: rulerBox.x + rulerBox.width * 0.5,
+    clientY: rulerBox.y + 5,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+  await ruler.dispatchEvent("pointermove", {
+    clientX: rulerBox.x + rulerBox.width * 0.95,
+    clientY: rulerBox.y + 5,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+  await ruler.dispatchEvent("pointerup", {
+    clientX: rulerBox.x + rulerBox.width * 0.95,
+    clientY: rulerBox.y + 5,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+
+  expect(await readViewportStart(timeline)).toBe(0);
+});
+
 // -- Trackpad gestures: wheel pan and pinch-to-zoom --
 
 /**

--- a/packages/stagebook/src/components/elements/Timeline.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.tsx
@@ -175,6 +175,12 @@ export function Timeline({
   const lastPlayheadRef = useRef(0);
   const lastTickWasPlayingRef = useRef(false);
 
+  // Set true while the user is actively dragging the red playhead time
+  // box. Auto-scroll skips while this is true — otherwise the scroll
+  // chases the cursor (cursor at >90% scrolls right; new viewport puts
+  // cursor at >90% again; runaway) and the user can't stop near the edge.
+  const playheadDraggingRef = useRef(false);
+
   // Selection state via reducer. Lazy initializer hydrates from saved state
   // when present so participants who reload mid-stage see their existing
   // selections (validated to drop malformed items).
@@ -326,6 +332,11 @@ export function Timeline({
     const lastT = lastPlayheadRef.current;
     lastPlayheadRef.current = currentTime;
     lastTickWasPlayingRef.current = !isPaused;
+
+    // While the user is manually dragging the playhead, they're the
+    // source of motion — auto-scroll/snap would fight the cursor and
+    // either run away to the edge or yank the viewport mid-drag.
+    if (playheadDraggingRef.current) return;
 
     // No motion → nothing to do
     if (currentTime === lastT) return;
@@ -682,13 +693,25 @@ export function Timeline({
         }
       />
 
-      {/* Time ruler — offset by gutter width */}
+      {/* Time ruler — offset by gutter width. Click/drag scrubs the
+          playhead (standard NLE convention). */}
       <div style={{ marginLeft: `${String(GUTTER_WIDTH)}px` }}>
         <TimeRuler
           duration={duration}
           width={waveformWidth}
           zoomLevel={zoomLevel}
           viewportStart={viewportStart}
+          onSeek={(t) => handle.seekTo(t)}
+          onDragStart={() => {
+            playheadDraggingRef.current = true;
+          }}
+          onDragEnd={() => {
+            playheadDraggingRef.current = false;
+            // Reset auto-scroll memory so the post-drag RAF tick doesn't
+            // see drag_end_time - 0 as a "jump" and snap-to-25%.
+            lastPlayheadRef.current =
+              handleRef.current?.getCurrentTime() ?? 0;
+          }}
         />
       </div>
 
@@ -792,6 +815,14 @@ export function Timeline({
             zoomLevel={zoomLevel}
             viewportStart={viewportStart}
             onSeek={(t) => handle.seekTo(t)}
+            onDragStart={() => {
+              playheadDraggingRef.current = true;
+            }}
+            onDragEnd={() => {
+              playheadDraggingRef.current = false;
+              lastPlayheadRef.current =
+                handleRef.current?.getCurrentTime() ?? 0;
+            }}
           />
         </div>
       </div>

--- a/packages/stagebook/src/components/elements/Timeline.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.tsx
@@ -709,8 +709,7 @@ export function Timeline({
             playheadDraggingRef.current = false;
             // Reset auto-scroll memory so the post-drag RAF tick doesn't
             // see drag_end_time - 0 as a "jump" and snap-to-25%.
-            lastPlayheadRef.current =
-              handleRef.current?.getCurrentTime() ?? 0;
+            lastPlayheadRef.current = handleRef.current?.getCurrentTime() ?? 0;
           }}
         />
       </div>

--- a/packages/stagebook/src/components/elements/timeline/Playhead.tsx
+++ b/packages/stagebook/src/components/elements/timeline/Playhead.tsx
@@ -27,6 +27,12 @@ export interface PlayheadProps {
   viewportStart: number;
   /** Called during drag to seek to a new time. */
   onSeek: (time: number) => void;
+  /** Called on pointerdown when a drag starts. Lets the parent suppress
+   *  auto-scroll while the user is in manual control of the playhead. */
+  onDragStart?: () => void;
+  /** Called on pointerup / cancel / lostpointercapture — i.e., whenever
+   *  a drag transaction ends, however it ends. */
+  onDragEnd?: () => void;
 }
 
 /**
@@ -49,21 +55,27 @@ export function Playhead({
   zoomLevel,
   viewportStart,
   onSeek,
+  onDragStart,
+  onDragEnd,
 }: PlayheadProps) {
   // All hooks must be called before any early returns (Rules of Hooks).
   const containerRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
 
-  const handlePointerDown = useCallback((e: React.PointerEvent) => {
-    if (e.button !== 0) return;
-    e.stopPropagation();
-    try {
-      e.currentTarget.setPointerCapture(e.pointerId);
-    } catch {
-      // ignore in test environments
-    }
-    isDragging.current = true;
-  }, []);
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.button !== 0) return;
+      e.stopPropagation();
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId);
+      } catch {
+        // ignore in test environments
+      }
+      isDragging.current = true;
+      onDragStart?.();
+    },
+    [onDragStart],
+  );
 
   const handlePointerMove = useCallback(
     (e: React.PointerEvent) => {
@@ -82,24 +94,40 @@ export function Playhead({
         zoomLevel,
         viewportStart,
       );
-      const clamped = Math.max(0, Math.min(duration, time));
+      // Clamp drag to the visible viewport so the playhead can't be dragged
+      // off-screen — without this, dragging into the gutter sends it to t=0
+      // (invisible left of viewport when zoomed in) and dragging past the
+      // right edge sends it past viewportEnd (invisible until you pan).
+      const visibleDuration =
+        zoomLevel > 0 ? duration / zoomLevel : duration;
+      const viewportEnd = Math.min(duration, viewportStart + visibleDuration);
+      const lo = Math.max(0, viewportStart);
+      const hi = Math.min(duration, viewportEnd);
+      const clamped = Math.max(lo, Math.min(hi, time));
       onSeek(clamped);
     },
     [duration, width, zoomLevel, viewportStart, onSeek],
   );
 
-  const handlePointerUp = useCallback((e: React.PointerEvent) => {
-    isDragging.current = false;
-    try {
-      e.currentTarget.releasePointerCapture(e.pointerId);
-    } catch {
-      // ignore
-    }
-  }, []);
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      const wasDragging = isDragging.current;
+      isDragging.current = false;
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        // ignore
+      }
+      if (wasDragging) onDragEnd?.();
+    },
+    [onDragEnd],
+  );
 
   const handlePointerCancel = useCallback(() => {
+    const wasDragging = isDragging.current;
     isDragging.current = false;
-  }, []);
+    if (wasDragging) onDragEnd?.();
+  }, [onDragEnd]);
 
   // Early returns after all hooks
   if (!Number.isFinite(duration) || duration <= 0) return null;
@@ -121,7 +149,13 @@ export function Playhead({
         pointerEvents: "none",
       }}
     >
-      {/* Time box — draggable handle in the ruler area */}
+      {/* Time box — draggable handle in the ruler area. The triangle child
+          hanging off the bottom is the "playhead head" affordance from
+          standard NLE timelines (Premiere, Resolve, etc.) — it visually
+          attaches the box to the line below and reads as "this is the
+          handle of the line." It inherits the box's red color and bubbles
+          pointer events up to the box, so dragging from the triangle works
+          the same as dragging from the box. */}
       <div
         draggable={false}
         onPointerDown={(e) => {
@@ -145,6 +179,24 @@ export function Playhead({
         }}
       >
         {formatTime(currentTime, zoomDecimals(zoomLevel))}
+        <div
+          data-testid="playhead-arrow"
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            top: "100%",
+            left: "50%",
+            transform: "translateX(-50%)",
+            width: 0,
+            height: 0,
+            borderLeft: "5px solid transparent",
+            borderRight: "5px solid transparent",
+            borderTop: "5px solid var(--stagebook-playhead, #e11d48)",
+            // Inherit auto pointer events so clicks bubble up to the box.
+            pointerEvents: "auto",
+            cursor: "ew-resize",
+          }}
+        />
       </div>
 
       {/* Vertical line — click-through */}

--- a/packages/stagebook/src/components/elements/timeline/Playhead.tsx
+++ b/packages/stagebook/src/components/elements/timeline/Playhead.tsx
@@ -98,8 +98,7 @@ export function Playhead({
       // off-screen — without this, dragging into the gutter sends it to t=0
       // (invisible left of viewport when zoomed in) and dragging past the
       // right edge sends it past viewportEnd (invisible until you pan).
-      const visibleDuration =
-        zoomLevel > 0 ? duration / zoomLevel : duration;
+      const visibleDuration = zoomLevel > 0 ? duration / zoomLevel : duration;
       const viewportEnd = Math.min(duration, viewportStart + visibleDuration);
       const lo = Math.max(0, viewportStart);
       const hi = Math.min(duration, viewportEnd);

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -807,6 +807,11 @@ export function SelectionOverlay({
       style={{
         position: "absolute",
         inset: 0,
+        // Clip ranges/points/drag preview at the waveform bounds so they
+        // don't bleed into the gutter (left) when scrolled into a range
+        // whose start is off-screen. The right side is already clipped by
+        // the outer timeline's overflow:hidden.
+        overflow: "hidden",
         // Crosshair signals "click adds a selection here." In single-select
         // range mode once a range exists, clicking empty space is a no-op
         // (we preserve the existing range) — switch to the default cursor

--- a/packages/stagebook/src/components/elements/timeline/TimeRuler.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimeRuler.tsx
@@ -49,6 +49,19 @@ export function TimeRuler({
   const seekToClientX = useCallback(
     (clientX: number) => {
       if (!onSeek) return;
+      // Bail on degenerate inputs — pixelToTime divides by `zoomLevel`
+      // internally, so 0 / NaN / negative values would produce
+      // Infinity/NaN times and unpredictable seeks.
+      if (
+        !Number.isFinite(zoomLevel) ||
+        zoomLevel <= 0 ||
+        !Number.isFinite(duration) ||
+        duration <= 0 ||
+        !Number.isFinite(width) ||
+        width <= 0
+      ) {
+        return;
+      }
       const el = elRef.current;
       if (!el) return;
       const rect = el.getBoundingClientRect();
@@ -60,7 +73,7 @@ export function TimeRuler({
         zoomLevel,
         viewportStart,
       );
-      const visibleDuration = zoomLevel > 0 ? duration / zoomLevel : duration;
+      const visibleDuration = duration / zoomLevel;
       const lo = Math.max(0, viewportStart);
       const hi = Math.min(duration, viewportStart + visibleDuration);
       onSeek(Math.max(lo, Math.min(hi, time)));

--- a/packages/stagebook/src/components/elements/timeline/TimeRuler.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimeRuler.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useCallback, useRef } from "react";
 import { formatTime } from "../../../utils/formatTime.js";
 import {
   timeToPixel,
+  pixelToTime,
   computeTickInterval,
   generateTicks,
 } from "./timelineLayout.js";
@@ -15,20 +16,96 @@ export interface TimeRulerProps {
   zoomLevel: number;
   /** Left edge of the visible region in seconds. */
   viewportStart: number;
+  /** Called on click / drag to seek the playhead. Standard NLE convention:
+   *  clicking the ruler moves the playhead to that time, dragging scrubs. */
+  onSeek?: (time: number) => void;
+  /** Optional drag-state callbacks so the parent can suppress auto-scroll
+   *  while the user is in manual control of the playhead. */
+  onDragStart?: () => void;
+  onDragEnd?: () => void;
 }
 
 export const RULER_HEIGHT = 24;
 
 /**
  * Time labels and tick marks along the top of the waveform area.
- * Tick density adapts to zoom level.
+ * Tick density adapts to zoom level. Click/drag scrubs the playhead.
  */
 export function TimeRuler({
   duration,
   width,
   zoomLevel,
   viewportStart,
+  onSeek,
+  onDragStart,
+  onDragEnd,
 }: TimeRulerProps) {
+  const elRef = useRef<HTMLDivElement>(null);
+  const isDragging = useRef(false);
+
+  // Convert a clientX to a clamped time inside the visible viewport. We
+  // clamp to viewport (not to [0, duration]) so the playhead stays visible
+  // when the user drags off the ruler — matching the Playhead's own clamp.
+  const seekToClientX = useCallback(
+    (clientX: number) => {
+      if (!onSeek) return;
+      const el = elRef.current;
+      if (!el) return;
+      const rect = el.getBoundingClientRect();
+      const localX = clientX - rect.left;
+      const time = pixelToTime(localX, duration, width, zoomLevel, viewportStart);
+      const visibleDuration = zoomLevel > 0 ? duration / zoomLevel : duration;
+      const lo = Math.max(0, viewportStart);
+      const hi = Math.min(duration, viewportStart + visibleDuration);
+      onSeek(Math.max(lo, Math.min(hi, time)));
+    },
+    [duration, width, zoomLevel, viewportStart, onSeek],
+  );
+
+  const handlePointerDown = useCallback(
+    (e: React.PointerEvent) => {
+      if (e.button !== 0) return;
+      if (!onSeek) return;
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId);
+      } catch {
+        // ignore in test environments
+      }
+      isDragging.current = true;
+      onDragStart?.();
+      seekToClientX(e.clientX);
+    },
+    [onSeek, onDragStart, seekToClientX],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: React.PointerEvent) => {
+      if (!isDragging.current) return;
+      seekToClientX(e.clientX);
+    },
+    [seekToClientX],
+  );
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent) => {
+      const wasDragging = isDragging.current;
+      isDragging.current = false;
+      try {
+        e.currentTarget.releasePointerCapture(e.pointerId);
+      } catch {
+        // ignore
+      }
+      if (wasDragging) onDragEnd?.();
+    },
+    [onDragEnd],
+  );
+
+  const handlePointerCancel = useCallback(() => {
+    const wasDragging = isDragging.current;
+    isDragging.current = false;
+    if (wasDragging) onDragEnd?.();
+  }, [onDragEnd]);
+
   if (!Number.isFinite(duration) || duration <= 0 || width <= 0) {
     return (
       <div
@@ -46,7 +123,13 @@ export function TimeRuler({
 
   return (
     <div
+      ref={elRef}
       data-testid="time-ruler"
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+      onPointerCancel={handlePointerCancel}
+      onLostPointerCapture={handlePointerCancel}
       style={{
         position: "relative",
         height: `${String(RULER_HEIGHT)}px`,
@@ -55,6 +138,7 @@ export function TimeRuler({
         fontSize: "0.72rem",
         color: "var(--stagebook-text-faint, #9ca3af)",
         userSelect: "none",
+        cursor: onSeek ? "pointer" : "default",
       }}
     >
       {ticks.map((t) => {

--- a/packages/stagebook/src/components/elements/timeline/TimeRuler.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimeRuler.tsx
@@ -53,7 +53,13 @@ export function TimeRuler({
       if (!el) return;
       const rect = el.getBoundingClientRect();
       const localX = clientX - rect.left;
-      const time = pixelToTime(localX, duration, width, zoomLevel, viewportStart);
+      const time = pixelToTime(
+        localX,
+        duration,
+        width,
+        zoomLevel,
+        viewportStart,
+      );
       const visibleDuration = zoomLevel > 0 ? duration / zoomLevel : duration;
       const lo = Math.max(0, viewportStart);
       const hi = Math.min(duration, viewportStart + visibleDuration);

--- a/packages/stagebook/src/components/elements/timeline/TimelineHeader.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineHeader.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { MIN_ZOOM, MAX_ZOOM } from "./viewport.js";
-import { GUTTER_WIDTH } from "./TimelineTrack.js";
 
 export interface TimelineHeaderProps {
   zoomLevel: number;
@@ -53,17 +52,16 @@ export function TimelineHeader({
         userSelect: "none",
       }}
     >
-      {/* Gutter-width zoom controls — align with the per-track labels below */}
+      {/* Zoom controls — sized to their content. (Used to be locked to the
+          gutter width when the gutter held the per-track labels; the labels
+          now overlay the waveform, so there's no alignment to preserve.) */}
       <div
         style={{
-          width: `${String(GUTTER_WIDTH)}px`,
-          minWidth: `${String(GUTTER_WIDTH)}px`,
           display: "flex",
           alignItems: "center",
-          justifyContent: "center",
           gap: "0.25rem",
           padding: "0.25rem",
-          boxSizing: "border-box",
+          flexShrink: 0,
         }}
       >
         <button

--- a/packages/stagebook/src/components/elements/timeline/TimelineTrack.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineTrack.tsx
@@ -25,7 +25,7 @@ export interface TimelineTrackProps {
   onToggleMute: (nextMuted: boolean) => void;
 }
 
-const GUTTER_WIDTH = 60;
+const GUTTER_WIDTH = 32;
 const MUTE_BUTTON_WIDTH = 22;
 
 /**


### PR DESCRIPTION
## Summary

Patch release on top of v0.8.0 with six related Timeline polish items.

### 1. Pointed-bottom playhead time box (▼)
Standard NLE convention — the time box now visually attaches to the playhead line below it instead of floating as a plain rectangle, making its drag-handle role discoverable without hovering.

### 2. Slim track gutter (60 → 32 px)
Now that the gutter only holds the mute button (post the label-overlay rewrite in #223), 60 px was excessive. Also un-coupled the zoom +/- buttons from `GUTTER_WIDTH` so they keep their natural 24×24 size — the prior "align to gutter" justification is moot since the labels moved out.

### 3. Range bodies clipped at the waveform edge
`overflow: hidden` on the SelectionOverlay so a range whose start has scrolled out of view doesn't bleed left into the gutter. Right side was already clipped by the timeline's outer `overflow: hidden`.

### 4. Playhead drag clamped to the viewport
Drag past the gutter (left) used to send the playhead to t=0 (off-screen); past the right edge let it run past `viewportEnd`. Now both clamp at viewport edges so the playhead stays visible.

### 5. Auto-scroll suppressed during manual playhead drag
The auto-scroll effect was designed for RAF-driven playback. Manually dragging into the past-90% zone made it chase the cursor — viewport scrolls right → cursor still at >90% of new viewport → another scroll → runaway to the right edge. Two refs on the Timeline (`playheadDraggingRef`, `lastPlayheadRef`) coordinate with `onDragStart`/`onDragEnd` callbacks on Playhead and TimeRuler:
- During drag: auto-scroll/snap effect early-returns
- On drag end: `lastPlayheadRef` is reset to current time so the next RAF tick doesn't see `drag_end_time - 0` as a "jump" and snap-to-25%

### 6. Time ruler scrubs the playhead
Click on the ruler seeks; click+drag scrubs continuously. Mirrors the Playhead's pointer-handler pattern (capture, viewport-clamp, drag-state callbacks) so it integrates cleanly with the auto-scroll suppression. Cursor changes to `pointer` when interactive.

## Test plan
- [x] 5 new CT tests (playhead-no-autoscroll, playhead-clamp-left, ruler-click, ruler-drag, ruler-no-autoscroll); use real `page.mouse` events where pointer-capture matters and `expect.poll` for post-seek RAF settle
- [x] Full unit + CT suites pass on a single run (407/408 — one RAF-throttling flake under heavy parallel load that resolves on retry; CI's `retries=2` handles it)
- [x] Manual: clicking the ruler seeks; dragging it scrubs; playhead drag stays inside the viewport and doesn't trigger auto-scroll
- [ ] CI green

## Versioning
Bumps `stagebook` 0.8.0 → 0.8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)