### PR TITLE
release v0.9.0: schema syntax review + new features

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13396,7 +13396,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.8.3",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.8.3",
+  "version": "0.9.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Minor bump on top of v0.8.3. The April 2026 schema syntax review landed in main as ~15 PRs (#235 through #265) — collectively a large set of breaking changes to the treatment-file format, plus several new library features. Cutting v0.9.0 to ship them.

A consolidated migration guide for downstream consumers landed in #265 (`docs/decisions/2026-04-syntax-review-migration.md`).

## Breaking changes (treatment file format)

- **`urlParams` → `entryUrl.params.*`** ([#246](https://github.com/deliberation-lab/stagebook/pull/260)). Renamed for clarity.
- **Structured references** ([#240](https://github.com/deliberation-lab/stagebook/pull/259)). `{ source, name?, path? }` is the canonical form; bare-string references are syntactic sugar that desugars to it.
- **`url:` split from `file:`** ([#249](https://github.com/deliberation-lab/stagebook/pull/258)). `url:` is browser-direct (CDN URLs); `file:` is platform-resolved (relative paths the host's `getTextContent` / `getAssetURL` interprets). They were conflated before.
- **Element type cleanup** ([#250](https://github.com/deliberation-lab/stagebook/pull/257)): `talkMeter` and `sharedNotepad` removed; `survey` deprecated (kept for one release).
- **Bare-string prompt shorthand dropped** ([#245](https://github.com/deliberation-lab/stagebook/pull/256)). `prompt: "foo.prompt.md"` is no longer accepted; use `prompt: { file: "foo.prompt.md" }` (or the `url:` form).
- **Template definition schema cleanup** ([#244](https://github.com/deliberation-lab/stagebook/pull/255)).
- **Conditions `position` narrowed** ([#238](https://github.com/deliberation-lab/stagebook/pull/254)). Read-selector only — no longer overloaded.
- **Prompt-file format cleanup** ([#243](https://github.com/deliberation-lab/stagebook/pull/261)). Header / body / response items separators tightened up.

## New features

- **Conditions: boolean-tree operators** ([#235](https://github.com/deliberation-lab/stagebook/pull/253)). `all`/`any`/`none` for combining conditions arbitrarily, replacing the implicit-AND-only model.
- **Timeline: Enter binds to real-time annotation** ([#263](https://github.com/deliberation-lab/stagebook/pull/264)). Point mode = tap to mark; range mode = press-and-hold to mark a span. Auto-repeat filtered, modifier keys reserved, edge cases (focus loss, backward scrub, brief tap) handled.

## Docs

- **April 2026 syntax review migration guide** ([#265](https://github.com/deliberation-lab/stagebook/pull/265)). One-stop doc covering every breaking change above, with before/after examples and a sequence to migrate large existing treatment files.
- Inline schema docs (#247, #248).

## Tests

All schema-level changes ship with Zod test coverage; the timeline Enter feature ships with 11 unit + 4 CT tests.

## Test plan
- [x] Full unit + CT suites pass on main.
- [x] Lint clean.
- [ ] CI green on this PR.

## Versioning

Bumps `stagebook` 0.8.3 → 0.9.0. Minor (rather than major) because the package is pre-1.0 — the schema layer signals this kind of change at the minor level, with the migration guide as the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)