### PR TITLE
useScrollAwareness: gate auto-peek on user engagement

### DIFF
--- a/packages/stagebook/src/components/Stage.scroll.ct.tsx
+++ b/packages/stagebook/src/components/Stage.scroll.ct.tsx
@@ -85,6 +85,23 @@ async function growContent(container: Locator, height = 200): Promise<void> {
   }, height);
 }
 
+// Like primeScrollState("top") but DOES NOT dispatch a scroll event —
+// used to set up overflow without registering user engagement, so we can
+// test the "user hasn't scrolled yet" branch of the hook.
+async function seedOverflowWithoutScroll(
+  container: Locator,
+  height = 1000,
+): Promise<void> {
+  await container.evaluate((el, h) => {
+    const pad = document.createElement("div");
+    pad.style.height = `${h}px`;
+    pad.style.width = "100%";
+    pad.style.flex = "0 0 auto";
+    pad.setAttribute("data-seed-pad", "1");
+    el.appendChild(pad);
+  }, height);
+}
+
 async function scrollToBottom(container: Locator): Promise<void> {
   await container.evaluate((el) => {
     el.scrollTop = el.scrollHeight;
@@ -191,4 +208,42 @@ test("dismissed indicator does not re-fire on subsequent mutations at the same s
   await expect(
     component.locator('[data-testid="scroll-indicator"]'),
   ).toHaveCount(0);
+});
+
+test("no auto-peek on first growth before user has scrolled", async ({
+  mount,
+}) => {
+  // Auto-peek used to fire on a fresh page load whenever async content
+  // pushed scrollHeight past the viewport — even though the user hadn't
+  // engaged with the content yet. The hook now gates peek on a real
+  // scroll event having fired on the container; this is the regression
+  // test for that gate.
+  const component = await mount(
+    <div style={WRAPPER_STYLE}>
+      <MockStageRenderer stage={staticStage} />
+    </div>,
+  );
+  const container = component.locator('[data-testid="stageContent"]');
+  await expect(container).toBeVisible();
+
+  // Push scrollHeight past clientHeight WITHOUT dispatching a scroll
+  // event — the user hasn't engaged at all.
+  await seedOverflowWithoutScroll(container);
+  await settleHook(component.page());
+  // First post-init growth: would have triggered peek under the old
+  // logic (wasAtBottomRef defaults to true, isAtBottom returns true on
+  // a not-yet-scrolled small container, so wasAtBottomNow=true).
+  await growContent(container);
+  await settleHook(component.page());
+
+  // The cue is the indicator, not a peek scroll.
+  await expect(
+    component.locator('[data-testid="scroll-indicator"]'),
+  ).toBeVisible();
+
+  // And scrollTop has not been animated — no peek happened.
+  // (peekAmount tops out at 150px; allow a tiny tolerance for any future
+  // animation fudge but expect it to be effectively 0.)
+  const scrollTop = await container.evaluate((el) => el.scrollTop);
+  expect(scrollTop).toBeLessThan(2);
 });

--- a/packages/stagebook/src/components/scroll/useScrollAwareness.ts
+++ b/packages/stagebook/src/components/scroll/useScrollAwareness.ts
@@ -15,6 +15,15 @@ export function useScrollAwareness(
   const prevScrollHeightRef = useRef(0);
   const wasAtBottomRef = useRef(true);
   const isInitializedRef = useRef(false);
+  // Auto-peek scrolling is meant to keep an *engaged* user oriented when
+  // new content arrives — e.g., a participant who scrolled to the
+  // bottom of a discussion to read the latest, then sees a new message.
+  // It should NOT fire on fresh page load, when the user hasn't read the
+  // top yet but the container is technically "at bottom" because content
+  // happens to fit in the viewport (or hasn't fully loaded). This flag
+  // gates peek on actual user scroll engagement; the indicator branch
+  // is unaffected.
+  const hasUserScrolledRef = useRef(false);
 
   const checkAtBottom = useCallback(() => {
     const container = containerRef.current;
@@ -33,6 +42,7 @@ export function useScrollAwareness(
     if (!container) return undefined;
 
     const handleScroll = () => {
+      hasUserScrolledRef.current = true;
       wasAtBottomRef.current = checkAtBottom();
       if (showIndicator && wasAtBottomRef.current) {
         setShowIndicator(false);
@@ -63,6 +73,15 @@ export function useScrollAwareness(
           return;
         }
 
+        // Nothing to peek or indicate if everything still fits in the
+        // viewport. Spares us from cueing on growths that don't push
+        // content below the fold (e.g. a header reflow inside short
+        // content).
+        if (currentScrollHeight <= container.clientHeight) {
+          prevScrollHeightRef.current = currentScrollHeight;
+          return;
+        }
+
         const wasAtBottomNow =
           wasAtBottomRef.current ||
           isAtBottom(
@@ -73,8 +92,15 @@ export function useScrollAwareness(
           );
         const heightDelta = currentScrollHeight - prevScrollHeight;
 
-        if (wasAtBottomNow) {
-          // User was at bottom — "peek" scroll to show top of new content
+        if (wasAtBottomNow && hasUserScrolledRef.current) {
+          // User was near bottom AND has scrolled at least once — a
+          // meaningful "I've read this and want to keep up with new
+          // content" signal. Peek the new content into view.
+          //
+          // Without the engagement gate, async content arriving on
+          // first paint triggers a peek before the user has read the
+          // top — disorienting and unwanted. (Reported observation
+          // from the viewer migration.)
           const peekAmount = Math.min(heightDelta, 150);
           const startScrollTop = scrollTop;
           const duration = 900;
@@ -95,7 +121,10 @@ export function useScrollAwareness(
 
           setTimeout(() => requestAnimationFrame(animateScroll), 50);
         } else {
-          // User was not at bottom — show indicator
+          // Either user isn't near the bottom, or they haven't engaged
+          // yet (no peek without engagement). Either way, content now
+          // overflows — surface the "more below" indicator so it's
+          // discoverable.
           setShowIndicator(true);
         }
       }


### PR DESCRIPTION
## Summary

Fix for an issue surfaced during the viewer's host-mode migration ([#239](https://github.com/deliberation-lab/stagebook/pull/239)): freshly-loaded stages were auto-scrolling on initial paint, before the user had read the top.

## Root cause

`wasAtBottomRef` defaults to `true` and is only updated by real scroll events. `isAtBottom` returns `true` whenever content fits in the viewport (which is the case on initial render before async content has finished arriving). The combined `wasAtBottomNow = wasAtBottomRef.current || isAtBottom(...)` is therefore trivially `true` on first paint, and the next async growth fires the peek branch — hijacking position before the user has engaged.

## Fix

Auto-peek now requires the user to have **actually scrolled** at least once. A real `scroll` event landing on the container is the cleanest signal of engagement: it covers wheel, touch, keyboard arrows, scrollbar drag — every surface a participant uses to navigate a long stage. Until that signal exists, the peek branch is suppressed; the indicator branch is unaffected.

Also adds an overflow guard: growths that don't push content past the viewport no longer trigger any cue. Spares us a spurious indicator fire when scrollHeight is still below clientHeight.

| Case | Cue |
|---|---|
| Overflow + user near bottom + has scrolled at least once | Auto-peek |
| Overflow + (user not near bottom OR hasn't scrolled yet) | Indicator |
| No overflow | Nothing |

## Test plan

- [x] New regression test (`no auto-peek on first growth before user has scrolled`) in `Stage.scroll.ct.tsx`. Seeds overflow without dispatching a scroll event, then grows content. Asserts indicator visible AND `scrollTop` unchanged.
- [x] Existing 4 scroll integration tests pass unchanged — they all `primeScrollState` (which dispatches a real scroll event) before any growth, so the engagement gate opens normally.
- [x] Lint clean. Full Stage CT suite: 23/23.
- [ ] Manual: open a long stage in the VS Code preview / standalone viewer, confirm position is preserved on first paint and the indicator pulses near the bottom-right.

## Forward

If gating peek on a real scroll event feels wrong in playtesting (e.g., a participant reads short content, doesn't scroll, more content arrives async, and they don't notice the indicator), we can either:
- Loosen the gate to also count wheel/touch events (which fire even when there's nothing to scroll), or
- Make the indicator more eye-catching, or
- Both.

Easier to relax the gate later than to retrofit it once participants have adapted to the unconditional-peek behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)