### PR TITLE
Fix template substitution for numeric/boolean broadcast fields

### DIFF
--- a/apps/viewer/src/lib/exampleCatalog.test.ts
+++ b/apps/viewer/src/lib/exampleCatalog.test.ts
@@ -5,7 +5,7 @@ import {
   exampleCatalog,
   prepareExampleTreatment,
 } from "./exampleCatalog";
-import { parseTreatmentYaml } from "./treatment";
+import { parseTreatmentYaml, expandTreatmentFile } from "./treatment";
 
 const SAMPLE_YAML = `
 introSequences:
@@ -166,6 +166,21 @@ describe("exampleCatalog (discovered via import.meta.glob)", () => {
     expect(walkthrough?.prompts["prompts/consent.prompt.md"]).toContain(
       "noResponse",
     );
+  });
+
+  it("every bundled example expands with no unresolved fields", () => {
+    // Regression for the PD broadcast bug: substituteFields previously
+    // skipped in-string substitution for non-string scalars, so the
+    // 3-round prisoner's-dilemma broadcast left `${roundN}` literal in
+    // stage names. The catalog's title-extraction step doesn't notice
+    // because it only reads `treatments[0].name`; only an explicit
+    // unresolved-fields check across all examples surfaces this kind
+    // of bug.
+    for (const entry of exampleCatalog) {
+      const parsed = parseTreatmentYaml(entry.yaml);
+      const { unresolvedFields } = expandTreatmentFile(parsed);
+      expect(unresolvedFields, `${entry.id} has unresolved fields`).toEqual([]);
+    }
   });
 });
 

--- a/examples/prisoners-dilemma/prisoners-dilemma.treatments.yaml
+++ b/examples/prisoners-dilemma/prisoners-dilemma.treatments.yaml
@@ -167,9 +167,9 @@ treatments:
       Same round structure repeated three times via broadcast. Each
       broadcast row produces 2 stages, so this treatment has 6 game
       stages — the participant alternates choosing and seeing the
-      outcome three times before the reflection step. Because each
-      round's prompt is named `choice_round_${roundN}`, references
-      from one round don't collide with another's.
+      outcome three times before the reflection step. Each round's
+      prompt is named `choice_round_<N>` (where N is 1, 2, or 3), so
+      references from one round don't collide with another's.
     playerCount: 2
     gameStages:
       - template: roundTemplate

--- a/packages/stagebook/src/templates/fillTemplates.test.ts
+++ b/packages/stagebook/src/templates/fillTemplates.test.ts
@@ -408,6 +408,79 @@ test("string field embedded in another string", () => {
   expect(result).toEqual({ label: "Item Alpha here" });
 });
 
+test("numeric field embedded in another string", () => {
+  // Regression: substituteFields previously skipped in-string substitution
+  // for non-string scalars, so `roundN: 1` left `${roundN}` literal in
+  // strings like `round_${roundN}_choice`. The function now stringifies
+  // numbers and booleans for embedded substitution.
+  const templates = [
+    {
+      name: "embedded",
+      content: { name: "round_${roundN}_choice" },
+    },
+  ];
+
+  const { result } = fillTemplates({
+    templates,
+    obj: { template: "embedded", fields: { roundN: 1 } },
+  });
+  expect(result).toEqual({ name: "round_1_choice" });
+});
+
+test("boolean field embedded in another string", () => {
+  const templates = [
+    {
+      name: "embedded",
+      content: { tag: "active=${flag}" },
+    },
+  ];
+
+  const { result } = fillTemplates({
+    templates,
+    obj: { template: "embedded", fields: { flag: true } },
+  });
+  expect(result).toEqual({ tag: "active=true" });
+});
+
+test("numeric broadcast field substituted into stage names (#PD repro)", () => {
+  // Mirrors the prisoner's-dilemma example: a `contentType: stages`
+  // template invoked with broadcast over a numeric `roundN`. Each
+  // expansion must produce stages with the round number substituted
+  // into the stage name.
+  const templates = [
+    {
+      name: "roundTemplate",
+      content: [
+        { name: "round_${roundN}_choice" },
+        { name: "round_${roundN}_outcome" },
+      ],
+    },
+  ];
+
+  const { result } = fillTemplates({
+    templates,
+    obj: {
+      gameStages: [
+        {
+          template: "roundTemplate",
+          broadcast: { d0: [{ roundN: 1 }, { roundN: 2 }, { roundN: 3 }] },
+        },
+      ],
+    },
+  });
+
+  expect(result).toEqual({
+    gameStages: [
+      { name: "round_1_choice" },
+      { name: "round_1_outcome" },
+      { name: "round_2_choice" },
+      { name: "round_2_outcome" },
+      { name: "round_3_choice" },
+      { name: "round_3_outcome" },
+    ],
+  });
+});
+
 test("array field values substituted correctly", () => {
   const templates = [
     {

--- a/packages/stagebook/src/templates/fillTemplates.ts
+++ b/packages/stagebook/src/templates/fillTemplates.ts
@@ -36,12 +36,20 @@ export function substituteFields({
       stringifiedValue,
     );
 
-    // if the value is just a string or number, we can also replace instances of ${key} within other strings
-    if (typeof value === "string") {
+    // For scalars (string / number / boolean), also replace `${key}`
+    // when it's embedded inside a longer string — e.g.
+    // `round_${roundN}_choice` with `roundN: 1` → `round_1_choice`.
+    // The earlier whole-value `"${key}"` regex already handles standalone
+    // placeholders (and arrays/objects, which can't be string-embedded).
+    if (
+      typeof value === "string" ||
+      typeof value === "number" ||
+      typeof value === "boolean"
+    ) {
       const stringReplacementRegex = new RegExp(`\\$\\{${escapedKey}\\}`, "g");
       stringifiedTemplate = stringifiedTemplate.replace(
         stringReplacementRegex,
-        value,
+        String(value),
       );
     }
 


### PR DESCRIPTION
## Summary

\`substituteFields\` only did in-string \`\${key}\` replacement when the field value was a string. Numeric and boolean values silently fell through the embedded-string path, so a YAML field like \`roundN: 1\` left \`\${roundN}\` literal inside longer strings such as \`round_\${roundN}_choice\`. The whole-value \`"\${key}"\` regex (which JSON-stringifies) already worked for all types — only the embedded-string path was missing.

The upstream comment already described the intended behaviour as "string or number" — only the implementation forgot the number case. Booleans get the same treatment for symmetry.

The 3-round prisoner's-dilemma broadcast surfaced this in the wild: \`{ roundN: 1 }\` produced six stages all named with the literal \`\${roundN}\` placeholder, and the viewer prompted for a \`roundN\` field at study start.

## Also

- New \`exampleCatalog\` test asserts zero unresolved fields across every bundled example (the existing catalog test only checked title extraction, so silent unresolved-field regressions would have slipped through).
- Fixed a \`\${roundN}\` literal in the 3-round treatment's \`notes:\` field — no scope to resolve in, so it was always going to leak as unresolved.

## Test plan

- [x] New stagebook unit tests cover numeric/boolean embedded substitution + the PD-shape broadcast case (839/839 pass).
- [x] New viewer unit test exercises every bundled example through \`expandTreatmentFile\` (85/85 pass).
- [ ] Manual: load \`prisoners-dilemma\` 3-round in the viewer, confirm no \`roundN\` prompt appears at study start and that the six round-stage names render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)