### PR TITLE
Single-select range mode: preserve existing range on all create gestures

### DIFF
--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -765,9 +765,13 @@ test("range mode multi-select: click adds a second range next to existing", asyn
   await expect(component.locator('[data-testid="range-1"]')).toBeAttached();
 });
 
-test("range mode: multiSelect false — new range replaces existing", async ({
+test("range mode: multiSelect false — drag-create preserves existing range", async ({
   mount,
 }) => {
+  // Single-select rule: once a range exists, every "create" gesture
+  // (click, drag, Enter) is a no-op. To replace, the user must first
+  // delete the existing range. A red pulse on the existing range gives
+  // immediate visual feedback that the gesture was blocked.
   const component = await mount(
     <MockTimeline
       source="player"
@@ -808,7 +812,13 @@ test("range mode: multiSelect false — new range replaces existing", async ({
     isPrimary: true,
   });
 
-  // Second range at 60%-80% (no overlap)
+  const savesBefore = await readSaveLog(component);
+  const before = savesBefore[savesBefore.length - 1]?.value as {
+    start: number;
+    end: number;
+  }[];
+
+  // Second drag-create at 60%-80% — should be blocked.
   await overlay.dispatchEvent("pointerdown", {
     clientX: box.x + box.width * 0.6,
     clientY: box.y + box.height * 0.5,
@@ -834,16 +844,22 @@ test("range mode: multiSelect false — new range replaces existing", async ({
     isPrimary: true,
   });
 
-  // Only one range should exist (range-0). The previous range was replaced.
+  // Existing range still there, no second range.
   await expect(component.locator('[data-testid="range-0"]')).toBeAttached();
   await expect(component.locator('[data-testid="range-1"]')).not.toBeAttached();
-  const saves = await readSaveLog(component);
-  const last = saves[saves.length - 1]?.value as {
+  const savesAfter = await readSaveLog(component);
+  const after = savesAfter[savesAfter.length - 1]?.value as {
     start: number;
     end: number;
   }[];
-  expect(last).toHaveLength(1);
-  expect(last[0]?.start).toBeCloseTo(36, 0); // 60% of 60
+  expect(after).toHaveLength(1);
+  expect(after[0]?.start).toBeCloseTo(before[0]?.start, 2);
+  expect(after[0]?.end).toBeCloseTo(before[0]?.end, 2);
+
+  // Pulse fires for visual feedback.
+  await expect(
+    component.locator('[data-testid="range-blocked-pulse"]'),
+  ).toBeAttached();
 });
 
 test("range mode: multiSelect true — ranges accumulate sorted", async ({
@@ -3929,4 +3945,181 @@ test("range mode: blur during hold clears the preview", async ({ mount }) => {
     el.blur();
   });
   await expect(preview).toHaveCount(0);
+});
+
+// -- Single-select / blocked-create rule (#268 follow-up) --
+
+test("range mode single-select: Enter with existing range is a no-op and pulses", async ({
+  mount,
+}) => {
+  // After a range exists in single-select mode, Enter must NOT create a
+  // new range (mirrors the click + drag rules). The existing range should
+  // pulse as visual feedback that the gesture was blocked.
+  const initial = [{ start: 5, end: 10 }];
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="single_enter_blocked"
+      selectionType="range"
+      multiSelect={false}
+      mockDuration={60}
+      mockCurrentTime={30}
+      initialSelections={initial}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await timeline.focus();
+
+  await timeline.dispatchEvent("keydown", {
+    key: "Enter",
+    code: "Enter",
+    repeat: false,
+    bubbles: true,
+    cancelable: true,
+  });
+
+  // No live-preview rectangle: keydown was rejected before pendingRangeStart
+  // was set.
+  await expect(
+    component.locator('[data-testid="range-keyboard-preview"]'),
+  ).toHaveCount(0);
+
+  // Pulse appears.
+  await expect(
+    component.locator('[data-testid="range-blocked-pulse"]'),
+  ).toBeAttached();
+
+  // Release just to confirm the keyup doesn't commit anything either.
+  await timeline.dispatchEvent("keyup", {
+    key: "Enter",
+    code: "Enter",
+    bubbles: true,
+    cancelable: true,
+  });
+
+  // Existing range still the only one, unmodified.
+  await expect(component.locator('[data-testid="range-0"]')).toBeAttached();
+  await expect(component.locator('[data-testid="range-1"]')).not.toBeAttached();
+});
+
+test("range mode multi-select: Enter inside existing range is a no-op and pulses", async ({
+  mount,
+}) => {
+  // In multi-select, the press-time-inside-existing-range case is
+  // blocked at keydown — clampToFreeGap would have rejected the commit
+  // anyway, but we want the user to see immediate feedback.
+  const initial = [{ start: 20, end: 40 }];
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="multi_enter_inside_blocked"
+      selectionType="range"
+      multiSelect={true}
+      mockDuration={60}
+      mockCurrentTime={30}
+      initialSelections={initial}
+    />,
+  );
+  const timeline = component.locator('[data-testid="timeline"]');
+  await timeline.focus();
+
+  await timeline.dispatchEvent("keydown", {
+    key: "Enter",
+    code: "Enter",
+    repeat: false,
+    bubbles: true,
+    cancelable: true,
+  });
+
+  await expect(
+    component.locator('[data-testid="range-keyboard-preview"]'),
+  ).toHaveCount(0);
+  await expect(
+    component.locator('[data-testid="range-blocked-pulse"]'),
+  ).toBeAttached();
+
+  await timeline.dispatchEvent("keyup", {
+    key: "Enter",
+    code: "Enter",
+    bubbles: true,
+    cancelable: true,
+  });
+
+  // Still exactly the original range.
+  await expect(component.locator('[data-testid="range-0"]')).toBeAttached();
+  await expect(component.locator('[data-testid="range-1"]')).not.toBeAttached();
+});
+
+test("range mode single-select: footer hint appears only when a range exists", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="single_footer_hint"
+      selectionType="range"
+      multiSelect={false}
+      mockDuration={60}
+    />,
+  );
+  const hint = component.locator('[data-testid="timeline-single-select-hint"]');
+
+  // No range yet → hint hidden.
+  await expect(hint).toHaveCount(0);
+
+  // Drag-create a range.
+  const overlay = component.locator('[data-testid="selection-overlay"]');
+  const box = await overlay.boundingBox();
+  if (!box) throw new Error("overlay not found");
+  await overlay.dispatchEvent("pointerdown", {
+    clientX: box.x + box.width * 0.2,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+  await overlay.dispatchEvent("pointermove", {
+    clientX: box.x + box.width * 0.4,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+  await overlay.dispatchEvent("pointerup", {
+    clientX: box.x + box.width * 0.4,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+
+  // Range exists → hint shown.
+  await expect(hint).toBeAttached();
+  await expect(hint).toContainText("Max 1 range");
+});
+
+test("range mode multi-select: footer hint never appears", async ({
+  mount,
+}) => {
+  const initial = [{ start: 5, end: 10 }];
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="multi_no_footer_hint"
+      selectionType="range"
+      multiSelect={true}
+      mockDuration={60}
+      initialSelections={initial}
+    />,
+  );
+  await expect(
+    component.locator('[data-testid="timeline-single-select-hint"]'),
+  ).toHaveCount(0);
 });

--- a/packages/stagebook/src/components/elements/Timeline.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.tsx
@@ -202,6 +202,20 @@ export function Timeline({
   const [pendingRangeStartTime, setPendingRangeStartTime] = useState<
     number | null
   >(null);
+  // Pulse trigger for blocked range-create attempts. Token increments each
+  // time the user attempts a creation that's blocked (single-select with
+  // an existing range, or multi-select with the playhead inside an existing
+  // range); SelectionOverlay restarts its pulse animation via React `key`.
+  const [pulseTrigger, setPulseTrigger] = useState<{
+    token: number;
+    indices: number[];
+  } | null>(null);
+  const triggerBlockedPulse = useCallback((indices: number[]) => {
+    setPulseTrigger((prev) => ({
+      token: (prev?.token ?? 0) + 1,
+      indices,
+    }));
+  }, []);
 
   // Selection state via reducer. Lazy initializer hydrates from saved state
   // when present so participants who reload mid-stage see their existing
@@ -632,6 +646,33 @@ export function Timeline({
         // playhead time; the matching keyup will commit the range.
         // Auto-repeat keydowns are filtered upstream by keyToAction.
         const t = clampToMedia(handleRef.current?.getCurrentTime() ?? 0);
+
+        // Blocked-attempt detection. Match what click/drag would do at
+        // commit time so the user sees consistent behavior across input
+        // modalities. Pulse the obstructing range(s) instead of starting
+        // a hold that would be silently rejected on keyup.
+        const existingRanges =
+          selectionType === "range"
+            ? (state.selections as RangeSelection[])
+            : [];
+        if (!multiSelect && existingRanges.length > 0) {
+          // Single-select: any existing range blocks creation.
+          triggerBlockedPulse(existingRanges.map((_, i) => i));
+          break;
+        }
+        if (multiSelect) {
+          // Multi-select: only ranges containing the press time block.
+          // (clampToFreeGap returns null on commit if fully enclosed.)
+          const blockingIndices: number[] = [];
+          existingRanges.forEach((r, i) => {
+            if (t >= r.start && t < r.end) blockingIndices.push(i);
+          });
+          if (blockingIndices.length > 0) {
+            triggerBlockedPulse(blockingIndices);
+            break;
+          }
+        }
+
         pendingRangeStartRef.current = t;
         setPendingRangeStartTime(t);
         break;
@@ -947,6 +988,8 @@ export function Timeline({
               containerElRef.current?.focus({ preventScroll: true })
             }
             keyboardRangePreview={keyboardRangePreview}
+            pulseTrigger={pulseTrigger}
+            onBlockedCreate={triggerBlockedPulse}
           />
 
           {/* Playhead — over selection overlay, extends into ruler via negative top */}
@@ -979,6 +1022,11 @@ export function Timeline({
         onHelpToggle={() => setHelpOpen((v) => !v)}
         helpOpen={helpOpen}
         helpButtonRef={helpButtonRef}
+        singleSelectFull={
+          selectionType === "range" &&
+          !multiSelect &&
+          state.selections.length > 0
+        }
       />
 
       {/* Help popover */}

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -22,9 +22,9 @@ export interface SelectionOverlayProps {
   selectionScope: "track" | "all";
   /** Number of tracks (for track-mode hit testing). */
   channelCount: number;
-  /** Whether multiple selections are allowed. When false, new selections
-   *  replace existing ones — the drag preview should not clamp against
-   *  ranges that are about to be replaced. */
+  /** Whether multiple selections are allowed. When false (single-select),
+   *  any "create" gesture (click, drag, Enter) is a no-op once a range
+   *  exists; the user must explicitly delete to replace. */
   multiSelect: boolean;
   /** Current selections from reducer state. */
   selections: TimelineValue;
@@ -72,6 +72,16 @@ export interface SelectionOverlayProps {
    *  range growing while the Enter key is held. Cleared by Timeline on
    *  keyup or blur. */
   keyboardRangePreview?: { start: number; end: number; track?: number } | null;
+  /** Pulse trigger for blocked range-create attempts. The overlay renders a
+   *  brief outline glow on the ranges identified by `indices`, restarting
+   *  whenever `token` changes (via React `key`). Owned by Timeline so both
+   *  click-drag (via `onBlockedCreate`) and Enter trigger the same effect. */
+  pulseTrigger?: { token: number; indices: number[] } | null;
+  /** Called when the user attempted to create a range but it was blocked
+   *  by single-select-with-existing-range. The parent is expected to
+   *  trigger a `pulseTrigger` update so feedback shows up on the existing
+   *  range(s). */
+  onBlockedCreate?: (indices: number[]) => void;
 }
 
 const DRAG_DEAD_ZONE_PX = 4;
@@ -228,6 +238,8 @@ export function SelectionOverlay({
   onEndDrag,
   onRequestFocus,
   keyboardRangePreview = null,
+  pulseTrigger = null,
+  onBlockedCreate,
 }: SelectionOverlayProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const dragRef = useRef<DragState | null>(null);
@@ -396,9 +408,11 @@ export function SelectionOverlay({
           if (!multiSelect && hasExistingRange) {
             // No range creation here, but still request focus so arrow /
             // Delete / Ctrl-Z keep working after the click (Timeline's
-            // container is what owns the keyboard listeners).
+            // container is what owns the keyboard listeners). Pulse the
+            // existing range so the user sees why the click did nothing.
             if (activeIndex !== null) onDeselect();
             onRequestFocus();
+            onBlockedCreate?.(selections.map((_, i) => i));
           } else {
             // Pick a width that's at least CLICK_CREATED_RANGE_SEC AND at
             // least CLICK_CREATED_RANGE_MIN_PX wide on screen — for long
@@ -428,8 +442,18 @@ export function SelectionOverlay({
         const start = Math.min(drag.startTime, time);
         const end = Math.max(drag.startTime, time);
         if (end - start > 0) {
-          onCreateRange(start, end, track);
-          onRequestFocus();
+          // Single-select with an existing range is blocked — the reducer
+          // would no-op the dispatch anyway, but skip it explicitly so the
+          // pulse callback fires and we don't push a phantom undo snapshot.
+          const hasExistingRange =
+            isRangeArray(selections) && selections.length > 0;
+          if (!multiSelect && hasExistingRange) {
+            onBlockedCreate?.(selections.map((_, i) => i));
+            onRequestFocus();
+          } else {
+            onCreateRange(start, end, track);
+            onRequestFocus();
+          }
         }
         setDragPreview(null);
       }
@@ -457,6 +481,7 @@ export function SelectionOverlay({
       onCreateRange,
       onEndDrag,
       onRequestFocus,
+      onBlockedCreate,
       releasePointer,
     ],
   );
@@ -810,6 +835,50 @@ export function SelectionOverlay({
     );
   };
 
+  // Pulse overlays for blocked range-create attempts. Renders a brief
+  // outline glow on each existing range identified by `pulseTrigger.indices`.
+  // The `key` includes `pulseTrigger.token` so each blocked attempt
+  // remounts the element and restarts the animation.
+  const renderBlockedPulses = () => {
+    if (!pulseTrigger || pulseTrigger.indices.length === 0) return null;
+    if (!isRangeArray(selections)) return null;
+    return pulseTrigger.indices.map((idx) => {
+      const r = selections[idx];
+      if (!r) return null;
+      const x1 = timeToPixel(
+        r.start,
+        duration,
+        width,
+        zoomLevel,
+        viewportStart,
+      );
+      const x2 = timeToPixel(r.end, duration, width, zoomLevel, viewportStart);
+      const left = Math.min(x1, x2);
+      const pulseWidth = Math.abs(x2 - x1);
+      const top =
+        selectionScope === "track" && r.track !== undefined
+          ? r.track * trackHeight
+          : 0;
+      const pulseHeight = selectionScope === "track" ? trackHeight : height;
+      return (
+        <div
+          key={`pulse-${String(pulseTrigger.token)}-${String(idx)}`}
+          data-testid="range-blocked-pulse"
+          style={{
+            position: "absolute",
+            left: `${String(left)}px`,
+            top: `${String(top)}px`,
+            width: `${String(pulseWidth)}px`,
+            height: `${String(pulseHeight)}px`,
+            pointerEvents: "none",
+            borderRadius: 2,
+            animation: "stagebookRangeBlockedPulse 600ms ease-out",
+          }}
+        />
+      );
+    });
+  };
+
   // Live preview while Enter is held for press-and-hold range creation
   // (#268 fix). Mirrors the click-drag preview style. Unlike the click
   // path, we don't clamp against existing ranges here — the keyup commit
@@ -896,9 +965,23 @@ export function SelectionOverlay({
         pointerEvents: "auto",
       }}
     >
+      <style>{`
+        @keyframes stagebookRangeBlockedPulse {
+          0% { box-shadow: 0 0 0 0 rgba(220, 38, 38, 0); }
+          30% { box-shadow: 0 0 0 4px rgba(220, 38, 38, 0.55); }
+          100% { box-shadow: 0 0 0 8px rgba(220, 38, 38, 0); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          @keyframes stagebookRangeBlockedPulse {
+            0%, 100% { background: rgba(220, 38, 38, 0); }
+            30% { background: rgba(220, 38, 38, 0.25); }
+          }
+        }
+      `}</style>
       {selectionType === "range" ? renderRanges() : renderPoints()}
       {renderDragPreview()}
       {renderKeyboardRangePreview()}
+      {renderBlockedPulses()}
     </div>
   );
 }

--- a/packages/stagebook/src/components/elements/timeline/TimelineFooter.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineFooter.tsx
@@ -9,6 +9,10 @@ export interface TimelineFooterProps {
   onHelpToggle: () => void;
   helpOpen: boolean;
   helpButtonRef?: React.RefObject<HTMLButtonElement | null>;
+  /** Show "Max 1 range — delete to replace" to the left of the help button.
+   *  True when the timeline is in single-select range mode and a range
+   *  already exists (further create attempts will be blocked). */
+  singleSelectFull?: boolean;
 }
 
 function isRangeArray(
@@ -69,6 +73,7 @@ export function TimelineFooter({
   onHelpToggle,
   helpOpen,
   helpButtonRef,
+  singleSelectFull = false,
 }: TimelineFooterProps) {
   return (
     <div
@@ -89,8 +94,16 @@ export function TimelineFooter({
         {summary(selectionType, selections, activeIndex)}
       </div>
 
-      {/* Right: help */}
-      <div style={{ display: "flex", alignItems: "center" }}>
+      {/* Right: single-select hint + help button */}
+      <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+        {singleSelectFull && (
+          <span
+            data-testid="timeline-single-select-hint"
+            style={{ fontStyle: "italic" }}
+          >
+            Max 1 range — delete to replace
+          </span>
+        )}
         <button
           ref={helpButtonRef}
           type="button"

--- a/packages/stagebook/src/components/elements/timeline/selectionsReducer.test.ts
+++ b/packages/stagebook/src/components/elements/timeline/selectionsReducer.test.ts
@@ -64,7 +64,11 @@ describe("selectionsReducer", () => {
       expect(sels[1]?.start).toBe(30);
     });
 
-    it("replaces existing when multiSelect is false (new is later)", () => {
+    it("preserves existing when multiSelect is false (new is later)", () => {
+      // Single-select rule: a CREATE_RANGE dispatch is rejected if a range
+      // already exists. The user must explicitly delete the existing range
+      // to make a new one. Visual feedback (pulse, footer hint) lives at
+      // the call sites; the reducer is the authoritative gate.
       let state = emptyState();
       state = selectionsReducer(state, {
         type: "CREATE_RANGE",
@@ -77,38 +81,34 @@ describe("selectionsReducer", () => {
         type: "CREATE_RANGE",
         start: 30,
         end: 40,
-        track: undefined,
-        multiSelect: false,
-      });
-      expect(state.selections).toEqual([{ start: 30, end: 40 }]);
-    });
-
-    it("replaces existing when multiSelect is false (new is EARLIER)", () => {
-      // Regression: previously the reducer kept the latest-by-time selection,
-      // not the newly-created one. Creating an earlier range incorrectly kept
-      // the older later range.
-      let state = emptyState();
-      state = selectionsReducer(state, {
-        type: "CREATE_RANGE",
-        start: 30,
-        end: 40,
-        track: undefined,
-        multiSelect: false,
-      });
-      state = selectionsReducer(state, {
-        type: "CREATE_RANGE",
-        start: 5,
-        end: 10,
         track: undefined,
         multiSelect: false,
       });
       expect(state.selections).toEqual([{ start: 5, end: 10 }]);
     });
 
-    it("multiSelect=false: new range is not blocked by existing range overlap", () => {
-      // Previously, createRange clamped against the existing range even
-      // when multiSelect=false, which could prevent creation entirely if
-      // the new range was fully enclosed by an existing one.
+    it("preserves existing when multiSelect is false (new is EARLIER)", () => {
+      let state = emptyState();
+      state = selectionsReducer(state, {
+        type: "CREATE_RANGE",
+        start: 30,
+        end: 40,
+        track: undefined,
+        multiSelect: false,
+      });
+      state = selectionsReducer(state, {
+        type: "CREATE_RANGE",
+        start: 5,
+        end: 10,
+        track: undefined,
+        multiSelect: false,
+      });
+      expect(state.selections).toEqual([{ start: 30, end: 40 }]);
+    });
+
+    it("multiSelect=false: rejects a new range that overlaps existing", () => {
+      // A second CREATE_RANGE in single-select mode is always rejected
+      // regardless of whether the proposed range overlaps the existing one.
       let state = emptyState();
       state = selectionsReducer(state, {
         type: "CREATE_RANGE",
@@ -124,7 +124,7 @@ describe("selectionsReducer", () => {
         track: undefined,
         multiSelect: false,
       });
-      expect(state.selections).toEqual([{ start: 20, end: 40 }]);
+      expect(state.selections).toEqual([{ start: 0, end: 60 }]);
     });
 
     it("includes track field in scope=track mode", () => {

--- a/packages/stagebook/src/components/elements/timeline/selectionsReducer.ts
+++ b/packages/stagebook/src/components/elements/timeline/selectionsReducer.ts
@@ -97,10 +97,16 @@ export function selectionsReducer(
 ): SelectionState {
   switch (action.type) {
     case "CREATE_RANGE": {
-      // multiSelect: false → the new range REPLACES any existing one. Don't
-      // clamp against ranges that are about to be discarded, and don't try
-      // to "keep the last in time order" (that would keep the wrong one).
+      // multiSelect: false → preserve any existing range. The user must
+      // explicitly delete the existing range to make a new one. This
+      // mirrors the no-op behavior of click-without-drag (SelectionOverlay)
+      // and Enter press-and-hold (Timeline). Visual feedback (pulse on the
+      // existing range, footer hint) lives at the call sites — the reducer
+      // is the authoritative gate.
       if (!action.multiSelect) {
+        const hasExistingRange =
+          isRangeArray(state.selections) && state.selections.length > 0;
+        if (hasExistingRange) return state;
         const lo = roundMs(Math.min(action.start, action.end));
         const hi = roundMs(Math.max(action.start, action.end));
         if (hi <= lo) return state;


### PR DESCRIPTION
## Summary

Previously, single-select range mode had an inconsistent rule: clicking without dragging preserved the existing range, but click+drag and (since v0.9.0) Enter press-and-hold both silently replaced it. This PR aligns all three gestures to the conservative behavior — any "create" attempt while a range exists is a no-op; the user must explicitly delete the existing range to make a new one.

To make the no-op discoverable, two pieces of feedback are added:
- **Pulse**: the existing range briefly glows red (600ms box-shadow expand+fade) on a blocked attempt. Reduced-motion users get a static background flash instead.
- **Footer hint**: \`Max 1 range — delete to replace\` shows in the timeline footer (right-justified, just left of the help button) only while in single-select with an existing range.

In multi-select mode, Enter at a press-time inside an existing range is also now a no-op + pulse — \`clampToFreeGap\` would have rejected the commit anyway, but blocking at keydown means no confusing live-preview rectangle spans through the obstructing range.

## Behavior matrix

| Mode | Existing range? | Click | Click+Drag | Enter |
|---|---|---|---|---|
| Single | none | create | create | create |
| Single | yes | **no-op + pulse** | **no-op + pulse** (was: replace) | **no-op + pulse** (was: replace) |
| Multi | n/a | create-clamped | create-clamped | create-clamped, blocked if press-time inside range |

## Test plan

- [x] Reducer unit tests updated: \`CREATE_RANGE\` in single-select with existing range is now rejected (was: replace).
- [x] CT test \`multiSelect false — drag-create preserves existing range\` updated from old replace assertion.
- [x] New CT tests:
  - Single-select: Enter w/ existing range → no-op + pulse + no preview rectangle.
  - Multi-select: Enter w/ playhead inside existing range → no-op + pulse.
  - Footer hint visible only in single-select w/ existing range.
- [x] All 200 Timeline + MediaPlayer CT tests pass; all 833 unit tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)