### PR TITLE
chore: sync package-lock.json with current workspace versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "agent-a29c9e264a47c0a31",
+  "name": "stagebook",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -13396,7 +13396,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.9.0",
+      "version": "0.9.4",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",


### PR DESCRIPTION
Cleanup follow-up to v0.9.4 release (#287).

## Why

Copilot flagged on #287 that `package-lock.json` records `packages/stagebook` at version `0.9.0` even though `package.json` is at `0.9.4`. While auditing I also noticed the top-level `"name"` field is a sandbox artifact (`"agent-a29c9e264a47c0a31"`).

Both are cosmetic — `npm publish` only reads `package.json`, so the published artifact is correct. But the drift produces a noisy diff every time anyone runs `npm install`, and prior release PRs never touched the lockfile so it'll keep accumulating.

## Fix

`npm install` regenerates a clean lockfile. Two-line diff:

```diff
-  "name": "agent-a29c9e264a47c0a31",
+  "name": "stagebook",
   ...
-  "packages/stagebook": { "version": "0.9.0", ... }
+  "packages/stagebook": { "version": "0.9.4", ... }
```

No dependency churn. No security alerts. Pure metadata sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)