### PR TITLE
Dismiss scroll indicator when content fits the viewport (closes #291)

### DIFF
--- a/packages/stagebook/src/components/scroll/useScrollAwareness.ct.tsx
+++ b/packages/stagebook/src/components/scroll/useScrollAwareness.ct.tsx
@@ -1,0 +1,54 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { Harness } from "./useScrollAwareness.testHarness";
+
+const CONTAINER_HEIGHT = 200;
+
+// `scrollHeight` after each render lets tests wait deterministically for
+// the MutationObserver+rAF tick to land before the next click.
+
+test.describe("useScrollAwareness", () => {
+  test("indicator fires on a second overflow growth (after init warmup)", async ({
+    mount,
+  }) => {
+    // The hook's first observed growth is treated as "initialization"
+    // and silently captures `prevScrollHeight`; the indicator only fires
+    // on subsequent growths.
+    const component = await mount(
+      <Harness containerHeight={CONTAINER_HEIGHT} />,
+    );
+    const indicator = component.locator('[data-testid="indicator-state"]');
+    const heightMirror = component.locator('[data-testid="scroll-height"]');
+
+    await component.locator('[data-testid="overflow-1"]').click();
+    await expect(heightMirror).toHaveText("720"); // 30 × 24
+    await expect(indicator).toHaveText("hidden");
+
+    await component.locator('[data-testid="overflow-2"]').click();
+    await expect(heightMirror).toHaveText("1440"); // 60 × 24
+    await expect(indicator).toHaveText("visible");
+  });
+
+  test("indicator dismisses when later content shrinks back to fit (#291)", async ({
+    mount,
+  }) => {
+    // Regression for #291: after a stage that overflows fires the
+    // indicator, transitioning to a stage whose content fits should
+    // dismiss it. The previous logic only dismissed on user-scroll,
+    // so the indicator stayed sticky between stages.
+    const component = await mount(
+      <Harness containerHeight={CONTAINER_HEIGHT} />,
+    );
+    const indicator = component.locator('[data-testid="indicator-state"]');
+    const heightMirror = component.locator('[data-testid="scroll-height"]');
+
+    await component.locator('[data-testid="overflow-1"]').click();
+    await expect(heightMirror).toHaveText("720");
+    await component.locator('[data-testid="overflow-2"]').click();
+    await expect(indicator).toHaveText("visible");
+
+    // "Stage transition" — content shrinks below the viewport height.
+    await component.locator('[data-testid="shrink-fits"]').click();
+    await expect(heightMirror).toHaveText("200"); // back to clientHeight
+    await expect(indicator).toHaveText("hidden");
+  });
+});

--- a/packages/stagebook/src/components/scroll/useScrollAwareness.testHarness.tsx
+++ b/packages/stagebook/src/components/scroll/useScrollAwareness.testHarness.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState } from "react";
+import { useScrollAwareness } from "./useScrollAwareness.js";
+
+/**
+ * Drives `useScrollAwareness` from a fixed-height scroll container with
+ * three buttons for the three growth states the test cares about. The
+ * hook's `showIndicator` is mirrored into a `data-testid="indicator-state"`
+ * element, and the container's post-render `scrollHeight` into a
+ * `data-testid="scroll-height"` element so tests can wait on a
+ * deterministic signal that the MutationObserver+rAF tick has landed
+ * before the next click.
+ *
+ * Sizing note: with `height: 200px; overflow: auto`, the container's
+ * `scrollHeight` is `max(clientHeight, contentHeight)`. So `scrollHeight`
+ * stays at 200 until content exceeds 200, after which it grows with
+ * content. The "fits" lines therefore all read 200; only the overflow
+ * lines produce observable growth events.
+ */
+export function Harness({ containerHeight }: { containerHeight: number }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const { showIndicator } = useScrollAwareness(containerRef);
+  // Discrete content sizes the tests step through. `fits` is the
+  // pre-overflow baseline; `overflow1` trips the hook's first-growth
+  // initialization gate; `overflow2` is the actual growth that should
+  // surface the indicator.
+  const [contentLines, setContentLines] = useState(2);
+  const [scrollHeight, setScrollHeight] = useState(0);
+
+  const lineHeight = 24;
+
+  useEffect(() => {
+    const id = requestAnimationFrame(() => {
+      if (containerRef.current) {
+        setScrollHeight(containerRef.current.scrollHeight);
+      }
+    });
+    return () => cancelAnimationFrame(id);
+  }, [contentLines]);
+
+  return (
+    <div>
+      <div data-testid="indicator-state">
+        {showIndicator ? "visible" : "hidden"}
+      </div>
+      <div data-testid="scroll-height">{scrollHeight}</div>
+      <button
+        type="button"
+        data-testid="overflow-1"
+        onClick={() => {
+          setContentLines(30);
+        }}
+      >
+        Overflow (warmup)
+      </button>
+      <button
+        type="button"
+        data-testid="overflow-2"
+        onClick={() => {
+          setContentLines(60);
+        }}
+      >
+        Overflow more
+      </button>
+      <button
+        type="button"
+        data-testid="shrink-fits"
+        onClick={() => {
+          setContentLines(2);
+        }}
+      >
+        Shrink (fits)
+      </button>
+      <div
+        ref={containerRef}
+        data-testid="scroll-container"
+        style={{
+          height: `${String(containerHeight)}px`,
+          overflow: "auto",
+          border: "1px solid #ccc",
+        }}
+      >
+        {Array.from({ length: contentLines }).map((_, i) => (
+          <div key={i} style={{ height: `${String(lineHeight)}px` }}>
+            line {i + 1}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/stagebook/src/components/scroll/useScrollAwareness.ts
+++ b/packages/stagebook/src/components/scroll/useScrollAwareness.ts
@@ -56,15 +56,31 @@ export function useScrollAwareness(
     return () => container.removeEventListener("scroll", handleScroll);
   }, [containerRef, checkAtBottom, showIndicator]);
 
-  // MutationObserver detects when React renders new content
+  // MutationObserver detects when React renders new content; a
+  // ResizeObserver catches viewport-size changes that bring content
+  // into fit. Both feed into the same "is there content to scroll to?"
+  // calculation so the indicator can be dismissed whenever that becomes
+  // false (#291).
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return undefined;
+
+    const dismissIfFits = () => {
+      if (container.scrollHeight <= container.clientHeight) {
+        setShowIndicator(false);
+      }
+    };
 
     const checkForNewContent = () => {
       const currentScrollHeight = container.scrollHeight;
       const scrollTop = container.scrollTop;
       const prevScrollHeight = prevScrollHeightRef.current;
+
+      // Dismiss whenever everything fits — covers stage transitions
+      // where a previously-overflowing stage left the indicator on,
+      // then the new stage's content is short enough that there's
+      // nothing to scroll to. (#291)
+      dismissIfFits();
 
       if (currentScrollHeight > prevScrollHeight && prevScrollHeight > 0) {
         if (!isInitializedRef.current) {
@@ -142,9 +158,20 @@ export function useScrollAwareness(
       characterData: true,
     });
 
+    // ResizeObserver covers the case where the viewport grows (or the
+    // container shrinks) enough to bring overflowing content into fit
+    // without any DOM mutation.
+    const resizeObserver = new ResizeObserver(() => {
+      dismissIfFits();
+    });
+    resizeObserver.observe(container);
+
     prevScrollHeightRef.current = container.scrollHeight;
 
-    return () => mutationObserver.disconnect();
+    return () => {
+      mutationObserver.disconnect();
+      resizeObserver.disconnect();
+    };
   }, [containerRef, threshold]);
 
   const dismissIndicator = useCallback(() => {


### PR DESCRIPTION
## Summary

The scroll indicator only had two dismiss paths: user scrolls to the bottom, or the consumer calls \`dismissIndicator()\`. Neither fired when content shrank to fit between stages — so a stage that legitimately overflowed and surfaced the indicator left it visible on the next, shorter stage. (Reported in #291 with a screenshot of an intro stage with empty space below it but a chevron indicator still rendered.)

## Fix

Add a \`dismissIfFits\` helper that clears \`showIndicator\` whenever \`scrollHeight <= clientHeight\`, and call it from:

- The MutationObserver's \`checkForNewContent\` (covers stage transitions and any other DOM-driven shrink).
- A new \`ResizeObserver\` on the container (covers viewport resizes that bring overflowing content into fit without DOM mutation).

The dismiss-on-engaged-scroll path stays as-is.

## Test plan

- [x] New \`useScrollAwareness\` CT harness tests cover overflow → shrink → indicator-dismissed (regression for the reported bug) and overflow-only → indicator-visible (verifies the fix didn't break the show path).
- [x] All 879 stagebook unit tests + 6 scroll CT tests pass.
- [x] Lint clean.
- [ ] Manual: load a stage with overflowing content, transition to a shorter stage, confirm the indicator disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)