### PR TITLE
Release v0.9.3

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Patch release for the template-substitution bug fixed in PR #276.

\`substituteFields\` now handles numeric and boolean values when the placeholder is embedded inside a longer string. YAML-native ints like \`roundN: 1\` previously left \`\${roundN}\` literal in strings such as \`round_\${roundN}_choice\`, leaking as unresolved fields and surfacing in the viewer's "fill in missing field" prompt at study start.

## Test plan

- [x] CI green on #276
- [ ] Cut GitHub release after merge to trigger npm-publish workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)