### PR TITLE
Tests: cover behaviors only exercised by cypress 01 (closes #232)

### DIFF
--- a/packages/stagebook/src/components/Stage.ct.tsx
+++ b/packages/stagebook/src/components/Stage.ct.tsx
@@ -143,6 +143,113 @@ test("timed stage shows elements at elapsed=0", async ({ mount }) => {
   await expect(component.locator("button")).toHaveCount(0);
 });
 
+// Time-advancing tests pin the show-after / hide-after branches that were
+// only covered by deliberation-empirica's cypress 01 omnibus. (Issue #232.)
+
+test("displayTime: element appears after elapsed >= displayTime", async ({
+  mount,
+}) => {
+  const stage: StageConfig = {
+    name: "DisplayTimeOnly",
+    duration: 60,
+    elements: [
+      {
+        type: "prompt",
+        file: "projects/example/delayed.md",
+        displayTime: 3,
+      },
+    ],
+  };
+  const component = await mount(
+    <MockStageRenderer stage={stage} elapsedTime={0} />,
+  );
+  await expect(component).not.toContainText(
+    "Mock content for projects/example/delayed.md",
+  );
+  // Advance to exactly displayTime — the boundary is `elapsed < displayTime`,
+  // so at elapsed === displayTime the element MUST be visible.
+  await component.update(<MockStageRenderer stage={stage} elapsedTime={3} />);
+  await expect(component).toContainText(
+    "Mock content for projects/example/delayed.md",
+  );
+  // And stays visible after.
+  await component.update(<MockStageRenderer stage={stage} elapsedTime={10} />);
+  await expect(component).toContainText(
+    "Mock content for projects/example/delayed.md",
+  );
+});
+
+test("hideTime: element disappears after elapsed > hideTime", async ({
+  mount,
+}) => {
+  const stage: StageConfig = {
+    name: "HideTimeOnly",
+    duration: 60,
+    elements: [
+      {
+        type: "prompt",
+        file: "projects/example/early.md",
+        hideTime: 3,
+      },
+    ],
+  };
+  const component = await mount(
+    <MockStageRenderer stage={stage} elapsedTime={0} />,
+  );
+  await expect(component).toContainText(
+    "Mock content for projects/example/early.md",
+  );
+  // hideTime check is `elapsed > hideTime`, so at elapsed === hideTime the
+  // element is still rendered…
+  await component.update(<MockStageRenderer stage={stage} elapsedTime={3} />);
+  await expect(component).toContainText(
+    "Mock content for projects/example/early.md",
+  );
+  // …and at elapsed > hideTime it disappears.
+  await component.update(<MockStageRenderer stage={stage} elapsedTime={5} />);
+  await expect(component).not.toContainText(
+    "Mock content for projects/example/early.md",
+  );
+});
+
+test("displayTime works for elements inside a discussion stage", async ({
+  mount,
+}) => {
+  // Mirrors cypress 01 lines 750–753 (a `displayTime` prompt that appears
+  // after the discussion-stage starts).
+  const stage: StageConfig = {
+    name: "DiscussionWithDelayed",
+    duration: 600,
+    discussion: {
+      chatType: "video",
+      showNickname: true,
+      showTitle: true,
+    },
+    elements: [
+      { type: "prompt", file: "projects/example/intro.md" },
+      {
+        type: "prompt",
+        file: "projects/example/late.md",
+        displayTime: 5,
+      },
+    ],
+  };
+  const component = await mount(
+    <MockStageRenderer stage={stage} elapsedTime={0} />,
+  );
+  // intro.md is unconditional, late.md isn't visible yet.
+  await expect(component).toContainText(
+    "Mock content for projects/example/intro.md",
+  );
+  await expect(component).not.toContainText(
+    "Mock content for projects/example/late.md",
+  );
+  await component.update(<MockStageRenderer stage={stage} elapsedTime={5} />);
+  await expect(component).toContainText(
+    "Mock content for projects/example/late.md",
+  );
+});
+
 // ----------------------------------------------------------------
 // Position-based visibility
 // ----------------------------------------------------------------

--- a/packages/stagebook/src/components/elements/Prompt.ct.tsx
+++ b/packages/stagebook/src/components/elements/Prompt.ct.tsx
@@ -369,3 +369,146 @@ test.describe("List Sorter", () => {
     await expect(component).toContainText("Albus Dumbledore");
   });
 });
+
+// ================================================================
+// Multiple Choice option order (shuffleOptions vs source order)
+// ================================================================
+//
+// Pins the contract that:
+//   - `shuffleOptions: true` produces a non-source-order rendering
+//     while keeping the same option set
+//   - the shuffled order is captured at first render and remains
+//     stable across re-renders (the user's randomized labels don't
+//     reshuffle on every parent state change)
+//   - omitting `shuffleOptions` preserves yaml-declared order, even
+//     when that order is intentionally non-alphabetical (e.g. mixed
+//     numeric and string labels)
+//
+// Used by deliberation-empirica's cypress 01 omnibus (now retiring);
+// this duplicates the assertions upstream so the upstream contract
+// is locked in. (Issue #232.)
+
+const SHUFFLE_OPTIONS = [
+  "alpha",
+  "bravo",
+  "charlie",
+  "delta",
+  "echo",
+  "foxtrot",
+  "golf",
+  "hotel",
+] as const;
+
+const shuffledMultipleChoice = {
+  metadata: {
+    name: "projects/example/shuffled.md",
+    type: "multipleChoice" as const,
+    shuffleOptions: true,
+  },
+  body: "# Pick one",
+  responseItems: [...SHUFFLE_OPTIONS],
+};
+
+const customOrderOptions = [
+  "0",
+  "0.5",
+  "3",
+  "4",
+  "5.5",
+  "six",
+  "7",
+  "8",
+] as const;
+
+const customOrderMultipleChoice = {
+  metadata: {
+    name: "projects/example/customOrder.md",
+    type: "multipleChoice" as const,
+  },
+  body: "# Pick one",
+  responseItems: [...customOrderOptions],
+};
+
+async function readRadioOrder(
+  component: import("@playwright/test").Locator,
+): Promise<string[]> {
+  return component
+    .locator('input[type="radio"]')
+    .evaluateAll((nodes) =>
+      nodes.map((n) => (n as HTMLInputElement).value ?? ""),
+    );
+}
+
+test.describe("Multiple Choice option order", () => {
+  test("shuffleOptions: true produces a different order with the same set", async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <Prompt
+        {...shuffledMultipleChoice}
+        name="testShuffle"
+        value={undefined}
+        progressLabel="game_0_shuffle"
+        save={() => {}}
+        getElapsedTime={() => 0}
+      />,
+    );
+    const order = await readRadioOrder(component);
+    // Same set membership.
+    expect([...order].sort()).toEqual([...SHUFFLE_OPTIONS].sort());
+    // Different from the source order. With 8 options, the chance of a
+    // shuffle happening to land in source order is 1/40320 — vanishingly
+    // small flake risk.
+    expect(order).not.toEqual([...SHUFFLE_OPTIONS]);
+  });
+
+  test("shuffled order is stable across re-renders (no reshuffle on update)", async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <Prompt
+        {...shuffledMultipleChoice}
+        name="testShuffleStable"
+        value={undefined}
+        progressLabel="game_0_shuffle_stable"
+        save={() => {}}
+        getElapsedTime={() => 0}
+      />,
+    );
+    const firstOrder = await readRadioOrder(component);
+    // Re-mount with the same props (different `value`) — the rendered
+    // order must match what was captured on first render.
+    await component.update(
+      <Prompt
+        {...shuffledMultipleChoice}
+        name="testShuffleStable"
+        value="alpha"
+        progressLabel="game_0_shuffle_stable"
+        save={() => {}}
+        getElapsedTime={() => 0}
+      />,
+    );
+    const secondOrder = await readRadioOrder(component);
+    expect(secondOrder).toEqual(firstOrder);
+  });
+
+  test("without shuffleOptions, options render in declared yaml order", async ({
+    mount,
+  }) => {
+    // Custom order: "0", "0.5", "3", "4", "5.5", "six", "7", "8" — not
+    // alphabetical, not numeric. Pins the contract that the rendering
+    // preserves source declaration order rather than re-sorting.
+    const component = await mount(
+      <Prompt
+        {...customOrderMultipleChoice}
+        name="testYamlOrder"
+        value={undefined}
+        progressLabel="game_0_yaml_order"
+        save={() => {}}
+        getElapsedTime={() => 0}
+      />,
+    );
+    const order = await readRadioOrder(component);
+    expect(order).toEqual([...customOrderOptions]);
+  });
+});

--- a/packages/stagebook/src/components/elements/TrackedLink.ct.tsx
+++ b/packages/stagebook/src/components/elements/TrackedLink.ct.tsx
@@ -1,5 +1,22 @@
 import { test, expect } from "@playwright/experimental-ct-react";
 import { TrackedLink } from "./TrackedLink";
+import { MockTrackedLink } from "../testing/MockTrackedLink";
+
+interface LinkRecord {
+  events: { type: string; timeAwaySeconds?: number }[];
+  totalTimeAwaySeconds: number;
+}
+
+async function readLastRecord(
+  component: import("@playwright/test").Locator,
+): Promise<LinkRecord | null> {
+  const text = await component
+    .locator('[data-testid="save-log"]')
+    .textContent();
+  const saves = JSON.parse(text ?? "[]") as { value: unknown }[];
+  if (saves.length === 0) return null;
+  return saves[saves.length - 1].value as LinkRecord;
+}
 
 test("renders link with display text", async ({ mount }) => {
   const component = await mount(
@@ -122,4 +139,145 @@ test("renders external link icon", async ({ mount }) => {
     />,
   );
   await expect(component.locator("svg")).toBeVisible();
+});
+
+// ================================================================
+// Event semantics + urlParam edge cases (issue #232)
+// ================================================================
+//
+// These pin behavior previously only exercised by deliberation-empirica's
+// cypress 01 omnibus: clicking emits a `click` event in the saved record;
+// blur after a click + focus on return accumulate `totalTimeAwaySeconds`;
+// urlParams resolved to empty strings still appear in the href (`&key=`)
+// rather than being dropped; resolved values are URL-encoded.
+
+test("clicking the link saves a record with a `click` event", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockTrackedLink
+      name="signup"
+      url="https://example.org/form"
+      displayText="Open form"
+      getElapsedTime={() => 12.5}
+      progressLabel="game_0_intro"
+    />,
+  );
+  // Use dispatchEvent rather than .click() to fire the click handler
+  // without the browser following the `target="_blank"` link out of the
+  // test context.
+  await component
+    .locator("a")
+    .evaluate((el) =>
+      el.dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
+  const record = await readLastRecord(component);
+  if (!record) throw new Error("no save was emitted");
+  expect(record.events.map((e) => e.type)).toEqual(["click"]);
+  // Pre-blur, no time-away accumulation yet.
+  expect(record.totalTimeAwaySeconds).toBe(0);
+});
+
+test("blur after click then focus accumulates totalTimeAwaySeconds", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <MockTrackedLink
+      name="signup"
+      url="https://example.org/form"
+      displayText="Open form"
+      getElapsedTime={() => 0}
+      progressLabel="game_0_intro"
+    />,
+  );
+
+  // Click first — handleBlur is a no-op until lastClickRef has been set.
+  await component
+    .locator("a")
+    .evaluate((el) =>
+      el.dispatchEvent(new MouseEvent("click", { bubbles: true })),
+    );
+  // Confirm pre-blur state: totalTimeAwaySeconds is still 0 after just a click.
+  let record = await readLastRecord(component);
+  expect(record?.totalTimeAwaySeconds).toBe(0);
+
+  // Dispatch a window blur (simulates user switching to the linked tab).
+  await page.evaluate(() => window.dispatchEvent(new Event("blur")));
+  // Wait briefly so the focus event sees a non-zero time-away delta.
+  await page.waitForTimeout(75);
+  await page.evaluate(() => window.dispatchEvent(new Event("focus")));
+
+  await expect
+    .poll(async () => {
+      const r = await readLastRecord(component);
+      return r?.totalTimeAwaySeconds ?? 0;
+    })
+    .toBeGreaterThan(0.05);
+
+  record = await readLastRecord(component);
+  if (!record) throw new Error("no save");
+  expect(record.events.map((e) => e.type)).toEqual(["click", "blur", "focus"]);
+  // The focus event carries the per-trip timeAwaySeconds.
+  const focusEvent = record.events.find((e) => e.type === "focus");
+  expect(focusEvent?.timeAwaySeconds).toBeGreaterThan(0.05);
+});
+
+test("urlParam with empty value is rendered as `&key=` (not dropped)", async ({
+  mount,
+}) => {
+  // Cypress 01 line 802 asserted href.endsWith("flag=") — i.e. an empty
+  // resolved value still appears in the query string. Without this, a
+  // host that resolves a missing variable to "" would silently drop the
+  // param key, changing the URL contract.
+  const component = await mount(
+    <TrackedLink
+      name="signup"
+      url="https://example.org/form"
+      displayText="Open form"
+      resolvedParams={[
+        { key: "id", value: "abc123" },
+        { key: "flag", value: "" },
+      ]}
+      save={() => {}}
+      getElapsedTime={() => 0}
+      progressLabel="game_0_test"
+    />,
+  );
+  await expect(component.locator("a")).toHaveAttribute(
+    "href",
+    "https://example.org/form?id=abc123&flag=",
+  );
+});
+
+test("participantInfo-style values are URL-encoded into the href", async ({
+  mount,
+}) => {
+  // Cypress 01 line 800 asserted href contains a URL-encoded
+  // `participantInfo.name` value. The ref is resolved by the host before
+  // it ever reaches TrackedLink — the contract here is that whatever
+  // string the host hands us gets encoded correctly into the href.
+  const nicknameRaw = "nickname_user with space&danger=1";
+  const component = await mount(
+    <TrackedLink
+      name="signup"
+      url="https://example.org/form"
+      displayText="Open form"
+      resolvedParams={[{ key: "participant", value: nicknameRaw }]}
+      save={() => {}}
+      getElapsedTime={() => 0}
+      progressLabel="game_0_test"
+    />,
+  );
+  // URLSearchParams encodes spaces as `+` and other reserved chars
+  // percent-encoded — what matters is that the value is preserved
+  // round-trippably (and the special chars don't bleed into the query
+  // structure as separators).
+  const href = await component.locator("a").getAttribute("href");
+  if (!href) throw new Error("no href");
+  // Exactly one query parameter — special chars in the value did NOT
+  // create new params.
+  const url = new URL(href);
+  expect([...url.searchParams.keys()]).toEqual(["participant"]);
+  expect(url.searchParams.get("participant")).toBe(nicknameRaw);
 });

--- a/packages/stagebook/src/components/testing/MockTrackedLink.tsx
+++ b/packages/stagebook/src/components/testing/MockTrackedLink.tsx
@@ -1,0 +1,26 @@
+/**
+ * Wrapper around `TrackedLink` that captures every `save` call and renders
+ * the resulting saves into a hidden `data-testid="save-log"` div as JSON.
+ * Component tests read this back to assert event semantics + accumulated
+ * `totalTimeAwaySeconds` (issue #232).
+ */
+import React, { useState } from "react";
+import {
+  TrackedLink,
+  type TrackedLinkProps,
+} from "../elements/TrackedLink.js";
+
+export function MockTrackedLink(props: Omit<TrackedLinkProps, "save">) {
+  const [saves, setSaves] = useState<{ key: string; value: unknown }[]>([]);
+  return (
+    <>
+      <TrackedLink
+        {...props}
+        save={(key, value) => setSaves((prev) => [...prev, { key, value }])}
+      />
+      <div data-testid="save-log" style={{ display: "none" }}>
+        {JSON.stringify(saves)}
+      </div>
+    </>
+  );
+}

--- a/packages/stagebook/src/components/testing/MockTrackedLink.tsx
+++ b/packages/stagebook/src/components/testing/MockTrackedLink.tsx
@@ -5,10 +5,7 @@
  * `totalTimeAwaySeconds` (issue #232).
  */
 import React, { useState } from "react";
-import {
-  TrackedLink,
-  type TrackedLinkProps,
-} from "../elements/TrackedLink.js";
+import { TrackedLink, type TrackedLinkProps } from "../elements/TrackedLink.js";
 
 export function MockTrackedLink(props: Omit<TrackedLinkProps, "save">) {
   const [saves, setSaves] = useState<{ key: string; value: unknown }[]>([]);

--- a/packages/stagebook/src/utils/evaluateConditions.test.ts
+++ b/packages/stagebook/src/utils/evaluateConditions.test.ts
@@ -362,4 +362,181 @@ describe("evaluateConditions", () => {
       ),
     ).toBe(true);
   });
+
+  // ----- Positional comparators by name (issue #232) -----
+  //
+  // `position: shared`, `position: "0"`, `position: "1"` are host-resolver
+  // concerns — stagebook itself doesn't know what "shared" or numeric
+  // positions mean, it just forwards the position string through to the
+  // host's `resolve(reference, position)` callback. These tests pin the
+  // forwarding contract (so deliberation-empirica-style hosts can rely on
+  // it) and confirm that once values come back, the comparator runs with
+  // default `all` semantics — every returned value must satisfy.
+
+  // A position-aware resolver that returns different values for the same
+  // reference depending on the position string. Modeled on the kind of
+  // resolver a multi-position host would supply.
+  const resolveByPosition = (
+    table: Record<string, Record<string, unknown[]>>,
+  ) => {
+    return (reference: string, position?: string) => {
+      const key = position ?? "__default";
+      return table[reference]?.[key] ?? [];
+    };
+  };
+
+  test("position: shared — forwards the string and uses the resolved value", () => {
+    const resolve = resolveByPosition({
+      "prompt.flag": {
+        shared: ["yes"],
+        "0": ["no"],
+        "1": ["maybe"],
+      },
+    });
+    // Resolving with `position: "shared"` returns ["yes"], which equals "yes".
+    expect(
+      evaluateConditions(
+        [
+          {
+            reference: "prompt.flag",
+            position: "shared",
+            comparator: "equals",
+            value: "yes",
+          },
+        ],
+        resolve,
+      ),
+    ).toBe(true);
+  });
+
+  test("position: shared — failure case (shared value doesn't match)", () => {
+    const resolve = resolveByPosition({
+      "prompt.flag": {
+        shared: ["no"],
+        "0": ["yes"],
+      },
+    });
+    expect(
+      evaluateConditions(
+        [
+          {
+            reference: "prompt.flag",
+            position: "shared",
+            comparator: "equals",
+            value: "yes",
+          },
+        ],
+        resolve,
+      ),
+    ).toBe(false);
+  });
+
+  test("position: 0 — resolves to the position-0 player's value", () => {
+    const resolve = resolveByPosition({
+      "prompt.q": {
+        "0": ["red"],
+        "1": ["blue"],
+      },
+    });
+    expect(
+      evaluateConditions(
+        [
+          {
+            reference: "prompt.q",
+            position: "0",
+            comparator: "equals",
+            value: "red",
+          },
+        ],
+        resolve,
+      ),
+    ).toBe(true);
+    // Failure case: position 0's value is "red", not "blue".
+    expect(
+      evaluateConditions(
+        [
+          {
+            reference: "prompt.q",
+            position: "0",
+            comparator: "equals",
+            value: "blue",
+          },
+        ],
+        resolve,
+      ),
+    ).toBe(false);
+  });
+
+  test("position: 1 — resolves to the position-1 player's value", () => {
+    const resolve = resolveByPosition({
+      "prompt.q": {
+        "0": ["red"],
+        "1": ["blue"],
+      },
+    });
+    expect(
+      evaluateConditions(
+        [
+          {
+            reference: "prompt.q",
+            position: "1",
+            comparator: "equals",
+            value: "blue",
+          },
+        ],
+        resolve,
+      ),
+    ).toBe(true);
+    expect(
+      evaluateConditions(
+        [
+          {
+            reference: "prompt.q",
+            position: "1",
+            comparator: "equals",
+            value: "red",
+          },
+        ],
+        resolve,
+      ),
+    ).toBe(false);
+  });
+
+  test("position string is forwarded to resolver verbatim (spy)", () => {
+    // Hosts implement `resolve` and can interpret any position string —
+    // stagebook's only contract is to pass it through. Verify with a spy.
+    const calls: { reference: string; position: string | undefined }[] = [];
+    const resolve = (reference: string, position?: string) => {
+      calls.push({ reference, position });
+      return ["x"];
+    };
+    evaluateConditions(
+      [
+        {
+          reference: "prompt.q",
+          position: "shared",
+          comparator: "equals",
+          value: "x",
+        },
+        {
+          reference: "prompt.q",
+          position: "0",
+          comparator: "equals",
+          value: "x",
+        },
+        {
+          reference: "prompt.q",
+          // position omitted — resolver receives undefined.
+          comparator: "equals",
+          value: "x",
+        },
+      ],
+      resolve,
+    );
+    expect(calls).toEqual([
+      { reference: "prompt.q", position: "shared" },
+      { reference: "prompt.q", position: "0" },
+      { reference: "prompt.q", position: undefined },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

Auditing deliberation-empirica's \`cypress/e2e/01_Normal_Paths_Omnibus.js\` before retiring it. Several stagebook contracts were exercised only by that downstream omnibus; this PR moves the assertions upstream so deliberation-empirica can finish retiring cypress 01 without losing coverage of stagebook-owned behaviors.

15 new tests across 4 areas, plus one new test wrapper.

### 1. \`shuffleOptions\` outcome (Prompt.ct.tsx — 3 tests)
Custom 8-option fixture (1/40320 flake risk):
- \`shuffleOptions: true\` produces a non-source-order rendering with the same set membership.
- Shuffled order is stable across re-renders (no reshuffle on \`component.update()\`).
- Without \`shuffleOptions\`, options render in declared yaml order — uses a deliberately non-alphabetical fixture (\`"0", "0.5", "3", …, "six"\`) so the test catches alphabetic re-sort regressions.

### 2. \`displayTime\` / \`hideTime\` time-advancing (Stage.ct.tsx — 3 tests)
Uses \`component.update()\` to advance elapsed time:
- \`displayTime\`: hidden at \`t=0\`, visible at \`t==displayTime\` (boundary check matches \`elapsed < displayTime\`), still visible after.
- \`hideTime\`: visible at \`t=0\` and \`t==hideTime\`, hidden at \`t > hideTime\`.
- \`displayTime\` works inside a discussion stage (mirrors cypress 01:750–753).

### 3. Positional comparators by name (evaluateConditions.test.ts — 5 tests)
Pins the resolver-forwarding contract:
- \`position: "shared"\` + success/failure
- \`position: "0"\` + success/failure
- \`position: "1"\` + success/failure
- spy-based test: position string is forwarded to the resolver verbatim (including \`undefined\` for the default case)

### 4. TrackedLink event semantics + url edge cases (TrackedLink.ct.tsx — 4 tests)
New \`MockTrackedLink\` wrapper (in \`src/components/testing/\`) captures \`save\` calls into a hidden \`data-testid="save-log"\` div:
- Clicking the link emits a record with \`{ events: [{type: "click"}] }\` and \`totalTimeAwaySeconds: 0\`.
- Blur-after-click + focus-on-return accumulates \`totalTimeAwaySeconds\` (uses \`page.evaluate\` for window-level events; \`expect.poll\` for the post-focus React commit).
- urlParam with empty value renders as \`&key=\` rather than being dropped (cypress 01:802 — \`href.endsWith("flag=")\`).
- participantInfo-style values URL-encode correctly into the href — asserts via \`URL.searchParams\` that special chars don't bleed into the query structure (round-trips raw value).

The click test uses \`el.dispatchEvent(new MouseEvent("click"))\` rather than Playwright's \`.click()\` to avoid following the \`target="_blank"\` link out of the test context.

## Test plan
- [x] All vitest unit tests: 688/688 (was 683)
- [x] All Playwright CT tests: 420/420 (was 410)
- [x] Lint clean
- [ ] Land + ship a stagebook release; deliberation-empirica picks up; cypress 01 retirement PRs (01-A through 01-6) can delete the corresponding assertions

Closes #232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)