### PR TITLE
vscode:prepublish rebuilds stagebook before bundling

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -109,7 +109,7 @@
     "build:production": "esbuild src/extension.ts --bundle --outfile=dist/extension.js --external:vscode --format=cjs --platform=node --minify && esbuild src/webview/index.tsx --bundle --outfile=dist/webview.js --format=iife --platform=browser --minify --loader:.css=text --define:process.env.NODE_ENV='\"production\"'",
     "build:watch:extension": "npm run build:extension -- --watch",
     "build:watch:webview": "npm run build:webview -- --watch",
-    "vscode:prepublish": "npm run build:production",
+    "vscode:prepublish": "npm run build --prefix ../../packages/stagebook && npm run build:production",
     "package": "vsce package --no-dependencies",
     "lint": "echo 'no linter configured yet'",
     "test": "vitest run"

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Why

The vscode extension imports `stagebook`, which resolves to `packages/stagebook/dist/index.js` (the built artifact, not the source). If a developer changes `packages/stagebook/src/` and runs `npm run package -w stagebook-vscode` directly without first running `npm run build -w stagebook`, the bundled extension contains a stale schema and validation diagnostics drift from the source of truth.

Hit this firsthand cutting v0.9.4 — the merged #284 placeholder support was missing from the freshly-packaged extension because stagebook's dist was stale.

## Fix

`vscode:prepublish` now rebuilds stagebook before bundling:

```diff
- "vscode:prepublish": "npm run build:production",
+ "vscode:prepublish": "npm run build --prefix ../../packages/stagebook && npm run build:production",
```

`vsce` runs `vscode:prepublish` automatically before `package`, so this also covers anyone who runs `npm run package` directly without first running root-level `npm run build`.

## Verification

Deleted `packages/stagebook/dist` entirely, ran `npm run package -w stagebook-vscode`, confirmed:

- `packages/stagebook/dist/index.js` was rebuilt with the current schema (`rooms: z.array(discussionRoomSchema).nonempty().or(fieldPlaceholderSchema).optional()`).
- The vsix's `dist/extension.js` bundles the fresh schema (`rooms:u.array(Ug).nonempty().or(D).optional()` after minification).

## CI impact

None. The npm-publish workflow and the pre-push hook both already run a workspace-wide `npm run build` first, so stagebook's dist was always current in those paths. This change only fixes the local dev workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)