### PR TITLE
feat(elements): drop bare-string prompt shorthand (closes #245)

### DIFF
--- a/docs/researcher/elements.md
+++ b/docs/researcher/elements.md
@@ -65,14 +65,6 @@ Renders a question or informational text from a Markdown file. This is the most 
   shared: true # optional — single response editable by all participants
 ```
 
-**Shorthand:** A bare string in the `elements` array is treated as a prompt:
-
-```yaml
-elements:
-  - game/discussion_prompt.prompt.md # equivalent to { type: prompt, file: "..." }
-  - type: submitButton
-```
-
 See [Prompt Files](prompts.md) for the Markdown format.
 
 ## Display

--- a/docs/researcher/syntax-reference.md
+++ b/docs/researcher/syntax-reference.md
@@ -84,8 +84,6 @@ All elements accept: `name?`, `notes?`, `file?`, `displayTime?`, `hideTime?`, `s
 | `sharedNotepad` | _(no extra fields)_                                                                                                                                                                                                                            |
 | `talkMeter`     | _(no extra fields)_                                                                                                                                                                                                                            |
 
-**Shorthand:** bare string → `{ type: "prompt", file: "<string>", name: "<string>" }`.
-
 ### Media hosting requirements
 
 The `<video>` element rendered by `mediaPlayer` always sets `crossOrigin="anonymous"`. This is required for the Web Audio API to read the audio stream when a `timeline` element with `showWaveform: true` is attached — without it, the analyser is silently CORS-tainted and the waveform tracks render as flat lines.

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -1938,10 +1938,10 @@ test("element: explicit prompt element still validates", () => {
 });
 
 test("element: missing `type` discriminator is rejected", () => {
-  // Parsed via `elementsSchema` (the array form) so the inner element goes
-  // straight into the discriminated union — not via `elementSchema`'s
-  // `altTemplateContext` wrapper, which would otherwise route an object
-  // with a `template:` key into the template-context branch first.
+  // Each array item is validated through `elementSchema` (which dispatches
+  // via `altTemplateContext`). With no `template:` key, the object falls
+  // straight through to the discriminated union and fails on the missing
+  // `type:` discriminator.
   const result = elementsSchema.safeParse([
     { file: "prompts/intro.prompt.md" },
   ]);

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -1907,3 +1907,75 @@ test("template: notes field is accepted", () => {
   });
   expect(result.success).toBe(true);
 });
+
+// ----------- Element Schema (#245) ------------
+//
+// promptShorthandSchema is gone — bare strings inside an `elements` array no
+// longer become prompts. They fail discriminated-union validation with a
+// clear "Expected object" message instead.
+
+test("element: bare string inside elements array is rejected", () => {
+  const result = elementsSchema.safeParse(["prompts/intro.prompt.md"]);
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    // Zod's discriminated-union complaint about a non-object — the surface
+    // message says it expected an object, not a string.
+    const messages = result.error.issues.map((i) => i.message).join("\n");
+    expect(messages.toLowerCase()).toMatch(/object/);
+  }
+});
+
+test("element: typo'd plain string in elements array is rejected (no silent prompt parse)", () => {
+  const result = elementsSchema.safeParse(["not-a-prompt.txt"]);
+  expect(result.success).toBe(false);
+});
+
+test("element: explicit prompt element still validates", () => {
+  const result = elementsSchema.safeParse([
+    { type: "prompt", file: "prompts/intro.prompt.md" },
+  ]);
+  expect(result.success).toBe(true);
+});
+
+test("element: missing `type` discriminator is rejected", () => {
+  // Parsed via `elementsSchema` (the array form) so the inner element goes
+  // straight into the discriminated union — not via `elementSchema`'s
+  // `altTemplateContext` wrapper, which would otherwise route an object
+  // with a `template:` key into the template-context branch first.
+  const result = elementsSchema.safeParse([
+    { file: "prompts/intro.prompt.md" },
+  ]);
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(
+      result.error.issues.some((i) => i.code === "invalid_union_discriminator"),
+    ).toBe(true);
+  }
+});
+
+test("element: mediaPlayer cross-field rule (stopAt > startAt) still applies", () => {
+  const result = elementSchema.safeParse({
+    type: "mediaPlayer",
+    url: "clip.mp4",
+    startAt: 10,
+    stopAt: 5,
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(
+      result.error.issues.some((i) =>
+        i.message.includes("stopAt must be greater than startAt"),
+      ),
+    ).toBe(true);
+  }
+});
+
+test("element: mediaPlayer playback 'once' + syncToStageTime still rejected", () => {
+  const result = elementSchema.safeParse({
+    type: "mediaPlayer",
+    url: "clip.mp4",
+    playback: "once",
+    syncToStageTime: true,
+  });
+  expect(result.success).toBe(false);
+});

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -1054,15 +1054,6 @@ export const promptSchema = elementBaseSchema
   })
   .strict();
 
-const promptShorthandSchema = promptFilePathSchema.transform((str) => {
-  const newElement = {
-    type: "prompt",
-    file: str,
-    name: str,
-  };
-  return newElement;
-});
-
 const separatorSchema = elementBaseSchema
   .extend({
     type: z.literal("separator"),
@@ -1137,6 +1128,57 @@ export const mediaPlayerSchema = elementBaseSchema
   .strict();
 
 export type MediaPlayerType = z.infer<typeof mediaPlayerSchema>;
+
+/**
+ * mediaPlayer cross-field rules. Lives outside `mediaPlayerSchema` because
+ * `z.discriminatedUnion` in Zod 3 only accepts plain `ZodObject` members
+ * (not `ZodEffects` wrappers), so any `.refine`/`.superRefine` applied to a
+ * member would break elementSchema's discriminated union. We apply these
+ * rules from the union's outer superRefine instead — same behavior, same
+ * error messages.
+ */
+function checkMediaPlayerCrossFields(
+  data: z.infer<typeof mediaPlayerSchema>,
+  ctx: z.RefinementCtx,
+): void {
+  // Only compare when both are concrete numbers — skip when either is an
+  // unresolved ${field} placeholder.
+  if (
+    typeof data.startAt === "number" &&
+    typeof data.stopAt === "number" &&
+    data.stopAt <= data.startAt
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "stopAt must be greater than startAt",
+      path: ["stopAt"],
+    });
+  }
+  if (data.syncToStageTime && data.controls) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        "controls cannot be specified when syncToStageTime is true (playback is locked to stage time)",
+      path: ["controls"],
+    });
+  }
+  if (data.playback === "once" && data.controls) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        'controls cannot be specified when playback is "once" (participant controls are disabled)',
+      path: ["controls"],
+    });
+  }
+  if (data.playback === "once" && data.syncToStageTime) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message:
+        'playback "once" cannot be combined with syncToStageTime (use syncToStageTime without playback instead)',
+      path: ["playback"],
+    });
+  }
+}
 
 export const timelineSchema = elementBaseSchema
   .extend({
@@ -1401,119 +1443,31 @@ export function getValidKeysForPlayer(): string[] {
 }
 
 export const elementSchema = altTemplateContext(
-  z.any().superRefine((data, ctx) => {
-    const isObject = typeof data === "object" && data !== null;
-    const hasTypeKey = isObject && "type" in data;
-
-    const schemaToUse = hasTypeKey
-      ? z.discriminatedUnion("type", [
-          audioSchema,
-          displaySchema,
-          imageSchema,
-          promptSchema,
-          qualtricsSchema,
-          separatorSchema,
-          sharedNotepadSchema,
-          submitButtonSchema,
-          surveySchema,
-          talkMeterSchema,
-          timerSchema,
-          mediaPlayerSchema,
-          timelineSchema,
-          trackedLinkSchema,
-        ])
-      : promptShorthandSchema;
-
-    const result = schemaToUse.safeParse(data);
-
-    if (!result.success) {
-      //promptShorthandSchema is a special case where we expect a string
-      //But there are 0 key mismatches as a result of this for whatever object
-      //is input
-      if (!hasTypeKey && isObject && schemaToUse === promptShorthandSchema) {
-        // If we expected a string (promptShorthand) but got an object instead
-        // Add one error per key
-        ctx.addIssue({
-          code: "invalid_type",
-          expected: "string",
-          received: "object",
-          message: `promptShorthandSchema expects a string, but received object.`,
-        });
-        for (const key of Object.keys(data)) {
-          ctx.addIssue({
-            code: "unrecognized_keys",
-            keys: [key],
-          });
-        }
-      } else {
-        // Forward errors from schemaToUse
-        result.error.issues.forEach((issue) =>
-          ctx.addIssue({
-            ...issue,
-            path: [...issue.path],
-          }),
-        );
+  z
+    .discriminatedUnion("type", [
+      audioSchema,
+      displaySchema,
+      imageSchema,
+      promptSchema,
+      qualtricsSchema,
+      separatorSchema,
+      sharedNotepadSchema,
+      submitButtonSchema,
+      surveySchema,
+      talkMeterSchema,
+      timerSchema,
+      mediaPlayerSchema,
+      timelineSchema,
+      trackedLinkSchema,
+    ])
+    .superRefine((data, ctx) => {
+      // Cross-field rules only run after base-shape validation succeeds —
+      // an incomplete mediaPlayer (e.g. missing `url`) already errored
+      // inside the discriminated union, so we never reach here for it.
+      if (data.type === "mediaPlayer") {
+        checkMediaPlayerCrossFields(data, ctx);
       }
-    }
-
-    // Cross-field validation for mediaPlayer
-    if (
-      isObject &&
-      (data as { type?: unknown }).type === "mediaPlayer" &&
-      result.success
-    ) {
-      const mp = data as {
-        startAt?: number | string;
-        stopAt?: number | string;
-      };
-      // Only compare when both are concrete numbers — skip when either is
-      // an unresolved ${field} placeholder
-      if (
-        typeof mp.startAt === "number" &&
-        typeof mp.stopAt === "number" &&
-        mp.stopAt <= mp.startAt
-      ) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: "stopAt must be greater than startAt",
-          path: ["stopAt"],
-        });
-      }
-      const mpSync = data as {
-        syncToStageTime?: boolean;
-        controls?: Record<string, boolean>;
-      };
-      if (mpSync.syncToStageTime && mpSync.controls) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message:
-            "controls cannot be specified when syncToStageTime is true (playback is locked to stage time)",
-          path: ["controls"],
-        });
-      }
-      const mpPlayback = data as {
-        playback?: string;
-        controls?: Record<string, boolean>;
-        syncToStageTime?: boolean;
-      };
-      if (mpPlayback.playback === "once" && mpPlayback.controls) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message:
-            'controls cannot be specified when playback is "once" (participant controls are disabled)',
-          path: ["controls"],
-        });
-      }
-      if (mpPlayback.playback === "once" && mpPlayback.syncToStageTime) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message:
-            'playback "once" cannot be combined with syncToStageTime (use syncToStageTime without playback instead)',
-          path: ["playback"],
-        });
-      }
-    }
-  }),
+    }),
 );
 
 export type ElementType = z.infer<typeof elementSchema>;

--- a/packages/stagebook/src/schemas/validateReferences.ts
+++ b/packages/stagebook/src/schemas/validateReferences.ts
@@ -662,55 +662,25 @@ function collectStepKeys(step: unknown): Set<string> {
  *  sub-values rather than trying to shape-check against `contentType`,
  *  because template shapes are flexible and we just want "every key that
  *  could come out of this template."
- *
- *  Bare `*.prompt.md` strings are only treated as produced keys when
- *  they appear as prompt-shorthand entries inside an `elements` array.
- *  Treating every matching string as a produced key would
- *  over-approximate — e.g. an explicit `{ type: prompt, name: foo,
- *  file: "p.prompt.md" }` element would add *both* `prompt_foo` (real
- *  key) and `prompt_p.prompt.md` (bogus) — and mask real typos.
  */
-function collectKeysFromAny(
-  node: unknown,
-  acc: Set<string>,
-  allowPromptShorthand = false,
-): void {
-  if (typeof node === "string") {
-    if (allowPromptShorthand && node.endsWith(".prompt.md")) {
-      acc.add(`prompt_${node}`);
-    }
-    return;
-  }
+function collectKeysFromAny(node: unknown, acc: Set<string>): void {
+  if (typeof node !== "object" || node === null) return;
   if (Array.isArray(node)) {
-    for (const item of node) {
-      collectKeysFromAny(item, acc, allowPromptShorthand);
-    }
+    for (const item of node) collectKeysFromAny(item, acc);
     return;
   }
   if (!isRecord(node)) return;
   // Try as an element first (matches the concrete-walker shape).
   collectProducedKeys(node, acc);
-  // Recurse into every sub-value. Only `elements` arrays carry
-  // prompt-shorthand strings — any other string field (e.g. `file:
-  // "…prompt.md"`) is not a shorthand and shouldn't be counted.
-  for (const [key, value] of Object.entries(node)) {
-    collectKeysFromAny(value, acc, key === "elements");
+  for (const value of Object.values(node)) {
+    collectKeysFromAny(value, acc);
   }
 }
 
-/** Map an element (or a bare prompt-shorthand path string) to its storage
- *  key (or keys) and add them to `acc`. The key conventions mirror
- *  `getReferenceKeyAndPath` so lookups line up.
+/** Map an element to its storage key (or keys) and add them to `acc`.
+ *  The key conventions mirror `getReferenceKeyAndPath` so lookups line up.
  */
 function collectProducedKeys(element: unknown, acc: Set<string>): void {
-  // Prompt-shorthand: a bare "*.prompt.md" string inside `elements` stands
-  // in for `{ type: "prompt", file: <str>, name: <str> }`. Without a name
-  // it still produces `prompt_<str>` since the shorthand auto-names from
-  // the path.
-  if (typeof element === "string" && element.endsWith(".prompt.md")) {
-    acc.add(`prompt_${element}`);
-    return;
-  }
   if (!isRecord(element)) return;
   const type = element.type;
   const name = element.name;

--- a/packages/stagebook/src/utils/referencedAssets.test.ts
+++ b/packages/stagebook/src/utils/referencedAssets.test.ts
@@ -375,75 +375,17 @@ describe("getReferencedAssets — structural walk", () => {
   });
 });
 
-describe("getReferencedAssets — prompt shorthand", () => {
-  test("bare .prompt.md string inside elements is collected as prompt.file", () => {
+describe("getReferencedAssets — bare strings inside elements are not collected", () => {
+  // Prompt shorthand was removed in #245. Bare strings inside an `elements`
+  // array now fail schema validation rather than silently becoming prompts;
+  // the walker no longer recognises them, even though it runs pre-validation.
+  test("bare .prompt.md string inside elements is not collected", () => {
     const tree = treatmentWithElements(["intro.prompt.md"]);
-    const assets = getReferencedAssets(tree);
-    expect(assets).toEqual<ReferencedAsset[]>([
-      {
-        path: "intro.prompt.md",
-        field: "file",
-        elementType: "prompt",
-        elementName: "intro.prompt.md",
-        pathInTree: ["treatments", 0, "gameStages", 0, "elements", 0],
-      },
-    ]);
-  });
-
-  test("shorthand works in intro and exit steps too", () => {
-    const tree = {
-      introSequences: [
-        {
-          name: "seq",
-          introSteps: [{ name: "s", elements: ["intro.prompt.md"] }],
-        },
-      ],
-      treatments: [
-        {
-          name: "t",
-          playerCount: 1,
-          gameStages: [
-            { name: "g", duration: 1, elements: [{ type: "submitButton" }] },
-          ],
-          exitSequence: [{ name: "e", elements: ["exit.prompt.md"] }],
-        },
-      ],
-    };
-    const paths = getReferencedAssets(tree).map((a) => a.path);
-    expect(paths).toEqual(["intro.prompt.md", "exit.prompt.md"]);
+    expect(getReferencedAssets(tree)).toEqual([]);
   });
 
   test("non-.prompt.md strings inside elements are not collected", () => {
     const tree = treatmentWithElements(["not-a-prompt.txt", 42, null]);
-    expect(getReferencedAssets(tree)).toEqual([]);
-  });
-
-  test("shorthand with template placeholder is excluded", () => {
-    const tree = treatmentWithElements(["${variant}.prompt.md"]);
-    expect(getReferencedAssets(tree)).toEqual([]);
-  });
-
-  test("bare .prompt.md strings outside an elements array are ignored", () => {
-    // Safety: only recognise shorthand where the schema actually allows it.
-    const tree = {
-      introSequences: [],
-      treatments: [
-        {
-          name: "t",
-          playerCount: 1,
-          notes: "see intro.prompt.md",
-          gameStages: [
-            {
-              name: "g",
-              duration: 1,
-              elements: [{ type: "submitButton" }],
-              // Some unrelated field that happens to hold a .prompt.md string
-              foo: "bar.prompt.md",
-            },
-          ],
-        },
-      ],
-    };
     expect(getReferencedAssets(tree)).toEqual([]);
   });
 });

--- a/packages/stagebook/src/utils/referencedAssets.ts
+++ b/packages/stagebook/src/utils/referencedAssets.ts
@@ -15,12 +15,6 @@ const FILE_FIELDS_BY_ELEMENT_TYPE: Record<string, readonly string[]> = {
   timeline: [],
 };
 
-// Keys whose array values hold elements. Strings inside these arrays are
-// recognised as the prompt-shorthand form (see promptShorthandSchema): a bare
-// `*.prompt.md` path stands in for `{ type: "prompt", file: <path> }`.
-const ELEMENTS_ARRAY_KEYS = new Set(["elements"]);
-const PROMPT_SHORTHAND_SUFFIX = ".prompt.md";
-
 const PLACEHOLDER_PATTERN = /\$\{[^}]*\}/;
 const FULL_URL_PATTERN = /^(?:https?:)?\/\//i;
 // Platform-provided assets (see #188) live outside the repo — the host
@@ -40,8 +34,7 @@ export interface ReferencedAsset {
   /** Element name if the element has one. */
   elementName?: string;
   /** Location of the scalar value in the parsed object, useful for source
-   *  mapping. For object elements this is `[…element path, fieldName]`; for
-   *  prompt-shorthand strings this is the scalar's own path. */
+   *  mapping. `[…element path, fieldName]`. */
   pathInTree: (string | number)[];
 }
 
@@ -56,8 +49,7 @@ function isCollectableLocalPath(value: unknown): value is string {
 
 /**
  * Walk a parsed treatment file and return every local-asset path it
- * references, per the per-element-type allowlist above (plus prompt
- * shorthand — bare `*.prompt.md` strings inside `elements` arrays).
+ * references, per the per-element-type allowlist above.
  *
  * Accepts `unknown` because callers typically pass the raw result of
  * parsing YAML — before schema validation — so that the asset list is
@@ -72,38 +64,18 @@ function isCollectableLocalPath(value: unknown): value is string {
  */
 export function getReferencedAssets(treatmentFile: unknown): ReferencedAsset[] {
   const results: ReferencedAsset[] = [];
-  walk(treatmentFile, [], false, results);
+  walk(treatmentFile, [], results);
   return results;
 }
 
 function walk(
   node: unknown,
   path: (string | number)[],
-  insideElementsArray: boolean,
   acc: ReferencedAsset[],
 ): void {
   if (Array.isArray(node)) {
     node.forEach((item, i) => {
-      walk(item, [...path, i], insideElementsArray, acc);
-    });
-    return;
-  }
-
-  // Prompt shorthand: a bare ".prompt.md" string within an `elements` array
-  // stands in for `{ type: "prompt", file: <string> }`. We emit it as such so
-  // consumers (file-existence checks, asset manifests) don't silently miss it.
-  if (
-    insideElementsArray &&
-    typeof node === "string" &&
-    node.endsWith(PROMPT_SHORTHAND_SUFFIX) &&
-    isCollectableLocalPath(node)
-  ) {
-    acc.push({
-      path: node,
-      field: "file",
-      elementType: "prompt",
-      elementName: node,
-      pathInTree: [...path],
+      walk(item, [...path, i], acc);
     });
     return;
   }
@@ -138,6 +110,6 @@ function walk(
   }
 
   for (const [key, value] of Object.entries(record)) {
-    walk(value, [...path, key], ELEMENTS_ARRAY_KEYS.has(key), acc);
+    walk(value, [...path, key], acc);
   }
 }


### PR DESCRIPTION
## Summary

Closes #245. Drops the bare-string prompt shorthand from the element schema and the related walkers.

- `promptShorthandSchema` deleted. `elementSchema` collapses from a `z.any().superRefine` (with object-vs-string branching) into a plain `altTemplateContext(z.discriminatedUnion(\"type\", [...]))`.
- `mediaPlayer` cross-field rules (stopAt > startAt; controls vs. syncToStageTime/playback-once) move into a `checkMediaPlayerCrossFields` helper called from the union's outer `.superRefine`. Same rules, same messages, same paths. They can't live on `mediaPlayerSchema` itself because Zod 3 rejects `ZodEffects` members inside `discriminatedUnion`.
- `getReferencedAssets` no longer recognises bare `*.prompt.md` strings in `elements:` arrays as collectable assets — `insideElementsArray`, `PROMPT_SHORTHAND_SUFFIX`, `ELEMENTS_ARRAY_KEYS` all gone.
- `validateReferences.collectKeysFromAny` and `collectProducedKeys` drop their parallel shorthand branches.
- Researcher docs (`syntax-reference.md`, `elements.md`) drop the \"Shorthand: bare string → ...\" callouts. The annotated walkthrough already used the explicit form throughout.

## Migration

Hard break for any treatment file using bare-string prompts. Mechanical conversion:

\`\`\`yaml
# Before
- prompts/familiarity.prompt.md

# After
- type: prompt
  file: prompts/familiarity.prompt.md
\`\`\`

## Test plan

- [x] All stagebook (745), viewer (84), and vscode (189) unit/integration tests pass on Node 24.
- [x] New tests in \`treatment.test.ts\` assert: bare strings in element arrays are rejected with an \"Expected object\" message; explicit-form prompts still validate; missing \`type\` discriminator is rejected with an \`invalid_union_discriminator\` issue; mediaPlayer cross-field rules survive the relocation.
- [x] referencedAssets test rewritten to assert that bare strings are no longer collected pre-validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)