### PR TITLE
Release v0.9.5: ResizeObserver guard + #291 fix

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/stagebook/src/components/scroll/useScrollAwareness.ts
+++ b/packages/stagebook/src/components/scroll/useScrollAwareness.ts
@@ -160,17 +160,22 @@ export function useScrollAwareness(
 
     // ResizeObserver covers the case where the viewport grows (or the
     // container shrinks) enough to bring overflowing content into fit
-    // without any DOM mutation.
-    const resizeObserver = new ResizeObserver(() => {
-      dismissIfFits();
-    });
-    resizeObserver.observe(container);
+    // without any DOM mutation. Guard the constructor — older browsers,
+    // some embedded webviews, and test environments without the API
+    // would otherwise throw at hook setup.
+    const resizeObserver =
+      typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(() => {
+            dismissIfFits();
+          })
+        : null;
+    resizeObserver?.observe(container);
 
     prevScrollHeightRef.current = container.scrollHeight;
 
     return () => {
       mutationObserver.disconnect();
-      resizeObserver.disconnect();
+      resizeObserver?.disconnect();
     };
   }, [containerRef, threshold]);
 


### PR DESCRIPTION
## Summary

Patch release bundling:

1. **ResizeObserver guard** in \`useScrollAwareness\` (Copilot review on #292) — only construct the observer when \`typeof ResizeObserver !== "undefined"\`, mirroring the existing \`Timeline.tsx\` pattern. Older browsers, embedded webviews, and test environments without the API would otherwise have thrown at hook setup. The MutationObserver path is the primary dismiss trigger, so environments without \`ResizeObserver\` still get the stage-transition dismiss from #291 — they just lose the viewport-resize path.
2. **The #291 scroll-indicator-stuck-when-content-fits fix** from #292 (already merged to main).

## Test plan

- [x] All 879 unit tests + 6 scroll CT tests pass.
- [x] Lint clean.
- [ ] Cut GitHub release after merge to trigger npm-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)