### PR TITLE
Widen separator to match widest sibling on the stage (#301)

### DIFF
--- a/packages/stagebook/src/components/Stage.test.ts
+++ b/packages/stagebook/src/components/Stage.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { maxWidthForElement } from "./Stage.js";
+import type { ElementConfig } from "./Element.js";
+
+const el = (type: string, name?: string): ElementConfig => ({ type, name });
+
+describe("maxWidthForElement", () => {
+  it("uses the narrow lane (42rem) for prompts and other default elements", () => {
+    expect(maxWidthForElement(el("prompt"))).toBe("42rem");
+    expect(maxWidthForElement(el("submitButton"))).toBe("42rem");
+    expect(maxWidthForElement(el("timer"))).toBe("42rem");
+  });
+
+  it("uses 56rem for mediaPlayer and timeline", () => {
+    expect(maxWidthForElement(el("mediaPlayer"))).toBe("56rem");
+    expect(maxWidthForElement(el("timeline"))).toBe("56rem");
+  });
+
+  it("uses 64rem for survey and qualtrics", () => {
+    expect(maxWidthForElement(el("survey"))).toBe("64rem");
+    expect(maxWidthForElement(el("qualtrics"))).toBe("64rem");
+  });
+
+  describe("separator (issue #301)", () => {
+    it("falls back to the default width when no siblings are provided", () => {
+      expect(maxWidthForElement(el("separator"))).toBe("42rem");
+    });
+
+    it("matches the default lane when all siblings are default-width", () => {
+      const siblings = [el("prompt"), el("submitButton")];
+      expect(maxWidthForElement(el("separator"), siblings)).toBe("42rem");
+    });
+
+    it("widens to the mediaPlayer lane when the stage has a player", () => {
+      const siblings = [
+        el("prompt"),
+        el("mediaPlayer"),
+        el("timeline"),
+        el("separator"),
+        el("submitButton"),
+      ];
+      expect(maxWidthForElement(el("separator"), siblings)).toBe("56rem");
+    });
+
+    it("widens to the survey lane when the stage has a survey or qualtrics", () => {
+      expect(
+        maxWidthForElement(el("separator"), [el("prompt"), el("survey")]),
+      ).toBe("64rem");
+      expect(
+        maxWidthForElement(el("separator"), [
+          el("prompt"),
+          el("qualtrics"),
+          el("mediaPlayer"),
+        ]),
+      ).toBe("64rem");
+    });
+
+    it("ignores other separators when picking the widest sibling", () => {
+      const siblings = [el("separator"), el("separator")];
+      expect(maxWidthForElement(el("separator"), siblings)).toBe("42rem");
+    });
+  });
+});

--- a/packages/stagebook/src/components/Stage.tsx
+++ b/packages/stagebook/src/components/Stage.tsx
@@ -15,17 +15,41 @@ import type { DiscussionType } from "../schemas/treatment.js";
 import type { Condition } from "./conditions/ConditionsConditionalRender.js";
 
 // Max-width per element type — wider for surveys/qualtrics/video
-function maxWidthForElement(element: ElementConfig): string {
-  switch (element.type) {
-    case "survey":
-    case "qualtrics":
-      return "64rem"; // ~1024px
-    case "mediaPlayer":
-    case "timeline":
-      return "56rem"; // ~896px
-    default:
-      return "42rem"; // ~672px
+const DEFAULT_LANE = "42rem"; // ~672px
+const ELEMENT_LANES: Record<string, string> = {
+  survey: "64rem", // ~1024px
+  qualtrics: "64rem",
+  mediaPlayer: "56rem", // ~896px
+  timeline: "56rem",
+};
+
+function laneFor(type: string): string {
+  return ELEMENT_LANES[type] ?? DEFAULT_LANE;
+}
+
+/**
+ * Compute the max-width lane for an element. Separators span at least as
+ * wide as the widest non-separator sibling on the stage so they read as
+ * true page-spanning dividers rather than stubs (issue #301).
+ */
+export function maxWidthForElement(
+  element: ElementConfig,
+  siblings: readonly ElementConfig[] = [],
+): string {
+  if (element.type !== "separator") return laneFor(element.type);
+
+  let widestRem = parseFloat(DEFAULT_LANE);
+  let widest = DEFAULT_LANE;
+  for (const s of siblings) {
+    if (s.type === "separator") continue;
+    const lane = laneFor(s.type);
+    const rem = parseFloat(lane);
+    if (rem > widestRem) {
+      widestRem = rem;
+      widest = lane;
+    }
   }
+  return widest;
 }
 
 export interface StageConfig {
@@ -66,10 +90,12 @@ export interface StageProps {
 
 function WrappedElement({
   element,
+  siblings,
   onSubmit,
   stageDuration,
 }: {
   element: ElementConfig;
+  siblings: readonly ElementConfig[];
   onSubmit: () => void;
   stageDuration?: number;
 }) {
@@ -95,7 +121,7 @@ function WrappedElement({
             style={{
               margin: "0 auto",
               width: "100%",
-              maxWidth: maxWidthForElement(element),
+              maxWidth: maxWidthForElement(element, siblings),
               padding: "0.5rem 1rem",
             }}
           >
@@ -131,6 +157,7 @@ function ElementsColumn({
         <WrappedElement
           key={element.name ?? `element-${i}`}
           element={element}
+          siblings={elements}
           onSubmit={onSubmit}
           stageDuration={stageDuration}
         />


### PR DESCRIPTION
Closes #301.

## Summary
- Separators on stages with a wider element (mediaPlayer, timeline, survey, qualtrics) were visibly narrower than the content they divide. `maxWidthForElement` now returns the widest non-separator lane in use on the stage when called for a separator, and falls back to the default lane otherwise.
- Refactored the per-type lane lookup from a switch to a small table to make the "widest sibling" pass a simple loop.
- Added unit tests for `maxWidthForElement` covering the existing per-type widths plus the new separator behavior.

## Test plan
- [x] `npm run test -w stagebook` (887 tests pass, including 8 new ones)
- [x] `npm run lint -w stagebook` (clean)
- [ ] Visually verify in VS Code preview that a stage with `mediaPlayer` + `prompt` + `separator` now shows the separator spanning the player's width