### PR TITLE
Viewer: expand templates when loading examples (closes #229)

### DIFF
--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -3,13 +3,13 @@ import type { TreatmentFileType } from "stagebook";
 import { loadTreatmentFromUrl } from "./lib/loader";
 import {
   TreatmentValidationError,
-  parseTreatmentYaml,
   type ValidationIssue,
 } from "./lib/treatment";
 import { createUrlContentFns } from "./lib/contentFns";
 import {
   exampleCatalog,
   createExampleContentFns,
+  prepareExampleTreatment,
   type ExampleEntry,
 } from "./lib/exampleCatalog";
 import { LandingPage } from "./components/LandingPage";
@@ -115,7 +115,7 @@ export function App() {
     async (entry: ExampleEntry) => {
       const seq = ++loadSeqRef.current;
       try {
-        const treatmentFile = parseTreatmentYaml(entry.yaml);
+        const treatmentFile = prepareExampleTreatment(entry);
         await enterTreatment(
           treatmentFile,
           createExampleContentFns(entry),

--- a/apps/viewer/src/lib/exampleCatalog.test.ts
+++ b/apps/viewer/src/lib/exampleCatalog.test.ts
@@ -3,7 +3,9 @@ import {
   buildCatalog,
   createExampleContentFns,
   exampleCatalog,
+  prepareExampleTreatment,
 } from "./exampleCatalog";
+import { parseTreatmentYaml } from "./treatment";
 
 const SAMPLE_YAML = `
 introSequences:
@@ -164,5 +166,41 @@ describe("exampleCatalog (discovered via import.meta.glob)", () => {
     expect(walkthrough?.prompts["prompts/consent.prompt.md"]).toContain(
       "noResponse",
     );
+  });
+});
+
+describe("prepareExampleTreatment", () => {
+  it("expands template broadcasts so the picker sees multiple treatments (issue #229)", () => {
+    // Regression for #229: App.handleLoadExample previously only parsed
+    // the YAML, leaving template-broadcast rows un-expanded. The
+    // OverviewPage's `treatments.length > 1` check then fell through to
+    // the single-button "Ready to view" state instead of showing the
+    // multi-radio picker the README promises.
+    const walkthrough = exampleCatalog.find(
+      (e) => e.id === "annotated-walkthrough",
+    );
+    if (!walkthrough) throw new Error("annotated-walkthrough missing");
+
+    // Pre-condition: the unexpanded YAML has a single `template:` row
+    // with a broadcast axis — exactly the shape that triggered the bug.
+    const parsed = parseTreatmentYaml(walkthrough.yaml);
+    expect(parsed.treatments.length).toBe(1);
+
+    // After: prepareExampleTreatment fans the broadcast out so the
+    // picker has multiple radios to render.
+    const prepared = prepareExampleTreatment(walkthrough);
+    expect(prepared.treatments.length).toBeGreaterThan(1);
+  });
+
+  it("works for examples without templates (no-op expansion)", () => {
+    // Sanity: examples that don't use templates are still parsed
+    // correctly and produce the same single-treatment result.
+    const [entry] = buildCatalog(
+      { "/root/examples/demo/foo.treatments.yaml": SAMPLE_YAML },
+      {},
+    );
+    const prepared = prepareExampleTreatment(entry);
+    expect(prepared.treatments).toHaveLength(1);
+    expect(prepared.treatments[0]?.name).toBe("Sample treatment title");
   });
 });

--- a/apps/viewer/src/lib/exampleCatalog.ts
+++ b/apps/viewer/src/lib/exampleCatalog.ts
@@ -1,3 +1,4 @@
+import type { TreatmentFileType } from "stagebook";
 import { parseTreatmentYaml } from "./treatment";
 import { expandTreatmentFile } from "./expandTreatmentFile";
 
@@ -87,6 +88,20 @@ export const exampleCatalog: ExampleEntry[] = buildCatalog(
   yamlByPath,
   textByPath,
 );
+
+/**
+ * Parse + expand the example's YAML the same way the URL load path does
+ * in `loader.ts`. Without expansion, a treatment template with a
+ * `broadcast` axis renders as a single row, so the OverviewPage's
+ * `treatments.length > 1` check fails and the picker collapses to the
+ * single-button "Ready to view" state instead of showing radios for
+ * each broadcasted variant. (Issue #229.)
+ */
+export function prepareExampleTreatment(entry: ExampleEntry): TreatmentFileType {
+  const parsed = parseTreatmentYaml(entry.yaml);
+  const { result } = expandTreatmentFile(parsed);
+  return result;
+}
 
 /**
  * Build `getTextContent` / `getAssetURL` functions for an example


### PR DESCRIPTION
## Symptom

The Annotated Walkthrough example's README states:

> Two treatments are generated from a single template by broadcasting over a list of topics — you'll see them side-by-side in the treatment picker.

But loading the example in the viewer showed the single-treatment **"Ready to view"** state with one **View →** button instead of the two-treatment picker.

## Root cause

The example-load path was parsing the YAML but skipping template expansion. The walkthrough's `treatments:` array has one row with a `broadcast.d0` axis that holds two values; without expansion that row stayed as one entry, so OverviewPage's `treatments.length > 1` check failed and the picker collapsed.

The URL-load path in `loader.ts` already did parse + expand correctly. The example-load path didn't.

## Fix

Extracted `prepareExampleTreatment(entry): TreatmentFileType` in `exampleCatalog.ts` (parse + expand, single source of truth) and called it from `App.handleLoadExample`. The helper lives next to the rest of the example-loading code so the relationship is obvious.

\`\`\`ts
// apps/viewer/src/lib/exampleCatalog.ts
export function prepareExampleTreatment(entry: ExampleEntry): TreatmentFileType {
  const parsed = parseTreatmentYaml(entry.yaml);
  const { result } = expandTreatmentFile(parsed);
  return result;
}
\`\`\`

\`PreviewHost\` already expands templates at render time, so the actual stages rendered correctly once you did get into a study. The bug was confined to the picker step.

## Test plan
- [x] New test: \`prepareExampleTreatment expands template broadcasts so the picker sees multiple treatments\` — uses the real walkthrough example via \`exampleCatalog\`, asserts pre-expansion has 1 treatment row and post-expansion has >1. This is the regression check.
- [x] New test: \`prepareExampleTreatment works for examples without templates\` — sanity that no-op expansion preserves a non-templated treatment.
- [x] Full viewer unit suite: 84/84 pass.
- [x] Viewer + stagebook builds clean.
- [ ] Manual repro per issue: Annotated Walkthrough now shows the multi-treatment picker.

Closes #229.

🤖 Generated with [Claude Code](https://claude.com/claude-code)