### PR TITLE
Fix Enter UX issues from #263 (closes #268)

### DIFF
--- a/packages/stagebook/src/components/elements/MediaPlayer.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.tsx
@@ -678,6 +678,14 @@ export function MediaPlayer({
       // "once" mode: no keyboard controls
       if (effectivePlayback === "once") return;
 
+      // Enter is reserved for Timeline annotation (#263). Preventing
+      // default stops focused-button activation so player behavior doesn't
+      // depend on which control last had focus.
+      if (e.key === "Enter") {
+        e.preventDefault();
+        return;
+      }
+
       // YouTube: only Space/K play-pause and J/L/Arrow seek work
       if (ytHandle) {
         switch (e.key) {

--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -3838,3 +3838,95 @@ test("range mode: Enter keyup without prior keydown is a no-op", async ({
   const last = saves[saves.length - 1]?.value as unknown[] | undefined;
   expect(last ?? []).toHaveLength(0);
 });
+
+test("range mode: Enter press-and-hold shows a live preview rectangle", async ({
+  mount,
+}) => {
+  // #268: while Enter is held, a dashed rectangle should be visible from
+  // the press time to the current playhead. It disappears on keyup.
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="enter_range_preview"
+      selectionType="range"
+      multiSelect={true}
+      mockDuration={60}
+      mockCurrentTime={10}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  const preview = component.locator('[data-testid="range-keyboard-preview"]');
+
+  await timeline.focus();
+  await expect(preview).toHaveCount(0);
+
+  await timeline.dispatchEvent("keydown", {
+    key: "Enter",
+    code: "Enter",
+    repeat: false,
+    bubbles: true,
+    cancelable: true,
+  });
+
+  // Preview should be visible immediately at the press time.
+  await expect(preview).toHaveCount(1);
+
+  // Advance the playhead — preview should still be there (with a wider
+  // box). We can't easily measure exact width but presence is enough to
+  // prove the live update.
+  await component.update(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="enter_range_preview"
+      selectionType="range"
+      multiSelect={true}
+      mockDuration={60}
+      mockCurrentTime={20}
+    />,
+  );
+  await expect(preview).toHaveCount(1);
+
+  // Release — preview should clear.
+  await timeline.dispatchEvent("keyup", {
+    key: "Enter",
+    code: "Enter",
+    bubbles: true,
+    cancelable: true,
+  });
+  await expect(preview).toHaveCount(0);
+});
+
+test("range mode: blur during hold clears the preview", async ({ mount }) => {
+  // If focus leaves the timeline while Enter is still held, the preview
+  // should disappear (mirrors the ref-clearing onBlur).
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="enter_range_preview_blur"
+      selectionType="range"
+      multiSelect={true}
+      mockDuration={60}
+      mockCurrentTime={10}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  const preview = component.locator('[data-testid="range-keyboard-preview"]');
+
+  await timeline.focus();
+  await timeline.dispatchEvent("keydown", {
+    key: "Enter",
+    code: "Enter",
+    repeat: false,
+    bubbles: true,
+    cancelable: true,
+  });
+  await expect(preview).toHaveCount(1);
+
+  await timeline.evaluate((el: HTMLElement) => {
+    el.blur();
+  });
+  await expect(preview).toHaveCount(0);
+});

--- a/packages/stagebook/src/components/elements/Timeline.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.tsx
@@ -195,6 +195,13 @@ export function Timeline({
   // at release. Cleared on commit, on Escape mid-hold, and on blur so a
   // dropped focus during the hold doesn't leave a stale start.
   const pendingRangeStartRef = useRef<number | null>(null);
+  // State mirror of pendingRangeStartRef for re-rendering the live
+  // preview rectangle while Enter is held (#268 fix). Kept in lockstep
+  // with the ref so the keyup handler can read synchronously while the
+  // overlay still re-renders on each playhead tick.
+  const [pendingRangeStartTime, setPendingRangeStartTime] = useState<
+    number | null
+  >(null);
 
   // Selection state via reducer. Lazy initializer hydrates from saved state
   // when present so participants who reload mid-stage see their existing
@@ -624,9 +631,9 @@ export function Timeline({
         // Press-and-hold range, keydown half (#263). Stash the current
         // playhead time; the matching keyup will commit the range.
         // Auto-repeat keydowns are filtered upstream by keyToAction.
-        pendingRangeStartRef.current = clampToMedia(
-          handleRef.current?.getCurrentTime() ?? 0,
-        );
+        const t = clampToMedia(handleRef.current?.getCurrentTime() ?? 0);
+        pendingRangeStartRef.current = t;
+        setPendingRangeStartTime(t);
         break;
       }
     }
@@ -662,6 +669,7 @@ export function Timeline({
     if (action.type === "endRangeAtPlayhead") {
       const startTime = pendingRangeStartRef.current;
       pendingRangeStartRef.current = null;
+      setPendingRangeStartTime(null);
       // Keyup without a prior keydown (e.g., focus changed mid-press) —
       // ignore.
       if (startTime === null) return;
@@ -762,6 +770,18 @@ export function Timeline({
 
   const tracksHeight = channelCount * TRACK_HEIGHT;
 
+  // Live preview rectangle for press-and-hold Enter range creation
+  // (#268 fix). Re-derived each render from currentTime so the right
+  // edge tracks the playhead as the video plays. Null when no hold is
+  // in progress.
+  const keyboardRangePreview =
+    pendingRangeStartTime !== null
+      ? {
+          start: Math.min(pendingRangeStartTime, currentTime),
+          end: Math.max(pendingRangeStartTime, currentTime),
+        }
+      : null;
+
   return (
     <div
       ref={containerRef}
@@ -783,6 +803,7 @@ export function Timeline({
         // Drop any in-progress press-and-hold range — focus left the
         // timeline before the matching keyup arrived. (#263)
         pendingRangeStartRef.current = null;
+        setPendingRangeStartTime(null);
       }}
       style={{
         border: "1px solid var(--stagebook-border, #e5e7eb)",
@@ -925,6 +946,7 @@ export function Timeline({
             onRequestFocus={() =>
               containerElRef.current?.focus({ preventScroll: true })
             }
+            keyboardRangePreview={keyboardRangePreview}
           />
 
           {/* Playhead — over selection overlay, extends into ruler via negative top */}

--- a/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
+++ b/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
@@ -1229,6 +1229,41 @@ test("K key toggles to playing state", async ({ mount }) => {
   ).toHaveAttribute("aria-label", "Pause");
 });
 
+test("Enter key does not toggle playback (#268 — reserved for Timeline)", async ({
+  mount,
+}) => {
+  // Without preventDefault on Enter, a focused play/pause button would
+  // fire a click and unpause the video — making playback behavior depend
+  // on which control had focus last. We suppress Enter unconditionally so
+  // the Timeline can own it for real-time annotation (#263).
+  const component = await mount(
+    <MockMediaPlayer
+      url="/sample-video.mp4"
+      name="test"
+      controls={{ playPause: true }}
+    />,
+  );
+  const player = component.locator('[data-testid="mediaPlayer"]');
+  await component
+    .locator('[data-testid="mediaPlayer-video"]')
+    .evaluate((el) => {
+      el.play = () => {
+        el.dispatchEvent(new Event("play"));
+        return Promise.resolve();
+      };
+    });
+  await player.focus();
+  await player.press("Enter");
+  // Reveal controls — hover doesn't auto-hide while paused, but be safe.
+  await player.evaluate((el) =>
+    el.dispatchEvent(new MouseEvent("mouseover", { bubbles: true })),
+  );
+  // Should still be paused (button still says Play, not Pause).
+  await expect(
+    component.locator('[data-testid="mediaPlayer-playPause"]'),
+  ).toHaveAttribute("aria-label", "Play");
+});
+
 test("ArrowRight seeks forward 1 second", async ({ mount }) => {
   const component = await mount(
     <MockMediaPlayer

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -67,6 +67,11 @@ export interface SelectionOverlayProps {
    *  selection actions so keyboard shortcuts (arrows, Tab, Delete, Escape)
    *  work immediately without the user manually clicking the timeline. */
   onRequestFocus: () => void;
+  /** Live preview of a press-and-hold range (#268 fix). When set, render a
+   *  dashed rectangle from `start` to `end` so the participant sees the
+   *  range growing while the Enter key is held. Cleared by Timeline on
+   *  keyup or blur. */
+  keyboardRangePreview?: { start: number; end: number; track?: number } | null;
 }
 
 const DRAG_DEAD_ZONE_PX = 4;
@@ -222,6 +227,7 @@ export function SelectionOverlay({
   onBeginDrag,
   onEndDrag,
   onRequestFocus,
+  keyboardRangePreview = null,
 }: SelectionOverlayProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<DragState | null>(null);
@@ -804,6 +810,52 @@ export function SelectionOverlay({
     );
   };
 
+  // Live preview while Enter is held for press-and-hold range creation
+  // (#268 fix). Mirrors the click-drag preview style. Unlike the click
+  // path, we don't clamp against existing ranges here — the keyup commit
+  // path clamps if needed, and showing a clipped preview during the hold
+  // would feel jumpy as the playhead moves.
+  const renderKeyboardRangePreview = () => {
+    if (!keyboardRangePreview) return null;
+    const x1 = timeToPixel(
+      keyboardRangePreview.start,
+      duration,
+      width,
+      zoomLevel,
+      viewportStart,
+    );
+    const x2 = timeToPixel(
+      keyboardRangePreview.end,
+      duration,
+      width,
+      zoomLevel,
+      viewportStart,
+    );
+    const left = Math.min(x1, x2);
+    const previewWidth = Math.abs(x2 - x1);
+    const top =
+      selectionScope === "track" && keyboardRangePreview.track !== undefined
+        ? keyboardRangePreview.track * trackHeight
+        : 0;
+    const previewHeight = selectionScope === "track" ? trackHeight : height;
+    return (
+      <div
+        data-testid="range-keyboard-preview"
+        style={{
+          position: "absolute",
+          left: `${String(left)}px`,
+          top: `${String(top)}px`,
+          width: `${String(previewWidth)}px`,
+          height: `${String(previewHeight)}px`,
+          background: "rgba(59, 130, 246, 0.25)",
+          border: "1px dashed rgba(59, 130, 246, 0.6)",
+          boxSizing: "border-box",
+          pointerEvents: "none",
+        }}
+      />
+    );
+  };
+
   return (
     <div
       ref={containerRef}
@@ -846,6 +898,7 @@ export function SelectionOverlay({
     >
       {selectionType === "range" ? renderRanges() : renderPoints()}
       {renderDragPreview()}
+      {renderKeyboardRangePreview()}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Two follow-ups from the v0.9.0 Enter-for-real-time-annotation feature (#263), filed as #268:

- **MediaPlayer Enter conflict**: A focused player button activated on Enter, making playback behavior depend on which control last had focus. Enter is now reserved exclusively for Timeline annotation; Space remains the canonical play/pause hotkey.
- **No visual feedback during range hold**: Pressing and holding Enter in range mode now shows a dashed live preview rectangle from press time to the current playhead, mirroring the existing click-drag preview style. Cleared on keyup, blur, and commit.

## Test plan

- [x] New CT test: \`Enter key does not toggle playback\` — focused player + Enter keeps Play button label as "Play".
- [x] New CT test: \`Enter press-and-hold shows a live preview rectangle\` — preview appears on keydown, persists across playhead advance, disappears on keyup.
- [x] New CT test: \`blur during hold clears the preview\` — focus loss mid-hold clears the preview rectangle.
- [x] All 196 Timeline + MediaPlayer CT tests pass.
- [x] All 833 unit tests pass; lint clean.

Closes #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)