### PR TITLE
Viewer: remount the stage after Clear all state and × clear (closes #170)

### DIFF
--- a/apps/viewer/src/components/StateInspector.tsx
+++ b/apps/viewer/src/components/StateInspector.tsx
@@ -39,6 +39,15 @@ interface StateInspectorProps {
   stageIndex: number;
   position: number;
   playerCount: number;
+  /**
+   * Called after every store-mutating action triggered from the inspector
+   * (Clear all state, ×-clear a reference). Components like Timeline read
+   * `initialSelections` from the store once on mount and then own that
+   * data locally, so a store edit alone doesn't update what's rendered —
+   * the Viewer wires this to a `<Stage>` key bump that forces a remount,
+   * letting elements re-read the post-edit store. (Issue #170.)
+   */
+  onResetStage?: () => void;
 }
 
 export function StateInspector({
@@ -47,6 +56,7 @@ export function StateInspector({
   stageIndex,
   position,
   playerCount,
+  onResetStage,
 }: StateInspectorProps) {
   const [showAll, setShowAll] = useState(false);
   const [confirmingClearAll, setConfirmingClearAll] = useState(false);
@@ -87,6 +97,7 @@ export function StateInspector({
               store={store}
               position={position}
               stageIndex={stageIndex}
+              onAfterClear={onResetStage}
             />
           ))}
         </>
@@ -110,6 +121,10 @@ export function StateInspector({
               type="button"
               onClick={() => {
                 store.clearAll();
+                // Remount so components like Timeline re-read the now-empty
+                // store; otherwise local state in mounted elements would
+                // still display the pre-clear values. (Issue #170.)
+                onResetStage?.();
                 setConfirmingClearAll(false);
               }}
               style={clearAllConfirmButtonStyle}
@@ -203,11 +218,15 @@ function ReferenceEditor({
   store,
   position,
   stageIndex,
+  onAfterClear,
 }: {
   reference: string;
   store: ViewerStateStore;
   position: number;
   stageIndex: number;
+  /** Fired after a × clear so the parent can remount the stage and let
+   *  read-once components (e.g. Timeline) pick up the post-delete store. */
+  onAfterClear?: () => void;
 }) {
   let referenceKey: string;
   let path: string[];
@@ -282,20 +301,29 @@ function ReferenceEditor({
   const handleClear = () => {
     if (path.length === 0) {
       store.delete(position, referenceKey);
-      return;
-    }
-    const existing = store.get(position, referenceKey)?.value;
-    if (!existing || typeof existing !== "object" || Array.isArray(existing)) {
-      // Nothing to prune at this path — drop the whole entry so `exists` fails
-      store.delete(position, referenceKey);
-      return;
-    }
-    const root = deletePath(existing as Record<string, unknown>, path);
-    if (root === undefined) {
-      store.delete(position, referenceKey);
     } else {
-      store.set(position, referenceKey, root, stageIndex);
+      const existing = store.get(position, referenceKey)?.value;
+      if (
+        !existing ||
+        typeof existing !== "object" ||
+        Array.isArray(existing)
+      ) {
+        // Nothing to prune at this path — drop the whole entry so `exists`
+        // fails.
+        store.delete(position, referenceKey);
+      } else {
+        const root = deletePath(existing as Record<string, unknown>, path);
+        if (root === undefined) {
+          store.delete(position, referenceKey);
+        } else {
+          store.set(position, referenceKey, root, stageIndex);
+        }
+      }
     }
+    // Remount the stage so read-once components (Timeline, etc.) pick up
+    // the post-delete store; without this, local state would still show
+    // the pre-clear values until manual navigation. (Issue #170.)
+    onAfterClear?.();
   };
 
   return (

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -65,6 +65,15 @@ export function Viewer({
   );
 
   const [stageIndex, setStageIndex] = useState(0);
+  // Bumped when the researcher clicks "Reset stage" in the inspector;
+  // included in the <Stage> key below so a bump forces a full remount.
+  // Lets components like Timeline (which read store values once on mount
+  // and then own them locally) re-read after the inspector clears or
+  // overrides a value. (Issue #170.)
+  const [stageResetVersion, setStageResetVersion] = useState(0);
+  const handleResetStage = useCallback(() => {
+    setStageResetVersion((v) => v + 1);
+  }, []);
   const [position, setPosition] = useState(0);
   const [store] = useState(() => new ViewerStateStore());
   const stageContainerRef = useRef<HTMLDivElement | null>(null);
@@ -201,6 +210,7 @@ export function Viewer({
             stageIndex={stageIndex}
             position={position}
             playerCount={treatment.playerCount}
+            onResetStage={handleResetStage}
           />
         </aside>
 
@@ -224,7 +234,11 @@ export function Viewer({
           ) : (
             <div ref={stageContainerRef} style={stageContainerStyle}>
               <StagebookProvider value={ctx}>
-                <Stage stage={stageConfig} onSubmit={handleSubmit} />
+                <Stage
+                  key={`stage-${String(stageIndex)}-${String(stageResetVersion)}`}
+                  stage={stageConfig}
+                  onSubmit={handleSubmit}
+                />
               </StagebookProvider>
               <NotesIconsOverlay
                 containerRef={stageContainerRef}


### PR DESCRIPTION
## Background

Components like Timeline read \`initialSelections\` from the store once on mount, then own that value via local state — by design for production, but a gap for the inspector workflow. Clearing or deleting a value through the inspector left the rendered Timeline still showing the pre-clear selections; the only escape was to navigate away and back.

## What changed from the issue's original plan

The issue (#170) sketched a standalone **Reset stage** button. After implementing it I noticed the inspector was getting button-heavy (Refresh in the header, Clear all state, × per-reference, Reset stage), and walking through real workflows the separate button didn't survive:

- The destructive clear actions are essentially never useful *without* a remount — researchers who clear data want to see the effect.
- The only case a standalone reset would cover is "I typed a new value into a reference's text input," which is genuinely rare and already loosely covered by the host's Refresh button.

So this PR folds the remount **into the existing clear paths** instead of adding a new button. Same number of buttons as before #170; one click now does what users expected.

## Implementation

- \`Viewer.tsx\` owns a \`stageResetVersion\` counter and a \`handleResetStage\` callback. \`<Stage>\`'s key is \`stage-\${stageIndex}-\${stageResetVersion}\`, so a bump forces a full unmount + remount of the stage subtree.
- \`StateInspector\` accepts an \`onResetStage\` prop:
  - **Clear all state**: after the two-step confirm, calls \`store.clearAll()\` and then \`onResetStage()\`.
  - **× per-reference**: \`ReferenceEditor\` receives the callback as \`onAfterClear\` and invokes it after the store mutation lands.

Viewer-level state (stageIndex, position, store data) is unaffected — only the Stage subtree resets.

## What this does NOT do

- Doesn't add a standalone Reset stage button (deliberately — see "What changed" above).
- Doesn't auto-remount on every keystroke in the reference text input. That would lose focus mid-edit. The text-edit-then-see-effect case stays uncovered for now; can be revisited if anyone hits it.
- Doesn't change behavior outside the viewer's inspector path.

## Test plan
- [x] All viewer unit tests pass (84/84).
- [x] Viewer typecheck + build clean.
- [ ] Manual: Timeline with selections → \`×\` clear the timeline reference → Timeline visually clears (was: still shows old selections).
- [ ] Manual: Timeline with selections → \`Clear all state\` → confirm → Timeline visually clears.
- [ ] Manual: \`stageIndex\`, \`position\`, and unrelated stored values are preserved across the remount.

Closes #170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)