### PR TITLE
release v0.8.2: flip handle hover tooltip near clipped edges

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13396,7 +13396,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -2872,9 +2872,7 @@ test("handle hover tooltip flips inward near the clipped edges", async ({
   // so its computed `left` style (relative to the handle) is non-empty
   // and `right` is "auto" / unset. Read the inline style of the tooltip
   // child element.
-  const startTooltip = startHandle.locator(
-    '[data-testid="handle-tooltip"]',
-  );
+  const startTooltip = startHandle.locator('[data-testid="handle-tooltip"]');
   const startPlacement = await startTooltip.evaluate((el) => ({
     left: (el as HTMLElement).style.left,
     right: (el as HTMLElement).style.right,
@@ -2910,9 +2908,7 @@ test("handle hover tooltip stays outside when there's room", async ({
   );
   const startHandle = component.locator('[data-testid="range-0-handle-start"]');
   await startHandle.hover();
-  const startTooltip = startHandle.locator(
-    '[data-testid="handle-tooltip"]',
-  );
+  const startTooltip = startHandle.locator('[data-testid="handle-tooltip"]');
   const startPlacement = await startTooltip.evaluate((el) => ({
     left: (el as HTMLElement).style.left,
     right: (el as HTMLElement).style.right,

--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -2841,6 +2841,86 @@ test("handle hover shows time tooltip", async ({ mount }) => {
   await expect(startHandle).toContainText("0:10");
 });
 
+test("handle hover tooltip flips inward near the clipped edges", async ({
+  mount,
+}) => {
+  // The SelectionOverlay clips horizontally to keep ranges out of the
+  // gutter; the tooltip's default outside-the-handle position would get
+  // clipped near the edges. So we flip the tooltip to the inside-handle
+  // side instead. Verify both edges:
+  //   - start handle near LEFT edge → tooltip flips to the RIGHT (inside
+  //     the range body)
+  //   - end handle near RIGHT edge → tooltip flips to the LEFT
+  const component = await mount(
+    <MockTimeline
+      source="coding_video"
+      playerName="coding_video"
+      name="tooltip_flip"
+      selectionType="range"
+      multiSelect={false}
+      mockDuration={60}
+      // Range spans nearly the full visible viewport so both handles sit
+      // close to their respective clip edges.
+      initialSelections={[{ start: 0, end: 60 }]}
+    />,
+  );
+  const startHandle = component.locator('[data-testid="range-0-handle-start"]');
+  const endHandle = component.locator('[data-testid="range-0-handle-end"]');
+
+  await startHandle.hover();
+  // The flipped start tooltip uses `left: 100%` instead of `right: 100%`,
+  // so its computed `left` style (relative to the handle) is non-empty
+  // and `right` is "auto" / unset. Read the inline style of the tooltip
+  // child element.
+  const startTooltip = startHandle.locator(
+    '[data-testid="handle-tooltip"]',
+  );
+  const startPlacement = await startTooltip.evaluate((el) => ({
+    left: (el as HTMLElement).style.left,
+    right: (el as HTMLElement).style.right,
+  }));
+  expect(startPlacement.left).toBe("100%");
+  expect(startPlacement.right).toBe("");
+
+  await endHandle.hover();
+  const endTooltip = endHandle.locator('[data-testid="handle-tooltip"]');
+  const endPlacement = await endTooltip.evaluate((el) => ({
+    left: (el as HTMLElement).style.left,
+    right: (el as HTMLElement).style.right,
+  }));
+  expect(endPlacement.right).toBe("100%");
+  expect(endPlacement.left).toBe("");
+});
+
+test("handle hover tooltip stays outside when there's room", async ({
+  mount,
+}) => {
+  // Range comfortably in the middle — both handles have ~50 px of room
+  // on the outside, so neither tooltip should flip.
+  const component = await mount(
+    <MockTimeline
+      source="coding_video"
+      playerName="coding_video"
+      name="tooltip_no_flip"
+      selectionType="range"
+      multiSelect={false}
+      mockDuration={60}
+      initialSelections={[{ start: 20, end: 40 }]}
+    />,
+  );
+  const startHandle = component.locator('[data-testid="range-0-handle-start"]');
+  await startHandle.hover();
+  const startTooltip = startHandle.locator(
+    '[data-testid="handle-tooltip"]',
+  );
+  const startPlacement = await startTooltip.evaluate((el) => ({
+    left: (el as HTMLElement).style.left,
+    right: (el as HTMLElement).style.right,
+  }));
+  expect(startPlacement.right).toBe("100%");
+  expect(startPlacement.left).toBe("");
+});
+
 test("playhead time box is draggable (pointerEvents: auto)", async ({
   mount,
 }) => {

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -555,6 +555,14 @@ export function SelectionOverlay({
       // is correct since the end handle is the one that can move right.
       const startHandleOnTop = x2 > width - 10;
 
+      // Hover-tooltip flip detection. Tooltip is ~50 px wide (varies with
+      // timestamp text) and sits OUTSIDE the handle by default. If the
+      // handle is too close to the SelectionOverlay's clipped edge, the
+      // outside-default would be cut off — flip to the inside instead.
+      const TOOLTIP_FLIP_PX = 50;
+      const flipStartTooltip = x1 < TOOLTIP_FLIP_PX;
+      const flipEndTooltip = x2 > width - TOOLTIP_FLIP_PX;
+
       // Per-track positioning in track scope
       const top =
         selectionScope === "track" && range.track !== undefined
@@ -621,7 +629,10 @@ export function SelectionOverlay({
             />
             {hoveredHandle?.index === i &&
               hoveredHandle?.handle === "start" && (
-                <div style={handleTooltipStyle("start")}>
+                <div
+                data-testid="handle-tooltip"
+                style={handleTooltipStyle("start", flipStartTooltip)}
+              >
                   {formatTime(range.start, zoomDecimals(zoomLevel))}
                 </div>
               )}
@@ -659,7 +670,10 @@ export function SelectionOverlay({
               }
             />
             {hoveredHandle?.index === i && hoveredHandle?.handle === "end" && (
-              <div style={handleTooltipStyle("end")}>
+              <div
+                data-testid="handle-tooltip"
+                style={handleTooltipStyle("end", flipEndTooltip)}
+              >
                 {formatTime(range.end, zoomDecimals(zoomLevel))}
               </div>
             )}

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -630,9 +630,9 @@ export function SelectionOverlay({
             {hoveredHandle?.index === i &&
               hoveredHandle?.handle === "start" && (
                 <div
-                data-testid="handle-tooltip"
-                style={handleTooltipStyle("start", flipStartTooltip)}
-              >
+                  data-testid="handle-tooltip"
+                  style={handleTooltipStyle("start", flipStartTooltip)}
+                >
                   {formatTime(range.start, zoomDecimals(zoomLevel))}
                 </div>
               )}

--- a/packages/stagebook/src/components/elements/timeline/timelineStyles.ts
+++ b/packages/stagebook/src/components/elements/timeline/timelineStyles.ts
@@ -34,19 +34,26 @@ export const tooltipBaseStyle: React.CSSProperties = {
 };
 
 /**
- * Compute inline styles for a range-handle hover tooltip.
- * Positions the tooltip to the left of the start handle or to the
- * right of the end handle, vertically centered.
+ * Compute inline styles for a range-handle hover tooltip. Positions the
+ * tooltip on the OUTSIDE of the handle by default (left of start, right
+ * of end) so it doesn't cover the range body. When `flip` is true the
+ * tooltip swings to the inside of the handle instead — used for handles
+ * near the SelectionOverlay's clipped edges, where the default outside
+ * position would extend past the clip and get cut off.
  *
  * @param handle - Which handle the tooltip is attached to.
+ * @param flip - When true, place the tooltip on the inside of the handle.
  */
 export function handleTooltipStyle(
   handle: "start" | "end",
+  flip = false,
 ): React.CSSProperties {
+  // start + !flip → left; end + flip → left; otherwise → right
+  const placeLeft = (handle === "start") !== flip;
   return {
     position: "absolute",
     top: "50%",
-    ...(handle === "start"
+    ...(placeLeft
       ? { right: "100%", marginRight: 4 }
       : { left: "100%", marginLeft: 4 }),
     transform: "translateY(-50%)",


### PR DESCRIPTION
## Summary

Patch release on top of v0.8.1 — closes #227.

### Range handle tooltips flip inward near the clipped edges

v0.8.1's `overflow: hidden` on the SelectionOverlay (which keeps range bodies from bleeding into the gutter) was clipping handle hover tooltips when the corresponding handle was within ~50 px of the visible left or right edge — the tooltip's content was correct, but its default position (outside the handle, away from the range body) was exactly the side that got cut off.

Fix: when the handle is too close to a clipped edge, the tooltip flips to the inside of the handle (over the range body) instead of the outside. Same auto-placement pattern used by Floating UI / Popper / Radix — the tooltip stays attached to the same handle and just appears on whichever side has room. Tooltip's own dark-blue background keeps it readable over the range body's color.

`handleTooltipStyle` gains an optional `flip` boolean. SelectionOverlay computes `flipStartTooltip = x1 < 50` and `flipEndTooltip = x2 > width - 50` per range and feeds them in.

## Test plan
- [x] 2 new component tests (one for both edges flipping, one for a comfortable mid-viewport range that doesn't flip)
- [x] Existing `handle hover shows time tooltip` test still passes (the new `data-testid="handle-tooltip"` makes the locator more precise; previously `.first()` was grabbing the HandleVisual's top tip, which we noticed by accident this round)
- [x] Full Timeline CT suite passes (106/106)
- [ ] CI green

## Upgrade notes
No breaking changes. `npm i stagebook@0.8.2` and rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)