### PR TITLE
Numeric values for multipleChoice prompts (#282)

### DIFF
--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -206,7 +206,7 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
           </p>
         );
       }
-      const { metadata, body, responseItems, sliderPoints } = parsed.data;
+      const { metadata, body, responseItems, responsePoints } = parsed.data;
       const promptName =
         element.name ?? `${progressLabel}_${metadata.name ?? element.file}`;
 
@@ -220,7 +220,7 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
           metadata={metadata}
           body={body}
           responseItems={responseItems}
-          sliderPoints={sliderPoints}
+          responsePoints={responsePoints}
           name={promptName}
           file={element.file}
           shared={element.shared}

--- a/packages/stagebook/src/components/elements/Prompt.ct.tsx
+++ b/packages/stagebook/src/components/elements/Prompt.ct.tsx
@@ -513,3 +513,78 @@ test.describe("Multiple Choice option order", () => {
     expect(order).toEqual([...customOrderOptions]);
   });
 });
+
+// ---------------------------------------------------------------------
+// #282 — shuffle + numeric mode must keep label/point pairing intact
+// ---------------------------------------------------------------------
+//
+// Bug surfaced during review: a previous implementation shuffled the
+// labels but kept `numericPoints` in source order, so a shuffled radio
+// would record the wrong number for the chosen label. This test pins
+// the invariant that whichever label the participant picks, the saved
+// numeric value is the one originally aligned with it in the source.
+
+const NUMERIC_LIKERT_LABELS = [
+  "Strongly disagree",
+  "Disagree",
+  "Neutral",
+  "Agree",
+  "Strongly agree",
+] as const;
+const NUMERIC_LIKERT_POINTS = [1, 2, 3, 4, 5] as const;
+
+const numericShuffledMultipleChoice = {
+  metadata: {
+    name: "projects/example/numericShuffled.md",
+    type: "multipleChoice" as const,
+    shuffle: true,
+  },
+  body: "# How much do you agree?",
+  responseItems: [...NUMERIC_LIKERT_LABELS],
+  responsePoints: [...NUMERIC_LIKERT_POINTS],
+};
+
+test.describe("Multiple Choice numeric mode + shuffle (#282)", () => {
+  test("shuffled labels stay paired with their original numeric points", async ({
+    mount,
+  }) => {
+    const saved: { key: string; value: unknown }[] = [];
+    const component = await mount(
+      <Prompt
+        {...numericShuffledMultipleChoice}
+        name="testNumericShuffle"
+        value={undefined}
+        progressLabel="game_0_numeric_shuffle"
+        save={(key, value) => {
+          saved.push({ key, value });
+        }}
+        getElapsedTime={() => 0}
+      />,
+    );
+
+    // Find the radio whose displayed label is "Strongly agree" (originally
+    // paired with point 5) and click it. Whatever its display position
+    // after shuffle, the saved numeric value must be 5.
+    const radios = component.locator('input[type="radio"]');
+    const labels = await component
+      .locator("label")
+      .evaluateAll((nodes) => nodes.map((n) => (n.textContent ?? "").trim()));
+    const stronglyAgreeIdx = labels.findIndex((t) =>
+      t.includes("Strongly agree"),
+    );
+    expect(stronglyAgreeIdx).toBeGreaterThanOrEqual(0);
+    // `.click()` not `.check()` — RadioGroup is controlled, so the input's
+    // `checked` attribute won't update without a parent re-render. We only
+    // care that onChange fires with the right value.
+    await radios.nth(stronglyAgreeIdx).click();
+
+    // Wait for the 50ms debounce to fire.
+    await component.page().waitForTimeout(80);
+
+    expect(saved.length).toBeGreaterThan(0);
+    const last = saved[saved.length - 1];
+    const record = last.value as { value: unknown; label: unknown };
+    expect(record.value).toBe(5);
+    expect(record.label).toBe("Strongly agree");
+  });
+});

--- a/packages/stagebook/src/components/elements/Prompt.tsx
+++ b/packages/stagebook/src/components/elements/Prompt.tsx
@@ -62,7 +62,12 @@ export function Prompt({
   const numericPoints = responsePoints ?? sliderPoints;
   const hasNumericPoints =
     numericPoints !== undefined && numericPoints.length > 0;
-  const [responses, setResponses] = useState<string[]>([]);
+  // `shuffleOrder[i]` is the original index of the option at display
+  // position `i`. We track *one* shuffle order and derive both labels and
+  // numeric points from it, so a shuffled label always stays paired with
+  // its corresponding numeric value (#282 — without this, a shuffled
+  // numeric multipleChoice records the wrong number for the chosen label).
+  const [shuffleOrder, setShuffleOrder] = useState<number[]>([]);
   const [debugMessages, setDebugMessages] = useState<DebugMessage[]>([]);
   const debounceTextRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const debounceInteractiveRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -84,19 +89,35 @@ export function Prompt({
     (promptType === "multipleChoice" || promptType === "listSorter") &&
     metadata.shuffle === true;
 
-  // Initialize responses from responseItems (with optional shuffle)
+  // Initialize shuffleOrder when responseItems first arrives or changes
+  // length. Reshuffles only when the option set itself changes — the
+  // setEquality guard prevents a re-shuffle on every render.
   if (
     promptType !== "noResponse" &&
     responseItems.length > 0 &&
-    (!responses.length ||
-      !setEquality(new Set(responseItems), new Set(responses)))
+    (shuffleOrder.length !== responseItems.length ||
+      !setEquality(
+        new Set(responseItems),
+        new Set(shuffleOrder.map((i) => responseItems[i] ?? "")),
+      ))
   ) {
+    const indices = Array.from({ length: responseItems.length }, (_, i) => i);
     if (shouldShuffle) {
-      setResponses([...responseItems].sort(() => 0.5 - Math.random()));
-    } else {
-      setResponses(responseItems);
+      indices.sort(() => 0.5 - Math.random());
     }
+    setShuffleOrder(indices);
   }
+
+  // Apply the shuffle to both labels and (when present) numeric points so
+  // they stay aligned at every display position.
+  const responses =
+    shuffleOrder.length === responseItems.length
+      ? shuffleOrder.map((i) => responseItems[i] ?? "")
+      : responseItems;
+  const shuffledNumericPoints =
+    numericPoints && shuffleOrder.length === numericPoints.length
+      ? shuffleOrder.map((i) => numericPoints[i] ?? 0)
+      : numericPoints;
 
   const record = {
     ...metadata,
@@ -157,19 +178,19 @@ export function Prompt({
         // In numeric mode (#282) the option key is the stringified number;
         // the saved value is the number (parsed back from the key) and the
         // label is the displayed text. In text mode value === label.
-        (hasNumericPoints ? (
+        (hasNumericPoints && shuffledNumericPoints ? (
           <RadioGroup
             options={responses.map((label, idx) => ({
-              key: String(numericPoints[idx]),
+              key: String(shuffledNumericPoints[idx]),
               value: label,
             }))}
             value={typeof value === "number" ? String(value) : undefined}
             layout={metadata.layout}
             onChange={(e) => {
-              const idx = (numericPoints ?? []).findIndex(
+              const idx = shuffledNumericPoints.findIndex(
                 (p) => String(p) === e.target.value,
               );
-              const numericValue = numericPoints[idx];
+              const numericValue = shuffledNumericPoints[idx];
               const label = responses[idx] ?? "";
               debouncedSaveInteractive(numericValue, record, label);
             }}

--- a/packages/stagebook/src/components/elements/Prompt.tsx
+++ b/packages/stagebook/src/components/elements/Prompt.tsx
@@ -17,11 +17,17 @@ export interface PromptProps {
   body: string;
   responseItems: string[];
   /**
-   * Slider points (numbers) parsed from the body section. Empty for
-   * non-slider types. After #243 slider points and labels share the same
-   * body lines (`- 50: Somewhat familiar`); upstream
-   * `promptFileSchema.transform` splits them into `sliderPoints` (numbers)
-   * and `responseItems` (labels) with the i-th index aligned across both.
+   * Numeric per-option values parsed from the body section, aligned i-th
+   * with `responseItems` (labels). Populated for sliders (always) and for
+   * multipleChoice prompts in numeric mode (#282). Empty for text-only
+   * multipleChoice, listSorter, and openResponse.
+   */
+  responsePoints?: number[];
+  /**
+   * Deprecated alias for `responsePoints`, kept for backward compatibility
+   * with consumers that referenced this field name pre-#282. Identical to
+   * `responsePoints` for slider prompts.
+   * @deprecated
    */
   sliderPoints?: number[];
   name: string;
@@ -41,6 +47,7 @@ export function Prompt({
   metadata,
   body,
   responseItems,
+  responsePoints,
   sliderPoints,
   name,
   file,
@@ -50,6 +57,11 @@ export function Prompt({
   resolveURL,
   renderSharedNotepad,
 }: PromptProps) {
+  // Prefer `responsePoints` (#282 canonical name); fall back to the
+  // deprecated `sliderPoints` alias if a caller still uses it.
+  const numericPoints = responsePoints ?? sliderPoints;
+  const hasNumericPoints =
+    numericPoints !== undefined && numericPoints.length > 0;
   const [responses, setResponses] = useState<string[]>([]);
   const [debugMessages, setDebugMessages] = useState<DebugMessage[]>([]);
   const debounceTextRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -97,10 +109,15 @@ export function Prompt({
   };
 
   const saveData = useCallback(
-    (newValue: unknown, recordData: typeof record) => {
+    (newValue: unknown, recordData: typeof record, label?: string) => {
       const updatedRecord = {
         ...recordData,
         value: newValue,
+        // For multipleChoice prompts (#282), record both the chosen value
+        // and its display label. In numeric mode `value` is the number and
+        // `label` is the text; in text mode `value === label`. Slider
+        // responses don't carry a label since the input is continuous.
+        ...(label !== undefined ? { label } : {}),
       };
       const scope = shared ? "shared" : "player";
       save(`prompt_${recordData.name}`, updatedRecord, scope);
@@ -120,11 +137,11 @@ export function Prompt({
   );
 
   const debouncedSaveInteractive = useCallback(
-    (newValue: unknown, recordData: typeof record) => {
+    (newValue: unknown, recordData: typeof record, label?: string) => {
       if (debounceInteractiveRef.current)
         clearTimeout(debounceInteractiveRef.current);
       debounceInteractiveRef.current = setTimeout(
-        () => saveData(newValue, recordData),
+        () => saveData(newValue, recordData, label),
         50,
       );
     },
@@ -136,7 +153,28 @@ export function Prompt({
       <Markdown text={body} resolveURL={resolveURL} />
 
       {promptType === "multipleChoice" &&
-        (metadata.select === "single" || metadata.select === undefined) && (
+        (metadata.select === "single" || metadata.select === undefined) &&
+        // In numeric mode (#282) the option key is the stringified number;
+        // the saved value is the number (parsed back from the key) and the
+        // label is the displayed text. In text mode value === label.
+        (hasNumericPoints ? (
+          <RadioGroup
+            options={responses.map((label, idx) => ({
+              key: String(numericPoints[idx]),
+              value: label,
+            }))}
+            value={typeof value === "number" ? String(value) : undefined}
+            layout={metadata.layout}
+            onChange={(e) => {
+              const idx = (numericPoints ?? []).findIndex(
+                (p) => String(p) === e.target.value,
+              );
+              const numericValue = numericPoints[idx];
+              const label = responses[idx] ?? "";
+              debouncedSaveInteractive(numericValue, record, label);
+            }}
+          />
+        ) : (
           <RadioGroup
             options={responses.map((choice) => ({
               key: choice,
@@ -144,9 +182,12 @@ export function Prompt({
             }))}
             value={value as string | undefined}
             layout={metadata.layout}
-            onChange={(e) => debouncedSaveInteractive(e.target.value, record)}
+            onChange={(e) =>
+              // Text mode: label === value.
+              debouncedSaveInteractive(e.target.value, record, e.target.value)
+            }
           />
-        )}
+        ))}
 
       {promptType === "multipleChoice" && metadata.select === "multiple" && (
         <CheckboxGroup
@@ -197,7 +238,7 @@ export function Prompt({
           min={metadata.min}
           max={metadata.max}
           interval={metadata.interval}
-          labelPts={sliderPoints}
+          labelPts={numericPoints}
           labels={responses}
           value={value as number | undefined}
           onChange={(val) => debouncedSaveInteractive(val, record)}

--- a/packages/stagebook/src/components/elements/fixtures/prompts.ts
+++ b/packages/stagebook/src/components/elements/fixtures/prompts.ts
@@ -19,6 +19,7 @@ We need to decide whether to use Markdown or HTML for storing deliberation topic
 
 _Which format is better for this task?_`,
   responseItems: ["Markdown", "HTML"],
+  responsePoints: [],
   sliderPoints: [],
 };
 
@@ -30,6 +31,7 @@ export const multipleChoiceMultiple = {
   } as MetadataType,
   body: "# Which colors indicate a strong magical field?",
   responseItems: ["Octarine", "Hooloovoo", "Ultrablack", "Ulfire", "Plaid"],
+  responsePoints: [],
   sliderPoints: [],
 };
 
@@ -43,6 +45,7 @@ export const openResponse = {
 
 _Are there any other reasons you can think of for choosing one or the other?_`,
   responseItems: ["Please enter your response here."],
+  responsePoints: [],
   sliderPoints: [],
 };
 
@@ -56,6 +59,7 @@ export const openResponseWithLimits = {
   } as MetadataType,
   body: "# Please write a response between 50 and 200 characters.",
   responseItems: ["Enter your response here."],
+  responsePoints: [],
   sliderPoints: [],
 };
 
@@ -68,6 +72,7 @@ export const noResponse = {
 
 We need to decide whether to use Markdown or HTML. _Discuss why markdown is the best._`,
   responseItems: [],
+  responsePoints: [],
   sliderPoints: [],
 };
 
@@ -84,6 +89,7 @@ export const slider = {
   // After #243 slider points live in the body alongside their labels.
   // The fixture shape mirrors `promptFileSchema.parse()` output, so
   // points and labels arrive as parallel arrays.
+  responsePoints: [0, 20, 50, 80, 100],
   sliderPoints: [0, 20, 50, 80, 100],
 };
 
@@ -100,5 +106,6 @@ export const listSorter = {
     "Albus Dumbledore",
     "Severus Snape",
   ],
+  responsePoints: [],
   sliderPoints: [],
 };

--- a/packages/stagebook/src/schemas/promptFile.test.ts
+++ b/packages/stagebook/src/schemas/promptFile.test.ts
@@ -591,4 +591,205 @@ Do you agree?
       expect(result.data.metadata.layout).toBe("horizontal");
     }
   });
+
+  // ---------------------------------------------------------------------
+  // #282 — numeric values for multipleChoice prompts
+  // ---------------------------------------------------------------------
+
+  describe("multipleChoice numeric mode (#282)", () => {
+    test("parses `<number>: <label>` options into responsePoints + responseItems", () => {
+      const markdown = `---
+name: agreement
+type: multipleChoice
+---
+How much do you agree?
+---
+- 1: Strongly disagree
+- 2: Disagree
+- 3: Neutral
+- 4: Agree
+- 5: Strongly agree`;
+      const result = promptFileSchema.safeParse(markdown);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.responsePoints).toEqual([1, 2, 3, 4, 5]);
+        expect(result.data.responseItems).toEqual([
+          "Strongly disagree",
+          "Disagree",
+          "Neutral",
+          "Agree",
+          "Strongly agree",
+        ]);
+        expect(result.data.sliderPoints).toEqual([]);
+      }
+    });
+
+    test("bare numbers are accepted; label defaults to stringified number", () => {
+      const markdown = `---
+name: scale
+type: multipleChoice
+---
+Rate it
+---
+- 1
+- 2
+- 3
+- 4
+- 5`;
+      const result = promptFileSchema.safeParse(markdown);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.responsePoints).toEqual([1, 2, 3, 4, 5]);
+        expect(result.data.responseItems).toEqual(["1", "2", "3", "4", "5"]);
+      }
+    });
+
+    test("non-integer values are accepted (any finite number)", () => {
+      const markdown = `---
+name: scale
+type: multipleChoice
+---
+Rate it
+---
+- -1.5: Very low
+- 0: Mid
+- 2.5: High`;
+      const result = promptFileSchema.safeParse(markdown);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.responsePoints).toEqual([-1.5, 0, 2.5]);
+      }
+    });
+
+    test("text-only mode leaves responsePoints empty (back-compat)", () => {
+      const markdown = `---
+name: prefs
+type: multipleChoice
+---
+Pick one
+---
+- Option A
+- Option B
+- Option C`;
+      const result = promptFileSchema.safeParse(markdown);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.responsePoints).toEqual([]);
+        expect(result.data.responseItems).toEqual([
+          "Option A",
+          "Option B",
+          "Option C",
+        ]);
+      }
+    });
+
+    test("mixed numeric + text options is a validation error", () => {
+      const markdown = `---
+name: mixed
+type: multipleChoice
+---
+Pick one
+---
+- 1: foo
+- bar
+- 3: baz`;
+      const result = promptFileSchema.safeParse(markdown);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) =>
+            i.message.includes("mixes numeric and text"),
+          ),
+        ).toBe(true);
+      }
+    });
+
+    test("duplicate numeric values are a validation error", () => {
+      const markdown = `---
+name: dup
+type: multipleChoice
+---
+Pick one
+---
+- 1: first
+- 1: second
+- 2: third`;
+      const result = promptFileSchema.safeParse(markdown);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) =>
+            i.message.includes("duplicate numeric value"),
+          ),
+        ).toBe(true);
+      }
+    });
+
+    test("multi-select with numeric mode is rejected (single-select only in v1)", () => {
+      const markdown = `---
+name: multi
+type: multipleChoice
+select: multiple
+---
+Pick all that apply
+---
+- 1: One
+- 2: Two
+- 3: Three`;
+      const result = promptFileSchema.safeParse(markdown);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(
+          result.error.issues.some((i) =>
+            i.message.includes("must be single-select"),
+          ),
+        ).toBe(true);
+      }
+    });
+
+    test("multi-select with text-only mode still works (no regression)", () => {
+      const markdown = `---
+name: multi
+type: multipleChoice
+select: multiple
+---
+Pick all that apply
+---
+- One
+- Two
+- Three`;
+      const result = promptFileSchema.safeParse(markdown);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.responseItems).toEqual(["One", "Two", "Three"]);
+        expect(result.data.responsePoints).toEqual([]);
+      }
+    });
+  });
+
+  // ---------------------------------------------------------------------
+  // #282 — back-compat: sliderPoints still populated for sliders
+  // ---------------------------------------------------------------------
+
+  test("slider populates both responsePoints and (deprecated) sliderPoints", () => {
+    const markdown = `---
+name: heat
+type: slider
+min: 0
+max: 100
+interval: 1
+---
+How warm?
+---
+- 0: Cold
+- 50: Mid
+- 100: Hot`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.responsePoints).toEqual([0, 50, 100]);
+      expect(result.data.sliderPoints).toEqual([0, 50, 100]);
+      expect(result.data.responseItems).toEqual(["Cold", "Mid", "Hot"]);
+    }
+  });
 });

--- a/packages/stagebook/src/schemas/promptFile.ts
+++ b/packages/stagebook/src/schemas/promptFile.ts
@@ -139,14 +139,15 @@ export const metadataLogicalSchema = promptMetadataSchema;
 export type MetadataRefineType = MetadataType;
 
 /**
- * Slider labels live in the body section as inline lines (#243). One of:
+ * Parse a numeric response line. Used by sliders (always numeric) and by
+ * multipleChoice prompts in numeric mode (#282). One of:
  *   - `- 50` — bare number (label defaults to the number's string form)
  *   - `- 50: Somewhat familiar` — number + label
  *   - `- 50:` — number + empty label (label defaults to the number)
  * The first colon separates point from label, so labels can themselves
  * contain colons.
  */
-function parseSliderLine(
+function parseNumericResponseLine(
   raw: string,
 ): { ok: true; point: number; label: string } | { ok: false; message: string } {
   // Caller has already stripped the `- ` prefix and `\n`.
@@ -155,7 +156,7 @@ function parseSliderLine(
     return {
       ok: false,
       message:
-        "Slider label line is empty (expected `- <number>(: <label>)?`).",
+        "Numeric response line is empty (expected `- <number>(: <label>)?`).",
     };
   }
   const colonIdx = trimmed.indexOf(":");
@@ -172,17 +173,32 @@ function parseSliderLine(
   if (pointStr.length === 0) {
     return {
       ok: false,
-      message: `Slider label "${trimmed}" must start with a number, e.g. "- 0: Not familiar".`,
+      message: `Numeric response line "${trimmed}" must start with a number, e.g. "- 0: Not familiar".`,
     };
   }
   const point = Number(pointStr);
   if (!Number.isFinite(point)) {
     return {
       ok: false,
-      message: `Slider label "${trimmed}" must start with a number, e.g. "- 0: Not familiar". Got "${pointStr}".`,
+      message: `Numeric response line "${trimmed}" must start with a number, e.g. "- 0: Not familiar". Got "${pointStr}".`,
     };
   }
   return { ok: true, point, label: label ?? pointStr };
+}
+
+/**
+ * Inspect a response-line content (already stripped of `- ` prefix) to see
+ * if it begins with a finite number followed by EOL, colon, or whitespace.
+ * Used by multipleChoice mode detection — if every option starts with a
+ * number, the prompt is in numeric mode (#282).
+ */
+function isNumericResponseLine(raw: string): boolean {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return false;
+  const colonIdx = trimmed.indexOf(":");
+  const pointStr = colonIdx < 0 ? trimmed : trimmed.slice(0, colonIdx).trim();
+  if (pointStr.length === 0) return false;
+  return Number.isFinite(Number(pointStr));
 }
 
 /**
@@ -207,13 +223,25 @@ export interface ParsedPromptFile {
    * Shape depends on `metadata.type`:
    *   - multipleChoice / listSorter — choice/item strings
    *   - openResponse — placeholder lines
-   *   - slider — labels (one per parsed line; aligned with `sliderPoints`)
+   *   - slider — labels (one per parsed line; aligned with `responsePoints`)
+   *   - multipleChoice (numeric mode, #282) — labels (aligned with `responsePoints`)
    *   - noResponse — empty array
    */
   responseItems: string[];
   /**
-   * Slider points (numbers) parsed from the body section. Empty for
-   * non-slider types. `sliderPoints[i]` corresponds to `responseItems[i]`.
+   * Numeric per-option values, parsed from the body section. Populated for:
+   *   - slider — every line is numeric
+   *   - multipleChoice in numeric mode (#282) — every option has a numeric
+   *     prefix (`- 1: Strongly disagree`, or bare `- 1`)
+   * Empty for text-only multipleChoice, listSorter, openResponse, noResponse.
+   * `responsePoints[i]` corresponds to `responseItems[i]`.
+   */
+  responsePoints: number[];
+  /**
+   * Deprecated: use `responsePoints`. Retained as an alias for sliders so
+   * existing consumers continue to work; identical to `responsePoints` for
+   * slider prompts. Will be removed in a future release.
+   * @deprecated
    */
   sliderPoints: number[];
 }
@@ -302,6 +330,7 @@ export const promptFileSchema: z.ZodType<
         metadata: parsedMetadata,
         body: body?.trim() ?? "",
         responseItems: [],
+        responsePoints: [],
         sliderPoints: [],
       };
     }
@@ -360,14 +389,14 @@ export const promptFileSchema: z.ZodType<
     }
 
     let responseItems: string[] = [];
-    let sliderPoints: number[] = [];
+    let responsePoints: number[] = [];
     if (parsedMetadata.type === "slider") {
       const points: number[] = [];
       const labels: string[] = [];
       for (const line of responseLines) {
         if (!(line.startsWith("- ") || line === "-")) continue;
         const stripped = line === "-" ? "" : line.substring(2);
-        const parsed = parseSliderLine(stripped);
+        const parsed = parseNumericResponseLine(stripped);
         if (!parsed.ok) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
@@ -379,8 +408,71 @@ export const promptFileSchema: z.ZodType<
         points.push(parsed.point);
         labels.push(parsed.label);
       }
-      sliderPoints = points;
+      responsePoints = points;
       responseItems = labels;
+    } else if (parsedMetadata.type === "multipleChoice") {
+      // #282: multipleChoice options can be all-numeric (`- 1: Strongly disagree`)
+      // or all-text (`- Strongly disagree`). Mixed = validation error.
+      // Numeric mode is restricted to single-select (radio); multi-select
+      // numeric mode has no clean averaging semantics and is out of scope for v1.
+      const stripped: string[] = [];
+      for (const line of responseLines) {
+        if (!(line.startsWith("- ") || line === "-")) continue;
+        stripped.push(line === "-" ? "" : line.substring(2));
+      }
+      const numericFlags = stripped.map((s) => isNumericResponseLine(s));
+      const allNumeric = stripped.length > 0 && numericFlags.every((f) => f);
+      const anyNumeric = numericFlags.some((f) => f);
+      if (anyNumeric && !allNumeric) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["responses"],
+          message:
+            "multipleChoice prompt mixes numeric and text response options. Either give every option a `<number>: <label>` prefix or remove all numeric prefixes.",
+        });
+      }
+      if (allNumeric) {
+        if (parsedMetadata.select === "multiple") {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["responses"],
+            message:
+              "multipleChoice prompts in numeric mode (#282) must be single-select. Multi-select numeric mode is not supported in v1.",
+          });
+        }
+        const points: number[] = [];
+        const labels: string[] = [];
+        for (const s of stripped) {
+          const parsed = parseNumericResponseLine(s);
+          if (!parsed.ok) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["responses"],
+              message: parsed.message,
+            });
+            continue;
+          }
+          points.push(parsed.point);
+          labels.push(parsed.label);
+        }
+        // Numeric values must be unique within the prompt.
+        const seen = new Set<number>();
+        for (const p of points) {
+          if (seen.has(p)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["responses"],
+              message: `multipleChoice prompt has duplicate numeric value ${p}. Each option must have a unique numeric value.`,
+            });
+            break;
+          }
+          seen.add(p);
+        }
+        responsePoints = points;
+        responseItems = labels;
+      } else {
+        responseItems = stripped.map((s) => s.trim());
+      }
     } else {
       responseItems = responseLines
         .filter(
@@ -399,7 +491,10 @@ export const promptFileSchema: z.ZodType<
       metadata: parsedMetadata,
       body: body?.trim() ?? "",
       responseItems,
-      sliderPoints,
+      responsePoints,
+      // Back-compat alias: identical to `responsePoints` for sliders;
+      // empty for everything else (matches pre-#282 behavior).
+      sliderPoints: parsedMetadata.type === "slider" ? responsePoints : [],
     };
   });
 


### PR DESCRIPTION
Closes #282.

## Summary

`multipleChoice` prompts gain the slider's `<number>: <label>` syntax for specifying per-option numeric values. The most common aggregate use cases (Likert composite scoring, partisan-style branching, TIPI-family scales) collapse from "case cascade mapping text → number, then average" into "average over the prompts directly" — the values are already numeric in the response.

## What's allowed

```yaml
---
type: multipleChoice
---
How much do you agree?
---
- 1: Strongly disagree
- 2: Disagree
- 3: Neutral
- 4: Agree
- 5: Strongly agree
```

Bare numbers are also accepted (`- 1` renders as a button labeled `"1"`):

```
- 1
- 2
- 3
```

## Rules

- **All-or-nothing per prompt.** Every option in a single prompt must be either all-numeric or all-text. Mixed = validation error.
- **Numeric values must be unique within the prompt.** Duplicates = validation error.
- **Single-select only in v1.** Numeric mode + `select: multiple` is rejected.
- **`label` is always a string** for multipleChoice responses.

## Storage shape (multipleChoice)

| Source line | `value` | `label` |
|---|---|---|
| `- 1: Strongly disagree` | `1` (number) | `"Strongly disagree"` |
| `- 1` | `1` (number) | `"1"` |
| `- Strongly disagree` | `"Strongly disagree"` | `"Strongly disagree"` |

Sliders save `value` only (continuous input, no honest label) — no change from previous behavior.

## Schema changes

- `ParsedPromptFile` gains `responsePoints: number[]` (canonical name for numeric per-option values).
- `sliderPoints` retained as a deprecated alias — identical to `responsePoints` for sliders, empty otherwise (matches pre-#282 behavior, no consumer break).
- `parseSliderLine` renamed to `parseNumericResponseLine`; new `isNumericResponseLine` helper drives mode detection.

## Tests

9 new tests in [promptFile.test.ts](packages/stagebook/src/schemas/promptFile.test.ts):
- numeric `<number>: <label>` parsing
- bare-number parsing (label = stringified number)
- non-integer values
- text-only mode (no regression)
- mixed numeric+text rejection
- duplicate-value rejection
- multi-select numeric rejection
- multi-select text mode still works
- slider populates both `responsePoints` and (deprecated) `sliderPoints`

## Test plan

- [x] `npm test` — stagebook 863 / viewer 85 / vscode 189 — all pass.
- [x] `npm run lint` — clean.
- [x] `npx prettier --check` — clean.
- [ ] Manual: open a numeric multipleChoice prompt in the viewer, click an option, verify the saved record has `value` as a number and `label` as the displayed text.

## Notes

This unblocks the most common patterns from #278 (aggregate values) — Likert composites and partisan branching no longer need `case` cascades to convert text labels to numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)