### PR TITLE
release v0.8.3: scrollMode prop on Stage + scroll-awareness fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13396,7 +13396,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.8.2",
+      "version": "0.8.3",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Patch release on top of v0.8.2. Three categories of changes since the last release:

### `<Stage>` gains opt-in `scrollMode="host"` ([#237](https://github.com/deliberation-lab/stagebook/pull/237))
- Lets the host page own the scroll container instead of Stage's internal `overflow: auto` div.
- In `host` mode Stage drops the internal scroll wrapper, the bottom padding, and the internal `<ScrollIndicator>`. Hosts mount the publicly exported `useScrollAwareness` + `<ScrollIndicator>` against their own ref.
- Default is `"internal"` — fully backward-compatible. Existing consumers can upgrade with no code changes.
- Unblocks the host-side bottom-spacer pattern recommended in [#234](https://github.com/deliberation-lab/stagebook/issues/234) for layouts where Stage isn't the scroller.

### `useScrollAwareness` no longer auto-peeks before user engagement ([#241](https://github.com/deliberation-lab/stagebook/pull/241))
- Auto-peek now requires the user to have actually scrolled the container at least once. Until then, content growth shows the indicator (or no-op if everything still fits) instead of hijacking position.
- Fixes a fresh-load auto-scroll surfaced during the viewer's host-mode migration: async content arriving on first paint was firing peek before the user had read the top.
- Indicator behavior is unchanged for the engaged case.

### Cypress 01 coverage moved upstream ([#233](https://github.com/deliberation-lab/stagebook/pull/233))
- 14 new component tests + 5 new unit tests covering behaviors deliberation-empirica's `01_Normal_Paths_Omnibus.js` was the only test exercising: `shuffleOptions` outcomes, yaml-declared option order, `displayTime`/`hideTime` time-advancing branches, positional-comparator forwarding, TrackedLink event semantics + url edge cases.
- No behavior change — tests only.

## Test plan
- [x] Full unit suite passes.
- [x] Full CT suite passes (425+).
- [x] Lint clean.
- [x] Manual: VS Code preview shows the bottom spacer + scroll indicator in the viewer (which migrated to `host` mode in [#239](https://github.com/deliberation-lab/stagebook/pull/239)). Auto-peek no longer fires on first load.

## Versioning

Bumps `stagebook` 0.8.2 → 0.8.3. The new `scrollMode` prop is additive with a backward-compat default, so patch is appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)