### PR TITLE
feat(conditions): boolean-tree operators all/any/none (closes #235)

### DIFF
--- a/docs/researcher/conditions.md
+++ b/docs/researcher/conditions.md
@@ -23,7 +23,99 @@ conditions:
     value: 15
 ```
 
-For OR logic, create multiple elements with different conditions.
+## Boolean operators: `all`, `any`, `none`
+
+When you need OR or NOR logic, wrap conditions in an operator-keyed object. The flat-array form above is sugar for `all:` — these two are equivalent:
+
+```yaml
+# Implicit all (sugar)
+conditions:
+  - reference: prompt.a
+    comparator: equals
+    value: yes
+  - reference: prompt.b
+    comparator: exists
+
+# Explicit all
+conditions:
+  all:
+    - { reference: prompt.a, comparator: equals, value: yes }
+    - { reference: prompt.b, comparator: exists }
+```
+
+Use `any:` for OR, `none:` for NOR (none of these are true):
+
+```yaml
+# Show element if either participant's previous answer was "yes"
+conditions:
+  any:
+    - {
+        reference: prompt.changedMind,
+        position: 0,
+        comparator: equals,
+        value: yes,
+      }
+    - {
+        reference: prompt.changedMind,
+        position: 1,
+        comparator: equals,
+        value: yes,
+      }
+```
+
+```yaml
+# Render fallback message when nobody hit the threshold
+conditions:
+  none:
+    - {
+        reference: prompt.familiarity,
+        position: 0,
+        comparator: isAtLeast,
+        value: 50,
+      }
+    - {
+        reference: prompt.familiarity,
+        position: 1,
+        comparator: isAtLeast,
+        value: 50,
+      }
+```
+
+Operators nest. Mix freely:
+
+```yaml
+# (P1 disagrees OR P2 disagrees) AND timer hasn't overflowed
+conditions:
+  all:
+    - any:
+        - {
+            reference: prompt.consensus,
+            position: 0,
+            comparator: equals,
+            value: disagree,
+          }
+        - {
+            reference: prompt.consensus,
+            position: 1,
+            comparator: equals,
+            value: disagree,
+          }
+    - { reference: prompt.discussion_overflow, comparator: doesNotExist }
+```
+
+### Three-valued logic — what happens before data arrives
+
+Each leaf condition can be **true**, **false**, or **unknown** (data not yet recorded). Operators propagate "unknown" so fallback elements gated on `none:` don't render prematurely:
+
+| Operator | True when            | False when           |
+| -------- | -------------------- | -------------------- |
+| `all`    | every child is true  | any child is false   |
+| `any`    | any child is true    | every child is false |
+| `none`   | every child is false | any child is true    |
+
+If neither row applies (because some children are still "unknown"), the operator itself is unknown — at the rendering boundary, that collapses to "don't show yet." The most common place this matters: a `none:` block whose children all reference data nobody has answered yet stays hidden until at least one answer arrives, instead of rendering as if "no one matched."
+
+For OR logic on a single reference (across positions, comparators, etc.), `any:` is usually clearer than creating separate elements. For NOR, `none:` replaces the De Morgan trick of stacking negated comparators (`doesNotEqual`, `doesNotInclude`, `isNotOneOf`).
 
 **Visibility-field interaction.** When an element also has `displayTime`, `hideTime`, `showToPositions`, or `hideFromPositions` set, all of those fields combine with `conditions` using implicit AND — the element is visible only when every visibility field that's set evaluates to "show." See [Element visibility](elements.md#visibility) for the full picture.
 

--- a/packages/stagebook/src/components/conditions/ConditionsConditionalRender.tsx
+++ b/packages/stagebook/src/components/conditions/ConditionsConditionalRender.tsx
@@ -1,57 +1,41 @@
 import React from "react";
 import {
-  evaluateCondition,
+  evaluateConditions,
   type Condition,
+  type ConditionNode,
 } from "../../utils/evaluateConditions.js";
 
-export type { Condition };
+export type { Condition, ConditionNode };
 
 export interface ConditionsConditionalRenderProps {
-  conditions: Condition[];
+  /** A `conditions:` value: a flat array (implicit `all`), an operator
+   *  node (`{all|any|none: [...]}`), a single leaf condition, or
+   *  null/undefined (which renders children unconditionally). */
+  conditions: ConditionNode[] | ConditionNode | null | undefined;
   resolve: (reference: string, position?: string) => unknown[];
   children: React.ReactNode;
   fallback?: React.ReactNode;
 }
 
+/**
+ * Renders `children` when the condition tree evaluates to true,
+ * `fallback` otherwise. Delegates to `evaluateConditions`, which
+ * handles all three shapes (array sugar, operator node, leaf) and
+ * collapses the tri-state "data not yet" case to false.
+ */
 export function ConditionsConditionalRender({
   conditions,
   resolve,
   children,
   fallback = null,
 }: ConditionsConditionalRenderProps) {
-  if (!conditions || !conditions.length) return <>{children}</>;
-
-  return (
-    <RecursiveConditionalRender
-      conditions={conditions}
-      resolve={resolve}
-      fallback={fallback}
-    >
-      {children}
-    </RecursiveConditionalRender>
-  );
-}
-
-function RecursiveConditionalRender({
-  conditions,
-  resolve,
-  children,
-  fallback = null,
-}: ConditionsConditionalRenderProps) {
-  const condition = conditions[0];
-  const referenceValues = resolve(condition.reference, condition.position);
-  const conditionMet = evaluateCondition(condition, referenceValues);
-
-  if (!conditionMet) return <>{fallback}</>;
-  if (conditions.length === 1) return <>{children}</>;
-
-  return (
-    <RecursiveConditionalRender
-      conditions={conditions.slice(1)}
-      resolve={resolve}
-      fallback={fallback}
-    >
-      {children}
-    </RecursiveConditionalRender>
-  );
+  if (
+    conditions === undefined ||
+    conditions === null ||
+    (Array.isArray(conditions) && conditions.length === 0)
+  ) {
+    return <>{children}</>;
+  }
+  const conditionMet = evaluateConditions(conditions, resolve);
+  return <>{conditionMet ? children : fallback}</>;
 }

--- a/packages/stagebook/src/components/conditions/StageConditionGate.tsx
+++ b/packages/stagebook/src/components/conditions/StageConditionGate.tsx
@@ -3,18 +3,29 @@ import React, { useEffect, useRef } from "react";
 import { useStagebookContext } from "../StagebookProvider.js";
 import { evaluateConditions } from "../../utils/evaluateConditions.js";
 import { Loading } from "../form/Loading.js";
-import type { Condition } from "./ConditionsConditionalRender.js";
+import type {
+  Condition,
+  ConditionNode,
+} from "./ConditionsConditionalRender.js";
 
 export interface StageConditionGateProps {
   /**
-   * Stage-level conditions from the treatment DSL (#183). When all
-   * conditions evaluate to `true`, children render normally. When any
-   * condition is `false`, stagebook asks the host to advance the stage
-   * via `context.advanceStage` (falling back to `submit`).
+   * Stage-level conditions from the treatment DSL (#183). When the
+   * condition tree evaluates to `true`, children render normally;
+   * when it evaluates to `false`, stagebook asks the host to advance
+   * the stage via `context.advanceStage` (falling back to `submit`).
+   *
+   * Accepts the full #235 boolean-tree shape: a flat array (implicit
+   * `all`), an `all`/`any`/`none` operator node, a single leaf, or
+   * undefined (no gate).
    */
-  conditions?: Condition[];
+  conditions?: ConditionNode[] | ConditionNode;
   children: React.ReactNode;
 }
+
+// Re-export `Condition` for consumers that still type against the
+// leaf-only form. Backward-compat — new code should use ConditionNode.
+export type { Condition };
 
 /**
  * Wraps a stage's render body and evaluates stage-level conditions.
@@ -54,7 +65,14 @@ export function StageConditionGate({
     advanceFiredRef.current = false;
   }
 
-  const hasConditions = !!conditions && conditions.length > 0;
+  // `conditions` accepts the full boolean-tree shape — a flat array
+  // (implicit `all`), an operator node, or a single leaf. The "no gate"
+  // case is a missing field or an empty array; everything else is a
+  // real condition tree to evaluate.
+  const hasConditions =
+    conditions !== undefined &&
+    conditions !== null &&
+    !(Array.isArray(conditions) && conditions.length === 0);
   const allMet = hasConditions ? evaluateConditions(conditions, resolve) : true;
 
   useEffect(() => {

--- a/packages/stagebook/src/components/conditions/index.ts
+++ b/packages/stagebook/src/components/conditions/index.ts
@@ -10,6 +10,7 @@ export {
   ConditionsConditionalRender,
   type ConditionsConditionalRenderProps,
   type Condition,
+  type ConditionNode,
 } from "./ConditionsConditionalRender.js";
 export {
   SubmissionConditionalRender,

--- a/packages/stagebook/src/components/index.ts
+++ b/packages/stagebook/src/components/index.ts
@@ -84,6 +84,7 @@ export {
   ConditionsConditionalRender,
   type ConditionsConditionalRenderProps,
   type Condition,
+  type ConditionNode,
   SubmissionConditionalRender,
   type SubmissionConditionalRenderProps,
 } from "./conditions/index.js";

--- a/packages/stagebook/src/schemas/conditionOperators.ts
+++ b/packages/stagebook/src/schemas/conditionOperators.ts
@@ -1,0 +1,13 @@
+/**
+ * Source-of-truth list of boolean-tree operator keys (#235).
+ *
+ * Lives in its own module so both `treatment.ts` (where the operator
+ * branches are defined) and `validateReferences.ts` (where the walker
+ * traverses them) can import it without forming an import cycle —
+ * `treatment.ts` imports `validateReferences.ts` for cross-stage
+ * checks, so the dependency arrow has to point the other way for the
+ * shared list.
+ */
+export const OPERATOR_KEYS = ["all", "any", "none"] as const;
+
+export type OperatorKey = (typeof OPERATOR_KEYS)[number];

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -27,7 +27,10 @@ import {
 // Resolved condition — no template placeholders in values
 // ----------------------------------------------------------------
 
-const resolvedConditionSchema = z
+// Leaf shape of a resolved condition: reference + comparator + optional
+// value, no template placeholders. Boolean-tree operators (#235) are
+// described separately below.
+const resolvedLeafConditionSchema = z
   .object({
     reference: referenceSchema,
     position: z
@@ -63,7 +66,33 @@ const resolvedConditionSchema = z
   })
   .strict();
 
-const resolvedConditionsSchema = z.array(resolvedConditionSchema).optional();
+// Recursive resolved-condition node: an `all`/`any`/`none` operator,
+// or a leaf. After template fill, the same boolean tree is what
+// runtime/component code sees — no template placeholders, no string
+// shorthand quirks, just the structured form.
+const resolvedConditionNodeSchema: z.ZodType = z.lazy(() =>
+  z.union([
+    z.object({ all: z.array(resolvedConditionNodeSchema).nonempty() }).strict(),
+    z.object({ any: z.array(resolvedConditionNodeSchema).nonempty() }).strict(),
+    z
+      .object({ none: z.array(resolvedConditionNodeSchema).nonempty() })
+      .strict(),
+    resolvedLeafConditionSchema,
+  ]),
+);
+
+// Backward-compat alias: `resolvedConditionSchema` previously meant a
+// single leaf; it now means any node in the tree (leaf or operator).
+const resolvedConditionSchema = resolvedConditionNodeSchema;
+
+// Field-level shape: array (implicit-`all` sugar) or a single node.
+// Mirrors `conditionsSchema` in treatment.ts.
+const resolvedConditionsSchema = z
+  .union([
+    z.array(resolvedConditionNodeSchema).nonempty(),
+    resolvedConditionNodeSchema,
+  ])
+  .optional();
 
 // ----------------------------------------------------------------
 // Resolved element — concrete type union, no placeholders

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -70,15 +70,34 @@ const resolvedLeafConditionSchema = z
 // or a leaf. After template fill, the same boolean tree is what
 // runtime/component code sees — no template placeholders, no string
 // shorthand quirks, just the structured form.
-const resolvedConditionNodeSchema: z.ZodType = z.lazy(() =>
-  z.union([
-    z.object({ all: z.array(resolvedConditionNodeSchema).nonempty() }).strict(),
-    z.object({ any: z.array(resolvedConditionNodeSchema).nonempty() }).strict(),
-    z
-      .object({ none: z.array(resolvedConditionNodeSchema).nonempty() })
-      .strict(),
-    resolvedLeafConditionSchema,
-  ]),
+//
+// The TS type is declared explicitly and threaded into `z.ZodType`'s
+// type parameter so `z.infer<typeof resolvedConditionSchema>`
+// resolves to the structured union rather than `any`. zod can't infer
+// the type from a `z.lazy(...)` body on its own — without the
+// annotation, every external consumer of `ResolvedConditionType`
+// would silently lose type safety.
+type ResolvedLeafCondition = z.infer<typeof resolvedLeafConditionSchema>;
+export type ResolvedConditionNode =
+  | { all: ResolvedConditionNode[] }
+  | { any: ResolvedConditionNode[] }
+  | { none: ResolvedConditionNode[] }
+  | ResolvedLeafCondition;
+
+const resolvedConditionNodeSchema: z.ZodType<ResolvedConditionNode> = z.lazy(
+  () =>
+    z.union([
+      z
+        .object({ all: z.array(resolvedConditionNodeSchema).nonempty() })
+        .strict(),
+      z
+        .object({ any: z.array(resolvedConditionNodeSchema).nonempty() })
+        .strict(),
+      z
+        .object({ none: z.array(resolvedConditionNodeSchema).nonempty() })
+        .strict(),
+      resolvedLeafConditionSchema,
+    ]),
 );
 
 // Backward-compat alias: `resolvedConditionSchema` previously meant a

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -71,38 +71,39 @@ const resolvedLeafConditionSchema = z
 // runtime/component code sees — no template placeholders, no string
 // shorthand quirks, just the structured form.
 //
-// The TS type is declared explicitly and threaded into `z.ZodType`'s
-// type parameter so `z.infer<typeof resolvedConditionSchema>`
-// resolves to the structured union rather than `any`. zod can't infer
-// the type from a `z.lazy(...)` body on its own — without the
-// annotation, every external consumer of `ResolvedConditionType`
-// would silently lose type safety.
-type ResolvedLeafCondition = z.infer<typeof resolvedLeafConditionSchema>;
-export type ResolvedConditionNode =
-  | { all: ResolvedConditionNode[] }
-  | { any: ResolvedConditionNode[] }
-  | { none: ResolvedConditionNode[] }
-  | ResolvedLeafCondition;
-
-const resolvedConditionNodeSchema: z.ZodType<ResolvedConditionNode> = z.lazy(
-  () =>
-    z.union([
-      z
-        .object({ all: z.array(resolvedConditionNodeSchema).nonempty() })
-        .strict(),
-      z
-        .object({ any: z.array(resolvedConditionNodeSchema).nonempty() })
-        .strict(),
-      z
-        .object({ none: z.array(resolvedConditionNodeSchema).nonempty() })
-        .strict(),
-      resolvedLeafConditionSchema,
-    ]),
+// The schema itself is untyped (`z.ZodType`) because the leaf's
+// `reference` field uses `referenceSchema`, which transforms a dotted
+// string into a string[] path — input and output types differ, and
+// `z.ZodType<T>` parameterized on a single type would force them
+// equal and break the dts build. The structural TS type
+// `ResolvedConditionNode` is exported separately for consumers that
+// want to type-narrow against the union; `ResolvedConditionType`
+// stays as a backward-compat alias.
+const resolvedConditionNodeSchema: z.ZodType = z.lazy(() =>
+  z.union([
+    z.object({ all: z.array(resolvedConditionNodeSchema).nonempty() }).strict(),
+    z.object({ any: z.array(resolvedConditionNodeSchema).nonempty() }).strict(),
+    z
+      .object({ none: z.array(resolvedConditionNodeSchema).nonempty() })
+      .strict(),
+    resolvedLeafConditionSchema,
+  ]),
 );
 
 // Backward-compat alias: `resolvedConditionSchema` previously meant a
 // single leaf; it now means any node in the tree (leaf or operator).
 const resolvedConditionSchema = resolvedConditionNodeSchema;
+
+// Structural TS type for the resolved boolean tree. Exposed so
+// consumers (host components, custom evaluators) can type their
+// `conditions` props as `ResolvedConditionNode | ResolvedConditionNode[]`
+// rather than falling through to `any` from the lazy schema.
+export type ResolvedConditionLeaf = z.infer<typeof resolvedLeafConditionSchema>;
+export type ResolvedConditionNode =
+  | { all: ResolvedConditionNode[] }
+  | { any: ResolvedConditionNode[] }
+  | { none: ResolvedConditionNode[] }
+  | ResolvedConditionLeaf;
 
 // Field-level shape: array (implicit-`all` sugar) or a single node.
 // Mirrors `conditionsSchema` in treatment.ts.
@@ -224,4 +225,8 @@ export type ResolvedTreatmentType = z.infer<typeof resolvedTreatmentSchema>;
 // ----------------------------------------------------------------
 
 export { resolvedConditionSchema, resolvedConditionsSchema };
-export type ResolvedConditionType = z.infer<typeof resolvedConditionSchema>;
+// `ResolvedConditionType` previously inferred from the leaf-only
+// schema; now aliases the structural tree type so consumers keep type
+// safety. (`z.infer` on the recursive `z.ZodType` lazy widens to
+// `any` — see the comment above `resolvedConditionNodeSchema`.)
+export type ResolvedConditionType = ResolvedConditionNode;

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -3,6 +3,7 @@ import { expect, test } from "vitest";
 import {
   referenceSchema,
   conditionSchema,
+  conditionsSchema,
   discussionSchema,
   elementsSchema,
   elementSchema,
@@ -1473,4 +1474,189 @@ test("introExitStepSchema rejects percentAgreement with a non-numeric comparator
     elements: [{ type: "submitButton" }],
   });
   expect(result.success).toBe(false);
+});
+
+// ----------- Boolean condition tree (#235) ------------
+
+const leaf = (value: string) => ({
+  reference: "prompt.q",
+  comparator: "equals" as const,
+  value,
+});
+
+test("conditionsSchema accepts the legacy flat-array form (backward compat)", () => {
+  const result = conditionsSchema.safeParse([leaf("a"), leaf("b")]);
+  expect(result.success).toBe(true);
+});
+
+test("conditionsSchema accepts an `all:` operator at the root", () => {
+  const result = conditionsSchema.safeParse({
+    all: [leaf("a"), leaf("b")],
+  });
+  expect(result.success).toBe(true);
+});
+
+test("conditionsSchema accepts an `any:` operator at the root", () => {
+  const result = conditionsSchema.safeParse({
+    any: [leaf("a"), leaf("b")],
+  });
+  expect(result.success).toBe(true);
+});
+
+test("conditionsSchema accepts a `none:` operator at the root", () => {
+  const result = conditionsSchema.safeParse({
+    none: [leaf("a"), leaf("b")],
+  });
+  expect(result.success).toBe(true);
+});
+
+test("conditionsSchema accepts a single leaf at the root (no array)", () => {
+  const result = conditionsSchema.safeParse(leaf("a"));
+  expect(result.success).toBe(true);
+});
+
+test("conditionsSchema accepts nested operators", () => {
+  const result = conditionsSchema.safeParse({
+    all: [{ any: [leaf("a"), leaf("b")] }, { none: [leaf("c")] }, leaf("d")],
+  });
+  expect(result.success).toBe(true);
+});
+
+test("conditionsSchema accepts deeply nested operators", () => {
+  // 3-deep nesting: all -> any -> none -> leaf
+  const result = conditionsSchema.safeParse({
+    all: [{ any: [{ none: [leaf("a")] }, leaf("b")] }],
+  });
+  expect(result.success).toBe(true);
+});
+
+test("conditionsSchema rejects empty `all:` array", () => {
+  const result = conditionsSchema.safeParse({ all: [] });
+  expect(result.success).toBe(false);
+});
+
+test("conditionsSchema rejects empty `any:` array", () => {
+  const result = conditionsSchema.safeParse({ any: [] });
+  expect(result.success).toBe(false);
+});
+
+test("conditionsSchema rejects empty `none:` array", () => {
+  const result = conditionsSchema.safeParse({ none: [] });
+  expect(result.success).toBe(false);
+});
+
+test("conditionsSchema rejects extra keys on operator object", () => {
+  // `.strict()` on the operator branches should reject
+  // `{all: [...], reference: ...}` etc. as ambiguous shapes.
+  const result = conditionsSchema.safeParse({
+    all: [leaf("a")],
+    reference: "prompt.q",
+  });
+  expect(result.success).toBe(false);
+});
+
+test("conditionsSchema suggests `all` for `al:` typo", () => {
+  const result = conditionsSchema.safeParse({ al: [leaf("a")] });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find((i) =>
+      i.message.includes('Did you mean "all"'),
+    );
+    expect(issue).toBeDefined();
+  }
+});
+
+test("conditionsSchema suggests `any` for `anny:` typo", () => {
+  const result = conditionsSchema.safeParse({ anny: [leaf("a")] });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find((i) =>
+      i.message.includes('Did you mean "any"'),
+    );
+    expect(issue).toBeDefined();
+  }
+});
+
+test("conditionsSchema suggests `none` for `nones:` typo", () => {
+  const result = conditionsSchema.safeParse({ nones: [leaf("a")] });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find((i) =>
+      i.message.includes('Did you mean "none"'),
+    );
+    expect(issue).toBeDefined();
+  }
+});
+
+test("conditionsSchema doesn't false-positive a leaf as a typo", () => {
+  // A leaf has `reference` and `comparator` keys — the typo heuristic
+  // should skip it (no "did you mean ..." for `reference`).
+  const result = conditionsSchema.safeParse(leaf("a"));
+  expect(result.success).toBe(true);
+});
+
+test("stageSchema accepts boolean-tree conditions", () => {
+  const result = stageSchema.safeParse({
+    name: "stage1",
+    duration: 60,
+    conditions: {
+      any: [
+        {
+          reference: "prompt.consent",
+          position: 0,
+          comparator: "equals",
+          value: "yes",
+        },
+        {
+          reference: "prompt.consent",
+          position: 1,
+          comparator: "equals",
+          value: "yes",
+        },
+      ],
+    },
+    elements: [{ type: "submitButton" }],
+  });
+  expect(result.success).toBe(true);
+});
+
+test("validateConditionRules recurses into operator branches (game-stage forbidSelfPosition)", () => {
+  // A nested `any:` containing a leaf without `position` (default
+  // "player") should be rejected by the game-stage rule.
+  const result = stageSchema.safeParse({
+    name: "stage1",
+    duration: 60,
+    conditions: {
+      any: [
+        {
+          reference: "prompt.q",
+          comparator: "equals",
+          value: "yes",
+          // position omitted — defaults to "player", forbidden at
+          // game-stage level
+        },
+      ],
+    },
+    elements: [{ type: "submitButton" }],
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find((i) =>
+      i.message.includes("cross-client position"),
+    );
+    expect(issue).toBeDefined();
+  }
+});
+
+test("conditionSchema (single node) accepts a leaf", () => {
+  // Backward-compat: `conditionSchema` previously meant a leaf; it
+  // now means any tree node (leaf or operator). Existing leaf inputs
+  // still validate.
+  const result = conditionSchema.safeParse(leaf("a"));
+  expect(result.success).toBe(true);
+});
+
+test("conditionSchema (single node) accepts an operator node", () => {
+  const result = conditionSchema.safeParse({ all: [leaf("a")] });
+  expect(result.success).toBe(true);
 });

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -672,26 +672,74 @@ const conditionIsNotOneOfSchema = baseConditionSchema
   })
   .strict();
 
-export const conditionSchema = altTemplateContext(
-  z.discriminatedUnion("comparator", [
-    conditionExistsSchema,
-    conditionDoesNotExistSchema,
-    conditionEqualsSchema,
-    conditionDoesNotEqualSchema,
-    conditionIsAboveSchema,
-    conditionIsBelowSchema,
-    conditionIsAtLeastSchema,
-    conditionIsAtMostSchema,
-    conditionHasLengthAtLeastSchema,
-    conditionHasLengthAtMostSchema,
-    conditionIncludesSchema,
-    conditionDoesNotIncludeSchema,
-    conditionMatchesSchema,
-    conditionDoesNotMatchSchema,
-    conditionIsOneOfSchema,
-    conditionIsNotOneOfSchema,
-  ]),
+// Leaf form of a condition: an object with a `comparator` plus the
+// reference/position/value triple. This is what the boolean tree's
+// `all`/`any`/`none` operator branches eventually bottom out at.
+const leafConditionSchema = z.discriminatedUnion("comparator", [
+  conditionExistsSchema,
+  conditionDoesNotExistSchema,
+  conditionEqualsSchema,
+  conditionDoesNotEqualSchema,
+  conditionIsAboveSchema,
+  conditionIsBelowSchema,
+  conditionIsAtLeastSchema,
+  conditionIsAtMostSchema,
+  conditionHasLengthAtLeastSchema,
+  conditionHasLengthAtMostSchema,
+  conditionIncludesSchema,
+  conditionDoesNotIncludeSchema,
+  conditionMatchesSchema,
+  conditionDoesNotMatchSchema,
+  conditionIsOneOfSchema,
+  conditionIsNotOneOfSchema,
+]);
+
+// Recursive boolean-tree node (#235). A condition is either:
+//   - an `all: [...]`, `any: [...]`, or `none: [...]` operator node
+//     whose children are themselves nodes (recurses), or
+//   - a leaf (`comparator`-typed condition object).
+// The operator branches are `.strict()` so combinations like
+// `{all: [...], reference: ...}` fail loudly. `.nonempty()` rejects
+// `all: []` etc. — vacuous truth on an empty operator is an
+// author-error shape worth catching at preflight.
+//
+// `z.lazy` is required because the operator schemas reference
+// `conditionNodeSchema` recursively; the outer `altTemplateContext`
+// wrapper preserves `template:` invocation support at any tree level.
+//
+// `OPERATOR_KEYS` is exported so the typo-detection superRefine in
+// `conditionsSchema` can show "did you mean `all`?" suggestions; keep
+// it in sync with the operator branches in the union below.
+export const OPERATOR_KEYS = ["all", "any", "none"] as const;
+
+export const conditionNodeSchema: z.ZodType = z.lazy(() =>
+  altTemplateContext(
+    z.union([
+      z
+        .object({
+          all: z.array(conditionNodeSchema).nonempty(),
+        })
+        .strict(),
+      z
+        .object({
+          any: z.array(conditionNodeSchema).nonempty(),
+        })
+        .strict(),
+      z
+        .object({
+          none: z.array(conditionNodeSchema).nonempty(),
+        })
+        .strict(),
+      leafConditionSchema,
+    ]),
+  ),
 );
+
+// Backward-compat alias: `conditionSchema` previously meant "a single
+// condition object." It now means "any node in the boolean tree" (leaf
+// or operator). Existing callers that expect a leaf still work for
+// leaf inputs; new callers can pass operator nodes too.
+export const conditionSchema = conditionNodeSchema;
 
 // Comparators that compare numeric magnitudes — the only ones that make
 // sense with `position: percentAgreement`, where the referenced value is
@@ -776,10 +824,17 @@ function validateTimelineSources(
 }
 
 /**
- * Apply cross-cutting rules to a list of conditions (stage-level or
- * element-level). Adds zod issues for each violation found; called from
- * stage/intro-exit superRefines so we can point issue paths at the
- * condition's actual location in the parent object.
+ * Apply cross-cutting rules to a condition tree (stage-level or
+ * element-level). Adds zod issues for each violation found; called
+ * from stage/intro-exit superRefines so we can point issue paths at
+ * the condition's actual location in the parent object.
+ *
+ * Walks the boolean tree (#235): if `conditions` is an array, treats
+ * it as the implicit-`all` sugar; if it's an `{all|any|none: [...]}`
+ * operator object, recurses through the children; if it's a leaf, the
+ * per-leaf rules apply directly. Templates (`{template: ...}` nodes)
+ * are skipped — they're checked after expansion against the resolved
+ * shape, not pre-expansion.
  */
 function validateConditionRules(
   conditions: unknown,
@@ -787,63 +842,155 @@ function validateConditionRules(
   ctx: z.RefinementCtx,
   options: { contextLabel: string; forbidSelfPosition: boolean },
 ): void {
-  if (!Array.isArray(conditions)) return;
-  conditions.forEach((rawCondition: unknown, idx: number) => {
-    if (!rawCondition || typeof rawCondition !== "object") return;
-    const c = rawCondition as {
-      position?: unknown;
-      comparator?: unknown;
-      value?: unknown;
-    };
+  if (conditions === undefined || conditions === null) return;
 
-    // `percentAgreement` aggregates the referenced values and compares
-    // the agreement percentage against `value`. Non-numeric comparators
-    // (equals, includes, matches, …) silently produce wrong results.
-    if (
-      c.position === "percentAgreement" &&
-      typeof c.comparator === "string" &&
-      !PERCENT_AGREEMENT_NUMERIC_COMPARATORS.has(c.comparator)
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: [...pathPrefix, idx, "comparator"],
-        message: `position: percentAgreement requires a numeric comparator (isAbove, isBelow, isAtLeast, isAtMost) — got "${c.comparator}". The comparator is applied to the percentage of agreement, not the raw response.`,
+  // Implicit-all sugar: a top-level array iterates each child as a
+  // sibling node (no `all` index in the path).
+  if (Array.isArray(conditions)) {
+    conditions.forEach((child, idx) => {
+      validateConditionRules(child, [...pathPrefix, idx], ctx, options);
+    });
+    return;
+  }
+
+  if (typeof conditions !== "object") return;
+  const node = conditions as Record<string, unknown>;
+
+  // Operator nodes: recurse into their children, scoping the path
+  // prefix with the operator key + child index.
+  for (const op of OPERATOR_KEYS) {
+    const children = node[op];
+    if (Array.isArray(children)) {
+      children.forEach((child, idx) => {
+        validateConditionRules(child, [...pathPrefix, op, idx], ctx, options);
       });
+      return;
     }
+  }
 
-    // Game-stage conditions must evaluate identically on every client or
-    // they'll desync (one player skips, the other renders). The default
-    // position is "player", which reads this participant's own data — so
-    // we reject both missing and explicitly "player".
-    if (
-      options.forbidSelfPosition &&
-      (c.position === undefined ||
-        (typeof c.position === "string" &&
-          GAME_STAGE_FORBIDDEN_POSITIONS.has(c.position)))
-    ) {
-      const shown =
-        c.position === undefined
-          ? "(default: player)"
-          : `"${String(c.position)}"`;
+  // Skip template invocations — content unknown until expansion.
+  if ("template" in node) return;
+
+  // Leaf condition: apply the per-leaf rules. The path prefix already
+  // points at the condition's location.
+  const c = node as {
+    position?: unknown;
+    comparator?: unknown;
+    value?: unknown;
+  };
+
+  // `percentAgreement` aggregates the referenced values and compares
+  // the agreement percentage against `value`. Non-numeric comparators
+  // (equals, includes, matches, …) silently produce wrong results.
+  if (
+    c.position === "percentAgreement" &&
+    typeof c.comparator === "string" &&
+    !PERCENT_AGREEMENT_NUMERIC_COMPARATORS.has(c.comparator)
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [...pathPrefix, "comparator"],
+      message: `position: percentAgreement requires a numeric comparator (isAbove, isBelow, isAtLeast, isAtMost) — got "${c.comparator}". The comparator is applied to the percentage of agreement, not the raw response.`,
+    });
+  }
+
+  // Game-stage conditions must evaluate identically on every client or
+  // they'll desync (one player skips, the other renders). The default
+  // position is "player", which reads this participant's own data — so
+  // we reject both missing and explicitly "player".
+  if (
+    options.forbidSelfPosition &&
+    (c.position === undefined ||
+      (typeof c.position === "string" &&
+        GAME_STAGE_FORBIDDEN_POSITIONS.has(c.position)))
+  ) {
+    const shown =
+      c.position === undefined
+        ? "(default: player)"
+        : `"${String(c.position)}"`;
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: [...pathPrefix, "position"],
+      message: `${options.contextLabel} conditions must use a cross-client position (shared, all, any, percentAgreement, or a numeric index) — got ${shown}. Per-player positions would let one participant skip the stage while the other renders it.`,
+    });
+  }
+}
+
+// Field-level conditions schema (#235): accepts either a flat array
+// (sugar for `all: [...]`) or a single node (operator or leaf).
+//
+// The pre-validation `superRefine` runs first to catch the most common
+// authoring mistake — typos in operator-keyed nodes — before zod's
+// union dispatch turns them into a confusing "didn't match any branch"
+// error. Without this, writing `al: [...]` or `ANY: [...]` produces a
+// pile of schema-mismatch errors instead of "did you mean `all`?".
+const conditionsRawSchema = z
+  .union([z.array(conditionNodeSchema).nonempty(), conditionNodeSchema], {
+    required_error:
+      "Expected an array of conditions, or an `all`/`any`/`none` operator object, or a single condition.",
+    invalid_type_error:
+      "Expected an array of conditions, or an `all`/`any`/`none` operator object, or a single condition.",
+  })
+  .superRefine((data, ctx) => {
+    // Pre-scan for operator-key typos on object inputs only. If the
+    // user wrote a single object (not an array) and its keys look like
+    // a near-miss for `all`/`any`/`none`, emit a hint *before* the
+    // union's per-branch errors swamp the output.
+    if (Array.isArray(data) || data === null || typeof data !== "object") {
+      return;
+    }
+    const keys = Object.keys(data);
+    if (keys.length !== 1) return;
+    const key = keys[0];
+    if ((OPERATOR_KEYS as readonly string[]).includes(key)) return;
+    // Skip leaf conditions (have `comparator`) and template invocations
+    // (have `template`).
+    if (key === "comparator" || key === "template" || key === "reference") {
+      return;
+    }
+    // Heuristic: lowercase prefix overlap with an operator. Catches
+    // `al`, `ALL`, `any:`, `nones`, etc.
+    const lower = key.toLowerCase();
+    const suggestion = OPERATOR_KEYS.find(
+      (op) =>
+        op.startsWith(lower) ||
+        lower.startsWith(op) ||
+        levenshtein(op, lower) <= 1,
+    );
+    if (suggestion) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: [...pathPrefix, idx, "position"],
-        message: `${options.contextLabel} conditions must use a cross-client position (shared, all, any, percentAgreement, or a numeric index) — got ${shown}. Per-player positions would let one participant skip the stage while the other renders it.`,
+        path: [],
+        message: `Unrecognized condition operator "${key}". Did you mean "${suggestion}"? Boolean operators are "all", "any", and "none".`,
       });
     }
   });
+
+export const conditionsSchema = altTemplateContext(conditionsRawSchema);
+
+// One-edit Levenshtein distance — small enough to inline rather than
+// pull in a dependency. Used by the typo heuristic above.
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (Math.abs(a.length - b.length) > 1) return 2;
+  const dp: number[][] = Array.from({ length: a.length + 1 }, () =>
+    new Array<number>(b.length + 1).fill(0),
+  );
+  for (let i = 0; i <= a.length; i++) dp[i][0] = i;
+  for (let j = 0; j <= b.length; j++) dp[0][j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      dp[i][j] = Math.min(
+        dp[i - 1][j] + 1,
+        dp[i][j - 1] + 1,
+        dp[i - 1][j - 1] + cost,
+      );
+    }
+  }
+  return dp[a.length][b.length];
 }
 
-export const conditionsSchema = altTemplateContext(
-  z
-    .array(conditionSchema, {
-      required_error:
-        "Expected an array for `conditions`. Make sure each item starts with a dash (`-`) in YAML.",
-      invalid_type_error:
-        "Expected an array for `conditions`. Make sure each item starts with a dash (`-`) in YAML.",
-    })
-    .nonempty(),
-);
 export type ConditionType = z.infer<typeof conditionSchema>;
 
 // ------------------ Players ------------------ //
@@ -852,12 +999,12 @@ export const playerSchema = z
   .object({
     position: positionSchema,
     title: z.string().max(25).optional(),
-    conditions: z
-      .array(conditionSchema, {
-        invalid_type_error:
-          "Expected an array for `conditions`. Make sure each item starts with a dash (`-`) in YAML.",
-      })
-      .optional(),
+    // Use `conditionsSchema` so player-block eligibility conditions
+    // accept the same forms as every other condition site (#235):
+    // flat array (implicit `all`), or `all`/`any`/`none` operator
+    // node, or a single leaf. Existing flat-array authored conditions
+    // continue to validate unchanged.
+    conditions: conditionsSchema.optional(),
   })
   .strict();
 export type PlayerType = z.infer<typeof playerSchema>;

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -707,10 +707,17 @@ const leafConditionSchema = z.discriminatedUnion("comparator", [
 // `conditionNodeSchema` recursively; the outer `altTemplateContext`
 // wrapper preserves `template:` invocation support at any tree level.
 //
-// `OPERATOR_KEYS` is exported so the typo-detection superRefine in
-// `conditionsSchema` can show "did you mean `all`?" suggestions; keep
-// it in sync with the operator branches in the union below.
-export const OPERATOR_KEYS = ["all", "any", "none"] as const;
+// `OPERATOR_KEYS` is the source-of-truth list of boolean-tree
+// operator names, used by the typo-detection superRefine in
+// `conditionsSchema` (below) and by the walker in
+// `validateReferences.ts`. Defined in `conditionOperators.ts` to
+// avoid an import cycle: `treatment.ts` imports
+// `validateReferences.ts` for the cross-stage reference walker, so
+// the shared list has to live in a third module both can import
+// from. Re-exported here as part of the schemas package's public
+// surface.
+export { OPERATOR_KEYS, type OperatorKey } from "./conditionOperators.js";
+import { OPERATOR_KEYS } from "./conditionOperators.js";
 
 export const conditionNodeSchema: z.ZodType = z.lazy(() =>
   altTemplateContext(

--- a/packages/stagebook/src/schemas/validateReferences.test.ts
+++ b/packages/stagebook/src/schemas/validateReferences.test.ts
@@ -933,6 +933,180 @@ describe("Rule 2 — stage-level always-skip-at-load (current-stage refs only)",
   });
 });
 
+describe("Rule 2 with boolean-tree operators (#235)", () => {
+  // Rule 2's per-leaf simulation is sound only when the leaf is reached
+  // without traversing `any:` or `none:`. Inside those operators a
+  // single non-true leaf doesn't doom the tree (a sibling can carry
+  // it). The implementation gates Rule 2 on a path-traversal check.
+
+  test("flat-array (implicit-all) leaf still triggers Rule 2 — backward compat", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          conditions: [
+            {
+              reference: "prompt.q",
+              comparator: "equals",
+              value: "yes",
+              position: "shared",
+            },
+          ],
+          elements: [
+            { type: "prompt", name: "q", file: "q.prompt.md" },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    const hit = issues.find((i) =>
+      /always skip the stage at load/i.test(i.message),
+    );
+    expect(hit).toBeDefined();
+  });
+
+  test("explicit `all:` operator leaf still triggers Rule 2 (`all` is equivalent to flat array)", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          conditions: {
+            all: [
+              {
+                reference: "prompt.q",
+                comparator: "equals",
+                value: "yes",
+                position: "shared",
+              },
+            ],
+          } as unknown as Record<string, unknown>[],
+          elements: [
+            { type: "prompt", name: "q", file: "q.prompt.md" },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    const hit = issues.find((i) =>
+      /always skip the stage at load/i.test(i.message),
+    );
+    expect(hit).toBeDefined();
+  });
+
+  test("leaf inside `any:` does NOT trigger Rule 2 (sibling can carry the operator)", () => {
+    // `any: [{equals: yes}, {equals: yes}]` evaluates to undefined at
+    // load (both children unknown), but a sibling becoming true would
+    // flip the operator true. Rule 2's per-leaf simulation can't see
+    // the sibling, so it conservatively skips this case rather than
+    // false-positiving.
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          conditions: {
+            any: [
+              {
+                reference: "prompt.q",
+                comparator: "equals",
+                value: "yes",
+                position: "shared",
+              },
+              {
+                reference: "prompt.r",
+                comparator: "equals",
+                value: "yes",
+                position: "shared",
+              },
+            ],
+          } as unknown as Record<string, unknown>[],
+          elements: [
+            { type: "prompt", name: "q", file: "q.prompt.md" },
+            { type: "prompt", name: "r", file: "r.prompt.md" },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    const hit = issues.find((i) =>
+      /always skip the stage at load/i.test(i.message),
+    );
+    expect(hit).toBeUndefined();
+  });
+
+  test("leaf inside `none:` does NOT trigger Rule 2", () => {
+    // Same reasoning: `none: [{equals: yes}]` is the canonical
+    // "render-until-somebody-answers" pattern; the leaf isn't true at
+    // load but the operator wraps the semantics.
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          conditions: {
+            none: [
+              {
+                reference: "prompt.q",
+                comparator: "equals",
+                value: "yes",
+                position: "shared",
+              },
+            ],
+          } as unknown as Record<string, unknown>[],
+          elements: [
+            { type: "prompt", name: "q", file: "q.prompt.md" },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    const hit = issues.find((i) =>
+      /always skip the stage at load/i.test(i.message),
+    );
+    expect(hit).toBeUndefined();
+  });
+
+  test("leaf inside nested `all > any` does NOT trigger Rule 2 (path traverses non-all operator)", () => {
+    const file = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          conditions: {
+            all: [
+              {
+                any: [
+                  {
+                    reference: "prompt.q",
+                    comparator: "equals",
+                    value: "yes",
+                    position: "shared",
+                  },
+                ],
+              },
+            ],
+          } as unknown as Record<string, unknown>[],
+          elements: [
+            { type: "prompt", name: "q", file: "q.prompt.md" },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    const issues = validateTreatmentFileReferences(file);
+    const hit = issues.find((i) =>
+      /always skip the stage at load/i.test(i.message),
+    );
+    expect(hit).toBeUndefined();
+  });
+});
+
 describe("treatmentFileSchema surfaces walker issues via superRefine (red-squiggle path)", () => {
   test("forward reference produces a zod issue whose path targets the reference", () => {
     const file = baseFile({

--- a/packages/stagebook/src/schemas/validateReferences.ts
+++ b/packages/stagebook/src/schemas/validateReferences.ts
@@ -21,6 +21,7 @@
 
 import { getReferenceKeyAndPath } from "../utils/reference.js";
 import { compare, type Comparator } from "../utils/compare.js";
+import { OPERATOR_KEYS } from "./treatment.js";
 
 /** Structured issue emitted by the walker. Translated to zod issues by the
  *  caller. `path` is relative to the top-level treatment file. */
@@ -65,6 +66,54 @@ const STAGE_PRODUCED_REF_TYPES = new Set([
   "timeline",
   "trackedLink",
 ]);
+
+/**
+ * Walk a `conditions:` value (#235) and yield each leaf condition with
+ * its absolute path. Handles all three shapes the boolean tree accepts:
+ *
+ *   - Array (sugar for implicit `all`): yields each child's leaves with
+ *     the array index in the path.
+ *   - Operator object (`{all|any|none: [...]}`): recurses into the
+ *     children, scoping the path with the operator key + child index.
+ *   - Leaf (anything with `comparator`, or a non-operator/template
+ *     object): yields itself.
+ *
+ * Template invocations (`{template: ...}`) are skipped — content
+ * unknown until expansion. The walker is "best-effort" because it
+ * runs pre-validation (`superRefine` input is partially-valid), so
+ * malformed shapes are silently dropped rather than throwing.
+ */
+function* walkConditionLeaves(
+  conditions: unknown,
+  pathPrefix: (string | number)[],
+): Generator<{ leaf: Record<string, unknown>; path: (string | number)[] }> {
+  if (conditions === undefined || conditions === null) return;
+
+  if (Array.isArray(conditions)) {
+    for (let i = 0; i < conditions.length; i++) {
+      yield* walkConditionLeaves(conditions[i], [...pathPrefix, i]);
+    }
+    return;
+  }
+
+  if (!isRecord(conditions)) return;
+  const node = conditions;
+
+  for (const op of OPERATOR_KEYS) {
+    const children = node[op];
+    if (Array.isArray(children)) {
+      for (let i = 0; i < children.length; i++) {
+        yield* walkConditionLeaves(children[i], [...pathPrefix, op, i]);
+      }
+      return;
+    }
+  }
+
+  // Template invocation — skip until expansion.
+  if ("template" in node) return;
+
+  yield { leaf: node, path: pathPrefix };
+}
 
 /**
  * Main entrypoint — given a parsed treatment-file tree, walks every reference
@@ -261,34 +310,31 @@ function validateTreatment({
   const groupComposition = toArray(treatment.groupComposition);
   groupComposition.forEach((player, playerIdx) => {
     if (!isRecord(player)) return;
-    const conditions = toArray(player.conditions);
-    conditions.forEach((cond, condIdx) => {
-      if (!isRecord(cond)) return;
-      const ref = cond.reference;
-      if (typeof ref !== "string") return;
-      const site = {
-        reference: ref,
-        kind: "groupComposition" as const,
-        path: [
-          ...treatmentPath,
-          "groupComposition",
-          playerIdx,
-          "conditions",
-          condIdx,
-          "reference",
-        ],
-      };
+    const conditionsBase = [
+      ...treatmentPath,
+      "groupComposition",
+      playerIdx,
+      "conditions",
+    ];
+    for (const { leaf, path } of walkConditionLeaves(
+      player.conditions,
+      conditionsBase,
+    )) {
+      const ref = leaf.reference;
+      if (typeof ref !== "string") continue;
       applyRules({
-        site,
+        site: {
+          reference: ref,
+          kind: "groupComposition" as const,
+          path: [...path, "reference"],
+        },
         enclosingRank: RANK_GROUP_COMPOSITION,
         producedAt,
         issues,
-        // groupComposition's rule: target must be intro-phase or external.
-        // Pass intro keys as the only valid phase.
         allowedProducerRanks: new Set([RANK_INTRO]),
         globalProducedKeys,
       });
-    });
+    }
   });
 
   // Game stages
@@ -309,22 +355,18 @@ function validateTreatment({
     // Discussion conditions nested under the stage
     const discussion = stage.discussion;
     if (isRecord(discussion)) {
-      const discConds = toArray(discussion.conditions);
-      discConds.forEach((cond, condIdx) => {
-        if (!isRecord(cond)) return;
-        const ref = cond.reference;
-        if (typeof ref !== "string") return;
+      for (const { leaf, path } of walkConditionLeaves(discussion.conditions, [
+        ...stagePath,
+        "discussion",
+        "conditions",
+      ])) {
+        const ref = leaf.reference;
+        if (typeof ref !== "string") continue;
         applyRules({
           site: {
             reference: ref,
             kind: "discussionCondition",
-            path: [
-              ...stagePath,
-              "discussion",
-              "conditions",
-              condIdx,
-              "reference",
-            ],
+            path: [...path, "reference"],
           },
           enclosingRank: rank,
           producedAt,
@@ -332,7 +374,7 @@ function validateTreatment({
           phaseLabel: "game stage",
           globalProducedKeys,
         });
-      });
+      }
     }
   });
 
@@ -372,6 +414,10 @@ interface RefSite {
  *  urlParam refs. Discussion conditions are handled separately at the
  *  stage walker (they live on `stage.discussion.conditions`, not on an
  *  element).
+ *
+ *  Conditions can be a flat array (implicit `all`), an `all`/`any`/`none`
+ *  operator object, or a single leaf — `walkConditionLeaves` flattens
+ *  the tree and yields each leaf with its absolute path.
  */
 function enumerateStepSites(
   step: unknown,
@@ -381,20 +427,21 @@ function enumerateStepSites(
   if (!isRecord(step)) return sites;
 
   // Stage-level conditions
-  const stepConditions = toArray(step.conditions);
-  stepConditions.forEach((cond, condIdx) => {
-    if (!isRecord(cond)) return;
-    const ref = cond.reference;
-    if (typeof ref !== "string") return;
+  for (const { leaf, path } of walkConditionLeaves(step.conditions, [
+    ...stepPath,
+    "conditions",
+  ])) {
+    const ref = leaf.reference;
+    if (typeof ref !== "string") continue;
     sites.push({
       reference: ref,
       kind: "stageCondition",
-      path: [...stepPath, "conditions", condIdx, "reference"],
+      path: [...path, "reference"],
       comparator:
-        typeof cond.comparator === "string" ? cond.comparator : undefined,
-      value: cond.value,
+        typeof leaf.comparator === "string" ? leaf.comparator : undefined,
+      value: leaf.value,
     });
-  });
+  }
 
   // Element-level sites
   const elements = toArray(step.elements);
@@ -404,17 +451,18 @@ function enumerateStepSites(
     const elemType = element.type;
 
     // conditions on any element
-    const elemConditions = toArray(element.conditions);
-    elemConditions.forEach((cond, condIdx) => {
-      if (!isRecord(cond)) return;
-      const ref = cond.reference;
-      if (typeof ref !== "string") return;
+    for (const { leaf, path } of walkConditionLeaves(element.conditions, [
+      ...elemPath,
+      "conditions",
+    ])) {
+      const ref = leaf.reference;
+      if (typeof ref !== "string") continue;
       sites.push({
         reference: ref,
         kind: "elementCondition",
-        path: [...elemPath, "conditions", condIdx, "reference"],
+        path: [...path, "reference"],
       });
-    });
+    }
 
     // display element: its own top-level `reference` field
     if (elemType === "display" && typeof element.reference === "string") {
@@ -546,10 +594,26 @@ function applyRules({
 
   // Rule 2 — stage-level "always-skip at load". Only applies to
   // stageCondition sites whose reference points at the *current* stage.
+  //
+  // Restriction (#235): the per-leaf simulation is only sound when the
+  // leaf is reached without traversing an `any:` or `none:` operator.
+  // Inside those operators a single non-true leaf doesn't doom the
+  // tree (a sibling can carry the operator to true), so flagging it
+  // would false-positive on perfectly valid authoring patterns. `all:`
+  // is equivalent to the flat-array sugar, so leaves inside `all:` are
+  // fair game.
+  //
+  // A future improvement: full tree simulation that replaces every
+  // current-stage leaf with `compare(undefined, …)` and evaluates the
+  // whole tri-state tree, flagging only when the result is strictly
+  // not-true. For now the conservative path-check below avoids
+  // false-positives at the cost of missing some legitimate
+  // always-skip-at-load patterns inside `any:`/`none:`.
   if (
     site.kind === "stageCondition" &&
     producerRank === enclosingRank &&
-    site.comparator !== undefined
+    site.comparator !== undefined &&
+    !pathTraversesNonAllOperator(site.path)
   ) {
     const result = compare(
       undefined,
@@ -563,6 +627,15 @@ function applyRules({
       });
     }
   }
+}
+
+/** True if the path passes through an `any:` or `none:` operator key
+ *  (not `all:`, since `all:` is semantically equivalent to the flat
+ *  array sugar). Used to gate Rule 2 (always-skip-at-load) so leaves
+ *  nested inside `any`/`none` operators don't false-positive — a
+ *  single non-true leaf there can be carried to true by siblings. */
+function pathTraversesNonAllOperator(path: (string | number)[]): boolean {
+  return path.some((seg) => seg === "any" || seg === "none");
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/stagebook/src/schemas/validateReferences.ts
+++ b/packages/stagebook/src/schemas/validateReferences.ts
@@ -21,7 +21,10 @@
 
 import { getReferenceKeyAndPath } from "../utils/reference.js";
 import { compare, type Comparator } from "../utils/compare.js";
-import { OPERATOR_KEYS } from "./treatment.js";
+// Imported from a sibling module (not `./treatment.js`) to avoid an
+// import cycle — `treatment.ts` imports this file for the cross-stage
+// reference walker.
+import { OPERATOR_KEYS } from "./conditionOperators.js";
 
 /** Structured issue emitted by the walker. Translated to zod issues by the
  *  caller. `path` is relative to the top-level treatment file. */

--- a/packages/stagebook/src/utils/evaluateConditions.test.ts
+++ b/packages/stagebook/src/utils/evaluateConditions.test.ts
@@ -540,3 +540,394 @@ describe("evaluateConditions", () => {
     ]);
   });
 });
+
+// --------------- Boolean tree (#235) ---------------
+
+describe("evaluateConditions — boolean tree (#235)", () => {
+  // Resolver helper: looks up reference name in a fixture map; returns
+  // an empty array for unknown references so the leaf evaluator's
+  // "no data → undefined" path triggers.
+  const makeResolve =
+    (data: Record<string, unknown[]>) =>
+    (reference: string): unknown[] =>
+      data[reference] ?? [];
+
+  describe("array form (implicit all)", () => {
+    test("empty array returns true (no gate)", () => {
+      expect(evaluateConditions([], makeResolve({}))).toBe(true);
+    });
+
+    test("single leaf in array", () => {
+      const resolve = makeResolve({ "prompt.q": ["yes"] });
+      expect(
+        evaluateConditions(
+          [{ reference: "prompt.q", comparator: "equals", value: "yes" }],
+          resolve,
+        ),
+      ).toBe(true);
+    });
+
+    test("multiple leaves AND together", () => {
+      const resolve = makeResolve({
+        "prompt.a": ["x"],
+        "prompt.b": ["y"],
+      });
+      expect(
+        evaluateConditions(
+          [
+            { reference: "prompt.a", comparator: "equals", value: "x" },
+            { reference: "prompt.b", comparator: "equals", value: "y" },
+          ],
+          resolve,
+        ),
+      ).toBe(true);
+    });
+
+    test("any leaf failing makes the array false", () => {
+      const resolve = makeResolve({
+        "prompt.a": ["x"],
+        "prompt.b": ["wrong"],
+      });
+      expect(
+        evaluateConditions(
+          [
+            { reference: "prompt.a", comparator: "equals", value: "x" },
+            { reference: "prompt.b", comparator: "equals", value: "y" },
+          ],
+          resolve,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("all operator", () => {
+    test("all children true → true", () => {
+      const resolve = makeResolve({
+        "prompt.a": ["x"],
+        "prompt.b": ["y"],
+      });
+      expect(
+        evaluateConditions(
+          {
+            all: [
+              { reference: "prompt.a", comparator: "equals", value: "x" },
+              { reference: "prompt.b", comparator: "equals", value: "y" },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(true);
+    });
+
+    test("any child false → false", () => {
+      const resolve = makeResolve({
+        "prompt.a": ["x"],
+        "prompt.b": ["wrong"],
+      });
+      expect(
+        evaluateConditions(
+          {
+            all: [
+              { reference: "prompt.a", comparator: "equals", value: "x" },
+              { reference: "prompt.b", comparator: "equals", value: "y" },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(false);
+    });
+
+    test("all data missing → undefined → false at boundary", () => {
+      // No data resolved for either reference. Each leaf is undefined
+      // (tri-state). `all` over [undefined, undefined] is undefined,
+      // which collapses to false at the public boundary.
+      const resolve = makeResolve({});
+      expect(
+        evaluateConditions(
+          {
+            all: [
+              { reference: "prompt.a", comparator: "equals", value: "x" },
+              { reference: "prompt.b", comparator: "equals", value: "y" },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("any operator", () => {
+    test("at least one child true → true", () => {
+      const resolve = makeResolve({
+        "prompt.a": ["wrong"],
+        "prompt.b": ["y"],
+      });
+      expect(
+        evaluateConditions(
+          {
+            any: [
+              { reference: "prompt.a", comparator: "equals", value: "x" },
+              { reference: "prompt.b", comparator: "equals", value: "y" },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(true);
+    });
+
+    test("all children false → false", () => {
+      const resolve = makeResolve({
+        "prompt.a": ["wrong"],
+        "prompt.b": ["wrong"],
+      });
+      expect(
+        evaluateConditions(
+          {
+            any: [
+              { reference: "prompt.a", comparator: "equals", value: "x" },
+              { reference: "prompt.b", comparator: "equals", value: "y" },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(false);
+    });
+
+    test("all children unknown → undefined → false at boundary", () => {
+      const resolve = makeResolve({});
+      expect(
+        evaluateConditions(
+          {
+            any: [
+              { reference: "prompt.a", comparator: "equals", value: "x" },
+              { reference: "prompt.b", comparator: "equals", value: "y" },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("none operator (the case that requires tri-state)", () => {
+    test("all children false → true", () => {
+      const resolve = makeResolve({
+        "prompt.a": ["wrong"],
+        "prompt.b": ["wrong"],
+      });
+      expect(
+        evaluateConditions(
+          {
+            none: [
+              { reference: "prompt.a", comparator: "equals", value: "x" },
+              { reference: "prompt.b", comparator: "equals", value: "y" },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(true);
+    });
+
+    test("any child true → false", () => {
+      const resolve = makeResolve({
+        "prompt.a": ["x"],
+        "prompt.b": ["wrong"],
+      });
+      expect(
+        evaluateConditions(
+          {
+            none: [
+              { reference: "prompt.a", comparator: "equals", value: "x" },
+              { reference: "prompt.b", comparator: "equals", value: "y" },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(false);
+    });
+
+    test("all children unknown → undefined → false (tri-state guard)", () => {
+      // This is the pivotal test: with two-valued logic, `none:` over
+      // unknown leaves would return true (no children are explicitly
+      // true), causing fallback elements to render before any
+      // participant has answered. Tri-state semantics catch this — the
+      // unknown propagates through `none` and collapses to false at the
+      // boundary.
+      const resolve = makeResolve({});
+      expect(
+        evaluateConditions(
+          {
+            none: [
+              { reference: "prompt.a", comparator: "equals", value: "x" },
+              { reference: "prompt.b", comparator: "equals", value: "y" },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(false);
+    });
+
+    test("one child known false, one unknown → undefined → false", () => {
+      const resolve = makeResolve({ "prompt.a": ["wrong"] });
+      expect(
+        evaluateConditions(
+          {
+            none: [
+              { reference: "prompt.a", comparator: "equals", value: "x" },
+              { reference: "prompt.b", comparator: "equals", value: "y" },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("nested operator unknown propagation", () => {
+    test("all containing none-of-unknowns → undefined → false at boundary", () => {
+      // Outer `all` should see the inner `none: [unknown, unknown]` as
+      // undefined (not true), so the overall result is undefined → false.
+      // If the inner `none` had two-valued semantics, this would
+      // incorrectly evaluate to true (no children true → none = true →
+      // all = true).
+      const resolve = makeResolve({});
+      expect(
+        evaluateConditions(
+          {
+            all: [
+              {
+                none: [
+                  { reference: "prompt.a", comparator: "equals", value: "x" },
+                ],
+              },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(false);
+    });
+
+    test("any containing all with one known-true and one unknown", () => {
+      // Inner `all` has [true, unknown] → undefined. Outer `any` has
+      // [undefined] → undefined → boundary false. The known-true child
+      // inside the inner `all` does not "leak out" because the
+      // surrounding `all` didn't reach a definitive answer.
+      const resolve = makeResolve({ "prompt.a": ["x"] });
+      expect(
+        evaluateConditions(
+          {
+            any: [
+              {
+                all: [
+                  { reference: "prompt.a", comparator: "equals", value: "x" },
+                  { reference: "prompt.b", comparator: "equals", value: "y" },
+                ],
+              },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("nested operators", () => {
+    test("(A or B) and C", () => {
+      const resolve = makeResolve({
+        "prompt.a": ["wrong"],
+        "prompt.b": ["yes"],
+        "prompt.c": ["go"],
+      });
+      expect(
+        evaluateConditions(
+          {
+            all: [
+              {
+                any: [
+                  { reference: "prompt.a", comparator: "equals", value: "yes" },
+                  { reference: "prompt.b", comparator: "equals", value: "yes" },
+                ],
+              },
+              { reference: "prompt.c", comparator: "equals", value: "go" },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(true);
+    });
+
+    test("array root with nested operator inside", () => {
+      const resolve = makeResolve({
+        "prompt.a": ["yes"],
+        "prompt.b": ["no"],
+        "prompt.c": ["yes"],
+      });
+      // Top-level array (implicit all): each item must hold.
+      // Item 1: leaf "prompt.a == yes" → true
+      // Item 2: any of (b == yes, c == yes) → c == yes → true
+      // overall true.
+      expect(
+        evaluateConditions(
+          [
+            { reference: "prompt.a", comparator: "equals", value: "yes" },
+            {
+              any: [
+                { reference: "prompt.b", comparator: "equals", value: "yes" },
+                { reference: "prompt.c", comparator: "equals", value: "yes" },
+              ],
+            },
+          ],
+          resolve,
+        ),
+      ).toBe(true);
+    });
+
+    test("none containing nested all", () => {
+      // `none` of [all(A,B), C] — true when neither (A and B) nor C
+      // holds.
+      const resolve = makeResolve({
+        "prompt.a": ["yes"],
+        "prompt.b": ["no"], // (a and b) is false
+        "prompt.c": ["no"], // c is false
+      });
+      expect(
+        evaluateConditions(
+          {
+            none: [
+              {
+                all: [
+                  { reference: "prompt.a", comparator: "equals", value: "yes" },
+                  { reference: "prompt.b", comparator: "equals", value: "yes" },
+                ],
+              },
+              { reference: "prompt.c", comparator: "equals", value: "yes" },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("single leaf at root", () => {
+    test("single leaf object (not in array) — true case", () => {
+      const resolve = makeResolve({ "prompt.q": ["yes"] });
+      expect(
+        evaluateConditions(
+          { reference: "prompt.q", comparator: "equals", value: "yes" },
+          resolve,
+        ),
+      ).toBe(true);
+    });
+
+    test("single leaf object — false case", () => {
+      const resolve = makeResolve({ "prompt.q": ["no"] });
+      expect(
+        evaluateConditions(
+          { reference: "prompt.q", comparator: "equals", value: "yes" },
+          resolve,
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/packages/stagebook/src/utils/evaluateConditions.ts
+++ b/packages/stagebook/src/utils/evaluateConditions.ts
@@ -1,5 +1,8 @@
 import { compare, type Comparator } from "./compare.js";
 
+/** A single leaf condition: a reference + comparator + optional value,
+ *  with optional cross-player aggregation via `position`. This is what
+ *  the boolean tree's operator branches eventually bottom out at. */
 export interface Condition {
   reference: string;
   position?: string;
@@ -7,34 +10,90 @@ export interface Condition {
   value?: unknown;
 }
 
-/**
- * Evaluate a single condition against resolved reference values.
- * Returns true if the condition is met, false otherwise.
+/** A node in the boolean condition tree (#235). Either an operator
+ *  with child nodes (`all`/`any`/`none`), or a leaf condition. The
+ *  tree composes with Kleene three-valued logic so unknown ("data not
+ *  yet") propagates correctly through `none` — see `evaluateNode`.
+ *
+ *  At a `conditions:` field site, the value can additionally be an
+ *  array of nodes (sugar for an implicit `all`); see
+ *  `evaluateConditions` for the field-level entrypoint. */
+export type ConditionNode =
+  | { all: ConditionNode[] }
+  | { any: ConditionNode[] }
+  | { none: ConditionNode[] }
+  | Condition;
+
+/** Tri-state result for the internal evaluator. `undefined` means
+ *  "the underlying data isn't there yet — can't decide." Operators
+ *  propagate it; the boundary collapses it to `false` for the
+ *  public-API boolean return. */
+type TriState = boolean | undefined;
+
+/** Type guards for operator nodes. Operator branches in `conditionsSchema`
+ *  enforce `Array.isArray(node[op])` and `.nonempty()`; the runtime guards
+ *  here re-check the array shape so callers that bypass the schema (e.g.
+ *  hand-built nodes in tests, or inputs from a host that didn't validate)
+ *  fall through to the leaf branch instead of throwing in the for-of loop.
  */
-export function evaluateCondition(
+function isAllNode(n: unknown): n is { all: ConditionNode[] } {
+  return (
+    !!n &&
+    typeof n === "object" &&
+    "all" in n &&
+    Array.isArray((n as { all: unknown }).all)
+  );
+}
+function isAnyNode(n: unknown): n is { any: ConditionNode[] } {
+  return (
+    !!n &&
+    typeof n === "object" &&
+    "any" in n &&
+    Array.isArray((n as { any: unknown }).any)
+  );
+}
+function isNoneNode(n: unknown): n is { none: ConditionNode[] } {
+  return (
+    !!n &&
+    typeof n === "object" &&
+    "none" in n &&
+    Array.isArray((n as { none: unknown }).none)
+  );
+}
+
+/**
+ * Tri-state leaf evaluator. Returns `undefined` when no resolved value
+ * is available (so operators above can know the leaf is "unknown"
+ * rather than "false"); returns `true`/`false` otherwise.
+ *
+ * Position semantics (kept identical to the pre-#235 behavior):
+ *   - `percentAgreement` — compute the fraction of definedValues that
+ *     match the modal value, compare against `value`.
+ *   - `any` — true if any value satisfies the comparator; undefined if
+ *     no value satisfies and at least one is unknown; else false.
+ *   - default (`all` / numeric / `shared` / `player`) — true if every
+ *     value satisfies; undefined if all-known children include any
+ *     compare-undefined; else false.
+ */
+function evaluateLeafTriState(
   condition: Condition,
   referenceValues: unknown[],
-): boolean {
+): TriState {
   const { position, comparator, value } = condition;
 
-  // No data to compare against — the condition cannot be satisfied
-  // except for doesNotExist, which explicitly asserts absence.
-  // Without this guard, [].every() returns true vacuously and conditional
-  // gates (e.g. submit buttons with `comparator: exists`) appear before
-  // any data has been saved.
+  // No values resolved at all — `doesNotExist` is satisfied
+  // (explicit absence assertion); every other comparator can't
+  // decide, so undefined.
   if (referenceValues.length === 0) {
-    return comparator === "doesNotExist";
+    return comparator === "doesNotExist" ? true : undefined;
   }
 
   if (position === "percentAgreement") {
     // Use a null-prototype object so response values like "constructor"
-    // or "toString" don't collide with inherited properties and produce
-    // NaN counts.
+    // or "toString" don't collide with inherited properties.
     const counts = Object.create(null) as Record<string, number>;
     const definedValues = referenceValues.filter((val) => val !== undefined);
-
-    if (definedValues.length === 0) return false;
-
+    if (definedValues.length === 0) return undefined;
     definedValues.forEach((val) => {
       const cleanValue =
         typeof val === "string"
@@ -43,39 +102,120 @@ export function evaluateCondition(
       counts[cleanValue] = (counts[cleanValue] || 0) + 1;
     });
     const maxCount = Math.max(...Object.values(counts));
-    return (
-      compare(
-        (maxCount / referenceValues.length) * 100,
-        comparator as Comparator,
-        value,
-      ) === true
+    const result = compare(
+      (maxCount / referenceValues.length) * 100,
+      comparator as Comparator,
+      value,
     );
+    return result === undefined ? undefined : result;
   }
 
   if (position === "any") {
-    return referenceValues.some(
-      (val) => compare(val, comparator as Comparator, value) === true,
-    );
+    let anyUnknown = false;
+    for (const val of referenceValues) {
+      const r = compare(val, comparator as Comparator, value);
+      if (r === true) return true;
+      if (r === undefined) anyUnknown = true;
+    }
+    return anyUnknown ? undefined : false;
   }
 
-  // Default: "all" — every value must satisfy
-  return referenceValues.every(
-    (val) => compare(val, comparator as Comparator, value) === true,
-  );
+  // Default ("all" / numeric / shared / player) — every value must
+  // satisfy; short-circuit on a definite false.
+  let anyUnknown = false;
+  for (const val of referenceValues) {
+    const r = compare(val, comparator as Comparator, value);
+    if (r === false) return false;
+    if (r === undefined) anyUnknown = true;
+  }
+  return anyUnknown ? undefined : true;
 }
 
 /**
- * Evaluate an array of conditions (AND logic).
- * All conditions must be met for the result to be true.
+ * Tri-state evaluator over the boolean tree (#235). Internal — public
+ * callers go through `evaluateConditions` which collapses the tri-state
+ * to a boolean at the boundary.
+ *
+ * Operator semantics (Kleene three-valued logic):
+ *   - `all`: any child false → false; else any undefined → undefined; else true.
+ *   - `any`: any child true → true; else any undefined → undefined; else false.
+ *   - `none`: any child true → false; else any undefined → undefined; else true.
+ *
+ * Why tri-state matters: with the leaf evaluator returning `undefined`
+ * when data isn't available yet, `none: [...]` correctly returns
+ * `undefined` (not `true`) when its children are all "data not yet."
+ * Without this, a fallback element gated on `none: [...]` would render
+ * prematurely before any participant had answered.
+ */
+function evaluateNode(
+  node: ConditionNode,
+  resolve: (reference: string, position?: string) => unknown[],
+): TriState {
+  if (isAllNode(node)) {
+    let anyUnknown = false;
+    for (const child of node.all) {
+      const r = evaluateNode(child, resolve);
+      if (r === false) return false;
+      if (r === undefined) anyUnknown = true;
+    }
+    return anyUnknown ? undefined : true;
+  }
+  if (isAnyNode(node)) {
+    let anyUnknown = false;
+    for (const child of node.any) {
+      const r = evaluateNode(child, resolve);
+      if (r === true) return true;
+      if (r === undefined) anyUnknown = true;
+    }
+    return anyUnknown ? undefined : false;
+  }
+  if (isNoneNode(node)) {
+    let anyUnknown = false;
+    for (const child of node.none) {
+      const r = evaluateNode(child, resolve);
+      if (r === true) return false;
+      if (r === undefined) anyUnknown = true;
+    }
+    return anyUnknown ? undefined : true;
+  }
+  // Leaf
+  const values = resolve(node.reference, node.position);
+  return evaluateLeafTriState(node, values);
+}
+
+/**
+ * Evaluate a single condition against resolved reference values.
+ * Returns true if the condition is met, false otherwise. The tri-state
+ * "data not yet available" case is collapsed to false here for the
+ * public boolean API; `none:` operator branches in `evaluateConditions`
+ * see the un-collapsed tri-state internally so they compose correctly.
+ */
+export function evaluateCondition(
+  condition: Condition,
+  referenceValues: unknown[],
+): boolean {
+  return evaluateLeafTriState(condition, referenceValues) === true;
+}
+
+/**
+ * Field-level entrypoint for evaluating a `conditions:` value (#235).
+ * Accepts:
+ *   - an array of condition nodes (implicit `all`),
+ *   - a single operator node (`{all|any|none: [...]}`),
+ *   - a single leaf condition.
+ *
+ * Returns boolean — undefined ("data not yet") collapses to false at
+ * this boundary. Existing callers that passed flat arrays continue to
+ * work unchanged.
  */
 export function evaluateConditions(
-  conditions: Condition[],
+  conditions: ConditionNode[] | ConditionNode | undefined | null,
   resolve: (reference: string, position?: string) => unknown[],
 ): boolean {
-  if (!conditions || conditions.length === 0) return true;
-
-  return conditions.every((condition) => {
-    const values = resolve(condition.reference, condition.position);
-    return evaluateCondition(condition, values);
-  });
+  if (conditions === undefined || conditions === null) return true;
+  if (Array.isArray(conditions)) {
+    if (conditions.length === 0) return true;
+    return evaluateNode({ all: conditions }, resolve) === true;
+  }
+  return evaluateNode(conditions, resolve) === true;
 }

--- a/packages/stagebook/src/utils/index.ts
+++ b/packages/stagebook/src/utils/index.ts
@@ -9,6 +9,7 @@ export {
   evaluateCondition,
   evaluateConditions,
   type Condition,
+  type ConditionNode,
 } from "./evaluateConditions.js";
 export {
   getReferencedAssets,


### PR DESCRIPTION
## Summary

Adds nested boolean logic to `conditions:` via three operator-keyed nodes — `all: [...]`, `any: [...]`, `none: [...]` — that recurse, with leaf conditions at the bottom of the tree. Backward compatible: a top-level array stays valid as sugar for `all: [...]`, so every existing treatment file continues to validate unchanged.

The pivotal correctness case is the tri-state evaluator's handling of `none:` over unknown leaves — without three-valued logic, fallback elements gated on `none:` would render before any participant had answered. The implementation propagates `undefined` through Kleene three-valued logic and collapses to `false` at the public boundary, so fallbacks stay hidden until at least one answer arrives.

This PR was developed under the local-convergence review protocol: implement → run tests + lint → independent review subagent (3 passes) → resolve substantive findings → push. The subagent caught one substantive bug on the second pass (Rule 2 false-positive for leaves nested inside `any:`/`none:` operators) which is fixed and tested. The third pass found no substantive issues.

## What's in the PR

- **Schema** (`treatment.ts`, `resolved.ts`): recursive `conditionNodeSchema` (`z.lazy` union with `.strict().nonempty()` operator branches), `conditionsSchema` accepting array (sugar) or single node, operator-key typo detection (`al` → suggest `all`), `OPERATOR_KEYS` exported as the source of truth.
- **Tri-state evaluator** (`evaluateConditions.ts`): internal `evaluateNode` returns `true | false | undefined`, operators propagate per Kleene three-valued logic, public boundary collapses unknown → false.
- **Walkers** (`validateReferences.ts`, `treatment.ts`): cross-stage walker uses `walkConditionLeaves` generator; per-rule walker recurses through operators with correct path scoping. Rule 2 (always-skip-at-load) gated to leaves whose path doesn't traverse `any:`/`none:` (where per-leaf simulation isn't sound).
- **Components** (`StageConditionGate.tsx`, `ConditionsConditionalRender.tsx`): widened to accept arrays, operator nodes, and leaves; `ConditionNode` re-exported through both component barrels.
- **Docs** (`docs/researcher/conditions.md`): "Boolean operators" section with OR/NOR examples, nested usage, and a "Three-valued logic" subsection explaining what happens before data arrives.

## Test plan

- [x] All 733 vitest tests pass (688 baseline + ~45 new across `evaluateConditions.test.ts`, `treatment.test.ts`, `validateReferences.test.ts`).
- [x] Lint clean (`eslint src/`).
- [x] Prettier clean across the diff.
- [x] Backward compat: existing flat-array conditions validate and evaluate unchanged.
- [x] Pivotal `none: [allUnknown] → undefined → false` case covered with a dedicated test.
- [x] Walker recursion verified via `forbidSelfPosition` reaching a leaf nested in `any:`.
- [x] Rule 2 path-awareness covered: positive cases for flat-array and `all:`, negative cases for `any:`, `none:`, and nested-via-`any:`.
- [ ] CI green on the PR.
- [ ] Copilot first-pass review (acting as backstop; local convergence already ran via 3 review-subagent passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)