### PR TITLE
chore(husky): pre-push hook honors .nvmrc when nvm is installed

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,16 @@
+# Honor `.nvmrc` when nvm is installed. Without this the hook inherits
+# whatever Node is on the calling shell's PATH, which on machines with
+# system Node + nvm-managed `.nvmrc` Node typically picks up the system
+# version (e.g. 20) and trips on transitively-installed deps that
+# require the repo's pinned `engines` (e.g. jsdom's `html-encoding-sniffer`
+# requires Node ≥ 20.18 / 22.12 / 24).
+#
+# No-op when nvm isn't present — non-nvm contributors fall through to
+# whatever Node is on their PATH, same as before.
+if [ -s "${NVM_DIR:-$HOME/.nvm}/nvm.sh" ]; then
+  # shellcheck disable=SC1091
+  . "${NVM_DIR:-$HOME/.nvm}/nvm.sh"
+  nvm use --silent >/dev/null 2>&1 || true
+fi
+
 npm run lint && npm test

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -5,12 +5,20 @@
 # require the repo's pinned `engines` (e.g. jsdom's `html-encoding-sniffer`
 # requires Node ≥ 20.18 / 22.12 / 24).
 #
-# No-op when nvm isn't present — non-nvm contributors fall through to
-# whatever Node is on their PATH, same as before.
+# - No nvm installed → fall through silently to whatever Node is on PATH,
+#   so non-nvm contributors see no behavior change.
+# - nvm installed but the pinned `.nvmrc` Node isn't → fail the hook with
+#   a clear message pointing at `nvm install`. Silent fallback would
+#   defeat the purpose and make the resulting test failures hard to
+#   diagnose.
 if [ -s "${NVM_DIR:-$HOME/.nvm}/nvm.sh" ]; then
   # shellcheck disable=SC1091
   . "${NVM_DIR:-$HOME/.nvm}/nvm.sh"
-  nvm use --silent >/dev/null 2>&1 || true
+  if ! nvm use --silent >/dev/null; then
+    echo "pre-push: nvm couldn't activate the Node version pinned in .nvmrc."
+    echo "pre-push: run \`nvm install\` (uses .nvmrc) and retry the push."
+    exit 1
+  fi
 fi
 
 npm run lint && npm test


### PR DESCRIPTION
## Summary

The pre-push hook ran `npm run lint && npm test` against whatever Node was on the calling shell's PATH. On machines with system Node + nvm-managed `.nvmrc` Node, that picked up the system version (e.g. 20) and tripped on jsdom's `html-encoding-sniffer`, which requires Node ≥ 20.18 (or 22.12, or 24). The same `EBADENGINE` warning that npm prints during `npm install` materialised here as a hard `ERR_REQUIRE_ESM` at vitest load time, blocking the push.

Source nvm (when present) and `nvm use --silent` at the top of the hook so it always runs against the repo's pinned `.nvmrc` Node. No-op when nvm isn't installed — non-nvm contributors fall through to whatever Node is on their PATH, same as before.

## Test plan

- [x] Verified the hook activates the pinned Node version under a bare PATH (`env -i HOME=$HOME PATH=/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin git push`): system Node was 20.14.0 before the hook ran; lint + all tests (stagebook 776 / viewer 84 / vscode 189) passed cleanly inside the hook on Node 24.15.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)