### PR TITLE
Release v0.9.6

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Patch release for the auto-peek regression fixed in PR #296. \`useScrollAwareness\` now ties engagement to \`container.scrollTop > 0\` rather than "any scroll event has fired," so stage transitions that reset \`scrollTop\` also reset engagement — restoring the no-peek-on-fresh-stage behaviour the original engagement gate (#239) was meant to provide.

## Test plan

- [x] CI green on #296
- [ ] Cut GitHub release after merge to trigger npm-publish