### PR TITLE
Add Prisoner's Dilemma and Ultimatum Game examples (closes #93, #94)

### DIFF
--- a/examples/prisoners-dilemma/README.md
+++ b/examples/prisoners-dilemma/README.md
@@ -1,0 +1,44 @@
+# Prisoner's Dilemma
+
+A two-player simultaneous-choice example. Each round, both participants independently choose **Cooperate** or **Defect**; payoffs follow the canonical PD matrix (3/3, 5/0, 0/5, 1/1).
+
+Two treatments share a single round template:
+
+- **One-shot** — a single round, then a brief reflection.
+- **3-round repeated** — same round structure repeated three times via broadcast.
+
+## What this example demonstrates
+
+| Feature                                                        | Where it lives                                       |
+| -------------------------------------------------------------- | ---------------------------------------------------- |
+| **Multi-player basics** (`playerCount: 2`)                     | Both treatments                                      |
+| **Templates** with `${fieldName}` placeholders                 | `roundTemplate` (`contentType: stages`)              |
+| **Template invocation with `fields:`** (single use)            | One-shot treatment                                   |
+| **Template invocation with `broadcast:`** (Cartesian expansion) | 3-round treatment                                    |
+| **Conditions with `comparator: equals`**                       | Outcome stage's six per-combination cards            |
+| **Position-based asymmetry** (`position`, `showToPositions`)   | Partner-choice display + asymmetric outcome cards    |
+| **`display` elements** (one player's response shown to another) | Outcome stage                                        |
+| **Multi-stage rounds** (choice → outcome)                      | `roundTemplate.content` returns 2 stages per call    |
+
+## How the outcome stage renders
+
+Each round ends in an outcome stage with seven elements:
+
+1. Two `display` elements — each shows the partner's choice to the opposite seat.
+2. Four conditional outcome cards — exactly one of these renders for each player, based on the (P0 × P1) choice combination:
+   - **Both cooperated** — same card, both players.
+   - **Both defected** — same card, both players.
+   - **Asymmetric (P0 cooperated, P1 defected)** — two cards, one per perspective ("you were exploited" vs. "you exploited your partner").
+   - **Asymmetric (P0 defected, P1 cooperated)** — mirror of the above.
+
+The two asymmetric outcomes use the same prompt files split across both perspectives, so we end up with four prompt files (not eight).
+
+## Running it
+
+From the viewer's landing page click the **prisoners-dilemma** example card, or paste a GitHub URL to this repo's `prisoners-dilemma.treatments.yaml` into the URL input. To run the dev viewer locally:
+
+```
+npm run dev -w stagebook-viewer
+```
+
+Once loaded, switch between the two treatments from the picker. The viewer simulates both positions, so you can step through choices and see how each player's outcome card differs.

--- a/examples/prisoners-dilemma/prisoners-dilemma.treatments.yaml
+++ b/examples/prisoners-dilemma/prisoners-dilemma.treatments.yaml
@@ -1,0 +1,198 @@
+# Prisoner's Dilemma — a 2-player simultaneous-choice example.
+# Two treatments share a single round template: a one-shot game and a
+# 3-round repeated game. Each round = one choice stage + one outcome
+# stage; the outcome stage uses condition leaves with `comparator: equals`
+# to render the right outcome card per (P0 × P1) choice combination.
+
+templates:
+  - name: roundTemplate
+    contentType: stages
+    notes: |
+      One full round: a simultaneous choice stage followed by an outcome
+      stage. Used by both treatments — the one-shot invokes it once with
+      `roundN: 1`; the 3-round version broadcasts over `roundN: [1, 2, 3]`,
+      and because the template's content is itself an array (`contentType:
+      stages`), each broadcast row contributes 2 stages to `gameStages`
+      for a total of 6.
+    content:
+      - name: round_${roundN}_choice
+        duration: 60
+        notes: |
+          Round ${roundN} simultaneous choice. The stage advances when
+          both positions submit (or `duration` expires). `name:
+          choice_round_${roundN}` on the prompt makes the response
+          addressable as `prompt.choice_round_${roundN}` in the matching
+          outcome stage's conditions.
+        elements:
+          - type: prompt
+            name: choice_round_${roundN}
+            file: prompts/choice.prompt.md
+          - type: timer
+          - type: submitButton
+            buttonText: Lock in choice
+
+      - name: round_${roundN}_outcome
+        duration: 30
+        notes: |
+          Round ${roundN} outcome. The participant sees the partner's
+          choice via two `display` elements (asymmetric per position),
+          then exactly one of four outcome cards via condition leaves
+          combined with `comparator: equals`. The two asymmetric
+          outcomes (one player exploited, one player exploiting) split
+          into one element per perspective so the same prompt file can
+          serve "you were exploited" for whoever cooperated.
+        elements:
+          # Show partner's choice — asymmetric per position.
+          - type: display
+            reference: prompt.choice_round_${roundN}
+            position: 1
+            showToPositions: [0]
+            notes: Position 0 sees position 1's choice.
+          - type: display
+            reference: prompt.choice_round_${roundN}
+            position: 0
+            showToPositions: [1]
+            notes: Position 1 sees position 0's choice.
+
+          - type: separator
+
+          # Both cooperated → both see the same card.
+          - type: prompt
+            file: prompts/outcome_both_cooperated.prompt.md
+            conditions:
+              - reference: prompt.choice_round_${roundN}
+                position: 0
+                comparator: equals
+                value: Cooperate
+              - reference: prompt.choice_round_${roundN}
+                position: 1
+                comparator: equals
+                value: Cooperate
+            notes: Flat-array conditions are AND-combined — only renders when *both* positions chose Cooperate.
+
+          # Both defected → both see the same card.
+          - type: prompt
+            file: prompts/outcome_both_defected.prompt.md
+            conditions:
+              - reference: prompt.choice_round_${roundN}
+                position: 0
+                comparator: equals
+                value: Defect
+              - reference: prompt.choice_round_${roundN}
+                position: 1
+                comparator: equals
+                value: Defect
+
+          # Asymmetric: position 0 cooperated, position 1 defected.
+          # Each side sees a different card; we instantiate the same
+          # prompt file twice with mirrored `showToPositions` /
+          # `position` selectors.
+          - type: prompt
+            file: prompts/outcome_you_cooperated_they_defected.prompt.md
+            showToPositions: [0]
+            conditions:
+              - reference: prompt.choice_round_${roundN}
+                position: 0
+                comparator: equals
+                value: Cooperate
+              - reference: prompt.choice_round_${roundN}
+                position: 1
+                comparator: equals
+                value: Defect
+          - type: prompt
+            file: prompts/outcome_you_defected_they_cooperated.prompt.md
+            showToPositions: [1]
+            conditions:
+              - reference: prompt.choice_round_${roundN}
+                position: 0
+                comparator: equals
+                value: Cooperate
+              - reference: prompt.choice_round_${roundN}
+                position: 1
+                comparator: equals
+                value: Defect
+
+          # Asymmetric: position 0 defected, position 1 cooperated. Mirror
+          # of the block above.
+          - type: prompt
+            file: prompts/outcome_you_defected_they_cooperated.prompt.md
+            showToPositions: [0]
+            conditions:
+              - reference: prompt.choice_round_${roundN}
+                position: 0
+                comparator: equals
+                value: Defect
+              - reference: prompt.choice_round_${roundN}
+                position: 1
+                comparator: equals
+                value: Cooperate
+          - type: prompt
+            file: prompts/outcome_you_cooperated_they_defected.prompt.md
+            showToPositions: [1]
+            conditions:
+              - reference: prompt.choice_round_${roundN}
+                position: 0
+                comparator: equals
+                value: Defect
+              - reference: prompt.choice_round_${roundN}
+                position: 1
+                comparator: equals
+                value: Cooperate
+
+          - type: submitButton
+            displayTime: 5
+            buttonText: Continue
+
+treatments:
+  - name: Prisoners Dilemma one-shot
+    notes: |
+      Single-round game. Invokes `roundTemplate` once with `roundN: 1`.
+      The template returns 2 stages (choice + outcome), so this
+      treatment ends up with 2 game stages plus the shared exit step.
+    playerCount: 2
+    gameStages:
+      - template: roundTemplate
+        fields:
+          roundN: 1
+    exitSequence:
+      - name: Reflection
+        elements:
+          - type: prompt
+            name: reflection
+            file: prompts/feedback.prompt.md
+          - type: submitButton
+
+  - name: Prisoners Dilemma 3-round repeated
+    notes: |
+      Same round structure repeated three times via broadcast. Each
+      broadcast row produces 2 stages, so this treatment has 6 game
+      stages — the participant alternates choosing and seeing the
+      outcome three times before the reflection step. Because each
+      round's prompt is named `choice_round_${roundN}`, references
+      from one round don't collide with another's.
+    playerCount: 2
+    gameStages:
+      - template: roundTemplate
+        broadcast:
+          d0:
+            - roundN: 1
+            - roundN: 2
+            - roundN: 3
+    exitSequence:
+      - name: Reflection
+        elements:
+          - type: prompt
+            name: reflection
+            file: prompts/feedback.prompt.md
+          - type: submitButton
+
+introSequences:
+  - name: orientation
+    notes: Solo intro — both players read the rules independently before being matched.
+    introSteps:
+      - name: Instructions
+        elements:
+          - type: prompt
+            file: prompts/instructions.prompt.md
+          - type: submitButton
+            buttonText: Continue

--- a/examples/prisoners-dilemma/prompts/choice.prompt.md
+++ b/examples/prisoners-dilemma/prompts/choice.prompt.md
@@ -1,0 +1,16 @@
+---
+type: multipleChoice
+name: Choice
+select: single
+layout: horizontal
+---
+
+# Make your choice
+
+Your partner is choosing at the same time. You will both see the
+outcome on the next screen.
+
+---
+
+- Cooperate
+- Defect

--- a/examples/prisoners-dilemma/prompts/feedback.prompt.md
+++ b/examples/prisoners-dilemma/prompts/feedback.prompt.md
@@ -1,0 +1,11 @@
+---
+type: openResponse
+name: Reflection
+rows: 3
+maxLength: 400
+---
+
+# Briefly: how did you decide?
+
+Was there a strategy you started with? Did your partner's behaviour
+change it? (Optional, 1–3 sentences.)

--- a/examples/prisoners-dilemma/prompts/instructions.prompt.md
+++ b/examples/prisoners-dilemma/prompts/instructions.prompt.md
@@ -1,0 +1,20 @@
+---
+type: noResponse
+name: Instructions
+---
+
+# Prisoner's Dilemma
+
+You and a partner will independently choose **Cooperate** or **Defect**.
+Neither of you sees the other's choice until you've both decided.
+
+Your earnings depend on the combination:
+
+|                       | Partner Cooperates | Partner Defects |
+| --------------------- | -----------------: | --------------: |
+| **You Cooperate**     |       3 / 3        |     0 / 5       |
+| **You Defect**        |       5 / 0        |     1 / 1       |
+
+(Your earnings / partner's earnings.)
+
+Click **Continue** when you're ready to start.

--- a/examples/prisoners-dilemma/prompts/outcome_both_cooperated.prompt.md
+++ b/examples/prisoners-dilemma/prompts/outcome_both_cooperated.prompt.md
@@ -1,0 +1,8 @@
+---
+type: noResponse
+name: Outcome — both cooperated
+---
+
+## Mutual cooperation
+
+Both of you chose **Cooperate**. You each earn **3** this round.

--- a/examples/prisoners-dilemma/prompts/outcome_both_defected.prompt.md
+++ b/examples/prisoners-dilemma/prompts/outcome_both_defected.prompt.md
@@ -1,0 +1,8 @@
+---
+type: noResponse
+name: Outcome — both defected
+---
+
+## Mutual defection
+
+Both of you chose **Defect**. You each earn **1** this round.

--- a/examples/prisoners-dilemma/prompts/outcome_you_cooperated_they_defected.prompt.md
+++ b/examples/prisoners-dilemma/prompts/outcome_you_cooperated_they_defected.prompt.md
@@ -1,0 +1,9 @@
+---
+type: noResponse
+name: Outcome — you cooperated, partner defected
+---
+
+## You were exploited
+
+You chose **Cooperate** but your partner chose **Defect**. You earn
+**0** this round; your partner earns **5**.

--- a/examples/prisoners-dilemma/prompts/outcome_you_defected_they_cooperated.prompt.md
+++ b/examples/prisoners-dilemma/prompts/outcome_you_defected_they_cooperated.prompt.md
@@ -1,0 +1,9 @@
+---
+type: noResponse
+name: Outcome — you defected, partner cooperated
+---
+
+## You exploited your partner
+
+You chose **Defect** while your partner chose **Cooperate**. You earn
+**5** this round; your partner earns **0**.

--- a/examples/ultimatum-game/README.md
+++ b/examples/ultimatum-game/README.md
@@ -1,0 +1,36 @@
+# Ultimatum Game
+
+A two-player asymmetric example. Position 0 is the **Proposer**: they choose how much of a $10 pot to offer. Position 1 is the **Responder**: they accept or reject. Reject and both earn $0.
+
+Roles are assigned via `groupComposition` from a multipleChoice in the intro — each participant says whether they'd prefer to be the Proposer or Responder, and the host platform matches them into seats accordingly.
+
+## What this example demonstrates
+
+| Feature                                                                        | Where it lives                                                  |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------- |
+| **`groupComposition`** with `comparator: equals` on a multipleChoice           | `treatments[0].groupComposition`                                |
+| **Position-based asymmetric content** via `showToPositions`                    | Offer + Decision stages                                         |
+| **`display` elements referencing other positions** (cross-player view)          | Decision stage's responder view; Outcome stage                  |
+| **Conditional outcome cards** (`comparator: equals` on the responder's decision) | Outcome stage                                                   |
+| **Two-stage waiting pattern** (one player acts, the other submits "Ready")      | Offer + Decision stages                                         |
+
+## How asymmetric stages work
+
+Stagebook stages advance when **all** positions submit (or `duration` expires). To give each player a different view of the same stage, every element gets a `showToPositions` filter. The responder's "Ready" button on stage 1 isn't a no-op — they have to submit it before the stage will advance, but it doesn't gate the proposer. So the proposer takes their time on the slider while the responder waits.
+
+The decision stage uses two paired patterns at once:
+
+- A `display` element with `position: 0` and `showToPositions: [0]` shows the proposer their own offer back as a recap.
+- The same `display` element with `position: 0` and `showToPositions: [1]` shows the proposer's offer to the responder.
+
+Both reference `prompt.offer` at `position: 0`, but the `showToPositions` filter changes who the rendering is for.
+
+## Running it
+
+From the viewer's landing page click the **ultimatum-game** example card, or paste a GitHub URL to this repo's `ultimatum-game.treatments.yaml` into the URL input. To run the dev viewer locally:
+
+```
+npm run dev -w stagebook-viewer
+```
+
+Once loaded, the viewer simulates both positions; you can step through the offer + decision + outcome stages and watch the two views diverge.

--- a/examples/ultimatum-game/prompts/decision.prompt.md
+++ b/examples/ultimatum-game/prompts/decision.prompt.md
@@ -1,0 +1,18 @@
+---
+type: multipleChoice
+name: Decision
+select: single
+layout: horizontal
+---
+
+# Accept or reject the offer
+
+If you **Accept**, you keep the offered amount and your partner keeps
+the rest.
+
+If you **Reject**, you both earn $0.
+
+---
+
+- Accept
+- Reject

--- a/examples/ultimatum-game/prompts/feedback.prompt.md
+++ b/examples/ultimatum-game/prompts/feedback.prompt.md
@@ -1,0 +1,11 @@
+---
+type: openResponse
+name: Reflection
+rows: 3
+maxLength: 400
+---
+
+# Briefly: how did you decide?
+
+What drove your choice — fairness, payoff, anticipating the other
+player? (Optional, 1–3 sentences.)

--- a/examples/ultimatum-game/prompts/instructions.prompt.md
+++ b/examples/ultimatum-game/prompts/instructions.prompt.md
@@ -1,0 +1,19 @@
+---
+type: noResponse
+name: Instructions
+---
+
+# Ultimatum Game
+
+You and a partner share a pot of **$10**.
+
+- One of you is the **Proposer**. They choose an offer between $0 and $10.
+- The other is the **Responder**. They see the offer and decide whether
+  to **Accept** or **Reject**.
+
+If the responder accepts, the pot is split per the offer: the responder
+keeps the offered amount, the proposer keeps the rest.
+
+If the responder rejects, **both of you earn $0**.
+
+You'll be assigned a role on the next screen.

--- a/examples/ultimatum-game/prompts/offer.prompt.md
+++ b/examples/ultimatum-game/prompts/offer.prompt.md
@@ -1,0 +1,21 @@
+---
+type: slider
+name: Offer
+min: 0
+max: 10
+interval: 1
+---
+
+# Choose your offer
+
+Drag the slider to choose how much of the $10 to offer the responder.
+You will keep whatever is left **if** they accept.
+
+Click anywhere on the bar to set your offer. There is no thumb yet —
+that is intentional, so the position you choose is your own.
+
+---
+
+- 0: Keep all $10, offer $0
+- 5: Even split
+- 10: Give them everything

--- a/examples/ultimatum-game/prompts/outcome_accepted.prompt.md
+++ b/examples/ultimatum-game/prompts/outcome_accepted.prompt.md
@@ -1,0 +1,9 @@
+---
+type: noResponse
+name: Outcome — offer accepted
+---
+
+## Deal
+
+The responder **accepted** the offer above. The split stands: the
+responder keeps the offered amount; the proposer keeps the rest.

--- a/examples/ultimatum-game/prompts/outcome_rejected.prompt.md
+++ b/examples/ultimatum-game/prompts/outcome_rejected.prompt.md
@@ -1,0 +1,9 @@
+---
+type: noResponse
+name: Outcome — offer rejected
+---
+
+## No deal
+
+The responder **rejected** the offer. **Both** of you earn $0 this
+round.

--- a/examples/ultimatum-game/prompts/proposer_waiting.prompt.md
+++ b/examples/ultimatum-game/prompts/proposer_waiting.prompt.md
@@ -1,0 +1,12 @@
+---
+type: noResponse
+name: Waiting for responder
+---
+
+# Your offer is in — waiting for the responder
+
+Your partner is now deciding whether to accept or reject your offer.
+You'll see the result on the next screen.
+
+Click **Ready** below when you've read this; the stage will advance
+once both of you have submitted.

--- a/examples/ultimatum-game/prompts/responder_waiting.prompt.md
+++ b/examples/ultimatum-game/prompts/responder_waiting.prompt.md
@@ -1,0 +1,13 @@
+---
+type: noResponse
+name: Waiting for proposer
+---
+
+# Your partner is choosing an offer
+
+Sit tight — they are deciding how much of the $10 to offer you. As soon
+as they submit, you will see the offer and decide whether to accept or
+reject it.
+
+Click **Ready** below when you've read this; the stage will advance
+once both of you have submitted.

--- a/examples/ultimatum-game/prompts/role_preference.prompt.md
+++ b/examples/ultimatum-game/prompts/role_preference.prompt.md
@@ -1,0 +1,18 @@
+---
+type: multipleChoice
+name: Role preference
+select: single
+layout: vertical
+---
+
+# Which role would you prefer?
+
+This preference is used to assign you to a position. If you and your
+partner pick different roles, you each get what you asked for. If you
+both pick the same role, the host platform's matching policy decides
+who gets which seat.
+
+---
+
+- Proposer
+- Responder

--- a/examples/ultimatum-game/ultimatum-game.treatments.yaml
+++ b/examples/ultimatum-game/ultimatum-game.treatments.yaml
@@ -1,0 +1,175 @@
+# Ultimatum Game — a 2-player asymmetric example.
+# Position 0 is the Proposer (offers a slice of $10); position 1 is the
+# Responder (accepts or rejects). Roles are assigned via
+# `groupComposition` from a multipleChoice in the intro. The two game
+# stages and the outcome stage demonstrate position-based asymmetric
+# content via `showToPositions` and cross-player `display` elements.
+
+treatments:
+  - name: Ultimatum Game
+    notes: |
+      Two-player single-round game. Position 0 (proposer) chooses an
+      offer between $0 and $10; position 1 (responder) sees the offer
+      and accepts or rejects it. Each game stage gives each position
+      a different element set via `showToPositions` so the proposer
+      and responder are working from the same stage but seeing
+      different content.
+    playerCount: 2
+
+    # `groupComposition` matches participants into seats based on the
+    # role-preference response captured in the intro. If both
+    # participants pick the same role the host's matching policy
+    # decides who gets which seat — Stagebook only specifies the
+    # contract.
+    groupComposition:
+      - position: 0
+        title: Proposer
+        conditions:
+          - reference: prompt.role_preference
+            comparator: equals
+            value: Proposer
+      - position: 1
+        title: Responder
+        conditions:
+          - reference: prompt.role_preference
+            comparator: equals
+            value: Responder
+
+    gameStages:
+      - name: offer
+        duration: 60
+        notes: |
+          Stage 1 — offer. Position 0 sees the slider prompt and submits
+          an offer; position 1 sees a "your partner is deciding" notice
+          and a Ready button. Both must submit before the stage advances,
+          so the responder is naturally held while the proposer thinks.
+        elements:
+          # Proposer-only: the actual offer slider.
+          - type: prompt
+            name: offer
+            file: prompts/offer.prompt.md
+            showToPositions: [0]
+            notes: |
+              `showToPositions: [0]` restricts this prompt to the
+              proposer. The response is named `offer`, so it is
+              addressable as `prompt.offer` from the responder's
+              `display` element on the next stage.
+
+          # Responder-only: a "wait" view.
+          - type: prompt
+            file: prompts/responder_waiting.prompt.md
+            showToPositions: [1]
+
+          - type: timer
+          - type: submitButton
+            buttonText: Ready
+
+      - name: decision
+        duration: 60
+        notes: |
+          Stage 2 — decision. Position 1 sees the offer (via a `display`
+          element that reads `prompt.offer` at `position: 0`) and the
+          Accept/Reject prompt. Position 0 sees a "your partner is
+          deciding" notice plus a `display` of their own offer as a
+          recap. Both submit; stage advances when both are in.
+        elements:
+          # Proposer-only: recap of the offer they made + waiting message.
+          - type: display
+            reference: prompt.offer
+            position: 0
+            showToPositions: [0]
+            notes: |
+              Same `display` element used for the recap and the
+              cross-player view — `position: 0` selects the
+              proposer's offer; `showToPositions: [0]` shows it to
+              the proposer themselves here. (See the next element
+              for the cross-player variant.)
+          - type: prompt
+            file: prompts/proposer_waiting.prompt.md
+            showToPositions: [0]
+
+          # Responder-only: cross-player display of the offer + decide
+          # prompt.
+          - type: display
+            reference: prompt.offer
+            position: 0
+            showToPositions: [1]
+            notes: |
+              Cross-player `display` — `position: 0` reads the
+              proposer's response; `showToPositions: [1]` renders
+              the value into the responder's view.
+          - type: prompt
+            name: decision
+            file: prompts/decision.prompt.md
+            showToPositions: [1]
+
+          - type: timer
+          - type: submitButton
+            buttonText: Submit
+
+      - name: outcome
+        duration: 30
+        notes: |
+          Stage 3 — outcome. Both positions see the offer (via `display`)
+          and exactly one of two outcome cards based on the responder's
+          decision. `comparator: equals` on `prompt.decision` at
+          position 1 selects accepted vs. rejected.
+        elements:
+          - type: display
+            reference: prompt.offer
+            position: 0
+            notes: Both positions see the offer value. No `showToPositions` defaults to all.
+
+          - type: separator
+
+          - type: prompt
+            file: prompts/outcome_accepted.prompt.md
+            conditions:
+              - reference: prompt.decision
+                position: 1
+                comparator: equals
+                value: Accept
+
+          - type: prompt
+            file: prompts/outcome_rejected.prompt.md
+            conditions:
+              - reference: prompt.decision
+                position: 1
+                comparator: equals
+                value: Reject
+
+          - type: submitButton
+            displayTime: 5
+            buttonText: Continue
+
+    exitSequence:
+      - name: Reflection
+        elements:
+          - type: prompt
+            name: reflection
+            file: prompts/feedback.prompt.md
+          - type: submitButton
+
+introSequences:
+  - name: orientation
+    notes: |
+      Solo intro. Asks each participant which role they would prefer;
+      that response feeds `groupComposition` to assign positions.
+    introSteps:
+      - name: Instructions
+        elements:
+          - type: prompt
+            file: prompts/instructions.prompt.md
+          - type: submitButton
+            buttonText: Continue
+
+      - name: Role preference
+        elements:
+          - type: prompt
+            name: role_preference
+            file: prompts/role_preference.prompt.md
+            notes: |
+              `name: role_preference` here is what makes this choice
+              addressable as `prompt.role_preference` in
+              `groupComposition`.
+          - type: submitButton


### PR DESCRIPTION
## Summary

Two new study examples bundled into the viewer's example catalog. Both follow the annotated-walkthrough conventions — \`notes:\` fields on every stage/element/template surface in the viewer sidebar with click-to-jump info icons.

### \`examples/prisoners-dilemma/\` — closes #93

Two-player simultaneous choice. Two treatments share one round template:
- **One-shot** — a single round (1 invocation of the round template).
- **3-round repeated** — same round structure broadcast over \`roundN: [1, 2, 3]\` for 6 game stages total.

The outcome stage uses \`comparator: equals\` on \`prompt.choice_round_\${roundN}\` at each position to render exactly one of four outcome cards (CC, CD, DC, DD) per (P0 × P1) combination. Asymmetric outcomes use the same prompt files split across both perspectives.

**Demonstrates:** multi-player basics, conditions with \`comparator: equals\`, display elements, position-based asymmetry, template invocation with both \`fields:\` and \`broadcast:\`.

### \`examples/ultimatum-game/\` — closes #94

Two-player asymmetric game. Position 0 (Proposer) picks an offer between $0 and $10 via slider; position 1 (Responder) sees the offer and chooses Accept or Reject. Roles assigned by \`groupComposition\` reading a multipleChoice in the intro — \`comparator: equals\` against "Proposer" / "Responder".

The two game stages give each position a different element set via \`showToPositions\`. The decision stage reuses the same \`display\` element with \`position: 0\` and different \`showToPositions\` to show the offer back to the proposer (recap) and to the responder (cross-player view).

**Demonstrates:** \`groupComposition\`, \`showToPositions\`, position-based asymmetric content, \`display\` elements referencing other positions, conditional outcome cards.

## Test plan

- [x] Viewer catalog test runs through the actual examples (parses YAML, expands templates, validates) — all 84 viewer tests pass.
- [x] Viewer build clean.
- [ ] Manual: open the viewer landing page and confirm both examples appear in the example list.
- [ ] Manual: load Prisoner's Dilemma 3-round, step through both positions, verify outcome cards render correctly.
- [ ] Manual: load Ultimatum Game, verify position-based asymmetric stages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)