### PR TITLE
Viewer: migrate to scrollMode="host" + integration docs

### DIFF
--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -7,7 +7,12 @@ import {
   useSyncExternalStore,
 } from "react";
 import type { TreatmentFileType } from "stagebook";
-import { StagebookProvider, Stage } from "stagebook/components";
+import {
+  StagebookProvider,
+  Stage,
+  ScrollIndicator,
+  useScrollAwareness,
+} from "stagebook/components";
 import { flattenSteps } from "../lib/steps";
 import { ViewerStateStore } from "../lib/store";
 import { createViewerContext } from "../lib/context";
@@ -77,6 +82,13 @@ export function Viewer({
   const [position, setPosition] = useState(0);
   const [store] = useState(() => new ViewerStateStore());
   const stageContainerRef = useRef<HTMLDivElement | null>(null);
+  // `<main>` is the scroll container in the viewer's host-owns-scroll
+  // model (see <Stage scrollMode="host"> below). `useScrollAwareness`
+  // observes it for content growth and produces the indicator visibility
+  // — same UX as Stage's old internal scroll, just hosted by us.
+  const mainScrollRef = useRef<HTMLElement | null>(null);
+  const { showIndicator: showScrollIndicator } =
+    useScrollAwareness(mainScrollRef);
 
   // Clamp stageIndex if the treatment was edited to have fewer stages
   // (e.g. researcher deleted a stage while the preview was open). Without
@@ -215,7 +227,7 @@ export function Viewer({
         </aside>
 
         {/* Main content */}
-        <main style={mainStyle}>
+        <main ref={mainScrollRef} style={mainStyle}>
           {isSubmitted ? (
             <div style={submittedOverlayStyle}>
               <p style={submittedTextStyle}>
@@ -232,19 +244,29 @@ export function Viewer({
               </button>
             </div>
           ) : (
-            <div ref={stageContainerRef} style={stageContainerStyle}>
-              <StagebookProvider value={ctx}>
-                <Stage
-                  key={`stage-${String(stageIndex)}-${String(stageResetVersion)}`}
-                  stage={stageConfig}
-                  onSubmit={handleSubmit}
+            <>
+              <div ref={stageContainerRef} style={stageContainerStyle}>
+                <StagebookProvider value={ctx}>
+                  <Stage
+                    key={`stage-${String(stageIndex)}-${String(stageResetVersion)}`}
+                    stage={stageConfig}
+                    onSubmit={handleSubmit}
+                    scrollMode="host"
+                  />
+                </StagebookProvider>
+                <NotesIconsOverlay
+                  containerRef={stageContainerRef}
+                  currentStep={currentStep}
                 />
-              </StagebookProvider>
-              <NotesIconsOverlay
-                containerRef={stageContainerRef}
-                currentStep={currentStep}
-              />
-            </div>
+              </div>
+              {/* Bottom-of-stage breathing room — see comment on
+                  stageBottomSpacerStyle. aria-hidden because it has no
+                  semantic content. */}
+              <div aria-hidden="true" style={stageBottomSpacerStyle} />
+              {/* The indicator is `position: sticky; bottom: 0`, so it
+                  pins to the bottom of <main> as content scrolls past. */}
+              <ScrollIndicator visible={showScrollIndicator} />
+            </>
           )}
         </main>
       </div>
@@ -346,23 +368,33 @@ const sidebarStyle: React.CSSProperties = {
 
 const mainStyle: React.CSSProperties = {
   flex: 1,
-  // overflow: hidden (not auto) so Stage's own scroll container is the
-  // element that actually scrolls. This is what lets useScrollAwareness
-  // inside Stage see scroll events and content growth — when main was
-  // the scroller, Stage's internal div never overflowed and the scroll
-  // indicator / auto-peek nudge never fired.
-  overflow: "hidden",
+  // The viewer is a host-owns-scroll consumer of Stagebook (see
+  // <Stage scrollMode="host"> in the render): `<main>` is the actual
+  // scroll container, and we mount the publicly exported
+  // `useScrollAwareness` + `<ScrollIndicator>` against it. This lets
+  // the host page flow naturally — the bottom spacer at the end of the
+  // stage actually scrolls into view, which it couldn't when Stage's
+  // own internal div was the scroller.
+  overflow: "auto",
   padding: "1.5rem",
   display: "flex",
-  justifyContent: "center",
+  flexDirection: "column",
+  alignItems: "center",
+  position: "relative",
 };
 
 const stageContainerStyle: React.CSSProperties = {
   position: "relative",
   width: "100%",
-  // Fill main's height so Stage's height: 100% scroll container resolves
-  // to a concrete size and actually overflows when content exceeds it.
-  height: "100%",
+};
+
+// Bottom-of-stage breathing room (#234). Without this, long stages end
+// at a hard scroll-stop and participants have no signal they've reached
+// the end. 8rem matches the annotator's spacer (deliberation-lab/
+// annotator#138) so the visual rhythm is consistent across hosts.
+const stageBottomSpacerStyle: React.CSSProperties = {
+  flexShrink: 0,
+  height: "8rem",
 };
 
 const submittedOverlayStyle: React.CSSProperties = {

--- a/docs/engineer/api-reference.md
+++ b/docs/engineer/api-reference.md
@@ -143,12 +143,43 @@ import { StagebookProvider, type StagebookContext } from "stagebook/components";
 ```tsx
 import { Stage, type StageConfig } from "stagebook/components";
 
-<Stage stage={stageConfig} onSubmit={handleSubmit} />
+<Stage
+  stage={stageConfig}
+  onSubmit={handleSubmit}
+  scrollMode="host"
+/>
 ```
 
 Requires StagebookProvider. Renders a complete stage: lays out elements with conditional rendering (time, position, conditions), handles two-column layout when a discussion is present, and shows a waiting message after submission. **This is the primary rendering API** — prefer `Stage` over manually rendering `Element` components.
 
 `StageConfig` has: `name` (string), `duration?` (number), `elements` (ElementConfig[]), `discussion?` (DiscussionType).
+
+`scrollMode?: "internal" | "host"` (default `"internal"`) — controls who owns the scroll container around Stage's elements. `internal` keeps the existing `overflow: auto` wrapper + internal `<ScrollIndicator>`; `host` drops both, lets content flow naturally, and lets you mount your own scroll container with the publicly exported `useScrollAwareness` + `<ScrollIndicator>`. See [Page Chrome and Scroll Model](./integration-guide.md#page-chrome-and-scroll-model) in the integration guide for the host-mode setup pattern.
+
+### Scroll Awareness
+
+```tsx
+import {
+  useScrollAwareness,
+  ScrollIndicator,
+} from "stagebook/components";
+
+const scrollRef = useRef<HTMLElement>(null);
+const { showIndicator, dismissIndicator } = useScrollAwareness(scrollRef);
+
+return (
+  <main ref={scrollRef} style={{ overflow: "auto" }}>
+    {/* … your stage … */}
+    <ScrollIndicator visible={showIndicator} />
+  </main>
+);
+```
+
+`useScrollAwareness(containerRef, { threshold? })` watches the container for new content appearing below the viewport. If the user is near the bottom (within `threshold` px, default 120) it auto-"peeks" the new content into view; otherwise it sets `showIndicator` to `true` and clears it when the user scrolls to the bottom.
+
+`<ScrollIndicator visible>` is a `position: sticky; bottom: 0` chevron that pulses to draw attention. It auto-renders nothing when `visible` is false, so you can leave it mounted unconditionally.
+
+These are the primitives Stage's `internal` mode uses internally; in `host` mode you mount them yourself against your own scroll container.
 
 ### Element Router
 

--- a/docs/engineer/integration-guide.md
+++ b/docs/engineer/integration-guide.md
@@ -216,6 +216,79 @@ The `Stage` component handles:
 
 If you need lower-level control, you can use the `Element` component directly to render individual elements, or the pure element components (e.g., `Prompt`, `Display`) with manual prop wiring.
 
+### Page Chrome and Scroll Model
+
+Stagebook draws a deliberate line between **measurement instruments** (its job) and **page chrome** (the host's job). Anything that's about how `<Stage>` sits in *your page* — the scroll container, the bottom-of-stage breathing room, sticky headers, branded backgrounds, in-page progress indicators — belongs to the host. This keeps Stage focused on rendering elements consistently while letting platforms decorate freely.
+
+#### Who owns the scroll?
+
+`<Stage>` accepts a `scrollMode` prop:
+
+- **`scrollMode="internal"` (default).** Stage owns its own `overflow: auto` wrapper and renders a `<ScrollIndicator>` inside it. Convenient for hosts that want a fixed-height column with internal scroll out of the box.
+- **`scrollMode="host"`.** Stage drops the internal scroll container, the bottom padding, and the indicator. Content flows naturally; the host decides what scrolls (the page, a `<main>` element, a custom shell) and is free to mount the publicly exported `useScrollAwareness` + `<ScrollIndicator>` against its own ref.
+
+For most hosts, **`host` mode is the better default** — it lets the page flow naturally and integrates with whatever surrounding chrome you already have. Use `internal` only when you genuinely need Stage to be a fixed-height column.
+
+#### Recommended host setup (host mode)
+
+```tsx
+import { useRef } from "react";
+import {
+  Stage,
+  StagebookProvider,
+  ScrollIndicator,
+  useScrollAwareness,
+} from "stagebook/components";
+
+function HostedStage({ stageConfig, context, onSubmit }) {
+  // Whatever element scrolls in your layout — could be <main>, the
+  // window (pass `null`/document.scrollingElement), or a custom shell.
+  const scrollRef = useRef<HTMLElement>(null);
+  const { showIndicator } = useScrollAwareness(scrollRef);
+
+  return (
+    <main ref={scrollRef} style={{ overflow: "auto" }}>
+      <StagebookProvider value={context}>
+        <Stage
+          stage={stageConfig}
+          onSubmit={onSubmit}
+          scrollMode="host"
+        />
+      </StagebookProvider>
+
+      {/* Bottom-of-stage breathing room. ~6–8rem is typical; size to
+          your own footer / page chrome. Without this, long stages end
+          at a hard scroll-stop and participants have no signal they've
+          reached the end. */}
+      <div aria-hidden="true" style={{ height: "8rem" }} />
+
+      {/* Sticky-bottom indicator that auto-shows when content grows
+          off-screen and auto-dismisses when the user scrolls to bottom.
+          Position-sticky inside the scroll container, no extra wiring. */}
+      <ScrollIndicator visible={showIndicator} />
+    </main>
+  );
+}
+```
+
+#### What the host owns vs. what Stage owns
+
+| | Host | Stage |
+|---|---|---|
+| The scroll container (`overflow`) | ✅ | — |
+| Bottom-of-stage breathing room | ✅ | — |
+| Page header / branded chrome / footers | ✅ | — |
+| Layout context (fixed-height vs. min-height page) | ✅ | — |
+| Element rendering (prompts, separators, etc.) | — | ✅ |
+| Per-element max-widths and spacing | — | ✅ |
+| Conditional rendering (time / position / conditions) | — | ✅ |
+| Submission overlay ("waiting for others") | — | ✅ |
+| Discussion two-column layout when `discussion:` is set | — | ✅ |
+
+#### Backward compatibility
+
+`scrollMode` defaults to `"internal"`, so existing integrations are unaffected. Migrate at your own pace: add a host-side scroll container + spacer + `<ScrollIndicator>`, then flip the prop.
+
 ### The Three Phases
 
 The same `StagebookContext` interface works across all three experiment phases. The platform adapts its implementation:


### PR DESCRIPTION
## Summary

Follow-up to #237. Migrates the viewer to opt into Stage's `host` scroll mode (the first first-party host to do so) and writes up the integration pattern in the engineer docs while it's still fresh.

The annotator already implements the spacer pattern via [annotator#138](https://github.com/deliberation-lab/annotator/pull/138) but doesn't yet use the new `scrollMode` prop or the scroll indicator. A separate annotator-side issue will follow this PR with explicit instructions.

## Viewer changes

- `<main>` now owns the scroll: `overflow: auto`, ref attached, mounts `useScrollAwareness` against itself.
- `<Stage scrollMode="host">` drops Stage's internal `overflow: auto`, bottom padding, and internal `<ScrollIndicator>`.
- `<ScrollIndicator visible={…}>` rendered as a sibling of the stage — position-sticky pins it to the bottom of `<main>` while content scrolls past.
- 8rem `aria-hidden` bottom spacer between the stage and the scroll end (#234, matches the annotator's existing spacer). Long stages now end with whitespace instead of a hard scroll-stop.

The `mainStyle` comment that previously explained why `<main>` had `overflow: hidden` is rewritten to explain the host-scroll model. `stageContainerStyle` loses its `height: 100%` (no longer needed now that Stage doesn't have an internal scroll container that depends on its parent's height).

## Docs

- **`docs/engineer/integration-guide.md`** gains a "Page Chrome and Scroll Model" section after the Stage wiring section. Covers:
  - the line between measurement-instrument concerns (Stagebook) and page-chrome concerns (host)
  - both `scrollMode` options with a recommendation toward `host` for most integrations
  - a complete host setup example showing `useScrollAwareness` + `<ScrollIndicator>` + bottom spacer
  - a "who owns what" table
- **`docs/engineer/api-reference.md`** documents the new `scrollMode` prop on `<Stage>` and adds a "Scroll Awareness" subsection covering the hook + indicator primitives.

## Compat

- Default `<Stage>` prop is still `"internal"`. No host needs to change to consume the new release.
- This PR's viewer migration is opt-in for the viewer alone; other hosts (annotator, deliberation-empirica, …) keep working unchanged on `internal` mode until they choose to migrate.

## Test plan
- [x] Viewer typecheck clean.
- [x] All 84 viewer tests pass.
- [x] Viewer + stagebook builds clean.
- [x] Manual: VSCode extension repackaged + reinstalled, long stages show the bottom spacer + scroll indicator instead of a hard scroll-stop.
- [ ] CI green on the standalone Vite build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)