### PR TITLE
Tie scroll engagement to scrollTop (closes #294)

### DIFF
--- a/packages/stagebook/src/components/scroll/useScrollAwareness.ct.tsx
+++ b/packages/stagebook/src/components/scroll/useScrollAwareness.ct.tsx
@@ -51,4 +51,48 @@ test.describe("useScrollAwareness", () => {
     await expect(heightMirror).toHaveText("200"); // back to clientHeight
     await expect(indicator).toHaveText("hidden");
   });
+
+  test("engagement does not stick across stage transitions (#294)", async ({
+    mount,
+  }) => {
+    // Regression for #294: in host-mode the scroll container outlives
+    // every stage, so once the user has scrolled anywhere the
+    // engagement flag was sticky-true for the rest of the session and
+    // every subsequent stage's overflow triggered auto-peek even from
+    // scrollTop=0. The flag is now derived from `scrollTop > 0` so a
+    // stage transition that resets scrollTop also resets engagement,
+    // and the next stage's overflow surfaces the indicator (the
+    // "fresh load" code path) rather than peeking.
+    const component = await mount(
+      <Harness containerHeight={CONTAINER_HEIGHT} />,
+    );
+    const indicator = component.locator('[data-testid="indicator-state"]');
+    const heightMirror = component.locator('[data-testid="scroll-height"]');
+    const container = component.locator('[data-testid="scroll-container"]');
+
+    // Stage 1: warm up + overflow + indicator fires.
+    await component.locator('[data-testid="overflow-1"]').click();
+    await expect(heightMirror).toHaveText("720");
+    await component.locator('[data-testid="overflow-2"]').click();
+    await expect(indicator).toHaveText("visible");
+
+    // User engages by scrolling down — engagement flag flips true.
+    await component.locator('[data-testid="scroll-down"]').click();
+
+    // Stage transition: content shrinks back to fit (#291 dismisses
+    // the indicator), then scrollTop resets to 0 the way a host's
+    // route change would.
+    await component.locator('[data-testid="shrink-fits"]').click();
+    await expect(indicator).toHaveText("hidden");
+    await component.locator('[data-testid="scroll-to-top"]').click();
+    await expect(container).toHaveJSProperty("scrollTop", 0);
+
+    // Stage 2: warm up + overflow. With the fix, engagement is now
+    // false (because scrollTop returned to 0) and the overflow surfaces
+    // the indicator. Without the fix, the auto-peek branch would fire
+    // and `showIndicator` would stay false.
+    await component.locator('[data-testid="overflow-1"]').click();
+    await component.locator('[data-testid="overflow-2"]').click();
+    await expect(indicator).toHaveText("visible");
+  });
 });

--- a/packages/stagebook/src/components/scroll/useScrollAwareness.testHarness.tsx
+++ b/packages/stagebook/src/components/scroll/useScrollAwareness.testHarness.tsx
@@ -70,6 +70,28 @@ export function Harness({ containerHeight }: { containerHeight: number }) {
       >
         Shrink (fits)
       </button>
+      <button
+        type="button"
+        data-testid="scroll-down"
+        onClick={() => {
+          if (containerRef.current) {
+            containerRef.current.scrollTop = 100;
+          }
+        }}
+      >
+        Scroll down (simulate user engagement)
+      </button>
+      <button
+        type="button"
+        data-testid="scroll-to-top"
+        onClick={() => {
+          if (containerRef.current) {
+            containerRef.current.scrollTop = 0;
+          }
+        }}
+      >
+        Scroll to top (simulate stage transition)
+      </button>
       <div
         ref={containerRef}
         data-testid="scroll-container"

--- a/packages/stagebook/src/components/scroll/useScrollAwareness.ts
+++ b/packages/stagebook/src/components/scroll/useScrollAwareness.ts
@@ -42,7 +42,15 @@ export function useScrollAwareness(
     if (!container) return undefined;
 
     const handleScroll = () => {
-      hasUserScrolledRef.current = true;
+      // Tie engagement to the actual scroll position, not "any scroll
+      // event has fired." In host-mode the scroll container outlives
+      // every stage, so a sticky engagement flag would stay true for
+      // the whole session — and after the first stage where the user
+      // scrolled, every subsequent stage's overflow would auto-peek
+      // even from scrollTop=0. Anchoring to `scrollTop > 0` lets the
+      // standard stage-transition reset (scrollTop -> 0) also reset
+      // engagement. (#294)
+      hasUserScrolledRef.current = container.scrollTop > 0;
       wasAtBottomRef.current = checkAtBottom();
       if (showIndicator && wasAtBottomRef.current) {
         setShowIndicator(false);


### PR DESCRIPTION
## Summary

In host-mode (\`<Stage scrollMode="host">\`, used by the viewer), \`useScrollAwareness\` is mounted once on the host's scroll container (\`<main>\`) for the entire session. The \`hasUserScrolledRef\` engagement gate flipped to \`true\` on any scroll event and never reset — so once the user scrolled anywhere on any stage, every subsequent stage's overflow triggered auto-peek even from \`scrollTop=0\`. That's the exact behaviour the engagement gate was supposed to prevent on first load (#239 / bd72a8c).

## Fix

Anchor the flag to the actual scroll position:

\`\`\`ts
hasUserScrolledRef.current = container.scrollTop > 0;
\`\`\`

A stage transition that resets \`scrollTop\` to 0 also resets engagement, without the hook needing to know about stages. Programmatic peeks and user-driven scrolls both update the flag accurately because both fire scroll events.

## Test plan

- [x] New CT regression test exercises the cross-stage case: overflow → scroll down → shrink → scroll-to-top → overflow → assert indicator (not peek). Without the fix the assertion fails because the peek branch fires.
- [x] Existing CT tests for #291 (scroll-indicator dismiss) and the basic show path still pass.
- [x] All 879 unit tests + 7 scroll CT tests pass; lint clean.
- [ ] Manual: load \`backchannel-manipulation\`'s \`storytelling_1\` stage in the viewer, advance to it from a previous stage where you've scrolled, confirm no auto-peek on first load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)