### PR TITLE
Release v0.9.2

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Patch release for the single-select range preservation rule (PR #271):

- Click, drag, and Enter all preserve an existing range in single-select mode (was: drag and Enter silently replaced).
- Multi-select Enter at a press-time inside an existing range is also blocked at keydown.
- Red pulse on the existing range + "Max 1 range — delete to replace" footer hint give immediate feedback for blocked attempts.

## Test plan

- [x] CI green on #271
- [ ] Cut GitHub release after merge to trigger npm-publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)