### PR TITLE
Stage: opt-in host-owns-scroll mode (issue #236)

### DIFF
--- a/packages/stagebook/src/components/Stage.ct.tsx
+++ b/packages/stagebook/src/components/Stage.ct.tsx
@@ -388,3 +388,109 @@ test("shows loading when submitted in single player", async ({ mount }) => {
   );
   await expect(component.locator('[aria-label="Loading"]')).toBeVisible();
 });
+
+// ----------------------------------------------------------------
+// scrollMode: "host" (issue #236)
+// ----------------------------------------------------------------
+//
+// In host mode Stage drops its internal scroll container, the bottom
+// padding, and the indicator. The host is responsible for whatever
+// scrolls (page, `<main>`, custom shell) and may mount the publicly
+// exported `useScrollAwareness` + `<ScrollIndicator>` against its own
+// ref. These tests pin the contract that no internal scroll affordance
+// leaks through when the prop is set.
+
+// MockStageRenderer's outermost rendered element IS the stageContent div
+// (StagebookProvider renders no DOM). When Playwright CT mounts it without
+// a wrapper, `component` becomes that div — and `component.locator(...)`
+// only searches descendants, so a query for `[data-testid="stageContent"]`
+// never matches its own host. Wrap in a plain `<div>` so `component` is
+// an ancestor, matching the pattern used in `Stage.scroll.ct.tsx`.
+async function readStageContentStyle(
+  component: import("@playwright/test").Locator,
+): Promise<{ overflow: string; overflowY: string; paddingBottom: string }> {
+  const el = component.locator('[data-testid="stageContent"]').first();
+  await expect(el).toBeAttached();
+  return el.evaluate((node) => {
+    const cs = getComputedStyle(node);
+    return {
+      overflow: cs.overflow,
+      overflowY: cs.overflowY,
+      paddingBottom: cs.paddingBottom,
+    };
+  });
+}
+
+test('scrollMode "internal" (default) keeps the overflow:auto wrapper', async ({
+  mount,
+}) => {
+  const component = await mount(
+    <div>
+      <MockStageRenderer stage={simpleStage} />
+    </div>,
+  );
+  const style = await readStageContentStyle(component);
+  // overflow shorthand reports "auto" / "auto" on a `overflow: auto` div.
+  expect(style.overflow).toBe("auto");
+});
+
+test('scrollMode "host" drops overflow on the stageContent wrapper', async ({
+  mount,
+}) => {
+  const component = await mount(
+    <div>
+      <MockStageRenderer stage={simpleStage} scrollMode="host" />
+    </div>,
+  );
+  const style = await readStageContentStyle(component);
+  // No internal scroll — host owns it.
+  expect(style.overflow).toBe("visible");
+  expect(style.overflowY).toBe("visible");
+});
+
+test('scrollMode "host" drops the internal bottom padding', async ({
+  mount,
+}) => {
+  // Stage's `paddingBottom: 0.5rem` is layout chrome that belongs to the
+  // host. In host mode it goes away — hosts are expected to add their
+  // own bottom-of-stage breathing room (see #234).
+  const component = await mount(
+    <div>
+      <MockStageRenderer stage={simpleStage} scrollMode="host" />
+    </div>,
+  );
+  const style = await readStageContentStyle(component);
+  expect(style.paddingBottom).toBe("0px");
+});
+
+test('scrollMode "host" does not render the internal ScrollIndicator', async ({
+  mount,
+}) => {
+  const component = await mount(
+    <div>
+      <MockStageRenderer stage={simpleStage} scrollMode="host" />
+    </div>,
+  );
+  // The ScrollIndicator carries data-testid="scroll-indicator" — assert
+  // it's never mounted (regardless of visibility, it shouldn't be in
+  // the tree at all in host mode).
+  await expect(
+    component.locator('[data-testid="scroll-indicator"]'),
+  ).toHaveCount(0);
+});
+
+test('scrollMode "host" still renders all elements correctly', async ({
+  mount,
+}) => {
+  // Sanity that the layout change doesn't break content rendering — the
+  // stage should still produce its prompts, separators, and submit
+  // button just like internal mode.
+  const component = await mount(
+    <div>
+      <MockStageRenderer stage={simpleStage} scrollMode="host" />
+    </div>,
+  );
+  await expect(component).toContainText("Mock content");
+  await expect(component.locator("hr")).toBeVisible();
+  await expect(component).toContainText("Continue");
+});

--- a/packages/stagebook/src/components/Stage.tsx
+++ b/packages/stagebook/src/components/Stage.tsx
@@ -46,6 +46,22 @@ export interface StageConfig {
 export interface StageProps {
   stage: StageConfig;
   onSubmit: () => void;
+  /**
+   * Who owns the scroll container?
+   *
+   * - `"internal"` (default, current behavior): Stage wraps its elements
+   *   in an `overflow: auto` div, calls `useScrollAwareness` on it, and
+   *   renders the `<ScrollIndicator>` itself. Convenient for hosts that
+   *   want a fixed-height column with internal scroll out of the box.
+   * - `"host"`: Stage drops the internal scroll container, the bottom
+   *   padding, and the indicator. Content flows naturally; the host
+   *   decides what scrolls (e.g. the page, a `<main>`, a custom shell)
+   *   and is free to mount `useScrollAwareness` + `<ScrollIndicator>`
+   *   against its own ref. Lets hosts add bottom-of-stage breathing
+   *   room (#234) and decorate around Stage without fighting an
+   *   internal scroller. (Issue #236.)
+   */
+  scrollMode?: "internal" | "host";
 }
 
 function WrappedElement({
@@ -145,13 +161,23 @@ function positionAllowsDiscussion(
   return true;
 }
 
-export function Stage({ stage, onSubmit }: StageProps) {
+export function Stage({
+  stage,
+  onSubmit,
+  scrollMode = "internal",
+}: StageProps) {
   const ctx = useStagebookContext();
   const { isSubmitted, playerCount, position, resolve, renderDiscussion } = ctx;
 
   const showDiscussion = positionAllowsDiscussion(stage.discussion, position);
 
-  // Scroll awareness — shows indicator when content overflows
+  // In "host" mode the host owns the scroll container; Stage's outer
+  // wrappers become semantic groupings without overflow, and the host
+  // is responsible for mounting `useScrollAwareness` + `ScrollIndicator`
+  // against its own ref. We still call the hooks unconditionally so hook
+  // order stays stable (they no-op on null refs); the refs just don't
+  // get attached in host mode.
+  const isHostScroll = scrollMode === "host";
   const discussionContentRef = useRef<HTMLDivElement>(null);
   const singleColumnRef = useRef<HTMLDivElement>(null);
   const { showIndicator: showDiscussionScrollIndicator } =
@@ -202,22 +228,25 @@ export function Stage({ stage, onSubmit }: StageProps) {
           {renderDiscussion(stage.discussion)}
         </div>
 
-        {/* Elements column — scrollable independently.
+        {/* Elements column — scrollable independently in `internal` mode.
             flex: "1 1 20rem" lets it share space in row mode (40vw preferred)
             but stretch to full width when the container wraps to column. */}
         <div
-          ref={discussionContentRef}
+          ref={isHostScroll ? null : discussionContentRef}
           data-testid="stageContent"
           style={{
             flex: "1 1 20rem",
             maxWidth: "48rem",
-            overflowY: "auto",
-            scrollBehavior: "smooth",
             alignSelf: "stretch",
+            ...(isHostScroll
+              ? {}
+              : { overflowY: "auto", scrollBehavior: "smooth" }),
           }}
         >
           {elementsColumn}
-          <ScrollIndicator visible={showDiscussionScrollIndicator} />
+          {!isHostScroll && (
+            <ScrollIndicator visible={showDiscussionScrollIndicator} />
+          )}
         </div>
       </div>
     );
@@ -238,11 +267,15 @@ export function Stage({ stage, onSubmit }: StageProps) {
                     data-testid="stageContent"
                     style={{
                       display: "flex",
-                      height: "100%",
                       width: "100%",
                       flexDirection: "column",
-                      paddingBottom: "0.5rem",
-                      overflow: "auto",
+                      ...(isHostScroll
+                        ? {}
+                        : {
+                            height: "100%",
+                            paddingBottom: "0.5rem",
+                            overflow: "auto",
+                          }),
                     }}
                   >
                     {elementsColumn}
@@ -269,19 +302,25 @@ export function Stage({ stage, onSubmit }: StageProps) {
           playerCount={playerCount}
         >
           <div
-            ref={singleColumnRef}
+            ref={isHostScroll ? null : singleColumnRef}
             data-testid="stageContent"
             style={{
               display: "flex",
-              height: "100%",
               width: "100%",
               flexDirection: "column",
-              paddingBottom: "0.5rem",
-              overflow: "auto",
+              ...(isHostScroll
+                ? {}
+                : {
+                    height: "100%",
+                    paddingBottom: "0.5rem",
+                    overflow: "auto",
+                  }),
             }}
           >
             {elementsColumn}
-            <ScrollIndicator visible={showSingleColumnScrollIndicator} />
+            {!isHostScroll && (
+              <ScrollIndicator visible={showSingleColumnScrollIndicator} />
+            )}
           </div>
         </SubmissionConditionalRender>
       </PlaybackProvider>

--- a/packages/stagebook/src/components/testing/MockStageRenderer.tsx
+++ b/packages/stagebook/src/components/testing/MockStageRenderer.tsx
@@ -29,6 +29,9 @@ export interface MockStageRendererProps {
   advanceStage?: () => void;
   /** Opaque stage id — for the gate's latch-reset logic. */
   stageId?: string;
+  /** Forwards to `<Stage scrollMode={...}>`. Default `"internal"` so
+   *  existing tests are unaffected. (Issue #236.) */
+  scrollMode?: "internal" | "host";
 }
 
 /** Wrap a value at a nested path, e.g. wrapAtPath("yes", ["value"]) → { value: "yes" } */
@@ -65,6 +68,7 @@ export function MockStageRenderer({
   stateValues = {},
   advanceStage,
   stageId,
+  scrollMode,
 }: MockStageRendererProps) {
   const flatValues = buildFlatValues(stateValues);
 
@@ -114,7 +118,11 @@ export function MockStageRenderer({
 
   return (
     <StagebookProvider value={mockContext}>
-      <Stage stage={stage} onSubmit={() => {}} />
+      <Stage
+        stage={stage}
+        onSubmit={() => {}}
+        scrollMode={scrollMode}
+      />
     </StagebookProvider>
   );
 }

--- a/packages/stagebook/src/components/testing/MockStageRenderer.tsx
+++ b/packages/stagebook/src/components/testing/MockStageRenderer.tsx
@@ -118,11 +118,7 @@ export function MockStageRenderer({
 
   return (
     <StagebookProvider value={mockContext}>
-      <Stage
-        stage={stage}
-        onSubmit={() => {}}
-        scrollMode={scrollMode}
-      />
+      <Stage stage={stage} onSubmit={() => {}} scrollMode={scrollMode} />
     </StagebookProvider>
   );
 }


### PR DESCRIPTION
## Summary

Adds `scrollMode?: "internal" | "host"` to `<Stage>`. Default `"internal"` — existing behavior, byte-equivalent. `scrollMode="host"` drops Stage's internal overflow / paddingBottom / ScrollIndicator and lets the host page own the scroll container.

This is the library-side refactor only — see #236 for the design, and the upcoming viewer + annotator migrations as the natural follow-ups.

## What this unblocks

- **#234** (bottom-of-stage breathing room as a host responsibility): hosts that opt into `host` mode can add a pb-spacer below Stage and have it actually scroll into view, even in viewer-style scroll models that previously couldn't fit one.
- **Consistent scroll-awareness UX across hosts**: today annotator (page scrolls) and viewer (Stage's internal div scrolls) get different affordances because of the layout-model assumption baked into Stage. `useScrollAwareness` and `<ScrollIndicator>` are already publicly exported, so any host on `host` mode can mount them against its own scroll ref.

## What changed

`<Stage>` gains the prop. When `scrollMode="host"`, all three render paths (single-column, discussion-elements column, discussion-fallback column) drop:
- `overflow: auto`
- `paddingBottom: 0.5rem`
- The internal `<ScrollIndicator>`
- The ref attachment for `useScrollAwareness` (the hook is still called for stable hook order; no-ops on null ref)

Discussion column itself is unchanged in either mode — no overflow set there today, so host ownership of its layout is the same in both.

`MockStageRenderer` gains a passthrough `scrollMode` prop so tests can exercise the new mode.

## Test plan
- [x] 5 new CT tests pinning the contract (`internal` keeps overflow:auto; `host` drops overflow, paddingBottom, and ScrollIndicator; `host` still renders content correctly).
- [x] Existing `Stage.ct.tsx` + `Stage.scroll.ct.tsx` suites: 17/17 pass unchanged on the default mode.
- [x] Full CT suite: 425/425.
- [x] Lint clean.

## Backwards compat

Default `"internal"` keeps every existing consumer byte-equivalent. No deprecation, no host-side changes required to upgrade.

## Out of scope (follow-ups)

- Viewer migration: drop `overflow: hidden` on `<main>`, attach `useScrollAwareness` to `<main>`, render `<ScrollIndicator>` + bottom spacer.
- Annotator already adds the spacer pattern via deliberation-lab/annotator#138 — no change needed there yet, but the same `host` mode is now available if/when annotator updates.
- Docs: README "Host platform responsibilities" section per #234.

🤖 Generated with [Claude Code](https://claude.com/claude-code)