### PR TITLE
feat(prompts): prompt-file format cleanup (closes #243)

### DIFF
--- a/apps/vscode/src/lib/validatePrompt.test.ts
+++ b/apps/vscode/src/lib/validatePrompt.test.ts
@@ -17,13 +17,12 @@ What is your favorite color?
       expect(result.diagnostics).toEqual([]);
     });
 
-    it("returns no diagnostics for a valid noResponse prompt", () => {
+    it("returns no diagnostics for a valid noResponse prompt (#243 — two-section file)", () => {
       const src = `---
 name: test/info.prompt.md
 type: noResponse
 ---
 Please read the following instructions carefully.
----
 `;
       const result = validatePromptSource(src);
       expect(result.diagnostics).toEqual([]);
@@ -51,15 +50,17 @@ Please describe your experience.
       expect(result.diagnostics[0].message).toMatch(/section|delimiter/i);
     });
 
-    it("reports error for only two delimiters", () => {
+    it("reports error for only two delimiters on a multipleChoice prompt (third section required)", () => {
       const src = `---
 name: test.prompt.md
-type: noResponse
+type: multipleChoice
 ---
-Body text but no third delimiter`;
+Body text but no third section`;
       const result = validatePromptSource(src);
       expect(result.diagnostics.length).toBeGreaterThan(0);
-      expect(result.diagnostics[0].message).toMatch(/section|delimiter/i);
+      expect(result.diagnostics[0].message).toMatch(
+        /section|delimiter|response/i,
+      );
     });
 
     it("reports error for empty file", () => {
@@ -73,9 +74,7 @@ Body text but no third delimiter`;
       const src = `---
 name: test/prompt.prompt.md
 ---
-Body text
----
-`;
+Body text`;
       const result = validatePromptSource(src);
       expect(result.diagnostics.length).toBeGreaterThan(0);
       expect(result.diagnostics[0].severity).toBe("error");
@@ -86,15 +85,13 @@ Body text
 name: test/prompt.prompt.md
 type: invalidType
 ---
-Body text
----
-`;
+Body text`;
       const result = validatePromptSource(src);
       expect(result.diagnostics.length).toBeGreaterThan(0);
       expect(result.diagnostics[0].severity).toBe("error");
     });
 
-    it("reports error for rows on non-openResponse type", () => {
+    it("reports error for rows on non-openResponse type (strict-keys per #243)", () => {
       const src = `---
 name: test/prompt.prompt.md
 type: multipleChoice
@@ -138,9 +135,7 @@ Blue`;
 name: test/prompt.prompt.md
 type: invalidType
 ---
-Body text
----
-`;
+Body text`;
       const result = validatePromptSource(src);
       const metadataErrors = result.diagnostics.filter(
         (d) =>
@@ -166,33 +161,33 @@ bad line`;
   });
 
   describe("extra delimiter warning", () => {
-    it("warns when more than 3 --- delimiters exist", () => {
+    it("warns when more than 3 --- delimiters appear in a 3-section prompt", () => {
+      // Stray `---` inside the body of a 3-section type is the classic
+      // "tried to use --- as a horizontal rule" footgun. After #243 the
+      // schema also rejects it (3-section types expect exactly one
+      // section delimiter between body and responses), but the explicit
+      // warning steers authors to *** / ___ instead.
       const src = `---
 name: test/prompt.prompt.md
-type: noResponse
+type: multipleChoice
 ---
-Some text
+Pick one
 ---
 then a horizontal rule
 ---
-`;
+- A
+- B`;
       const result = validatePromptSource(src);
       const warnings = result.diagnostics.filter(
         (d) => d.severity === "warning",
       );
-      expect(warnings).toHaveLength(1);
+      expect(warnings.length).toBeGreaterThanOrEqual(1);
       expect(warnings[0].message).toMatch(/horizontal rule|\*\*\*|___/i);
-      expect(warnings[0].range).toEqual({
-        startLine: 7,
-        startCol: 0,
-        endLine: 7,
-        endCol: 3,
-      });
     });
   });
 
   describe("slider type", () => {
-    it("returns no diagnostics for a valid slider prompt", () => {
+    it("returns no diagnostics for a valid slider prompt (#243 — labels in body, `- <n>: <label>`)", () => {
       const src = `---
 name: test/slider.prompt.md
 type: slider
@@ -202,39 +197,40 @@ interval: 10
 ---
 Rate your agreement.
 ---
-> Low
-> High`;
+- 0: Low
+- 100: High`;
       const result = validatePromptSource(src);
       expect(result.diagnostics).toEqual([]);
     });
 
-    it("reports errors when slider is missing required fields", () => {
+    it("reports errors when slider is missing required fields (#243 — strict required)", () => {
       const src = `---
 name: test/slider.prompt.md
 type: slider
 ---
 Rate something.
 ---
-> Low`;
+- 0: Low`;
       const result = validatePromptSource(src);
       const messages = result.diagnostics.map((d) => d.message);
-      expect(messages).toContain("min is required for slider type");
-      expect(messages).toContain("max is required for slider type");
-      expect(messages).toContain("interval is required for slider type");
+      // After #243 the discriminated-union branch declares min/max/interval
+      // as required (not optional), so missing them triggers Zod's
+      // "Required" message rather than a custom per-field message.
+      expect(messages.filter((m) => m === "Required").length).toBe(3);
     });
   });
 
   describe("listSorter type", () => {
-    it("returns no diagnostics for a valid listSorter prompt", () => {
+    it("returns no diagnostics for a valid listSorter prompt (#243 — `-` marker required)", () => {
       const src = `---
 name: test/sort.prompt.md
 type: listSorter
 ---
 Rank these items.
 ---
-> Item A
-> Item B
-> Item C`;
+- Item A
+- Item B
+- Item C`;
       const result = validatePromptSource(src);
       expect(result.diagnostics).toEqual([]);
     });
@@ -246,9 +242,7 @@ Rank these items.
 name: test/prompt.prompt.md
 type: [unclosed bracket
 ---
-Body text
----
-`;
+Body text`;
       const result = validatePromptSource(src);
       expect(result.diagnostics).toContainEqual(
         expect.objectContaining({

--- a/apps/vscode/src/lib/validatePrompt.ts
+++ b/apps/vscode/src/lib/validatePrompt.ts
@@ -34,12 +34,15 @@ function mapPromptErrorToRange(
   path: (string | number)[],
   delimiters: number[],
 ): SourceRange | null {
-  if (delimiters.length < 3) {
-    // Can't map without delimiters — fall back to line 0
+  if (delimiters.length < 2) {
+    // Need at least the frontmatter open + close to localize anything.
     return { startLine: 0, startCol: 0, endLine: 0, endCol: 1 };
   }
 
-  const [metaStart, metaEnd, responseStart] = delimiters;
+  const [metaStart, metaEnd] = delimiters;
+  // For 2-section (`noResponse`) files there's no response delimiter; fall
+  // back to "end of frontmatter" for any response-section path.
+  const responseStart = delimiters[2] ?? metaEnd;
 
   if (path.length === 0) {
     return { startLine: 0, startCol: 0, endLine: 0, endCol: 1 };
@@ -130,7 +133,19 @@ export function validatePromptSource(source: string): PromptValidationResult {
 
   if (!result.success) {
     for (const issue of result.error.issues) {
-      const range = mapPromptErrorToRange(source, issue.path, delimiters);
+      // Zod's `unrecognized_keys` puts the bad keys in `issue.keys` and
+      // leaves `issue.path` pointing at the parent object. Synthesize a
+      // path that includes the bad key so `mapPromptErrorToRange` can
+      // find its source line.
+      let issuePath = issue.path;
+      if (
+        issue.code === "unrecognized_keys" &&
+        Array.isArray((issue as { keys?: unknown[] }).keys) &&
+        (issue as { keys: string[] }).keys.length > 0
+      ) {
+        issuePath = [...issue.path, (issue as { keys: string[] }).keys[0]];
+      }
+      const range = mapPromptErrorToRange(source, issuePath, delimiters);
       diagnostics.push({
         message: issue.message,
         severity: "error",

--- a/docs/engineer/api-reference.md
+++ b/docs/engineer/api-reference.md
@@ -26,11 +26,10 @@ All schemas are [Zod](https://zod.dev/) objects. Use `.safeParse(data)` for vali
 
 | Export | Description |
 |--------|-------------|
-| `promptFileSchema` | Parses raw markdown → `{ metadata, body, responseItems }` with full validation |
-| `metadataTypeSchema` | Prompt metadata field types (name, type, rows, min/max, etc.) |
-| `metadataRefineSchema` | Cross-field metadata rules (e.g., slider requires min/max/interval) |
-| `metadataLogicalSchema` | Alias for `metadataRefineSchema` (name field is optional, no filename matching) |
-| `validateSliderLabels(metadata, items)` | Checks labelPts length matches response item count |
+| `promptFileSchema` | Parses raw markdown → `{ metadata, body, responseItems, sliderPoints }` with full validation |
+| `promptMetadataSchema` | Discriminated-union schema for the YAML frontmatter (one strict branch per `type:`) |
+| `metadataTypeSchema` / `metadataRefineSchema` / `metadataLogicalSchema` | Back-compat aliases for `promptMetadataSchema` (#243 — the parallel pre-refine pair was unified into one schema) |
+| `validateSliderLabels(metadata, items)` | No-op shim retained for back-compat — slider points and labels share the same body lines after #243, so this check is structurally impossible to fail |
 
 ### Types
 
@@ -200,7 +199,7 @@ Requires StagebookProvider. Dispatches to the appropriate element component base
 | `RadioGroup` | `options`, `value`, `onChange`, `label?` |
 | `CheckboxGroup` | `options`, `value`, `onChange`, `label?` |
 | `TextArea` | `value`, `onChange`, `rows?`, `minLength?`, `maxLength?`, `showCharacterCount?`, `onDebugMessage?` |
-| `Slider` | `min`, `max`, `interval`, `value?`, `onChange`, `labelPts?`, `labels?` |
+| `Slider` | `min`, `max`, `interval`, `value?`, `onChange`, `labelPts?` (parallel to `labels?`, sourced from `promptFileSchema.parse(...).sliderPoints` after #243), `labels?` |
 | `ListSorter` | `items`, `onChange` |
 | `Markdown` | `text`, `resolveURL?` |
 

--- a/docs/researcher/prompts.md
+++ b/docs/researcher/prompts.md
@@ -1,10 +1,10 @@
 # Prompt Files
 
-Prompts are Markdown files with three sections separated by lines of three or more dashes (`---`):
+Prompts are Markdown files with two or three sections separated by lines of three or more dashes (`---`):
 
-1. **Metadata** — YAML frontmatter defining the prompt type and behavior
-2. **Body** — Markdown-formatted text displayed to the participant
-3. **Responses** — Response options (format depends on type)
+1. **Metadata** — YAML frontmatter defining the prompt type and behavior.
+2. **Body** — Markdown-formatted text displayed to the participant.
+3. **Responses** — Response options (format depends on type). Required for `multipleChoice`, `openResponse`, `listSorter`, `slider`. **Omitted entirely for `noResponse`** (#243 — `noResponse` files are two-section).
 
 ## Example
 
@@ -24,6 +24,8 @@ type: multipleChoice
 ```
 
 ## Metadata Fields
+
+Each per-type schema is `.strict()` (#243) — unknown frontmatter keys (typos like `tytle:`, `placholder:`, `interavl:`) are rejected at preflight.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
@@ -45,8 +47,8 @@ type: multipleChoice
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `select` | `"single"` or `"multiple"` | Radio buttons (default) or checkboxes |
-| `shuffleOptions` | boolean | Randomize option order before display |
+| `select` | `"single"` or `"multiple"` | Radio buttons (default: `single`) or checkboxes. The legacy `"undefined"` enum value was removed in #243 — omit the field for the default. |
+| `shuffle` | boolean | Randomize option order before display. (Renamed from `shuffleOptions:` in #243.) |
 | `layout` | `"vertical"` or `"horizontal"` | Option layout direction (default: `vertical`) |
 
 **`slider`:**
@@ -55,14 +57,17 @@ type: multipleChoice
 |-------|------|-------------|
 | `min` | number | **Required.** Minimum slider value |
 | `max` | number | **Required.** Maximum slider value (must be > min) |
-| `interval` | number | **Required.** Step size (min + interval must be <= max) |
-| `labelPts` | number[] | Positions where tick marks and labels appear |
+| `interval` | number | **Required.** Step size (min + interval must be ≤ max) |
 
-When `labelPts` is specified, the number of entries must match the number of response items.
+Slider tick labels live in the body's response section (#243), not in the frontmatter — see [Slider](#slider) below. The legacy `labelPts:` frontmatter field was removed.
 
-**`noResponse`:** No type-specific fields. The responses section should be empty.
+**`noResponse`:** No type-specific fields. The file has only two sections (frontmatter + body) — no trailing `---` and no third section.
 
-**`listSorter`:** No type-specific fields. Response items are the list to be reordered.
+**`listSorter`:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `shuffle` | boolean | Randomize item order on first render |
 
 ## Body Section
 
@@ -74,11 +79,11 @@ Images use paths relative to the asset repository root:
 ![diagram](shared/question_diagram.png)
 ```
 
-**Note:** You cannot use `---` as a horizontal rule in the body since it's used as the section delimiter. Use `***` or `___` instead.
+**Note:** You cannot use `---` as a horizontal rule in the body since it's used as the section delimiter. Use `***` or `___` instead — both render identically to `---` in any markdown viewer.
 
 ## Response Section
 
-The format depends on the prompt type:
+Per-type marker enforcement (#243): each type accepts exactly one of `-` or `>` for response lines. Mixing the wrong marker for the type is a preflight error.
 
 ### Multiple Choice / List Sorter
 
@@ -100,19 +105,21 @@ Placeholder text prefixed with `> `:
 
 ### Slider
 
-Labels for tick marks, prefixed with `- `:
+Slider tick labels are inline `- <number>(: <label>)?` lines (#243). The number is the slider point; the label (if present, after the first colon) is what the participant sees beneath the tick. Bare numbers default to using the number as the label.
 
 ```markdown
-- Strongly Disagree
-- Disagree
-- Neutral
-- Agree
-- Strongly Agree
+- 0: Strongly Disagree
+- 25
+- 50: Neutral
+- 75
+- 100: Strongly Agree
 ```
+
+Mixed labeled and unlabeled points are valid. Labels can themselves contain colons — everything after the first colon is the label.
 
 ### No Response
 
-Leave the section empty (or blank lines).
+`noResponse` files don't have a response section at all. Drop the trailing `---` and the third section entirely.
 
 ## Prompt Types in Detail
 
@@ -121,7 +128,7 @@ Leave the section empty (or blank lines).
 ```markdown
 ---
 type: multipleChoice
-shuffleOptions: true
+shuffle: true
 ---
 
 What is your favorite color?
@@ -197,18 +204,17 @@ type: slider
 min: 0
 max: 100
 interval: 1
-labelPts: [0, 25, 50, 75, 100]
 ---
 
 How much do you agree with the following statement?
 
 ---
 
-- Strongly Disagree
-- Disagree
-- Neutral
-- Agree
-- Strongly Agree
+- 0: Strongly Disagree
+- 25
+- 50: Neutral
+- 75
+- 100: Strongly Agree
 ```
 
 ### List Sorter
@@ -216,6 +222,7 @@ How much do you agree with the following statement?
 ```markdown
 ---
 type: listSorter
+shuffle: true
 ---
 
 Drag the following items into your preferred order:
@@ -231,7 +238,7 @@ Drag the following items into your preferred order:
 
 ### No Response
 
-Use for informational text that doesn't collect a response:
+Use for informational text that doesn't collect a response. Two-section file (no trailing `---`):
 
 ```markdown
 ---
@@ -241,7 +248,4 @@ type: noResponse
 Please read the following instructions carefully before proceeding.
 
 The study will take approximately 15 minutes.
-
----
-
 ```

--- a/examples/annotated-walkthrough/prompts/consent.prompt.md
+++ b/examples/annotated-walkthrough/prompts/consent.prompt.md
@@ -16,5 +16,3 @@ Your responses are confidential and will only be used in aggregate. You
 can stop at any time.
 
 Click **I consent** below to begin.
-
----

--- a/examples/annotated-walkthrough/prompts/discussion_guide.prompt.md
+++ b/examples/annotated-walkthrough/prompts/discussion_guide.prompt.md
@@ -16,5 +16,3 @@ You can also jot points in the shared notepad — both of you can edit it
 at the same time.
 
 The **End discussion** button will appear after one minute.
-
----

--- a/examples/annotated-walkthrough/prompts/familiarity.prompt.md
+++ b/examples/annotated-walkthrough/prompts/familiarity.prompt.md
@@ -4,7 +4,6 @@ name: Familiarity
 min: 0
 max: 100
 interval: 1
-labelPts: [0, 50, 100]
 ---
 
 # Workplace policy familiarity
@@ -17,6 +16,6 @@ yet — that is intentional, so the position you choose is your own.
 
 ---
 
-- Not familiar
-- Somewhat familiar
-- Very familiar
+- 0: Not familiar
+- 50: Somewhat familiar
+- 100: Very familiar

--- a/examples/annotated-walkthrough/prompts/initial_intro.prompt.md
+++ b/examples/annotated-walkthrough/prompts/initial_intro.prompt.md
@@ -9,5 +9,3 @@ In a moment you will see a short policy question. Take a few seconds to
 think about it before the prompt appears.
 
 You will have 90 seconds total for this stage.
-
----

--- a/examples/annotated-walkthrough/prompts/post_consensus.prompt.md
+++ b/examples/annotated-walkthrough/prompts/post_consensus.prompt.md
@@ -6,5 +6,3 @@ name: Both responded
 You and your partner have both submitted your post-discussion answers.
 
 When you are ready, click **Next** to continue to the debrief.
-
----

--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -206,7 +206,7 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
           </p>
         );
       }
-      const { metadata, body, responseItems } = parsed.data;
+      const { metadata, body, responseItems, sliderPoints } = parsed.data;
       const promptName =
         element.name ?? `${progressLabel}_${metadata.name ?? element.file}`;
 
@@ -220,6 +220,7 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
           metadata={metadata}
           body={body}
           responseItems={responseItems}
+          sliderPoints={sliderPoints}
           name={promptName}
           file={element.file}
           shared={element.shared}

--- a/packages/stagebook/src/components/elements/Prompt.ct.tsx
+++ b/packages/stagebook/src/components/elements/Prompt.ct.tsx
@@ -371,22 +371,23 @@ test.describe("List Sorter", () => {
 });
 
 // ================================================================
-// Multiple Choice option order (shuffleOptions vs source order)
+// Multiple Choice option order (shuffle vs source order)
 // ================================================================
 //
 // Pins the contract that:
-//   - `shuffleOptions: true` produces a non-source-order rendering
+//   - `shuffle: true` produces a non-source-order rendering
 //     while keeping the same option set
 //   - the shuffled order is captured at first render and remains
 //     stable across re-renders (the user's randomized labels don't
 //     reshuffle on every parent state change)
-//   - omitting `shuffleOptions` preserves yaml-declared order, even
+//   - omitting `shuffle` preserves yaml-declared order, even
 //     when that order is intentionally non-alphabetical (e.g. mixed
 //     numeric and string labels)
 //
-// Used by deliberation-empirica's cypress 01 omnibus (now retiring);
-// this duplicates the assertions upstream so the upstream contract
-// is locked in. (Issue #232.)
+// (Renamed from `shuffleOptions:` in #243.) Used by
+// deliberation-empirica's cypress 01 omnibus (now retiring); this
+// duplicates the assertions upstream so the upstream contract is
+// locked in. (Issue #232.)
 
 const SHUFFLE_OPTIONS = [
   "alpha",
@@ -403,7 +404,7 @@ const shuffledMultipleChoice = {
   metadata: {
     name: "projects/example/shuffled.md",
     type: "multipleChoice" as const,
-    shuffleOptions: true,
+    shuffle: true,
   },
   body: "# Pick one",
   responseItems: [...SHUFFLE_OPTIONS],
@@ -440,7 +441,7 @@ async function readRadioOrder(
 }
 
 test.describe("Multiple Choice option order", () => {
-  test("shuffleOptions: true produces a different order with the same set", async ({
+  test("shuffle: true produces a different order with the same set", async ({
     mount,
   }) => {
     const component = await mount(
@@ -492,7 +493,7 @@ test.describe("Multiple Choice option order", () => {
     expect(secondOrder).toEqual(firstOrder);
   });
 
-  test("without shuffleOptions, options render in declared yaml order", async ({
+  test("without shuffle, options render in declared yaml order", async ({
     mount,
   }) => {
     // Custom order: "0", "0.5", "3", "4", "5.5", "six", "7", "8" — not

--- a/packages/stagebook/src/components/elements/Prompt.tsx
+++ b/packages/stagebook/src/components/elements/Prompt.tsx
@@ -16,6 +16,14 @@ export interface PromptProps {
   metadata: MetadataType;
   body: string;
   responseItems: string[];
+  /**
+   * Slider points (numbers) parsed from the body section. Empty for
+   * non-slider types. After #243 slider points and labels share the same
+   * body lines (`- 50: Somewhat familiar`); upstream
+   * `promptFileSchema.transform` splits them into `sliderPoints` (numbers)
+   * and `responseItems` (labels) with the i'th index aligned across both.
+   */
+  sliderPoints?: number[];
   name: string;
   file?: string;
   shared?: boolean;
@@ -33,6 +41,7 @@ export function Prompt({
   metadata,
   body,
   responseItems,
+  sliderPoints,
   name,
   file,
   shared = false,
@@ -49,9 +58,19 @@ export function Prompt({
   );
 
   const promptType = metadata.type;
-  const rows = metadata.rows ?? 5;
-  const minLength = metadata.minLength ?? undefined;
-  const maxLength = metadata.maxLength ?? undefined;
+  // Per-type fields only exist on the discriminated-union branch where
+  // they were declared (#243). Safely-narrowed lookups via the type tag.
+  const rows = promptType === "openResponse" ? (metadata.rows ?? 5) : 5;
+  const minLength =
+    promptType === "openResponse" ? metadata.minLength : undefined;
+  const maxLength =
+    promptType === "openResponse" ? metadata.maxLength : undefined;
+  // `shuffle` (renamed from `shuffleOptions` in #243) lives on
+  // multipleChoice and listSorter. Sliders never shuffle — points and
+  // labels share an i'th-position alignment that scrambling would break.
+  const shouldShuffle =
+    (promptType === "multipleChoice" || promptType === "listSorter") &&
+    metadata.shuffle === true;
 
   // Initialize responses from responseItems (with optional shuffle)
   if (
@@ -60,7 +79,7 @@ export function Prompt({
     (!responses.length ||
       !setEquality(new Set(responseItems), new Set(responses)))
   ) {
-    if (metadata.shuffleOptions) {
+    if (shouldShuffle) {
       setResponses([...responseItems].sort(() => 0.5 - Math.random()));
     } else {
       setResponses(responseItems);
@@ -178,7 +197,7 @@ export function Prompt({
           min={metadata.min}
           max={metadata.max}
           interval={metadata.interval}
-          labelPts={metadata.labelPts}
+          labelPts={sliderPoints}
           labels={responses}
           value={value as number | undefined}
           onChange={(val) => debouncedSaveInteractive(val, record)}

--- a/packages/stagebook/src/components/elements/Prompt.tsx
+++ b/packages/stagebook/src/components/elements/Prompt.tsx
@@ -21,7 +21,7 @@ export interface PromptProps {
    * non-slider types. After #243 slider points and labels share the same
    * body lines (`- 50: Somewhat familiar`); upstream
    * `promptFileSchema.transform` splits them into `sliderPoints` (numbers)
-   * and `responseItems` (labels) with the i'th index aligned across both.
+   * and `responseItems` (labels) with the i-th index aligned across both.
    */
   sliderPoints?: number[];
   name: string;

--- a/packages/stagebook/src/components/elements/fixtures/prompts.ts
+++ b/packages/stagebook/src/components/elements/fixtures/prompts.ts
@@ -1,5 +1,7 @@
 // Parsed prompt fixtures for testing.
-// These mirror the structure returned by promptFileSchema.parse().
+// These mirror the structure returned by promptFileSchema.parse() — every
+// fixture includes `sliderPoints` (empty for non-slider types) so consumers
+// can spread the fixture into <Prompt {...fixture} /> without special-casing.
 
 import type { MetadataType } from "../../../schemas/promptFile.js";
 
@@ -17,6 +19,7 @@ We need to decide whether to use Markdown or HTML for storing deliberation topic
 
 _Which format is better for this task?_`,
   responseItems: ["Markdown", "HTML"],
+  sliderPoints: [],
 };
 
 export const multipleChoiceMultiple = {
@@ -27,6 +30,7 @@ export const multipleChoiceMultiple = {
   } as MetadataType,
   body: "# Which colors indicate a strong magical field?",
   responseItems: ["Octarine", "Hooloovoo", "Ultrablack", "Ulfire", "Plaid"],
+  sliderPoints: [],
 };
 
 export const openResponse = {
@@ -39,6 +43,7 @@ export const openResponse = {
 
 _Are there any other reasons you can think of for choosing one or the other?_`,
   responseItems: ["Please enter your response here."],
+  sliderPoints: [],
 };
 
 export const openResponseWithLimits = {
@@ -51,6 +56,7 @@ export const openResponseWithLimits = {
   } as MetadataType,
   body: "# Please write a response between 50 and 200 characters.",
   responseItems: ["Enter your response here."],
+  sliderPoints: [],
 };
 
 export const noResponse = {
@@ -62,6 +68,7 @@ export const noResponse = {
 
 We need to decide whether to use Markdown or HTML. _Discuss why markdown is the best._`,
   responseItems: [],
+  sliderPoints: [],
 };
 
 export const slider = {
@@ -93,4 +100,5 @@ export const listSorter = {
     "Albus Dumbledore",
     "Severus Snape",
   ],
+  sliderPoints: [],
 };

--- a/packages/stagebook/src/components/elements/fixtures/prompts.ts
+++ b/packages/stagebook/src/components/elements/fixtures/prompts.ts
@@ -71,10 +71,13 @@ export const slider = {
     min: 0,
     max: 100,
     interval: 1,
-    labelPts: [0, 20, 50, 80, 100],
   } as MetadataType,
   body: "# How warm is your love for avocados?",
   responseItems: ["Very cold", "Chilly", "Tolerable", "Warm", "Super Hot"],
+  // After #243 slider points live in the body alongside their labels.
+  // The fixture shape mirrors `promptFileSchema.parse()` output, so
+  // points and labels arrive as parallel arrays.
+  sliderPoints: [0, 20, 50, 80, 100],
 };
 
 export const listSorter = {

--- a/packages/stagebook/src/components/testing/MockSaveTracker.tsx
+++ b/packages/stagebook/src/components/testing/MockSaveTracker.tsx
@@ -35,9 +35,8 @@ export function MockSaveTracker({
     submit: () => {},
     getAssetURL: (path: string) => `https://cdn.test/${path}`,
     getTextContent: () =>
-      Promise.resolve(
-        "---\nname: mock\ntype: noResponse\n---\nMock content\n---\n",
-      ),
+      // After #243 noResponse files are two-section.
+      Promise.resolve("---\nname: mock\ntype: noResponse\n---\nMock content\n"),
     progressLabel: `game_0_${stage.name}`,
     playerId: "player-1",
     position: 0,

--- a/packages/stagebook/src/components/testing/MockStageRenderer.tsx
+++ b/packages/stagebook/src/components/testing/MockStageRenderer.tsx
@@ -85,7 +85,8 @@ export function MockStageRenderer({
     getAssetURL: (path: string) => `https://mock-cdn.test/${path}`,
     getTextContent: (path: string) =>
       Promise.resolve(
-        `---\nname: ${path}\ntype: noResponse\n---\nMock content for ${path}\n---\n`,
+        // After #243 noResponse files are two-section (no trailing `---`).
+        `---\nname: ${path}\ntype: noResponse\n---\nMock content for ${path}\n`,
       ),
     progressLabel: `game_0_${stage.name}`,
     playerId: "test-player-1",

--- a/packages/stagebook/src/components/testing/MockSurveyStage.tsx
+++ b/packages/stagebook/src/components/testing/MockSurveyStage.tsx
@@ -39,7 +39,8 @@ export function MockSurveyStage() {
     submit: () => {},
     getAssetURL: (path: string) => `https://mock-cdn.test/${path}`,
     getTextContent: () =>
-      Promise.resolve("---\nname: mock\ntype: noResponse\n---\nMock\n---\n"),
+      // After #243 noResponse files are two-section.
+      Promise.resolve("---\nname: mock\ntype: noResponse\n---\nMock\n"),
     progressLabel: "game_0_SurveyStage",
     playerId: "test-player",
     position: 0,

--- a/packages/stagebook/src/schemas/promptFile.test.ts
+++ b/packages/stagebook/src/schemas/promptFile.test.ts
@@ -1,5 +1,6 @@
 import { expect, test, describe } from "vitest";
 import {
+  promptMetadataSchema,
   metadataTypeSchema,
   metadataRefineSchema,
   metadataLogicalSchema,
@@ -7,434 +8,245 @@ import {
   promptFileSchema,
 } from "./promptFile.js";
 
-// ----------- Type Schema Validation (metadataTypeSchema) ------------
-
-test("valid metadata passes type schema", () => {
-  const metadata = {
-    name: "mock-prompt-files/prompt.md",
-    type: "openResponse",
-    notes: "Optional notes",
-    rows: 3,
-  };
-  const result = metadataTypeSchema.safeParse(metadata);
-  if (!result.success) console.log(result.error);
-  expect(result.success).toBe(true);
+// Back-compat aliases all point at `promptMetadataSchema` after #243; the
+// pre-#243 dual-schema workaround is gone. We exercise the canonical name
+// here, but keep one cross-check that the aliases still resolve to the
+// same schema.
+test("metadata back-compat aliases resolve to promptMetadataSchema", () => {
+  expect(metadataTypeSchema).toBe(promptMetadataSchema);
+  expect(metadataRefineSchema).toBe(promptMetadataSchema);
+  expect(metadataLogicalSchema).toBe(promptMetadataSchema);
 });
 
-test("missing required type field fails type schema", () => {
-  const metadata = {
-    name: "mock-prompt-files/prompt.md",
-  };
-  const result = metadataTypeSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
+// ----------- Frontmatter — discriminated union per type ------------
+
+describe("promptMetadataSchema", () => {
+  test("openResponse with rows is valid", () => {
+    const result = promptMetadataSchema.safeParse({
+      name: "Welcome",
+      type: "openResponse",
+      rows: 3,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("noResponse with just name + type is valid", () => {
+    const result = promptMetadataSchema.safeParse({
+      name: "Welcome",
+      type: "noResponse",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("name field is optional", () => {
+    const result = promptMetadataSchema.safeParse({ type: "openResponse" });
+    expect(result.success).toBe(true);
+  });
+
+  test("missing type is rejected", () => {
+    const result = promptMetadataSchema.safeParse({ name: "x" });
+    expect(result.success).toBe(false);
+  });
+
+  test("invalid type value is rejected", () => {
+    const result = promptMetadataSchema.safeParse({
+      name: "x",
+      type: "invalidType",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rows on multipleChoice is rejected (strict-keys)", () => {
+    // After #243 each per-type schema is `.strict()`; a field that lives on
+    // another branch (here `rows`, only on openResponse) fails strict-key
+    // validation rather than running through a separate cross-field rule.
+    const result = promptMetadataSchema.safeParse({
+      name: "x",
+      type: "multipleChoice",
+      rows: 3,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("select on openResponse is rejected (strict-keys)", () => {
+    const result = promptMetadataSchema.safeParse({
+      name: "x",
+      type: "openResponse",
+      select: "single",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("shuffleOptions (legacy spelling) is rejected — use `shuffle` (#243)", () => {
+    const result = promptMetadataSchema.safeParse({
+      name: "x",
+      type: "multipleChoice",
+      shuffleOptions: true,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("shuffle (renamed from shuffleOptions in #243) is accepted", () => {
+    const result = promptMetadataSchema.safeParse({
+      name: "x",
+      type: "multipleChoice",
+      shuffle: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("listSorter accepts `shuffle`", () => {
+    const result = promptMetadataSchema.safeParse({
+      type: "listSorter",
+      shuffle: true,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("select: 'undefined' (legacy enum value) is rejected — omit field for default", () => {
+    const result = promptMetadataSchema.safeParse({
+      type: "multipleChoice",
+      select: "undefined",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("multipleChoice without select defaults to 'single'", () => {
+    const result = promptMetadataSchema.safeParse({ type: "multipleChoice" });
+    expect(result.success).toBe(true);
+    if (result.success && result.data.type === "multipleChoice") {
+      expect(result.data.select).toBe("single");
+      expect(result.data.layout).toBe("vertical");
+    }
+  });
+
+  test("openResponse: minLength > maxLength is rejected", () => {
+    const result = promptMetadataSchema.safeParse({
+      type: "openResponse",
+      minLength: 100,
+      maxLength: 50,
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) =>
+          i.message.includes("minLength cannot be greater than maxLength"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("slider: min/max/interval all required (strict)", () => {
+    expect(
+      promptMetadataSchema.safeParse({ type: "slider", max: 100, interval: 1 })
+        .success,
+    ).toBe(false);
+    expect(
+      promptMetadataSchema.safeParse({ type: "slider", min: 0, interval: 1 })
+        .success,
+    ).toBe(false);
+    expect(
+      promptMetadataSchema.safeParse({ type: "slider", min: 0, max: 100 })
+        .success,
+    ).toBe(false);
+    expect(
+      promptMetadataSchema.safeParse({
+        type: "slider",
+        min: 0,
+        max: 100,
+        interval: 1,
+      }).success,
+    ).toBe(true);
+  });
+
+  test("slider: min >= max rejected", () => {
+    const result = promptMetadataSchema.safeParse({
+      type: "slider",
+      min: 100,
+      max: 100,
+      interval: 1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("slider: min + interval > max rejected", () => {
+    const result = promptMetadataSchema.safeParse({
+      type: "slider",
+      min: 0,
+      max: 10,
+      interval: 20,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("slider: legacy labelPts frontmatter key is rejected (#243 — labels are body lines now)", () => {
+    const result = promptMetadataSchema.safeParse({
+      type: "slider",
+      min: 0,
+      max: 100,
+      interval: 1,
+      labelPts: [0, 50, 100],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("multipleChoice with layout: horizontal/vertical accepted", () => {
+    expect(
+      promptMetadataSchema.safeParse({
+        type: "multipleChoice",
+        layout: "horizontal",
+      }).success,
+    ).toBe(true);
+    expect(
+      promptMetadataSchema.safeParse({
+        type: "multipleChoice",
+        layout: "vertical",
+      }).success,
+    ).toBe(true);
+  });
+
+  test("layout outside vertical|horizontal rejected", () => {
+    const result = promptMetadataSchema.safeParse({
+      type: "multipleChoice",
+      layout: "diagonal",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("layout on openResponse rejected (strict-keys)", () => {
+    const result = promptMetadataSchema.safeParse({
+      type: "openResponse",
+      layout: "horizontal",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("unknown frontmatter key (typo) is rejected (strict-keys per type)", () => {
+    // Typos like `tytle:` / `placholder:` / `interavl:` fail at preflight
+    // because each branch is `.strict()`.
+    expect(
+      promptMetadataSchema.safeParse({ type: "openResponse", tytle: "x" })
+        .success,
+    ).toBe(false);
+  });
 });
 
-test("invalid type value fails type schema", () => {
-  const metadata = {
-    name: "mock-prompt-files/prompt.md",
-    type: "invalidType",
-  };
-  const result = metadataTypeSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-});
+// ----------- validateSliderLabels back-compat shim ------------
 
-test("notes field is optional in type schema", () => {
-  const metadata = {
-    name: "mock-prompt-files/prompt.md",
-    type: "noResponse",
-  };
-  const result = metadataTypeSchema.safeParse(metadata);
-  expect(result.success).toBe(true);
-});
-
-// ----------- Refined Validation (metadataRefineSchema) ------------
-
-test("valid refined metadata passes all refine rules", () => {
-  const metadata = {
-    name: "mock-prompt-files/prompt.md",
-    type: "openResponse",
-    rows: 5,
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(true);
-});
-
-test("invalid: rows provided but type is not openResponse", () => {
-  const metadata = {
-    name: "mock-prompt-files/prompt.md",
-    type: "multipleChoice",
-    rows: 3,
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-});
-
-test("invalid: select provided but type is not multipleChoice", () => {
-  const metadata = {
-    name: "mock-prompt-files/prompt.md",
-    type: "openResponse",
-    select: "single",
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-});
-
-test("invalid: shuffleOptions provided but type is noResponse", () => {
-  const metadata = {
-    name: "mock-prompt-files/prompt.md",
-    type: "noResponse",
-    shuffleOptions: true,
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-});
-
-// ----------- Logical Schema (metadataLogicalSchema) ------------
-
-test("valid logical schema with arbitrary name", () => {
-  const metadata = {
-    name: "any name the author wants",
-    type: "openResponse",
-  };
-  const result = metadataLogicalSchema.safeParse(metadata);
-  expect(result.success).toBe(true);
-});
-
-test("valid logical schema without name", () => {
-  const metadata = {
-    type: "openResponse",
-  };
-  const result = metadataLogicalSchema.safeParse(metadata);
-  expect(result.success).toBe(true);
-});
-
-// ----------- Slider Type Validation ------------
-
-test("valid slider metadata with all required fields", () => {
-  const metadata = {
-    name: "mock-prompt-files/slider.md",
-    type: "slider",
-    min: 0,
-    max: 100,
-    interval: 1,
-    labelPts: [0, 25, 50, 75, 100],
-  };
-  const result = metadataTypeSchema.safeParse(metadata);
-  expect(result.success).toBe(true);
-});
-
-test("invalid: slider missing min field", () => {
-  const metadata = {
-    name: "mock-prompt-files/slider.md",
-    type: "slider",
-    max: 100,
-    interval: 1,
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-  if (!result.success) {
-    const minError = result.error.issues.find(
-      (issue) => issue.path[0] === "min",
-    );
-    expect(minError?.message).toBe("min is required for slider type");
-  }
-});
-
-test("invalid: slider missing max field", () => {
-  const metadata = {
-    name: "mock-prompt-files/slider.md",
-    type: "slider",
-    min: 0,
-    interval: 1,
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-  if (!result.success) {
-    const maxError = result.error.issues.find(
-      (issue) => issue.path[0] === "max",
-    );
-    expect(maxError?.message).toBe("max is required for slider type");
-  }
-});
-
-test("invalid: slider missing interval field", () => {
-  const metadata = {
-    name: "mock-prompt-files/slider.md",
-    type: "slider",
-    min: 0,
-    max: 100,
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-  if (!result.success) {
-    const intervalError = result.error.issues.find(
-      (issue) => issue.path[0] === "interval",
-    );
-    expect(intervalError?.message).toBe("interval is required for slider type");
-  }
-});
-
-test("invalid: slider min >= max", () => {
-  const metadata = {
-    name: "mock-prompt-files/slider.md",
-    type: "slider",
-    min: 100,
-    max: 100,
-    interval: 1,
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-  if (!result.success) {
-    const minError = result.error.issues.find(
-      (issue) => issue.path[0] === "min",
-    );
-    expect(minError?.message).toBe("min must be less than max");
-  }
-});
-
-test("invalid: slider min + interval > max", () => {
-  const metadata = {
-    name: "mock-prompt-files/slider.md",
-    type: "slider",
-    min: 0,
-    max: 10,
-    interval: 20,
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-  if (!result.success) {
-    const intervalError = result.error.issues.find(
-      (issue) => issue.path[0] === "interval",
-    );
-    expect(intervalError?.message).toBe(
-      "min + interval must be less than or equal to max",
-    );
-  }
-});
-
-test("invalid: non-slider type with min field", () => {
-  const metadata = {
-    name: "mock-prompt-files/prompt.md",
-    type: "openResponse",
-    min: 0,
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-  if (!result.success) {
-    const minError = result.error.issues.find(
-      (issue) => issue.path[0] === "min",
-    );
-    expect(minError?.message).toBe("min can only be specified for slider type");
-  }
-});
-
-test("invalid: non-slider type with max field", () => {
-  const metadata = {
-    name: "mock-prompt-files/prompt.md",
-    type: "openResponse",
-    max: 100,
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-  if (!result.success) {
-    const maxError = result.error.issues.find(
-      (issue) => issue.path[0] === "max",
-    );
-    expect(maxError?.message).toBe("max can only be specified for slider type");
-  }
-});
-
-test("invalid: non-slider type with interval field", () => {
-  const metadata = {
-    name: "mock-prompt-files/prompt.md",
-    type: "openResponse",
-    interval: 1,
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-  if (!result.success) {
-    const intervalError = result.error.issues.find(
-      (issue) => issue.path[0] === "interval",
-    );
-    expect(intervalError?.message).toBe(
-      "interval can only be specified for slider type",
-    );
-  }
-});
-
-test("invalid: non-slider type with labelPts field", () => {
-  const metadata = {
-    name: "mock-prompt-files/prompt.md",
-    type: "openResponse",
-    labelPts: [0, 50, 100],
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-  if (!result.success) {
-    const labelPtsError = result.error.issues.find(
-      (issue) => issue.path[0] === "labelPts",
-    );
-    expect(labelPtsError?.message).toBe(
-      "labelPts can only be specified for slider type",
-    );
-  }
-});
-
-// ----------- Layout Field (multipleChoice only) ------------
-
-test("valid: multipleChoice with layout: horizontal", () => {
-  const metadata = {
-    name: "mock-prompt-files/mc.md",
-    type: "multipleChoice",
-    layout: "horizontal",
-  };
-  const typeResult = metadataTypeSchema.safeParse(metadata);
-  expect(typeResult.success).toBe(true);
-  const refineResult = metadataRefineSchema.safeParse(metadata);
-  expect(refineResult.success).toBe(true);
-});
-
-test("valid: multipleChoice with layout: vertical", () => {
-  const metadata = {
-    name: "mock-prompt-files/mc.md",
-    type: "multipleChoice",
-    layout: "vertical",
-  };
-  const typeResult = metadataTypeSchema.safeParse(metadata);
-  expect(typeResult.success).toBe(true);
-  const refineResult = metadataRefineSchema.safeParse(metadata);
-  expect(refineResult.success).toBe(true);
-});
-
-test("valid: multipleChoice without layout (optional)", () => {
-  const metadata = {
-    name: "mock-prompt-files/mc.md",
-    type: "multipleChoice",
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(true);
-});
-
-test("invalid: layout value other than vertical or horizontal", () => {
-  const metadata = {
-    name: "mock-prompt-files/mc.md",
-    type: "multipleChoice",
-    layout: "diagonal",
-  };
-  const result = metadataTypeSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-});
-
-test("invalid: layout on openResponse type", () => {
-  const metadata = {
-    name: "mock-prompt-files/open.md",
-    type: "openResponse",
-    layout: "horizontal",
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-  if (!result.success) {
-    const layoutError = result.error.issues.find(
-      (issue) => issue.path[0] === "layout",
-    );
-    expect(layoutError?.message).toBe(
-      "layout can only be specified for multipleChoice type",
-    );
-  }
-});
-
-test("invalid: layout on slider type", () => {
-  const metadata = {
-    name: "mock-prompt-files/slider.md",
-    type: "slider",
-    min: 0,
-    max: 100,
-    interval: 1,
-    layout: "horizontal",
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-  if (!result.success) {
-    const layoutError = result.error.issues.find(
-      (issue) => issue.path[0] === "layout",
-    );
-    expect(layoutError?.message).toBe(
-      "layout can only be specified for multipleChoice type",
-    );
-  }
-});
-
-test("invalid: layout on listSorter type", () => {
-  const metadata = {
-    name: "mock-prompt-files/ls.md",
-    type: "listSorter",
-    layout: "horizontal",
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-});
-
-test("invalid: layout on noResponse type", () => {
-  const metadata = {
-    name: "mock-prompt-files/nr.md",
-    type: "noResponse",
-    layout: "horizontal",
-  };
-  const result = metadataRefineSchema.safeParse(metadata);
-  expect(result.success).toBe(false);
-});
-
-// ----------- Slider Label Validation ------------
-
-test("valid: labelPts length matches number of labels", () => {
-  const metadata = {
-    name: "mock-prompt-files/slider.md",
-    type: "slider" as const,
-    min: 0,
-    max: 100,
-    interval: 1,
-    labelPts: [0, 25, 50, 75, 100],
-  };
-  const responseItems = [
-    "Very cold",
-    "Chilly",
-    "Tolerable",
-    "Warm",
-    "Super Hot",
-  ];
-  const issues = validateSliderLabels(metadata, responseItems);
-  expect(issues.length).toBe(0);
-});
-
-test("invalid: labelPts length does not match number of labels", () => {
-  const metadata = {
-    name: "mock-prompt-files/slider.md",
-    type: "slider" as const,
-    min: 0,
-    max: 100,
-    interval: 1,
-    labelPts: [0, 50, 100],
-  };
-  const responseItems = [
-    "Very cold",
-    "Chilly",
-    "Tolerable",
-    "Warm",
-    "Super Hot",
-  ];
-  const issues = validateSliderLabels(metadata, responseItems);
-  expect(issues.length).toBe(1);
-  expect(issues[0].message).toContain(
-    "labelPts length (3) must match the number of labels (5)",
+test("validateSliderLabels is a no-op after #243 (slider labels live in the body)", () => {
+  const issues = validateSliderLabels(
+    { type: "slider", min: 0, max: 100, interval: 1 },
+    ["Low", "Mid", "High"],
   );
+  expect(issues).toEqual([]);
 });
 
-// ----------- Prompt File Schema (unified markdown validation) ------------
+// ----------- File-level parsing ------------
 
 describe("promptFileSchema", () => {
-  test("valid multipleChoice prompt file parses correctly", () => {
+  test("multipleChoice file parses correctly", () => {
     const markdown = `---
-name: projects/example/myPrompt.md
+name: myPrompt
 type: multipleChoice
 ---
 Which option do you prefer?
@@ -442,11 +254,10 @@ Which option do you prefer?
 - Option A
 - Option B
 - Option C`;
-
     const result = promptFileSchema.safeParse(markdown);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.metadata.name).toBe("projects/example/myPrompt.md");
+      expect(result.data.metadata.name).toBe("myPrompt");
       expect(result.data.metadata.type).toBe("multipleChoice");
       expect(result.data.body).toContain("Which option do you prefer?");
       expect(result.data.responseItems).toEqual([
@@ -454,70 +265,264 @@ Which option do you prefer?
         "Option B",
         "Option C",
       ]);
+      expect(result.data.sliderPoints).toEqual([]);
     }
   });
 
-  test("valid openResponse prompt file", () => {
+  test("openResponse file parses correctly", () => {
     const markdown = `---
-name: projects/example/openQ.md
+name: openQ
 type: openResponse
 rows: 5
 ---
 Please describe your experience.
 ---
 > Write your response here`;
-
     const result = promptFileSchema.safeParse(markdown);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.metadata.type).toBe("openResponse");
-      expect(result.data.metadata.rows).toBe(5);
       expect(result.data.responseItems).toEqual(["Write your response here"]);
     }
   });
 
-  test("valid noResponse prompt file has empty responseItems", () => {
+  test("noResponse file is valid as a two-section file (#243 — no trailing ---)", () => {
     const markdown = `---
-name: projects/example/info.md
+name: info
 type: noResponse
 ---
-This is informational text with no response needed.
----
-`;
-
+This is informational text with no response needed.`;
     const result = promptFileSchema.safeParse(markdown);
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.metadata.type).toBe("noResponse");
       expect(result.data.responseItems).toEqual([]);
+      expect(result.data.body).toContain("informational text");
     }
   });
 
-  test("valid slider prompt file", () => {
+  test("noResponse file with a stray third section is rejected (#243)", () => {
     const markdown = `---
-name: projects/example/slider.md
+name: info
+type: noResponse
+---
+Body text.
+---
+- accidental list item`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) =>
+          i.message.includes(
+            "noResponse prompt must have exactly two sections",
+          ),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("slider file with bare-number labels", () => {
+    const markdown = `---
 type: slider
 min: 0
 max: 100
-interval: 10
-labelPts: [0, 50, 100]
+interval: 1
 ---
-Rate your agreement.
+Rate this.
 ---
-- Disagree
-- Neutral
-- Agree`;
-
+- 0
+- 50
+- 100`;
     const result = promptFileSchema.safeParse(markdown);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.metadata.type).toBe("slider");
-      expect(result.data.metadata.min).toBe(0);
+      expect(result.data.sliderPoints).toEqual([0, 50, 100]);
+      expect(result.data.responseItems).toEqual(["0", "50", "100"]);
+    }
+  });
+
+  test("slider file with `<n>: <label>` form", () => {
+    const markdown = `---
+type: slider
+min: 0
+max: 100
+interval: 1
+---
+Rate this.
+---
+- 0: Not familiar
+- 50: Somewhat familiar
+- 100: Very familiar`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.sliderPoints).toEqual([0, 50, 100]);
       expect(result.data.responseItems).toEqual([
-        "Disagree",
-        "Neutral",
-        "Agree",
+        "Not familiar",
+        "Somewhat familiar",
+        "Very familiar",
       ]);
+    }
+  });
+
+  test("slider file with mixed labeled and bare-number forms", () => {
+    const markdown = `---
+type: slider
+min: 0
+max: 100
+interval: 1
+---
+Rate this.
+---
+- 0: Strongly disagree
+- 25
+- 50: Neutral
+- 75
+- 100: Strongly agree`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.sliderPoints).toEqual([0, 25, 50, 75, 100]);
+      expect(result.data.responseItems).toEqual([
+        "Strongly disagree",
+        "25",
+        "Neutral",
+        "75",
+        "Strongly agree",
+      ]);
+    }
+  });
+
+  test("slider labels can contain colons (everything after the first one is the label)", () => {
+    const markdown = `---
+type: slider
+min: 0
+max: 10
+interval: 1
+---
+Rate this.
+---
+- 5: Neutral: middle of the road`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.responseItems).toEqual([
+        "Neutral: middle of the road",
+      ]);
+    }
+  });
+
+  test("slider line whitespace around the colon is forgiving", () => {
+    const markdown = `---
+type: slider
+min: 0
+max: 10
+interval: 1
+---
+Rate.
+---
+-   5   :   Middle  `;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.sliderPoints).toEqual([5]);
+      expect(result.data.responseItems).toEqual(["Middle"]);
+    }
+  });
+
+  test("slider line with `<n>:` (empty label) defaults label to the number", () => {
+    const markdown = `---
+type: slider
+min: 0
+max: 10
+interval: 1
+---
+Rate.
+---
+- 5:`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.sliderPoints).toEqual([5]);
+      expect(result.data.responseItems).toEqual(["5"]);
+    }
+  });
+
+  test("slider line with non-numeric leading token is rejected", () => {
+    const markdown = `---
+type: slider
+min: 0
+max: 10
+interval: 1
+---
+Rate.
+---
+- not-a-number: a label`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) =>
+          i.message.includes("must start with a number"),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("multipleChoice with `>` lines is rejected (#243 — wrong marker for the type)", () => {
+    const markdown = `---
+type: multipleChoice
+---
+Pick one.
+---
+> Option A
+> Option B`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) =>
+          i.message.includes(
+            `multipleChoice response lines must start with "- "`,
+          ),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("openResponse with `-` lines is rejected (#243 — wrong marker for the type)", () => {
+    const markdown = `---
+type: openResponse
+---
+Describe.
+---
+- not a placeholder`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(
+        result.error.issues.some((i) =>
+          i.message.includes(
+            `openResponse placeholder lines must start with "> "`,
+          ),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  test("listSorter with `-` lines is accepted", () => {
+    const markdown = `---
+type: listSorter
+---
+Rank these.
+---
+- Speed
+- Cost
+- Quality`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.responseItems).toEqual(["Speed", "Cost", "Quality"]);
     }
   });
 
@@ -532,95 +537,38 @@ Rate your agreement.
   });
 
   test("fails when missing --- delimiters", () => {
-    const markdown = `name: foo.md
+    const markdown = `name: foo
 type: noResponse
 Some body text`;
-
     const result = promptFileSchema.safeParse(markdown);
     expect(result.success).toBe(false);
-    if (!result.success) {
-      const structureError = result.error.issues.find((i) =>
-        i.message.includes("three sections"),
-      );
-      expect(structureError).toBeDefined();
-    }
   });
 
-  test("fails when body section is empty", () => {
+  test("fails when body section is empty (noResponse)", () => {
     const markdown = `---
-name: projects/example/empty.md
+name: empty
 type: noResponse
 ---
-
----
-`;
-
+   `;
     const result = promptFileSchema.safeParse(markdown);
     expect(result.success).toBe(false);
     if (!result.success) {
-      const bodyError = result.error.issues.find((i) =>
-        i.message.includes("body"),
+      expect(result.error.issues.some((i) => i.message.includes("body"))).toBe(
+        true,
       );
-      expect(bodyError).toBeDefined();
     }
   });
 
   test("fails with invalid metadata type", () => {
     const markdown = `---
-name: projects/example/bad.md
+name: bad
 type: invalidType
 ---
 Some body.
 ---
 - response`;
-
     const result = promptFileSchema.safeParse(markdown);
     expect(result.success).toBe(false);
-  });
-
-  test("fails when response lines have wrong format", () => {
-    const markdown = `---
-name: projects/example/badResponse.md
-type: multipleChoice
----
-Pick one.
----
-Option A
-Option B`;
-
-    const result = promptFileSchema.safeParse(markdown);
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const responseError = result.error.issues.find((i) =>
-        i.message.includes("- "),
-      );
-      expect(responseError).toBeDefined();
-    }
-  });
-
-  test("fails when slider labelPts length mismatches response items", () => {
-    const markdown = `---
-name: projects/example/badSlider.md
-type: slider
-min: 0
-max: 100
-interval: 10
-labelPts: [0, 100]
----
-Rate this.
----
-- Low
-- Medium
-- High`;
-
-    const result = promptFileSchema.safeParse(markdown);
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const labelError = result.error.issues.find((i) =>
-        i.message.includes("labelPts"),
-      );
-      expect(labelError).toBeDefined();
-    }
   });
 
   test("non-string input fails", () => {
@@ -628,9 +576,8 @@ Rate this.
     expect(result.success).toBe(false);
   });
 
-  test("valid multipleChoice prompt file with layout: horizontal", () => {
+  test("multipleChoice file with layout: horizontal", () => {
     const markdown = `---
-name: projects/example/yesNo.md
 type: multipleChoice
 layout: horizontal
 ---
@@ -638,32 +585,10 @@ Do you agree?
 ---
 - Yes
 - No`;
-
     const result = promptFileSchema.safeParse(markdown);
     expect(result.success).toBe(true);
-    if (result.success) {
+    if (result.success && result.data.metadata.type === "multipleChoice") {
       expect(result.data.metadata.layout).toBe("horizontal");
-    }
-  });
-
-  test("fails when layout is set on openResponse prompt file", () => {
-    const markdown = `---
-name: projects/example/open.md
-type: openResponse
-layout: horizontal
----
-Describe something.
----
-> Write your response here`;
-
-    const result = promptFileSchema.safeParse(markdown);
-    expect(result.success).toBe(false);
-    if (!result.success) {
-      const layoutError = result.error.issues.find(
-        (i) =>
-          i.message === "layout can only be specified for multipleChoice type",
-      );
-      expect(layoutError).toBeDefined();
     }
   });
 });

--- a/packages/stagebook/src/schemas/promptFile.ts
+++ b/packages/stagebook/src/schemas/promptFile.ts
@@ -314,9 +314,25 @@ export const promptFileSchema: z.ZodType<
       });
       return z.NEVER;
     }
+    // Exact section count enforcement: extra `---` after the response
+    // section (e.g. a stray trailing delimiter, or a `---` used as a
+    // horizontal rule inside the response section) silently splits a
+    // valid file into pieces we'd otherwise drop. Reject so the author
+    // gets the same `***`/`___` migration hint as the section-count
+    // collisions inside the body section.
+    if (sections.length > 4) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["responses"],
+        message: `${parsedMetadata.type} prompt must have exactly three sections (frontmatter + body + responses). Use \`***\` or \`___\` for horizontal rules in the body, since \`---\` delimits sections.`,
+      });
+    }
 
     const responseLines = responseString
-      .split(/\r?\n/g)
+      // Match the structural section split (`/^-{3,}$/gm`) by also
+      // accepting `\r`-only line endings — legacy Mac files and some
+      // Windows tooling normalise line breaks differently.
+      .split(/\r?\n|\r/g)
       .filter((line) => line.trim().length > 0);
 
     // Per-type marker enforcement (#243). Both forms require a trailing

--- a/packages/stagebook/src/schemas/promptFile.ts
+++ b/packages/stagebook/src/schemas/promptFile.ts
@@ -1,214 +1,231 @@
 import { z, ZodIssue } from "zod";
 import { load as loadYaml } from "js-yaml";
 
-// This schema is used to ensure that the metadata conforms to the expected structure and types.
-// Cannot be combined with the refine schema, if conditions within z.object fail, superRefine conditions will not be checked.
-// We want all of the condtions to be checked simultaneously, so we use a separate refine schema.
-export const metadataTypeSchema = z.object({
+// ---------------------------------------------------------------------------
+// Prompt file format (#243)
+// ---------------------------------------------------------------------------
+//
+// A prompt file is a `*.prompt.md` markdown document with two or three
+// sections separated by `---` lines:
+//
+//   ---
+//   <YAML frontmatter — `type:` discriminates the response shape>
+//   ---
+//   <markdown body — the participant-facing question>
+//   ---                       <-- third section omitted for `noResponse`
+//   <response items — `-` lines for list types, `>` lines for openResponse>
+//
+// Per-type frontmatter is `.strict()` — unknown keys (`tytle:`,
+// `placholder:`, `interavl:`, …) fail at preflight. Per-type marker
+// enforcement in the body section catches `>` lines on a multipleChoice
+// or `-` lines on an openResponse.
+//
+// `***` and `___` are the body's horizontal-rule alternatives (since
+// `---` is the section delimiter).
+
+// --- Per-type metadata schemas ---
+
+const baseMetadataFields = {
+  // `name` is kept (Principle 9 — name is the universal identifier
+  // across all study portions, addressable or not). Optional.
   name: z.string().optional(),
-  type: z.enum([
-    "openResponse",
-    "multipleChoice",
-    "noResponse",
-    "listSorter",
-    "slider",
-  ]),
   notes: z.string().optional(),
-  rows: z.number().int().min(1).optional(),
-  shuffleOptions: z.boolean().optional(),
-  select: z.enum(["single", "multiple", "undefined"]).optional(),
-  layout: z.enum(["vertical", "horizontal"]).optional(),
-  minLength: z.number().int().min(0).optional(),
-  maxLength: z.number().int().min(1).optional(),
-  min: z.number().optional(),
-  max: z.number().optional(),
-  interval: z.number().optional(),
-  labelPts: z.array(z.number()).optional(),
-});
-
-// Refined schema that adds additional validation rules based on the type of prompt
-// This schema checks that certain fields are only present for specific types of prompts.
-// Conditions in z.object will always pass as long as the extension detects the file,
-// so we are guarenteed to always check against superRefine conditions.
-export const metadataRefineSchema = z
-  .object({
-    name: z.any(),
-    type: z.any(),
-    notes: z.any().optional(),
-    rows: z.any().optional(),
-    shuffleOptions: z.any().optional(),
-    select: z.any().optional(),
-    layout: z.any().optional(),
-    minLength: z.any().optional(),
-    maxLength: z.any().optional(),
-    min: z.any().optional(),
-    max: z.any().optional(),
-    interval: z.any().optional(),
-    labelPts: z.any().optional(),
-  })
-  .superRefine((data, ctx) => {
-    if (data.type !== "openResponse" && data.rows !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `rows can only be specified for openResponse type`,
-        path: ["rows"],
-      });
-    }
-    if (data.type !== "multipleChoice" && data.select !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `select can only be specified for multipleChoice type`,
-        path: ["select"],
-      });
-    }
-    if (data.type !== "multipleChoice" && data.layout !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `layout can only be specified for multipleChoice type`,
-        path: ["layout"],
-      });
-    }
-    if (data.type === "noResponse" && data.shuffleOptions !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `shuffleOptions cannot be specified for noResponse type`,
-        path: ["shuffleOptions"],
-      });
-    }
-    if (data.type !== "openResponse" && data.minLength !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `minLength can only be specified for openResponse type`,
-        path: ["minLength"],
-      });
-    }
-    if (data.type !== "openResponse" && data.maxLength !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `maxLength can only be specified for openResponse type`,
-        path: ["maxLength"],
-      });
-    }
-    if (
-      data.minLength !== undefined &&
-      data.maxLength !== undefined &&
-      data.minLength > data.maxLength
-    ) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `minLength cannot be greater than maxLength`,
-        path: ["minLength"],
-      });
-    }
-    // Slider-specific validation
-    if (data.type === "slider") {
-      if (data.min === undefined) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `min is required for slider type`,
-          path: ["min"],
-        });
-      }
-      if (data.max === undefined) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `max is required for slider type`,
-          path: ["max"],
-        });
-      }
-      if (data.interval === undefined) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `interval is required for slider type`,
-          path: ["interval"],
-        });
-      }
-      if (
-        data.min !== undefined &&
-        data.max !== undefined &&
-        data.min >= data.max
-      ) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `min must be less than max`,
-          path: ["min"],
-        });
-      }
-      if (
-        data.min !== undefined &&
-        data.max !== undefined &&
-        data.interval !== undefined &&
-        data.min + data.interval > data.max
-      ) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `min + interval must be less than or equal to max`,
-          path: ["interval"],
-        });
-      }
-    }
-    if (data.type !== "slider" && data.min !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `min can only be specified for slider type`,
-        path: ["min"],
-      });
-    }
-    if (data.type !== "slider" && data.max !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `max can only be specified for slider type`,
-        path: ["max"],
-      });
-    }
-    if (data.type !== "slider" && data.interval !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `interval can only be specified for slider type`,
-        path: ["interval"],
-      });
-    }
-    if (data.type !== "slider" && data.labelPts !== undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: `labelPts can only be specified for slider type`,
-        path: ["labelPts"],
-      });
-    }
-  });
-
-export const metadataLogicalSchema = metadataRefineSchema;
-
-export type MetadataType = z.infer<typeof metadataTypeSchema>;
-export type MetadataRefineType = z.infer<typeof metadataRefineSchema>;
-
-// Function to validate that labelPts length matches the number of response items for slider type
-export const validateSliderLabels = (
-  metadata: MetadataType,
-  responseItems: string[],
-): ZodIssue[] => {
-  const issues: ZodIssue[] = [];
-
-  if (metadata.type === "slider" && metadata.labelPts !== undefined) {
-    if (metadata.labelPts.length !== responseItems.length) {
-      issues.push({
-        code: z.ZodIssueCode.custom,
-        message: `labelPts length (${metadata.labelPts.length}) must match the number of labels (${responseItems.length})`,
-        path: ["labelPts"],
-      });
-    }
-  }
-
-  return issues;
 };
 
-// Unified schema that validates and parses a complete prompt markdown file.
-// Input: raw markdown string with three sections delimited by ---
-// Output: { metadata, body, responseItems }
-export const promptFileSchema = z
+const noResponseMetadataSchema = z
+  .object({
+    type: z.literal("noResponse"),
+    ...baseMetadataFields,
+  })
+  .strict();
+
+const openResponseMetadataSchema = z
+  .object({
+    type: z.literal("openResponse"),
+    ...baseMetadataFields,
+    rows: z.number().int().min(1).optional(),
+    minLength: z.number().int().min(0).optional(),
+    maxLength: z.number().int().min(1).optional(),
+  })
+  .strict();
+
+const multipleChoiceMetadataSchema = z
+  .object({
+    type: z.literal("multipleChoice"),
+    ...baseMetadataFields,
+    select: z.enum(["single", "multiple"]).optional().default("single"),
+    layout: z.enum(["vertical", "horizontal"]).optional().default("vertical"),
+    shuffle: z.boolean().optional(),
+  })
+  .strict();
+
+const listSorterMetadataSchema = z
+  .object({
+    type: z.literal("listSorter"),
+    ...baseMetadataFields,
+    shuffle: z.boolean().optional(),
+  })
+  .strict();
+
+const sliderMetadataSchema = z
+  .object({
+    type: z.literal("slider"),
+    ...baseMetadataFields,
+    min: z.number(),
+    max: z.number(),
+    interval: z.number().positive(),
+  })
+  .strict();
+
+/**
+ * One per response type, each `.strict()` per #243. The discriminated
+ * union's input `type:` selects exactly one branch — cross-field rules
+ * (e.g. "rows can only appear on openResponse") fall out of the per-branch
+ * field lists for free.
+ *
+ * Cross-field numeric rules (min<max, min+interval<=max, minLength<=maxLength)
+ * live in the union's outer `.superRefine` rather than per-branch
+ * `.refine()`. Reason: Zod 3's `discriminatedUnion` rejects `ZodEffects`
+ * members, so any `.refine` applied to a branch breaks the union.
+ */
+export const promptMetadataSchema = z
+  .discriminatedUnion("type", [
+    noResponseMetadataSchema,
+    openResponseMetadataSchema,
+    multipleChoiceMetadataSchema,
+    listSorterMetadataSchema,
+    sliderMetadataSchema,
+  ])
+  .superRefine((data, ctx) => {
+    if (data.type === "openResponse") {
+      if (
+        data.minLength !== undefined &&
+        data.maxLength !== undefined &&
+        data.minLength > data.maxLength
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "minLength cannot be greater than maxLength",
+          path: ["minLength"],
+        });
+      }
+    }
+    if (data.type === "slider") {
+      if (data.min >= data.max) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "min must be less than max",
+          path: ["min"],
+        });
+      }
+      if (data.min + data.interval > data.max) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "min + interval must be ≤ max",
+          path: ["interval"],
+        });
+      }
+    }
+  });
+export type MetadataType = z.infer<typeof promptMetadataSchema>;
+
+// Back-compat aliases — the old `metadataTypeSchema` / `metadataRefineSchema`
+// pair was the workaround for `z.object().superRefine()` skipping its
+// refinement when object validation failed (pre-discriminatedUnion). Both
+// roles are now served by `promptMetadataSchema` itself.
+export const metadataTypeSchema = promptMetadataSchema;
+export const metadataRefineSchema = promptMetadataSchema;
+export const metadataLogicalSchema = promptMetadataSchema;
+export type MetadataRefineType = MetadataType;
+
+/**
+ * Slider labels live in the body section as inline lines (#243). One of:
+ *   - `- 50` — bare number (label defaults to the number's string form)
+ *   - `- 50: Somewhat familiar` — number + label
+ *   - `- 50:` — number + empty label (label defaults to the number)
+ * The first colon separates point from label, so labels can themselves
+ * contain colons.
+ */
+function parseSliderLine(
+  raw: string,
+): { ok: true; point: number; label: string } | { ok: false; message: string } {
+  // Caller has already stripped the `- ` prefix and `\n`.
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return {
+      ok: false,
+      message:
+        "Slider label line is empty (expected `- <number>(: <label>)?`).",
+    };
+  }
+  const colonIdx = trimmed.indexOf(":");
+  let pointStr: string;
+  let label: string | null;
+  if (colonIdx < 0) {
+    pointStr = trimmed;
+    label = null;
+  } else {
+    pointStr = trimmed.slice(0, colonIdx).trim();
+    const afterColon = trimmed.slice(colonIdx + 1).trim();
+    label = afterColon.length > 0 ? afterColon : null;
+  }
+  if (pointStr.length === 0) {
+    return {
+      ok: false,
+      message: `Slider label "${trimmed}" must start with a number, e.g. "- 0: Not familiar".`,
+    };
+  }
+  const point = Number(pointStr);
+  if (!Number.isFinite(point)) {
+    return {
+      ok: false,
+      message: `Slider label "${trimmed}" must start with a number, e.g. "- 0: Not familiar". Got "${pointStr}".`,
+    };
+  }
+  return { ok: true, point, label: label ?? pointStr };
+}
+
+/**
+ * Back-compat shim. The old runtime had a separate `validateSliderLabels`
+ * that cross-checked `metadata.labelPts.length === responseItems.length`.
+ * After #243 slider labels and points come from the same body lines, so
+ * the cross-check is structurally impossible to fail and the helper is a
+ * no-op. Kept exported because external tooling may still import it.
+ */
+export const validateSliderLabels = (
+  _metadata: MetadataType,
+  _responseItems: string[],
+): ZodIssue[] => [];
+
+// --- File-level parser ---
+
+export interface ParsedPromptFile {
+  metadata: MetadataType;
+  body: string;
+  /**
+   * Response section items, one entry per non-empty body-section line.
+   * Shape depends on `metadata.type`:
+   *   - multipleChoice / listSorter — choice/item strings
+   *   - openResponse — placeholder lines
+   *   - slider — labels (one per parsed line; aligned with `sliderPoints`)
+   *   - noResponse — empty array
+   */
+  responseItems: string[];
+  /**
+   * Slider points (numbers) parsed from the body section. Empty for
+   * non-slider types. `sliderPoints[i]` corresponds to `responseItems[i]`.
+   */
+  sliderPoints: number[];
+}
+
+export const promptFileSchema: z.ZodType<
+  ParsedPromptFile,
+  z.ZodTypeDef,
+  string
+> = z
   .string()
   .min(1, "Prompt file string is empty")
-  .transform((str, ctx) => {
+  .transform((str, ctx): ParsedPromptFile | typeof z.NEVER => {
     const trimmed = str.trim();
     if (trimmed.length === 0) {
       ctx.addIssue({
@@ -220,22 +237,23 @@ export const promptFileSchema = z
 
     const sections = trimmed.split(/^-{3,}$/gm);
 
-    // Expect: ["", metadataYaml, body, responseString]
-    // The first element is empty because the file starts with ---
-    if (sections.length < 4) {
+    // First section is the empty string before the leading `---`.
+    if (sections.length < 3) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message:
-          "Prompt file must have three sections separated by --- delimiters: metadata, body, and responses",
+          "Prompt file must have a `---`-delimited frontmatter and body. Use `***` or `___` for horizontal rules in the body, since `---` delimits sections.",
       });
       return z.NEVER;
     }
 
     const metadataYaml = sections[1];
     const body = sections[2];
+    // For `noResponse` files this stays undefined; everyone else expects
+    // exactly one response section. We validate the section count below
+    // once we know the type.
     const responseString = sections[3];
 
-    // Parse YAML metadata
     let metadata: unknown;
     try {
       metadata = loadYaml(metadataYaml);
@@ -248,10 +266,9 @@ export const promptFileSchema = z
       return z.NEVER;
     }
 
-    // Validate metadata against type schema
-    const typeResult = metadataTypeSchema.safeParse(metadata);
-    if (!typeResult.success) {
-      typeResult.error.issues.forEach((issue) =>
+    const metaResult = promptMetadataSchema.safeParse(metadata);
+    if (!metaResult.success) {
+      metaResult.error.issues.forEach((issue) =>
         ctx.addIssue({
           ...issue,
           path: ["metadata", ...issue.path],
@@ -259,19 +276,8 @@ export const promptFileSchema = z
       );
       return z.NEVER;
     }
+    const parsedMetadata = metaResult.data;
 
-    // Validate metadata against refine schema (cross-field rules)
-    const refineResult = metadataRefineSchema.safeParse(metadata);
-    if (!refineResult.success) {
-      refineResult.error.issues.forEach((issue) =>
-        ctx.addIssue({
-          ...issue,
-          path: ["metadata", ...issue.path],
-        }),
-      );
-    }
-
-    // Validate body exists
     if (!body || body.trim().length === 0) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -280,43 +286,104 @@ export const promptFileSchema = z
       });
     }
 
-    // Parse and validate response items
-    const parsedMetadata = typeResult.data;
-    let responseItems: string[] = [];
-
-    if (parsedMetadata.type !== "noResponse" && responseString) {
-      const responseLines = responseString
-        .split(/\r?\n|\r|\n/g)
-        .filter((line) => line.trim().length > 0);
-
-      for (const line of responseLines) {
-        if (!(line.startsWith("- ") || line.startsWith(">"))) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            message: `Response line must start with "- " (for multiple choice) or "> " (for open response). Got: "${line}"`,
-            path: ["responses"],
-          });
-        }
+    // Section-count rules per #243:
+    //   noResponse — exactly two sections (frontmatter + body).
+    //   everyone else — exactly three (frontmatter + body + responses).
+    if (parsedMetadata.type === "noResponse") {
+      if (sections.length > 3) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["responses"],
+          message:
+            "noResponse prompt must have exactly two sections (frontmatter + body). Drop the trailing `---` and any third section.",
+        });
       }
-
-      responseItems = responseLines
-        .filter((line) => line.startsWith("- ") || line.startsWith(">"))
-        .map((line) => line.substring(2).trim());
+      return {
+        metadata: parsedMetadata,
+        body: body?.trim() ?? "",
+        responseItems: [],
+        sliderPoints: [],
+      };
     }
 
-    // Validate slider labelPts against response items
-    const sliderIssues = validateSliderLabels(parsedMetadata, responseItems);
-    sliderIssues.forEach((issue) =>
+    if (sections.length < 4 || responseString === undefined) {
       ctx.addIssue({
-        ...issue,
-        path: ["metadata", ...issue.path],
-      }),
-    );
+        code: z.ZodIssueCode.custom,
+        path: ["responses"],
+        message: `${parsedMetadata.type} prompt must have a third section listing the responses.`,
+      });
+      return z.NEVER;
+    }
+
+    const responseLines = responseString
+      .split(/\r?\n/g)
+      .filter((line) => line.trim().length > 0);
+
+    // Per-type marker enforcement (#243). Both forms require a trailing
+    // space (or the bare marker on its own line) — `>X` / `-X` no-space
+    // forms are rejected so the substring(2) extraction always lands on
+    // the actual content.
+    const expectedMarker = parsedMetadata.type === "openResponse" ? ">" : "-";
+    for (const line of responseLines) {
+      const isDash = line.startsWith("- ") || line === "-";
+      const isAngle = line.startsWith("> ") || line === ">";
+      if (expectedMarker === ">" && !isAngle) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["responses"],
+          message: `openResponse placeholder lines must start with "> ". Got: "${line}"`,
+        });
+      }
+      if (expectedMarker === "-" && !isDash) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["responses"],
+          message: `${parsedMetadata.type} response lines must start with "- ". Got: "${line}"`,
+        });
+      }
+    }
+
+    let responseItems: string[] = [];
+    let sliderPoints: number[] = [];
+    if (parsedMetadata.type === "slider") {
+      const points: number[] = [];
+      const labels: string[] = [];
+      for (const line of responseLines) {
+        if (!(line.startsWith("- ") || line === "-")) continue;
+        const stripped = line === "-" ? "" : line.substring(2);
+        const parsed = parseSliderLine(stripped);
+        if (!parsed.ok) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["responses"],
+            message: parsed.message,
+          });
+          continue;
+        }
+        points.push(parsed.point);
+        labels.push(parsed.label);
+      }
+      sliderPoints = points;
+      responseItems = labels;
+    } else {
+      responseItems = responseLines
+        .filter(
+          (line) =>
+            line.startsWith("- ") ||
+            line === "-" ||
+            line.startsWith("> ") ||
+            line === ">",
+        )
+        .map((line) =>
+          line === "-" || line === ">" ? "" : line.substring(2).trim(),
+        );
+    }
 
     return {
       metadata: parsedMetadata,
       body: body?.trim() ?? "",
       responseItems,
+      sliderPoints,
     };
   });
 


### PR DESCRIPTION
## Summary

Closes #243. Five threads of work cleaning up the `*.prompt.md` schema and parser.

**Schema becomes a discriminated union.** `promptMetadataSchema` is `z.discriminatedUnion(\"type\", [...])` with one `.strict()` branch per type. The pre-#243 parallel `metadataTypeSchema` + `metadataRefineSchema` workaround is gone; both names alias the new schema for back-compat. `validateSliderLabels` becomes a no-op shim.

**Slider labels move into the body.** Inline lines `- <number>(: <label>)?`. Bare numbers default to using the number as the label; mixed labeled/unlabeled lines coexist; labels can contain colons. The legacy `labelPts:` frontmatter array is rejected.

**`noResponse` drops the third section.** Files validate as two-section (frontmatter + body); a stray third section is rejected with a migration message.

**Per-type marker enforcement.** `multipleChoice`/`listSorter`/`slider` use `-` lines; `openResponse` uses `>` lines. Both forms require a trailing space (or the bare marker on its own line).

**Frontmatter renames.** `shuffleOptions:` → `shuffle:`. `select: \"undefined\"` removed (omit for default). Strict per-type frontmatter keys reject typos. `name:` is **kept** (Principle 9).

## Threaded through

- `promptFileSchema.parse(...)` returns `{ metadata, body, responseItems, sliderPoints }`. The new `sliderPoints` is parallel to `responseItems`'s labels for slider.
- `Element.tsx` extracts `sliderPoints` and forwards to `<Prompt>`.
- `Prompt.tsx` accepts `sliderPoints?` and threads to `<Slider labelPts={sliderPoints}>`. Per-branch metadata fields are now narrowed via `promptType ===` checks.
- VS Code `validatePrompt.ts` handles the 2-section noResponse case; for `unrecognized_keys` issues it synthesizes a path including the bad key so diagnostics land on the typo's line.

## Migration

| Before                              | After                              |
|-------------------------------------|------------------------------------|
| `shuffleOptions: true`              | `shuffle: true`                    |
| `select: undefined`                 | (omit field; `single` is default)  |
| `noResponse` files: trailing `---`  | drop the trailing `---`            |
| Slider: `labelPts: [0, 50, 100]` + `- Not familiar` body lines | `- 0: Not familiar` (labels in body) |
| `---` as a horizontal rule in body  | use `***` or `___`                 |

## Test plan

- [x] All stagebook (776), viewer (84), vscode (189) tests pass on Node 24.
- [x] New tests cover slider edge cases (bare numbers, mixed forms, colons in labels, no leading number, whitespace around colon, `<n>:` empty fallback), per-type marker enforcement, two-section noResponse acceptance, three-section noResponse rejection, strict-key rejection of typos, every frontmatter rename.
- [x] Walkthrough prompt files migrated to the new format and parse against the new schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)