### PR TITLE
Release v0.9.4

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Patch release covering three merged feature PRs since v0.9.3.

## What's in this release

### Storage-key collision detection (#281, PR #283)

`{type}_{name}` storage keys must be unique within every phase a participant traverses (intro sequence × treatment, or game stages + exit sequence within a single treatment). Cross-treatment and cross-intro-sequence reuse remains allowed since participants only experience one of each.

**Migration note:** Treatment files that reused the same `name:` across phases of a single participant's flow will now fail validation. The fix is the per-element `name:` override:

```yaml
# Stage 1 (pre-test)
- type: prompt
  file: tipi/q1.prompt.md
  name: pretest_q1

# Stage 5 (post-test)
- type: prompt
  file: tipi/q1.prompt.md
  name: posttest_q1
```

Also catches mediaPlayer name-fallback collisions and Qualtrics fixed-key collisions.

### Numeric values for multipleChoice prompts (#282, PR #285)

multipleChoice prompts gain the slider's `<number>: <label>` syntax:

```yaml
---
type: multipleChoice
---
How much do you agree?
---
- 1: Strongly disagree
- 2: Disagree
- 3: Neutral
- 4: Agree
- 5: Strongly agree
```

Likert composite scoring, partisan-style branching, and TIPI-family scales can now aggregate over the prompts directly. New `responsePoints` field on parsed prompt output (`sliderPoints` retained as deprecated alias). Saved record gains a `label` field for multipleChoice. Single-select numeric only in v1; mixed numeric+text within a prompt and duplicate numeric values are rejected.

### `${field}` placeholders in complex slots (#284, PR #286)

Pre-fill schema validation accepts `${field}` placeholder strings in:
- `discussion.rooms`
- `discussion.layout.feeds`
- `groupComposition` (treatment-level field and standalone schema)
- `conditions.{all,any,none}` arrays
- Top-level `conditions:`

Unblocks the canonical template-with-broadcast pattern where a complex value (room assignments, group composition, condition trees) varies per broadcast row but is bound by a template field. Resolved schemas continue to reject placeholders that survive substitution, so unbound fields still surface clearly.

## Publishing

After merge, create the GitHub release `v0.9.4` to trigger the npm publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)