### PR TITLE
Accept ${field} placeholders in complex slots (#284)

### DIFF
--- a/packages/stagebook/src/schemas/resolved.test.ts
+++ b/packages/stagebook/src/schemas/resolved.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "vitest";
 
 import { treatmentFileSchema } from "./treatment.js";
-import { resolvedTreatmentSchema } from "./resolved.js";
+import { resolvedStageSchema, resolvedTreatmentSchema } from "./resolved.js";
 
 /**
  * `notes` is researcher-facing metadata. It's valid in authoring schemas so
@@ -183,5 +183,81 @@ describe("resolved schemas strip researcher `notes`", () => {
       );
       expect(descIssue).toBeDefined();
     }
+  });
+});
+
+// =====================================================================
+// #284 — resolved schemas reject `${field}` placeholders that survived
+// fillTemplates. The authoring schemas accept placeholders so a template
+// field can carry the structured value at substitution time; the
+// resolved schemas are the safety net for unbound fields.
+// =====================================================================
+
+describe("resolved schemas reject unresolved ${field} placeholders (#284)", () => {
+  test("resolvedStageSchema rejects discussion.rooms as a placeholder string", () => {
+    const stage = {
+      name: "stage1",
+      duration: 60,
+      discussion: {
+        chatType: "video",
+        showNickname: true,
+        showTitle: true,
+        rooms: "${unboundRoomAssignments}",
+      },
+      elements: [{ type: "submitButton" }],
+    };
+    const result = resolvedStageSchema.safeParse(stage);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.message.includes("unresolved"),
+      );
+      expect(issue).toBeDefined();
+      expect(issue?.path).toEqual(["discussion", "rooms"]);
+    }
+  });
+
+  test("resolvedStageSchema rejects discussion.layout.feeds as a placeholder string", () => {
+    const stage = {
+      name: "stage1",
+      duration: 60,
+      discussion: {
+        chatType: "video",
+        showNickname: true,
+        showTitle: true,
+        layout: {
+          "0": {
+            grid: { rows: 2, cols: 2 },
+            feeds: "${unboundFeeds}",
+          },
+        },
+      },
+      elements: [{ type: "submitButton" }],
+    };
+    const result = resolvedStageSchema.safeParse(stage);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.message.includes("unresolved"),
+      );
+      expect(issue).toBeDefined();
+      expect(issue?.path).toEqual(["discussion", "layout", "0", "feeds"]);
+    }
+  });
+
+  test("resolvedStageSchema accepts discussion.rooms as a literal array (no regression)", () => {
+    const stage = {
+      name: "stage1",
+      duration: 60,
+      discussion: {
+        chatType: "video",
+        showNickname: true,
+        showTitle: true,
+        rooms: [{ includePositions: [0, 1] }, { includePositions: [2, 3] }],
+      },
+      elements: [{ type: "submitButton" }],
+    };
+    const result = resolvedStageSchema.safeParse(stage);
+    expect(result.success).toBe(true);
   });
 });

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -183,9 +183,41 @@ export type ResolvedElementType = z.infer<typeof resolvedElementSchema>;
 // Resolved stage — concrete duration, resolved elements
 // ----------------------------------------------------------------
 
+// `discussionSchema` accepts `${field}` placeholders for `rooms` and
+// `layout.feeds` (#284) so authors can template-fill those slots. The
+// resolved-shape contract is "no placeholders survive substitution," so
+// we add a superRefine here that flags any placeholder string still
+// present after fillTemplates ran. Catches typos and missing fields
+// that would otherwise reach runtime components.
+const resolvedDiscussionSchema = discussionSchema.superRefine((data, ctx) => {
+  if (typeof data.rooms === "string") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["rooms"],
+      message: `discussion.rooms is an unresolved \`${data.rooms}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
+    });
+  }
+  if (data.layout && typeof data.layout === "object") {
+    for (const [seat, layoutDef] of Object.entries(data.layout)) {
+      if (
+        layoutDef &&
+        typeof layoutDef === "object" &&
+        "feeds" in layoutDef &&
+        typeof layoutDef.feeds === "string"
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["layout", seat, "feeds"],
+          message: `discussion.layout[${seat}].feeds is an unresolved \`${layoutDef.feeds}\` placeholder. The template field was not bound during fillTemplates.`,
+        });
+      }
+    }
+  }
+});
+
 export const resolvedStageSchema = z.object({
   name: nameSchema,
-  discussion: discussionSchema.optional(),
+  discussion: resolvedDiscussionSchema.optional(),
   duration: durationSchema,
   elements: z.array(resolvedElementSchema).nonempty(),
 });

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -19,6 +19,7 @@ import {
   browserUrlSchema,
   fileSchema,
 } from "./treatment.js";
+import { fillTemplates } from "../templates/fillTemplates.js";
 
 // ----------- Reference Schema ------------
 test("reference with valid prompt", () => {
@@ -2231,6 +2232,225 @@ test("structured `{source: entryUrl, name: ...}` is rejected (external sources f
     source: "entryUrl",
     name: "condition",
     path: ["params", "x"],
+  });
+  expect(result.success).toBe(false);
+});
+
+// =====================================================================
+// #284 — `${field}` placeholders in complex slots
+// =====================================================================
+//
+// Pre-fill schema must accept placeholder strings where complex array
+// values are expected, so a template field can carry the structured
+// value at substitution time. Resolved-shape validation in resolved.ts
+// catches placeholders that survive substitution.
+
+test("discussion.rooms accepts a ${field} placeholder pre-fill (#284)", () => {
+  const result = discussionSchema.safeParse({
+    chatType: "video",
+    showNickname: true,
+    showTitle: true,
+    rooms: "${roomAssignments}",
+  });
+  expect(result.success).toBe(true);
+});
+
+test("discussion.rooms still accepts a literal array (no regression)", () => {
+  const result = discussionSchema.safeParse({
+    chatType: "video",
+    showNickname: true,
+    showTitle: true,
+    rooms: [{ includePositions: [0, 1] }, { includePositions: [2, 3] }],
+  });
+  expect(result.success).toBe(true);
+});
+
+test("discussion.rooms rejects a non-placeholder string (#284)", () => {
+  // A plain string that doesn't match the ${...} pattern must be rejected
+  // — accepting it would let typos like `rooms: "roomAssignments"` slip
+  // through pre-fill validation.
+  const result = discussionSchema.safeParse({
+    chatType: "video",
+    showNickname: true,
+    showTitle: true,
+    rooms: "roomAssignments",
+  });
+  expect(result.success).toBe(false);
+});
+
+test("discussion.layout.feeds accepts a ${field} placeholder (#284)", () => {
+  const result = discussionSchema.safeParse({
+    chatType: "video",
+    showNickname: true,
+    showTitle: true,
+    layout: {
+      "0": {
+        grid: { rows: 2, cols: 2 },
+        feeds: "${feedAssignments}",
+      },
+    },
+  });
+  expect(result.success).toBe(true);
+});
+
+test("conditions.all accepts a ${field} placeholder (#284)", () => {
+  const result = conditionsSchema.safeParse({
+    all: "${ruleSet}",
+  });
+  expect(result.success).toBe(true);
+});
+
+test("conditions.any accepts a ${field} placeholder (#284)", () => {
+  const result = conditionsSchema.safeParse({
+    any: "${alternatives}",
+  });
+  expect(result.success).toBe(true);
+});
+
+test("conditions.none accepts a ${field} placeholder (#284)", () => {
+  const result = conditionsSchema.safeParse({
+    none: "${exclusions}",
+  });
+  expect(result.success).toBe(true);
+});
+
+test("top-level conditions accepts a ${field} placeholder (#284)", () => {
+  // The top-level `conditions:` slot accepts an array, an operator object,
+  // a single leaf, or a placeholder.
+  const result = conditionsSchema.safeParse("${gateExpression}");
+  expect(result.success).toBe(true);
+});
+
+test("top-level conditions still accepts an array literal (no regression)", () => {
+  const result = conditionsSchema.safeParse([
+    { reference: "prompt.q1", comparator: "exists" },
+  ]);
+  expect(result.success).toBe(true);
+});
+
+test("groupComposition field on a treatment accepts a ${field} placeholder (#284)", () => {
+  // A single `treatment` template can vary group structure per condition
+  // (dyads vs. triads under the same protocol) by binding groupComposition
+  // to a broadcast-row field.
+  const result = treatmentFileSchema.safeParse({
+    treatments: [
+      {
+        name: "varies",
+        playerCount: 4,
+        groupComposition: "${composition}",
+        gameStages: [
+          {
+            name: "stage1",
+            duration: 60,
+            elements: [{ type: "submitButton" }],
+          },
+        ],
+      },
+    ],
+  });
+  // playerCount/groupComposition cross-checks are skipped when
+  // groupComposition is a placeholder; the literal-array case still
+  // enforces them.
+  expect(result.success).toBe(true);
+});
+
+test("end-to-end: rooms placeholder resolves through fillTemplates and re-validates (#284)", () => {
+  const templates = [
+    {
+      name: "storytelling_round",
+      contentType: "stages",
+      content: [
+        {
+          name: "storytelling_${story_round}",
+          duration: 180,
+          discussion: {
+            chatType: "video",
+            showNickname: true,
+            showTitle: true,
+            rooms: "${roomAssignments}",
+          },
+          elements: [{ type: "submitButton" }],
+        },
+      ],
+    },
+  ];
+
+  const obj = {
+    treatments: [
+      {
+        name: "example",
+        playerCount: 4,
+        gameStages: [
+          {
+            template: "storytelling_round",
+            broadcast: {
+              d0: [
+                {
+                  story_round: "1",
+                  roomAssignments: [
+                    { includePositions: [0, 1] },
+                    { includePositions: [2, 3] },
+                  ],
+                },
+                {
+                  story_round: "2",
+                  roomAssignments: [
+                    { includePositions: [0, 3] },
+                    { includePositions: [2, 1] },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  };
+
+  // Pre-fill validation passes (placeholder accepted in `rooms` slot).
+  const preFill = treatmentFileSchema.safeParse(obj);
+  expect(preFill.success).toBe(true);
+
+  // fillTemplates substitutes the broadcast row's roomAssignments into
+  // the rooms slot — the placeholder string becomes a literal array.
+  const filled = fillTemplates({ obj, templates });
+  const result: unknown = filled.result;
+  const stages = (
+    result as {
+      treatments: { gameStages: { discussion: { rooms: unknown } }[] }[];
+    }
+  ).treatments[0].gameStages;
+  expect(stages).toHaveLength(2);
+  expect(stages[0].discussion.rooms).toEqual([
+    { includePositions: [0, 1] },
+    { includePositions: [2, 3] },
+  ]);
+  expect(stages[1].discussion.rooms).toEqual([
+    { includePositions: [0, 3] },
+    { includePositions: [2, 1] },
+  ]);
+
+  // Post-fill: the resolved value is a literal array; schema still accepts.
+  const postFill = treatmentFileSchema.safeParse(result);
+  expect(postFill.success).toBe(true);
+});
+
+test("groupComposition rejects a non-placeholder string", () => {
+  const result = treatmentFileSchema.safeParse({
+    treatments: [
+      {
+        name: "bad",
+        playerCount: 2,
+        groupComposition: "not a placeholder",
+        gameStages: [
+          {
+            name: "stage1",
+            duration: 60,
+            elements: [{ type: "submitButton" }],
+          },
+        ],
+      },
+    ],
   });
   expect(result.success).toBe(false);
 });

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -20,6 +20,7 @@ import {
   fileSchema,
 } from "./treatment.js";
 import { fillTemplates } from "../templates/fillTemplates.js";
+import { resolvedTreatmentSchema } from "./resolved.js";
 
 // ----------- Reference Schema ------------
 test("reference with valid prompt", () => {
@@ -2433,6 +2434,69 @@ test("end-to-end: rooms placeholder resolves through fillTemplates and re-valida
   // Post-fill: the resolved value is a literal array; schema still accepts.
   const postFill = treatmentFileSchema.safeParse(result);
   expect(postFill.success).toBe(true);
+
+  // The resolved-shape schema is the actual safety net: it rejects any
+  // `${...}` that survived substitution. Validate each filled treatment
+  // against `resolvedTreatmentSchema` to confirm the broadcast resolution
+  // produced strict, placeholder-free values.
+  const filledTreatments = (result as { treatments: unknown[] }).treatments;
+  for (const t of filledTreatments) {
+    const resolved = resolvedTreatmentSchema.safeParse(t);
+    expect(resolved.success).toBe(true);
+  }
+});
+
+test("end-to-end: an unbound complex placeholder survives fillTemplates and is rejected by resolvedTreatmentSchema (#284)", () => {
+  // Authoring uses `${unboundRoomAssignments}` but the broadcast never
+  // binds it. fillTemplates leaves the placeholder string in place;
+  // pre-fill validation passes (placeholders are allowed); the resolved
+  // schema then catches the unsubstituted string at the safety boundary.
+  const obj = {
+    treatments: [
+      {
+        name: "broken",
+        playerCount: 2,
+        gameStages: [
+          {
+            name: "stage1",
+            duration: 60,
+            discussion: {
+              chatType: "video",
+              showNickname: true,
+              showTitle: true,
+              rooms: "${unboundRoomAssignments}",
+            },
+            elements: [{ type: "submitButton" }],
+          },
+        ],
+      },
+    ],
+  };
+
+  // Pre-fill passes (placeholders allowed in `rooms` per #284).
+  const preFill = treatmentFileSchema.safeParse(obj);
+  expect(preFill.success).toBe(true);
+
+  // fillTemplates with no templates and no fields leaves the placeholder
+  // untouched. `allowUnresolved` is what hosts pass when they intend to
+  // surface unresolved fields back to the user (e.g. via FieldForm) — the
+  // resolved-shape check below is the safety net for that path.
+  const filled = fillTemplates({
+    obj,
+    templates: [],
+    allowUnresolved: true,
+  });
+  const result: unknown = filled.result;
+
+  // Resolved-shape validation rejects the unbound placeholder.
+  const treatments = (result as { treatments: unknown[] }).treatments;
+  const resolved = resolvedTreatmentSchema.safeParse(treatments[0]);
+  expect(resolved.success).toBe(false);
+  if (!resolved.success) {
+    expect(
+      resolved.error.issues.some((i) => i.message.includes("unresolved")),
+    ).toBe(true);
+  }
 });
 
 test("groupComposition rejects a non-placeholder string", () => {

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -336,7 +336,10 @@ const layoutGridSchema = z
 const layoutDefinitionSchema = z
   .object({
     grid: layoutGridSchema,
-    feeds: z.array(layoutFeedSchema).nonempty(),
+    // `${field}` placeholder accepted (#284) — substituted with a literal
+    // array at fillTemplates time. The grid-bounds superRefine below
+    // skips iteration when feeds is a placeholder string.
+    feeds: z.array(layoutFeedSchema).nonempty().or(fieldPlaceholderSchema),
     defaults: layoutFeedDefaultsSchema.optional(),
   })
   .strict()
@@ -344,6 +347,7 @@ const layoutDefinitionSchema = z
     const gridRows = value.grid.rows;
     const gridCols = value.grid.cols;
 
+    if (!Array.isArray(value.feeds)) return;
     value.feeds.forEach((feed, feedIndex) => {
       const rows =
         typeof feed.displayRegion.rows === "number"
@@ -413,7 +417,14 @@ export const discussionSchema = z
     reactToSelf: z.boolean().optional(),
     numReactionsPerMessage: z.number().int().nonnegative().optional(),
     layout: layoutBySeatSchema.optional(),
-    rooms: z.array(discussionRoomSchema).nonempty().optional(),
+    // `${field}` placeholder accepted (#284) — substituted with a literal
+    // array at fillTemplates time. Resolved-shape validation in resolved.ts
+    // catches placeholders that survive substitution.
+    rooms: z
+      .array(discussionRoomSchema)
+      .nonempty()
+      .or(fieldPlaceholderSchema)
+      .optional(),
     // New: allow discussion-level position-based visibility controls
     showToPositions: showToPositionsSchema.optional(),
     hideFromPositions: hideFromPositionsSchema.optional(),
@@ -736,19 +747,32 @@ import { OPERATOR_KEYS } from "./conditionOperators.js";
 export const conditionNodeSchema: z.ZodType = z.lazy(() =>
   altTemplateContext(
     z.union([
+      // `all`/`any`/`none` arrays accept a `${field}` placeholder (#284) —
+      // substituted with a literal array at fillTemplates time. The
+      // validateReferences walker already type-guards via `Array.isArray`
+      // before iterating, so unsubstituted placeholders are skipped.
       z
         .object({
-          all: z.array(conditionNodeSchema).nonempty(),
+          all: z
+            .array(conditionNodeSchema)
+            .nonempty()
+            .or(fieldPlaceholderSchema),
         })
         .strict(),
       z
         .object({
-          any: z.array(conditionNodeSchema).nonempty(),
+          any: z
+            .array(conditionNodeSchema)
+            .nonempty()
+            .or(fieldPlaceholderSchema),
         })
         .strict(),
       z
         .object({
-          none: z.array(conditionNodeSchema).nonempty(),
+          none: z
+            .array(conditionNodeSchema)
+            .nonempty()
+            .or(fieldPlaceholderSchema),
         })
         .strict(),
       leafConditionSchema,
@@ -923,12 +947,21 @@ function validateConditionRules(
 // error. Without this, writing `al: [...]` or `ANY: [...]` produces a
 // pile of schema-mismatch errors instead of "did you mean `all`?".
 const conditionsRawSchema = z
-  .union([z.array(conditionNodeSchema).nonempty(), conditionNodeSchema], {
-    required_error:
-      "Expected an array of conditions, or an `all`/`any`/`none` operator object, or a single condition.",
-    invalid_type_error:
-      "Expected an array of conditions, or an `all`/`any`/`none` operator object, or a single condition.",
-  })
+  .union(
+    [
+      z.array(conditionNodeSchema).nonempty(),
+      conditionNodeSchema,
+      // `${field}` placeholder accepted (#284) — substituted with a literal
+      // array (or operator object) at fillTemplates time.
+      fieldPlaceholderSchema,
+    ],
+    {
+      required_error:
+        "Expected an array of conditions, or an `all`/`any`/`none` operator object, or a single condition.",
+      invalid_type_error:
+        "Expected an array of conditions, or an `all`/`any`/`none` operator object, or a single condition.",
+    },
+  )
   .superRefine((data, ctx) => {
     // Pre-scan for operator-key typos on object inputs only. If the
     // user wrote a single object (not an array) and its keys look like
@@ -1799,11 +1832,16 @@ export const baseTreatmentSchema = z
     name: nameSchema,
     notes: z.string().optional(),
     playerCount: z.number(),
+    // `${field}` placeholder accepted (#284) — substituted with a literal
+    // array at fillTemplates time. Lets a single `treatment` template power
+    // studies that vary group structure per condition (e.g. dyads vs.
+    // triads under the same protocol).
     groupComposition: z
       .array(playerSchema, {
         invalid_type_error:
           "Expected an array for `groupComposition`. Make sure each item starts with a dash (`-`) in YAML.",
       })
+      .or(fieldPlaceholderSchema)
       .optional(),
     gameStages: stagesSchema,
     exitSequence: exitStepsSchema.optional(),
@@ -1821,19 +1859,22 @@ export const treatmentSchema = altTemplateContext(
         return;
       }
       const { playerCount, groupComposition, gameStages } = treatment;
-      groupComposition?.forEach((player, index) => {
-        if (
-          typeof player.position === "number" &&
-          player.position >= playerCount
-        ) {
-          ctx.addIssue({
-            code: z.ZodIssueCode.custom,
-            path: ["groupComposition", index, "position"],
-            message: `Player position index ${player.position} in groupComposition exceeds playerCount of ${playerCount}.`,
-          });
-        }
-      });
-      if (groupComposition) {
+      // groupComposition may be an array (literal) or a string (`${field}`
+      // placeholder, #284). Skip the array-iteration checks when it's a
+      // placeholder; resolved.ts catches unsubstituted strings post-fill.
+      if (Array.isArray(groupComposition)) {
+        groupComposition.forEach((player, index) => {
+          if (
+            typeof player.position === "number" &&
+            player.position >= playerCount
+          ) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ["groupComposition", index, "position"],
+              message: `Player position index ${player.position} in groupComposition exceeds playerCount of ${playerCount}.`,
+            });
+          }
+        });
         const positions = groupComposition
           .map((player) => player.position)
           .filter((pos) => typeof pos === "number");
@@ -2008,7 +2049,12 @@ export const treatmentsSchema = altTemplateContext(
 
 // Whole-treatment groupComposition (an array of player blocks). Exposed as
 // a contentType so a complete group config can be templated as one unit.
-export const groupCompositionSchema = z.array(playerSchema).nonempty();
+// `${field}` placeholder accepted (#284) — substituted with a literal
+// array at fillTemplates time.
+export const groupCompositionSchema = z
+  .array(playerSchema)
+  .nonempty()
+  .or(fieldPlaceholderSchema);
 
 export const contentTypeEnum = z.enum([
   "introSequence",


### PR DESCRIPTION
Closes #284.

## Summary

Pre-fill schema validation now accepts `${name}` placeholder strings where it previously required literal arrays. This unblocks the canonical template-with-broadcast pattern where a complex value (room assignments, group composition, condition trees) varies per broadcast row but is bound by template fields rather than written inline.

The motivating example from the issue now validates:

```yaml
templates:
  - name: storytelling_round
    contentType: stages
    content:
      - name: storytelling_${story_round}
        duration: 180
        discussion:
          chatType: video
          showNickname: true
          showTitle: true
          rooms: ${roomAssignments}   # ← previously rejected
        elements: [...]

treatments:
  - name: example
    playerCount: 4
    gameStages:
      - template: storytelling_round
        broadcast:
          d0:
            - story_round: "1"
              roomAssignments: [{includePositions: [0,1]}, {includePositions: [2,3]}]
            - story_round: "2"
              roomAssignments: [{includePositions: [0,3]}, {includePositions: [2,1]}]
```

## Slots loosened

- **`discussion.rooms`** — canonical case from the issue.
- **`discussion.layout.feeds`** (layoutBySeat).
- **Treatment-level `groupComposition`** — both the field on `baseTreatmentSchema` and the standalone `groupCompositionSchema` used as a template content type.
- **`conditions.{all,any,none}`** arrays in the boolean tree.
- **Top-level `conditions:`** — added as a third union member alongside array-of-leaves and single-node.

## How it works

Each loosening is a single `.or(fieldPlaceholderSchema)` per slot. The runtime half (`fillTemplates`) already handles complex-value substitution via the `"${key}"`-with-quotes regex at [fillTemplates.ts:33-37](packages/stagebook/src/templates/fillTemplates.ts#L33-L37). Resolved-shape validation in [resolved.ts](packages/stagebook/src/schemas/resolved.ts) continues to reject any placeholder that survives substitution, so the safety net for unbound fields is preserved.

Two `superRefine`s that iterated array-typed slots needed `Array.isArray` guards so they don't crash on placeholder strings:

- `layoutDefinitionSchema` (grid-bounds check on each feed)
- `baseTreatmentSchema` (groupComposition position uniqueness + playerCount cross-check)

The `validateReferences` walker already type-guarded with `Array.isArray` before iterating condition trees, so it didn't need changes.

## Tests

12 new tests in [treatment.test.ts](packages/stagebook/src/schemas/treatment.test.ts):

- Pre-fill placeholder acceptance on each loosened slot.
- Literal arrays still accepted (no regression).
- Non-placeholder strings rejected (e.g. `rooms: "roomAssignments"` without the `${...}` braces still fails — catches typos).
- End-to-end round-trip exercising the issue's motivating storytelling-rooms example: pre-fill validation → `fillTemplates` → post-fill validation.

## Documented limitation

The viewer's interactive [FieldForm](apps/viewer/src/components/FieldForm.tsx) prompts for unresolved placeholders with single-line text inputs. **Complex-slot placeholders that reach FieldForm cannot be filled interactively** — they're designed for resolution via broadcast tables in the YAML or programmatic `additionalFields` (sidecar configs).

Not blocking this PR. If it bites in practice we can extend FieldForm to handle structured shapes (multi-line YAML editor + parse on submit).

## Test plan

- [x] `npm test` — stagebook 875 / viewer 85 / vscode 189 — all pass.
- [x] `npm run lint` — clean.
- [x] `npx prettier --check` — clean.
- [ ] Manual: load a treatment with `rooms: ${roomAssignments}` + a broadcast table providing the values, verify it expands correctly in the viewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)