### PR TITLE
feat(elements): drop talkMeter/sharedNotepad; deprecate survey (closes #250)

### DIFF
--- a/apps/viewer/src/components/SkeletonPlaceholder.tsx
+++ b/apps/viewer/src/components/SkeletonPlaceholder.tsx
@@ -119,7 +119,6 @@ export function SkeletonPlaceholder({
     survey: "Survey element — requires external survey platform",
     sharedNotepad:
       "Shared notepad — requires live session with multiple participants",
-    talkMeter: "Talk meter — requires live audio session",
     qualtrics: "Qualtrics survey — requires external integration",
   };
 
@@ -162,7 +161,6 @@ export function createSkeletonRenderers() {
         config={{ padName: config.padName }}
       />
     ),
-    renderTalkMeter: () => <SkeletonPlaceholder type="talkMeter" />,
   };
 }
 

--- a/apps/viewer/src/lib/context.ts
+++ b/apps/viewer/src/lib/context.ts
@@ -13,10 +13,7 @@ export interface ViewerContextOptions {
   renderers?: Partial<
     Pick<
       StagebookContext,
-      | "renderDiscussion"
-      | "renderSurvey"
-      | "renderSharedNotepad"
-      | "renderTalkMeter"
+      "renderDiscussion" | "renderSurvey" | "renderSharedNotepad"
     >
   >;
 }

--- a/docs/engineer/api-reference.md
+++ b/docs/engineer/api-reference.md
@@ -222,10 +222,9 @@ Requires StagebookProvider. Dispatches to the appropriate element component base
 
 | Slot | Config | When Used |
 |------|--------|-----------|
-| `renderSurvey` | `{ surveyName, onComplete }` | `type: "survey"` element |
+| `renderSurvey` | `{ surveyName, onComplete }` | `type: "survey"` element (deprecated — pending removal once a module-reuse pattern lands) |
 | `renderDiscussion` | Full `DiscussionType` config | Stage with `discussion` block |
-| `renderSharedNotepad` | `{ padName }` | `type: "sharedNotepad"` or `shared: true` prompt |
-| `renderTalkMeter` | _(none)_ | `type: "talkMeter"` element |
+| `renderSharedNotepad` | `{ padName }` | `shared: true` open-response prompt |
 
 ### Conditional Components
 

--- a/docs/engineer/architecture.md
+++ b/docs/engineer/architecture.md
@@ -41,7 +41,7 @@ interface StagebookContext {
   // Platform-provided renderers for service-coupled elements
   renderDiscussion?: (config: DiscussionType) => React.ReactNode;
   renderSharedNotepad?: (config: { padName: string }) => React.ReactNode;
-  renderTalkMeter?: () => React.ReactNode;
+  /** @deprecated pending removal once a module-reuse pattern lands */
   renderSurvey?: (config: {
     surveyName: string;
     onComplete: (results: unknown) => void;
@@ -106,12 +106,11 @@ Stagebook provides `useTextContent(path)` — a hook that wraps `getTextContent`
 
 Some elements depend on external services. Stagebook validates config, manages layout, and handles conditional rendering — but the platform supplies the actual component:
 
-| Slot                  | When used                                        | What the platform provides                           |
-| --------------------- | ------------------------------------------------ | ---------------------------------------------------- |
-| `renderDiscussion`    | Stage has `discussion` block                     | Video call or text chat component                    |
-| `renderSurvey`        | `type: "survey"` element                         | Survey UI component that calls `onComplete(results)` |
-| `renderSharedNotepad` | `type: "sharedNotepad"` or `shared: true` prompt | Collaborative text editor                            |
-| `renderTalkMeter`     | `type: "talkMeter"` element                      | Speaking time display                                |
+| Slot                  | When used                          | What the platform provides                           |
+| --------------------- | ---------------------------------- | ---------------------------------------------------- |
+| `renderDiscussion`    | Stage has `discussion` block       | Video call or text chat component                    |
+| `renderSurvey`        | `type: "survey"` element (deprecated — pending removal once a module-reuse pattern lands) | Survey UI component that calls `onComplete(results)` |
+| `renderSharedNotepad` | `shared: true` open-response prompt | Collaborative text editor                            |
 
 All slots are optional. If not provided, the element renders nothing.
 

--- a/docs/engineer/integration-guide.md
+++ b/docs/engineer/integration-guide.md
@@ -355,6 +355,8 @@ Some elements depend on external services or platform-specific libraries. Stageb
 
 ### Survey
 
+> **Deprecated.** `type: survey` is pending removal once Stagebook's module-reuse pattern lands. The element still works (the host's `renderSurvey` slot is still called); the runtime emits a one-time `console.warn` per `surveyName` at parse time. New treatment files should prefer prompt-based patterns where the survey can be expressed as a sequence of prompt elements.
+
 Surveys are rendered by the platform because they depend on a survey library (e.g., `@watts-lab/surveys`). Stagebook validates the element config, wraps the survey in conditional rendering, and handles data storage — but the platform provides the actual survey UI.
 
 #### What the researcher writes

--- a/docs/engineer/integration-guide.md
+++ b/docs/engineer/integration-guide.md
@@ -170,7 +170,6 @@ const context: StagebookContext = {
   // Optional: platform-provided renderers for service-coupled elements
   renderDiscussion: (config) => <YourVideoComponent {...config} />,
   renderSharedNotepad: (config) => <YourNotepadComponent {...config} />,
-  renderTalkMeter: () => <YourTalkMeter />,
 };
 ```
 
@@ -441,23 +440,13 @@ The `config` parameter is the full `discussion` object from the treatment YAML, 
 
 ### Shared Notepad
 
-Collaborative text editors (e.g., Etherpad) are used for `sharedNotepad` elements and `shared: true` open response prompts.
+Collaborative text editors (e.g., Etherpad) are used by `shared: true` open-response prompts. (The standalone `sharedNotepad` element type was removed in #250.)
 
 ```typescript
 const context: StagebookContext = {
   renderSharedNotepad: ({ padName }) => (
     <EtherpadEmbed padName={padName} />
   ),
-};
-```
-
-### Talk Meter
-
-Speaking time tracking requires audio analysis, which is platform-specific.
-
-```typescript
-const context: StagebookContext = {
-  renderTalkMeter: () => <TalkTimeDisplay />,
 };
 ```
 

--- a/docs/engineer/platform-requirements.md
+++ b/docs/engineer/platform-requirements.md
@@ -440,7 +440,7 @@ Provide via: `renderDiscussion(config)` on StagebookProvider (same slot as video
 
 ### Shared Notepad
 
-Required for `sharedNotepad` elements and `shared: true` open response prompts.
+Required for `shared: true` open-response prompts. (The standalone `sharedNotepad` element type was removed in #250 — shared prompts are the single path now.)
 
 The platform must:
 
@@ -452,18 +452,6 @@ The platform must:
 **Services used in deliberation-empirica**: Etherpad
 
 Provide via: `renderSharedNotepad(config)` on StagebookProvider.
-
-### Talk Meter
-
-Required for `talkMeter` elements.
-
-The platform must:
-
-- Detect which participant is speaking (requires audio analysis)
-- Track cumulative speaking time per participant
-- Display the results
-
-Provide via: `renderTalkMeter()` on StagebookProvider.
 
 ---
 

--- a/docs/researcher/elements.md
+++ b/docs/researcher/elements.md
@@ -1,6 +1,23 @@
 # Page Elements
 
-Elements are the building blocks of every stage. The `elements` array is rendered top-to-bottom as a single column. All element types accept these common fields:
+Elements are the building blocks of every stage. The `elements` array is rendered top-to-bottom as a single column.
+
+## Element typology
+
+A few element types look superficially redundant but encode distinct intents — they answer different authoring questions, so they stay distinct.
+
+| Type          | Intent                                                                                              |
+| ------------- | --------------------------------------------------------------------------------------------------- |
+| `audio`       | Non-interactive audio (chimes, alerts, ambient sound). One-shot; no participant controls expected. `audio` ≠ `mediaPlayer with playVideo: false`. |
+| `image`       | Non-interactive image display. Static picture; conceptually parallel to `audio`, not `display`. `image` ≠ `display`. |
+| `mediaPlayer` | Interactive audio/video with playback controls (play, pause, scrub, speed). Participant interacts with the clip. |
+| `display`     | Shows a value looked up by reference from elsewhere in the study (e.g., `prompt.foo`'s response). Reactive to stored data, not a static resource. |
+
+Use `audio` for a chime, `mediaPlayer` for a video, `image` for a picture, `display` to show a stored value. The four types are intentionally separate — a sequence of `if (playVideo) ... else ...` configuration on a single type would conflate "fire-and-forget asset" with "controllable surface" and "live data view."
+
+## Common fields
+
+All element types accept these common fields:
 
 | Field               | Type     | Description                                                         |
 | ------------------- | -------- | ------------------------------------------------------------------- |
@@ -435,6 +452,8 @@ Saved selections are **restored on reload** — if a participant refreshes mid-s
 
 ## Survey
 
+> **Deprecated.** `type: survey` is pending removal once Stagebook's module-reuse pattern lands. The element still works (the host's `renderSurvey` slot is still called), but the runtime emits a one-time deprecation warning per `surveyName` at parse time. Prefer prompt-based patterns for new treatment files.
+
 Renders a pre-built survey from the `@watts-lab/surveys` package.
 
 ```yaml
@@ -495,22 +514,30 @@ guidance, or set it to an empty string to hide the helper entirely:
 | `helperText`  | string | no       | Text shown below the link. Defaults to "Link opens in a new tab. Return to this tab to complete the study." Pass an empty string to hide. |
 | `urlParams`   | list   | no       | Query parameters appended to the URL (see Qualtrics example)                                                                              |
 
-## Shared Notepad
+## Shared Notepad (via `shared: true` prompt)
 
-A collaborative text editor (backed by Etherpad) where participants can write together.
+A collaborative text editor where multiple participants edit a single saved value. Use a `prompt` element with `shared: true` and an `openResponse` prompt file:
 
 ```yaml
-- type: sharedNotepad
+- type: prompt
   name: group_notes
+  file: prompts/group_notes.prompt.md
+  shared: true
 ```
 
-## Talk Meter
-
-Displays cumulative speaking time for each participant. Only meaningful in video discussion stages.
+Where `prompts/group_notes.prompt.md` is a minimal openResponse file:
 
 ```yaml
-- type: talkMeter
+---
+type: openResponse
+---
+
+# Group notes
+
+(Optional framing for the notepad goes in the body.)
 ```
+
+The host platform implements the collaborative semantics via the `renderSharedNotepad` context slot. The standalone `sharedNotepad` element type was removed in #250; shared prompts are the single path now.
 
 ## Time fields and reference frames
 

--- a/docs/researcher/syntax-reference.md
+++ b/docs/researcher/syntax-reference.md
@@ -78,11 +78,9 @@ All elements accept: `name?`, `notes?`, `file?`, `displayTime?`, `hideTime?`, `s
 | `image`         | `file` (required), `width?`                                                                                                                                                                                                                    |
 | `mediaPlayer`   | `url` (required), `name`, `controls?`, `syncToStageTime?`, `submitOnComplete?`, `startAt?`, `stopAt?`, `stepDuration?`, `playVideo?`, `playAudio?`, `captionsFile?`, `allowScrubOutsideBounds?`                                                |
 | `timeline`      | `source` (required, name of a sibling `mediaPlayer`), `name` (required), `selectionType` (required, `range` or `point`), `selectionScope?` (default `all`), `multiSelect?` (default `false`), `showWaveform?` (default `true`), `trackLabels?` |
-| `survey`        | `surveyName` (required)                                                                                                                                                                                                                        |
+| `survey`        | `surveyName` (required) — _deprecated; pending removal once a module-reuse pattern lands. Prefer prompt-based patterns._                                                                                                                       |
 | `qualtrics`     | `url` (required), `urlParams?`                                                                                                                                                                                                                 |
 | `trackedLink`   | `name` (required), `url` (required), `displayText` (required), `helperText?`, `urlParams?`                                                                                                                                                     |
-| `sharedNotepad` | _(no extra fields)_                                                                                                                                                                                                                            |
-| `talkMeter`     | _(no extra fields)_                                                                                                                                                                                                                            |
 
 ### Media hosting requirements
 

--- a/examples/annotated-walkthrough/README.md
+++ b/examples/annotated-walkthrough/README.md
@@ -16,7 +16,7 @@ Two treatments are generated from a single template by broadcasting over a list 
 | **`groupComposition`** (matching participants by condition)          | `studyTreatment.groupComposition`                                      |
 | **Conditional rendering** on elements                                | Stage 3 consensus prompt                                               |
 | **`display` elements** (one player's response shown to another)      | Stage 3                                                                |
-| **Platform-coupled elements** (`survey`, `discussion`, `sharedNotepad`) | Intro `Personality`, Stage 2                                           |
+| **Platform-coupled elements** (`survey` ⚠️ deprecated, `discussion`, `shared: true` open-response prompt) | Intro `Personality`, Stage 2                                           |
 | **`qualtrics` element** (real iframe to an external survey)          | exit `Exit Survey`                                                     |
 
 The platform-coupled elements render as skeleton placeholders in the viewer — they require a host that implements the corresponding `render*` slot. The `qualtrics` element is different: stagebook renders it directly as an iframe to the configured URL, so the viewer will attempt to load `example.qualtrics.com` (which will fail, since that's a placeholder URL) rather than showing a skeleton.

--- a/examples/annotated-walkthrough/prompts/discussion_notes.prompt.md
+++ b/examples/annotated-walkthrough/prompts/discussion_notes.prompt.md
@@ -1,0 +1,15 @@
+---
+type: openResponse
+name: Discussion notes
+rows: 6
+---
+
+# Shared notes
+
+Use this space to jot down points you and your partner agree on, questions
+that came up, or anything else you'd like to remember when summarising the
+discussion.
+
+---
+
+> Either participant can edit. Saved as you type.

--- a/examples/annotated-walkthrough/walkthrough.treatments.yaml
+++ b/examples/annotated-walkthrough/walkthrough.treatments.yaml
@@ -84,10 +84,10 @@ templates:
           duration: 300
           notes: |
             Platform-coupled stage. The `discussion` block adds a
-            synchronised chat panel; `sharedNotepad` adds a
-            collaborative editor. Both are slots the host platform
-            implements — they render as skeleton placeholders in the
-            viewer because they require a live multi-participant
+            synchronised chat panel; a `shared: true` open-response
+            prompt adds a collaborative editor. Both are slots the host
+            platform implements — they render as skeleton placeholders
+            in the viewer because they require a live multi-participant
             session.
           discussion:
             chatType: text
@@ -97,9 +97,17 @@ templates:
           elements:
             - type: prompt
               file: prompts/discussion_guide.prompt.md
-            - type: sharedNotepad
+            - type: prompt
               name: ${topic}_notes
-              notes: Platform-coupled collaborative editor. Renders as a skeleton placeholder in the viewer.
+              file: prompts/discussion_notes.prompt.md
+              shared: true
+              notes: |
+                Collaborative editor implemented via the host's
+                `renderSharedNotepad` slot. Both participants edit a
+                single saved value (`shared: true` on an openResponse
+                prompt). The standalone `sharedNotepad` element type
+                was removed in #250 — shared prompts are the single
+                path now.
             - type: timer
             - type: submitButton
               buttonText: End discussion
@@ -171,11 +179,11 @@ templates:
         - name: Exit Survey
           notes: |
             Stagebook renders `qualtrics` directly as an iframe (not via
-            a host slot, unlike `survey` / `discussion` /
-            `sharedNotepad`). The step auto-submits when the iframe
-            posts its end-of-survey message — no `submitButton` needed.
-            In the viewer the placeholder URL below won't load; swap in
-            a real Qualtrics form URL to test the flow.
+            a host slot, unlike `survey` / `discussion`). The step
+            auto-submits when the iframe posts its end-of-survey
+            message — no `submitButton` needed. In the viewer the
+            placeholder URL below won't load; swap in a real Qualtrics
+            form URL to test the flow.
           elements:
             - type: qualtrics
               name: exit_qualtrics

--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -94,7 +94,6 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
     progressLabel,
     renderSharedNotepad,
     renderDiscussion,
-    renderTalkMeter,
     renderSurvey,
     playerId,
     setAllowIdle,
@@ -315,16 +314,6 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
           progressLabel={progressLabel}
           setAllowIdle={setAllowIdle}
         />
-      );
-
-    case "talkMeter":
-      return renderTalkMeter?.() ?? null;
-
-    case "sharedNotepad":
-      return (
-        renderSharedNotepad?.({
-          padName: element.name ?? "",
-        }) ?? null
       );
 
     case "qualtrics": {

--- a/packages/stagebook/src/components/StagebookProvider.test.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.test.tsx
@@ -91,18 +91,15 @@ describe("StagebookContext interface", () => {
     const ctx = createMockContext();
     expect(ctx.renderDiscussion).toBeUndefined();
     expect(ctx.renderSharedNotepad).toBeUndefined();
-    expect(ctx.renderTalkMeter).toBeUndefined();
   });
 
   test("render slots can be provided", () => {
     const ctx = createMockContext({
       renderDiscussion: () => React.createElement("div", null, "discussion"),
       renderSharedNotepad: () => React.createElement("div", null, "notepad"),
-      renderTalkMeter: () => React.createElement("div", null, "meter"),
     });
     expect(ctx.renderDiscussion).toBeDefined();
     expect(ctx.renderSharedNotepad).toBeDefined();
-    expect(ctx.renderTalkMeter).toBeDefined();
   });
 });
 

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -85,12 +85,22 @@ export interface StagebookContext {
 
   // Platform-provided renderers for service-coupled elements
   renderDiscussion?: (config: DiscussionType) => React.ReactNode;
+  /**
+   * Renders a shared text input with collaborative editing semantics.
+   * Called by `prompt` elements with `shared: true` and an openResponse
+   * prompt file. (The standalone `sharedNotepad` element type was removed
+   * in #250 — shared prompts are now the single path.)
+   */
   renderSharedNotepad?: (config: {
     padName: string;
     defaultText?: string;
     rows?: number;
   }) => React.ReactNode;
-  renderTalkMeter?: () => React.ReactNode;
+  /**
+   * @deprecated `type: survey` is pending removal once Stagebook's
+   *   module-reuse pattern lands. Hosts should keep implementing this
+   *   for now; new treatment files should prefer prompt-based patterns.
+   */
   renderSurvey?: (config: {
     surveyName: string;
     onComplete: (results: unknown) => void;

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -1979,3 +1979,58 @@ test("element: mediaPlayer playback 'once' + syncToStageTime still rejected", ()
   });
   expect(result.success).toBe(false);
 });
+
+// ----------- Element Types (#250) ------------
+
+test("element: type 'talkMeter' is rejected (removed in #250)", () => {
+  const result = elementSchema.safeParse({ type: "talkMeter" });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(
+      result.error.issues.some((i) => i.code === "invalid_union_discriminator"),
+    ).toBe(true);
+  }
+});
+
+test("element: type 'sharedNotepad' is rejected (removed in #250)", () => {
+  const result = elementSchema.safeParse({
+    type: "sharedNotepad",
+    name: "groupNotes",
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    expect(
+      result.error.issues.some((i) => i.code === "invalid_union_discriminator"),
+    ).toBe(true);
+  }
+});
+
+test("element: type 'survey' still accepted with a one-time deprecation warning", async () => {
+  const { vi } = await import("vitest");
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    // First parse fires the warning.
+    const r1 = elementSchema.safeParse({
+      type: "survey",
+      surveyName: "deprecation_test_TIPI",
+    });
+    expect(r1.success).toBe(true);
+    // Second parse with the same surveyName does NOT re-warn — the dedupe is
+    // module-scoped per process, keyed on surveyName.
+    const r2 = elementSchema.safeParse({
+      type: "survey",
+      surveyName: "deprecation_test_TIPI",
+    });
+    expect(r2.success).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("`type: survey` is deprecated");
+  } finally {
+    warnSpy.mockRestore();
+  }
+});
+
+test("validElementTypes does not include talkMeter or sharedNotepad", async () => {
+  const { validElementTypes } = await import("./treatment.js");
+  expect(validElementTypes).not.toContain("talkMeter");
+  expect(validElementTypes).not.toContain("sharedNotepad");
+});

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -2029,6 +2029,27 @@ test("element: type 'survey' still accepted with a one-time deprecation warning"
   }
 });
 
+test("element: survey deprecation warning escapes newlines/quotes in surveyName", async () => {
+  const { vi } = await import("vitest");
+  const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  try {
+    const result = elementSchema.safeParse({
+      type: "survey",
+      surveyName: 'has\nnewline and "quotes"',
+    });
+    expect(result.success).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const message = warnSpy.mock.calls[0][0] as string;
+    // The message stays a single line — no raw newlines from the user input.
+    expect(message.split("\n")).toHaveLength(1);
+    // JSON.stringify escapes the embedded quote → \" and the newline → \\n.
+    expect(message).toContain('\\"quotes\\"');
+    expect(message).toContain("\\n");
+  } finally {
+    warnSpy.mockRestore();
+  }
+});
+
 test("validElementTypes does not include talkMeter or sharedNotepad", async () => {
   const { validElementTypes } = await import("./treatment.js");
   expect(validElementTypes).not.toContain("talkMeter");

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -1087,11 +1087,23 @@ const surveySchema = elementBaseSchema
 // survey logs at most once per process. Tracked for removal once the
 // module-reuse pattern lands; until then `survey` keeps working.
 const _warnedSurveys = new Set<string>();
+
+// Format the user-supplied surveyName for safe inclusion in a one-line
+// console message: JSON.stringify escapes quotes / control chars / newlines,
+// then truncate so a pathological multi-kilobyte string can't blow out logs.
+const MAX_SURVEY_NAME_LOG_CHARS = 200;
+function formatSurveyNameForLog(surveyName: string): string {
+  const escaped = JSON.stringify(surveyName);
+  return escaped.length > MAX_SURVEY_NAME_LOG_CHARS
+    ? `${escaped.slice(0, MAX_SURVEY_NAME_LOG_CHARS - 1)}…`
+    : escaped;
+}
+
 function warnSurveyDeprecation(surveyName: string): void {
   if (_warnedSurveys.has(surveyName)) return;
   _warnedSurveys.add(surveyName);
   console.warn(
-    `[stagebook] \`type: survey\` is deprecated and tracked for removal once a module-reuse pattern lands (surveyName: "${surveyName}"). Prefer prompt-based patterns where the survey can be expressed as a sequence of prompt elements.`,
+    `[stagebook] \`type: survey\` is deprecated and tracked for removal once a module-reuse pattern lands (surveyName: ${formatSurveyNameForLog(surveyName)}). Prefer prompt-based patterns where the survey can be expressed as a sequence of prompt elements.`,
   );
 }
 

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -1061,12 +1061,6 @@ const separatorSchema = elementBaseSchema
   })
   .strict();
 
-const sharedNotepadSchema = elementBaseSchema
-  .extend({
-    type: z.literal("sharedNotepad"),
-  })
-  .strict();
-
 const submitButtonSchema = elementBaseSchema
   .extend({
     type: z.literal("submitButton"),
@@ -1074,19 +1068,32 @@ const submitButtonSchema = elementBaseSchema
   })
   .strict();
 
+/**
+ * @deprecated `type: survey` is pending removal once Stagebook's module-reuse
+ *   pattern lands. New treatment files should prefer prompt-based patterns
+ *   where the survey can be expressed as a sequence of prompt elements. The
+ *   schema still accepts it; the runtime emits a one-time warning per
+ *   `surveyName` when a survey element is parsed (see `warnSurveyDeprecation`
+ *   on the element-union outer superRefine).
+ */
 const surveySchema = elementBaseSchema
   .extend({
     type: z.literal("survey"),
     surveyName: z.string(),
-    // Todo: check that surveyName is a valid survey name
   })
   .strict();
 
-const talkMeterSchema = elementBaseSchema
-  .extend({
-    type: z.literal("talkMeter"),
-  })
-  .strict();
+// One-time `survey` deprecation warning — keyed by surveyName so each unique
+// survey logs at most once per process. Tracked for removal once the
+// module-reuse pattern lands; until then `survey` keeps working.
+const _warnedSurveys = new Set<string>();
+function warnSurveyDeprecation(surveyName: string): void {
+  if (_warnedSurveys.has(surveyName)) return;
+  _warnedSurveys.add(surveyName);
+  console.warn(
+    `[stagebook] \`type: survey\` is deprecated and tracked for removal once a module-reuse pattern lands (surveyName: "${surveyName}"). Prefer prompt-based patterns where the survey can be expressed as a sequence of prompt elements.`,
+  );
+}
 
 const timerSchema = elementBaseSchema
   .extend({
@@ -1258,10 +1265,9 @@ export const validElementTypes = [
   "prompt",
   "qualtrics",
   "separator",
-  "sharedNotepad",
   "submitButton",
+  // `survey` is deprecated (see surveySchema's JSDoc) but still accepted.
   "survey",
-  "talkMeter",
   "timer",
   "mediaPlayer",
   "timeline",
@@ -1320,10 +1326,8 @@ const elementSchemasByType = {
   prompt: promptSchema,
   qualtrics: qualtricsSchema,
   separator: separatorSchema,
-  sharedNotepad: sharedNotepadSchema,
   submitButton: submitButtonSchema,
   survey: surveySchema,
-  talkMeter: talkMeterSchema,
   timer: timerSchema,
   mediaPlayer: mediaPlayerSchema,
   timeline: timelineSchema,
@@ -1451,10 +1455,8 @@ export const elementSchema = altTemplateContext(
       promptSchema,
       qualtricsSchema,
       separatorSchema,
-      sharedNotepadSchema,
       submitButtonSchema,
       surveySchema,
-      talkMeterSchema,
       timerSchema,
       mediaPlayerSchema,
       timelineSchema,
@@ -1466,6 +1468,9 @@ export const elementSchema = altTemplateContext(
       // inside the discriminated union, so we never reach here for it.
       if (data.type === "mediaPlayer") {
         checkMediaPlayerCrossFields(data, ctx);
+      }
+      if (data.type === "survey") {
+        warnSurveyDeprecation(data.surveyName);
       }
     }),
 );


### PR DESCRIPTION
## Summary

Closes #250. Removes two element types and marks one for removal.

**Removed entirely** (hard break):
- `talkMeter` — niche, inconsistently implemented across hosts; discussions already manage their own speaker UI. Element schema, router case, `StagebookContext.renderTalkMeter` slot, and the viewer's skeleton renderer all go.
- `sharedNotepad` — redundant with `prompt` elements that have `shared: true` and an openResponse prompt file. The shared-prompt path already routes through the host's `renderSharedNotepad`; the standalone element type was a parallel path doing the same thing. `renderSharedNotepad` stays — shared prompts still call it.

**Deprecated** (kept working, runtime warning):
- `survey` — pending removal once a module-reuse pattern lands. Marked `@deprecated` in JSDoc on both `surveySchema` and `StagebookContext.renderSurvey`. The runtime emits a one-time `console.warn` per `surveyName` at parse time via the element-union's outer superRefine.

**Walkthrough migration:** the annotated walkthrough's `type: sharedNotepad` element becomes a `type: prompt` + `shared: true` pointing at a new `prompts/discussion_notes.prompt.md` openResponse file. The TIPI `type: survey` element stays — it's the kept-deprecated case the issue body documents.

**Docs:** `docs/researcher/elements.md` adds an element-typology table (audio/image/mediaPlayer/display intents) so the kept-types rationale is captured for future re-litigation. `syntax-reference.md`, `architecture.md`, `api-reference.md`, `integration-guide.md`, `platform-requirements.md` all updated. The viewer's `lib/context.ts` drops `renderTalkMeter` from its renderers Pick.

## Migration

| Field                      | Migration                                                                                               |
|----------------------------|---------------------------------------------------------------------------------------------------------|
| \`type: talkMeter\`        | Remove the element. If speaker indication mattered, rely on the discussion's own UI.                    |
| \`type: sharedNotepad\`    | Replace with \`type: prompt\` + \`shared: true\` + an openResponse prompt file (see walkthrough).      |
| \`type: survey\`           | No immediate migration. Tracked for removal when the module-reuse design lands.                         |

## Test plan

- [x] Stagebook (747), viewer (84), and vscode (189) tests pass on Node 24.
- [x] New tests assert: \`talkMeter\` and \`sharedNotepad\` rejected with \`invalid_union_discriminator\`; \`survey\` still validates; the deprecation warning fires once per \`surveyName\` (verified via console.warn spy); \`validElementTypes\` no longer contains the removed types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)