### PR TITLE
Catch Space anywhere on the page when a player is mounted (#300)

### DIFF
--- a/packages/stagebook/src/components/elements/MediaPlayer.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.tsx
@@ -9,7 +9,11 @@ import { isYouTubeURL } from "./mediaPlayer/isYouTubeURL.js";
 import { parseVTT, type CaptionCue } from "./mediaPlayer/parseVTT.js";
 import { YouTubePlayer } from "./mediaPlayer/YouTubePlayer.js";
 import { HTML5Controls, YouTubeControls } from "./mediaPlayer/controls.js";
-import { useRegisterPlayback } from "../playback/PlaybackProvider.js";
+import {
+  useRegisterPlayback,
+  useMarkActive,
+  useIsActiveSpaceTarget,
+} from "../playback/PlaybackProvider.js";
 import type { PlaybackHandle } from "../playback/PlaybackHandle.js";
 import { computeWatchedRanges } from "../../utils/watchedRanges.js";
 import {
@@ -425,6 +429,24 @@ export function MediaPlayer({
   );
   // Use the YouTube handle when available, fall back to the HTML5 handle
   useRegisterPlayback(name, ytHandle ?? handle);
+
+  // Tell the global Space handler "this is the player the user is
+  // interacting with" on mousedown anywhere in the player area (#300).
+  // Without this, multi-player pages route an off-player Space press to
+  // the most-recently-mounted player instead of the one the user just
+  // clicked.
+  const markActivePlayback = useMarkActive();
+  const markSelfActive = useCallback(
+    () => markActivePlayback(name),
+    [markActivePlayback, name],
+  );
+  // Subtle "this is what Space will toggle" cue, shown only on multi-
+  // player pages (#300). On a single-player page Space already targets
+  // the lone player, so the indicator would be redundant noise.
+  const isActiveSpaceTarget = useIsActiveSpaceTarget(name);
+  const activeBoxShadow = isActiveSpaceTarget
+    ? "0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25))"
+    : undefined;
 
   // Hold-to-scrub state
   const arrowRepeatCountRef = useRef(0);
@@ -1004,9 +1026,14 @@ export function MediaPlayer({
         tabIndex={0}
         onKeyDown={handleKeyDown}
         onKeyUp={handleKeyUp}
+        onMouseDown={markSelfActive}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
-        style={{ position: "relative" }}
+        style={{
+          position: "relative",
+          borderRadius: "0.25rem",
+          boxShadow: activeBoxShadow,
+        }}
       >
         <div data-testid="mediaPlayer-viewport" style={VIEWPORT_STYLE}>
           <YouTubePlayer
@@ -1090,9 +1117,14 @@ export function MediaPlayer({
       tabIndex={0}
       onKeyDown={handleKeyDown}
       onKeyUp={handleKeyUp}
+      onMouseDown={markSelfActive}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      style={{ position: "relative" }}
+      style={{
+        position: "relative",
+        borderRadius: "0.25rem",
+        boxShadow: activeBoxShadow,
+      }}
     >
       {/* Audio-only: hidden video element (no viewport div) */}
       {!playVideo && (

--- a/packages/stagebook/src/components/elements/Timeline.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.tsx
@@ -5,7 +5,11 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { usePlayback } from "../playback/PlaybackProvider.js";
+import {
+  usePlayback,
+  useMarkActive,
+  useIsActiveSpaceTarget,
+} from "../playback/PlaybackProvider.js";
 import { TimeRuler, RULER_HEIGHT } from "./timeline/TimeRuler.js";
 import { TimelineTrack, GUTTER_WIDTH } from "./timeline/TimelineTrack.js";
 import { Playhead } from "./timeline/Playhead.js";
@@ -125,6 +129,17 @@ export function Timeline({
   save,
 }: TimelineProps) {
   const handle = usePlayback(source);
+  // Mark the linked player as active on any pointer-down inside the
+  // Timeline, so an off-player Space press still toggles the right one
+  // on multi-player pages (#300).
+  const markActivePlayback = useMarkActive();
+  const markLinkedPlayerActive = useCallback(
+    () => markActivePlayback(source),
+    [markActivePlayback, source],
+  );
+  // Subtle indicator when this Timeline's player is the active Space
+  // target, shown only on multi-player pages (#300).
+  const isActiveSpaceTarget = useIsActiveSpaceTarget(source);
   const tracksAreaRef = useRef<HTMLDivElement>(null);
   const [containerWidth, setContainerWidth] = useState(0);
   const [currentTime, setCurrentTime] = useState(0);
@@ -840,6 +855,7 @@ export function Timeline({
       tabIndex={0}
       onKeyDown={onKeyDown}
       onKeyUp={onKeyUp}
+      onMouseDown={markLinkedPlayerActive}
       onBlur={() => {
         // Drop any in-progress press-and-hold range — focus left the
         // timeline before the matching keyup arrived. (#263)
@@ -852,6 +868,9 @@ export function Timeline({
         overflow: "hidden",
         outline: "none",
         position: "relative",
+        boxShadow: isActiveSpaceTarget
+          ? "0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25))"
+          : undefined,
       }}
     >
       {/* Header: zoom controls (always) + minimap (when zoomed in) — puts

--- a/packages/stagebook/src/components/playback/PlaybackProvider.test.tsx
+++ b/packages/stagebook/src/components/playback/PlaybackProvider.test.tsx
@@ -252,6 +252,46 @@ describe("global Space handler (issue #300)", () => {
     }
   });
 
+  test("ignores Space when a button is focused (so Space still activates the button)", () => {
+    const { play, cleanup } = setupWithHandle(true);
+    const button = document.createElement("button");
+    button.textContent = "Submit";
+    document.body.appendChild(button);
+    try {
+      const e = dispatchSpaceOn(button);
+      expect(play).not.toHaveBeenCalled();
+      expect(e.defaultPrevented).toBe(false);
+    } finally {
+      button.remove();
+      cleanup();
+    }
+  });
+
+  test("ignores Space on a link, summary, and ARIA-button (other Space-activated controls)", () => {
+    const { play, cleanup } = setupWithHandle(true);
+    const link = document.createElement("a");
+    link.setAttribute("href", "#");
+    document.body.appendChild(link);
+    const summary = document.createElement("summary");
+    document.body.appendChild(summary);
+    const ariaButton = document.createElement("div");
+    ariaButton.setAttribute("role", "button");
+    ariaButton.setAttribute("tabindex", "0");
+    document.body.appendChild(ariaButton);
+    try {
+      for (const el of [link, summary, ariaButton]) {
+        const e = dispatchSpaceOn(el);
+        expect(e.defaultPrevented).toBe(false);
+      }
+      expect(play).not.toHaveBeenCalled();
+    } finally {
+      link.remove();
+      summary.remove();
+      ariaButton.remove();
+      cleanup();
+    }
+  });
+
   test("ignores Space typed inside a text input", () => {
     const { play, pause, cleanup } = setupWithHandle(true);
     const input = document.createElement("input");

--- a/packages/stagebook/src/components/playback/PlaybackProvider.test.tsx
+++ b/packages/stagebook/src/components/playback/PlaybackProvider.test.tsx
@@ -7,6 +7,8 @@ import {
   PlaybackProvider,
   useRegisterPlayback,
   usePlayback,
+  useMarkActive,
+  useIsActiveSpaceTarget,
 } from "./PlaybackProvider.js";
 import type { PlaybackHandle } from "./PlaybackHandle.js";
 
@@ -183,6 +185,31 @@ describe("global Space handler (issue #300)", () => {
     return e;
   }
 
+  test("K on document body toggles the registered handle (YouTube-standard play/pause key)", () => {
+    const { play, cleanup } = setupWithHandle(true);
+    try {
+      const e = dispatchSpaceOn(document.body, { key: "k" });
+      expect(play).toHaveBeenCalledTimes(1);
+      expect(e.defaultPrevented).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("seek/scrub keys (J, L, ArrowLeft, ArrowRight, period, comma) are NOT routed globally", () => {
+    const { play, pause, cleanup } = setupWithHandle(true);
+    try {
+      for (const key of ["j", "l", "ArrowLeft", "ArrowRight", ".", ","]) {
+        const e = dispatchSpaceOn(document.body, { key });
+        expect(e.defaultPrevented).toBe(false);
+      }
+      expect(play).not.toHaveBeenCalled();
+      expect(pause).not.toHaveBeenCalled();
+    } finally {
+      cleanup();
+    }
+  });
+
   test("Space on document body toggles the registered handle and prevents default", () => {
     const { play, pause, cleanup } = setupWithHandle(true);
     try {
@@ -305,7 +332,7 @@ describe("global Space handler (issue #300)", () => {
     }
   });
 
-  test("only the most recently registered handle is toggled", () => {
+  test("falls back to the most recently registered handle when nothing has been marked active", () => {
     const isPausedA = { current: true };
     const playA = vi.fn(() => {
       isPausedA.current = false;
@@ -359,6 +386,191 @@ describe("global Space handler (issue #300)", () => {
     } finally {
       act(() => root.unmount());
       container.remove();
+    }
+  });
+
+  test("Space toggles the markActive target, not the most recently registered", () => {
+    // Two players A and B, registered in that order. Without markActive,
+    // the fallback would target B. Marking A active should override that.
+    const isPausedA = { current: true };
+    const playA = vi.fn(() => {
+      isPausedA.current = false;
+    });
+    const pauseA = vi.fn(() => {
+      isPausedA.current = true;
+    });
+    const handleA = makeHandle({
+      play: playA,
+      pause: pauseA,
+      isPaused: () => isPausedA.current,
+    });
+
+    const isPausedB = { current: true };
+    const playB = vi.fn(() => {
+      isPausedB.current = false;
+    });
+    const pauseB = vi.fn(() => {
+      isPausedB.current = true;
+    });
+    const handleB = makeHandle({
+      play: playB,
+      pause: pauseB,
+      isPaused: () => isPausedB.current,
+    });
+
+    let markActiveFromConsumer: (name: string) => void = () => {};
+    function Registrar(): ReactNode {
+      const a = useMemo(() => handleA, []);
+      const b = useMemo(() => handleB, []);
+      useRegisterPlayback("a", a);
+      useRegisterPlayback("b", b);
+      markActiveFromConsumer = useMarkActive();
+      return null;
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    let root: Root;
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <PlaybackProvider>
+          <Registrar />
+        </PlaybackProvider>,
+      );
+    });
+    try {
+      act(() => markActiveFromConsumer("a"));
+      dispatchSpaceOn(document.body);
+      expect(playA).toHaveBeenCalledTimes(1);
+      expect(playB).not.toHaveBeenCalled();
+
+      // Re-target B and try again.
+      act(() => markActiveFromConsumer("b"));
+      dispatchSpaceOn(document.body);
+      expect(playB).toHaveBeenCalledTimes(1);
+      expect(playA).toHaveBeenCalledTimes(1); // unchanged
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("markActive on an unknown name falls back to the last-registered handle", () => {
+    const isPausedA = { current: true };
+    const playA = vi.fn(() => {
+      isPausedA.current = false;
+    });
+    const handleA = makeHandle({
+      play: playA,
+      isPaused: () => isPausedA.current,
+    });
+    const isPausedB = { current: true };
+    const playB = vi.fn(() => {
+      isPausedB.current = false;
+    });
+    const handleB = makeHandle({
+      play: playB,
+      isPaused: () => isPausedB.current,
+    });
+
+    let markActive: (name: string) => void = () => {};
+    function Registrar(): ReactNode {
+      const a = useMemo(() => handleA, []);
+      const b = useMemo(() => handleB, []);
+      useRegisterPlayback("a", a);
+      useRegisterPlayback("b", b);
+      markActive = useMarkActive();
+      return null;
+    }
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    let root: Root;
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <PlaybackProvider>
+          <Registrar />
+        </PlaybackProvider>,
+      );
+    });
+    try {
+      act(() => markActive("does-not-exist"));
+      dispatchSpaceOn(document.body);
+      // Falls back to last-registered (b); a untouched.
+      expect(playB).toHaveBeenCalledTimes(1);
+      expect(playA).not.toHaveBeenCalled();
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+    }
+  });
+});
+
+describe("useIsActiveSpaceTarget", () => {
+  test("returns false on a single-player page even when active", () => {
+    let isActive = false;
+    let markActive: (n: string) => void = () => {};
+    function Registrar(): ReactNode {
+      const handle = useMemo(() => makeHandle(), []);
+      useRegisterPlayback("only", handle);
+      isActive = useIsActiveSpaceTarget("only");
+      markActive = useMarkActive();
+      return null;
+    }
+    const container = document.createElement("div");
+    let root: Root;
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <PlaybackProvider>
+          <Registrar />
+        </PlaybackProvider>,
+      );
+    });
+    try {
+      act(() => markActive("only"));
+      expect(isActive).toBe(false);
+    } finally {
+      act(() => root.unmount());
+    }
+  });
+
+  test("returns true for the active player when 2+ are mounted, false for the others", () => {
+    const states: { a?: boolean; b?: boolean } = {};
+    let markActive: (n: string) => void = () => {};
+    function Registrar(): ReactNode {
+      const a = useMemo(() => makeHandle(), []);
+      const b = useMemo(() => makeHandle(), []);
+      useRegisterPlayback("a", a);
+      useRegisterPlayback("b", b);
+      states.a = useIsActiveSpaceTarget("a");
+      states.b = useIsActiveSpaceTarget("b");
+      markActive = useMarkActive();
+      return null;
+    }
+    const container = document.createElement("div");
+    let root: Root;
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <PlaybackProvider>
+          <Registrar />
+        </PlaybackProvider>,
+      );
+    });
+    try {
+      // Initially nothing is marked → both false.
+      expect(states.a).toBe(false);
+      expect(states.b).toBe(false);
+      act(() => markActive("a"));
+      expect(states.a).toBe(true);
+      expect(states.b).toBe(false);
+      act(() => markActive("b"));
+      expect(states.a).toBe(false);
+      expect(states.b).toBe(true);
+    } finally {
+      act(() => root.unmount());
     }
   });
 });

--- a/packages/stagebook/src/components/playback/PlaybackProvider.test.tsx
+++ b/packages/stagebook/src/components/playback/PlaybackProvider.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
 import React, { useMemo, type ReactNode } from "react";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -119,5 +119,246 @@ describe("PlaybackProvider register/unregister render loop (#103)", () => {
     expect(status.current).toBe("found");
 
     act(() => root.unmount());
+  });
+});
+
+describe("global Space handler (issue #300)", () => {
+  // Render PlaybackProvider with a single registered handle and return tools
+  // for driving the test: spies on play/pause, an `isPausedRef` to flip the
+  // handle's apparent state, and an unmount cleanup.
+  function setupWithHandle(initialIsPaused = true) {
+    const isPausedRef = { current: initialIsPaused };
+    const play = vi.fn(() => {
+      isPausedRef.current = false;
+    });
+    const pause = vi.fn(() => {
+      isPausedRef.current = true;
+    });
+    const handle = makeHandle({
+      play,
+      pause,
+      isPaused: () => isPausedRef.current,
+    });
+
+    function Registrar(): ReactNode {
+      const stable = useMemo(() => handle, []);
+      useRegisterPlayback("player", stable);
+      return null;
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    let root: Root;
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <PlaybackProvider>
+          <Registrar />
+        </PlaybackProvider>,
+      );
+    });
+
+    return {
+      play,
+      pause,
+      isPausedRef,
+      cleanup: () => {
+        act(() => root.unmount());
+        container.remove();
+      },
+    };
+  }
+
+  function dispatchSpaceOn(
+    target: EventTarget,
+    init: KeyboardEventInit = {},
+  ): KeyboardEvent {
+    const e = new KeyboardEvent("keydown", {
+      key: " ",
+      bubbles: true,
+      cancelable: true,
+      ...init,
+    });
+    target.dispatchEvent(e);
+    return e;
+  }
+
+  test("Space on document body toggles the registered handle and prevents default", () => {
+    const { play, pause, cleanup } = setupWithHandle(true);
+    try {
+      const e = dispatchSpaceOn(document.body);
+      expect(play).toHaveBeenCalledTimes(1);
+      expect(pause).not.toHaveBeenCalled();
+      expect(e.defaultPrevented).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("a second Space pauses when the handle is now playing", () => {
+    const { play, pause, cleanup } = setupWithHandle(true);
+    try {
+      dispatchSpaceOn(document.body); // play
+      dispatchSpaceOn(document.body); // pause
+      expect(play).toHaveBeenCalledTimes(1);
+      expect(pause).toHaveBeenCalledTimes(1);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("does nothing when no handle is registered", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    let root: Root;
+    act(() => {
+      root = createRoot(container);
+      root.render(<PlaybackProvider>{null}</PlaybackProvider>);
+    });
+    try {
+      const e = dispatchSpaceOn(document.body);
+      // No handle → no preventDefault, browser keeps its default scroll.
+      expect(e.defaultPrevented).toBe(false);
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+    }
+  });
+
+  test("ignores Space typed inside a text input", () => {
+    const { play, pause, cleanup } = setupWithHandle(true);
+    const input = document.createElement("input");
+    input.type = "text";
+    document.body.appendChild(input);
+    try {
+      const e = dispatchSpaceOn(input);
+      expect(play).not.toHaveBeenCalled();
+      expect(pause).not.toHaveBeenCalled();
+      expect(e.defaultPrevented).toBe(false);
+    } finally {
+      input.remove();
+      cleanup();
+    }
+  });
+
+  test("ignores Space typed inside a textarea", () => {
+    const { play, cleanup } = setupWithHandle(true);
+    const textarea = document.createElement("textarea");
+    document.body.appendChild(textarea);
+    try {
+      const e = dispatchSpaceOn(textarea);
+      expect(play).not.toHaveBeenCalled();
+      expect(e.defaultPrevented).toBe(false);
+    } finally {
+      textarea.remove();
+      cleanup();
+    }
+  });
+
+  test("ignores Space inside a contenteditable element", () => {
+    const { play, cleanup } = setupWithHandle(true);
+    const editable = document.createElement("div");
+    // jsdom's `.contentEditable = "true"` setter doesn't write the attribute,
+    // so set it directly to keep the assertion realistic for real browsers.
+    editable.setAttribute("contenteditable", "true");
+    document.body.appendChild(editable);
+    try {
+      const e = dispatchSpaceOn(editable);
+      expect(play).not.toHaveBeenCalled();
+      expect(e.defaultPrevented).toBe(false);
+    } finally {
+      editable.remove();
+      cleanup();
+    }
+  });
+
+  test("ignores Space combined with a modifier key (shortcut)", () => {
+    const { play, pause, cleanup } = setupWithHandle(true);
+    try {
+      dispatchSpaceOn(document.body, { ctrlKey: true });
+      dispatchSpaceOn(document.body, { metaKey: true });
+      dispatchSpaceOn(document.body, { altKey: true });
+      dispatchSpaceOn(document.body, { shiftKey: true });
+      expect(play).not.toHaveBeenCalled();
+      expect(pause).not.toHaveBeenCalled();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("skips when an inner handler already prevented default (no double-toggle)", () => {
+    const { play, pause, cleanup } = setupWithHandle(true);
+    try {
+      const inner = (e: Event) => {
+        e.preventDefault();
+      };
+      document.body.addEventListener("keydown", inner);
+      try {
+        dispatchSpaceOn(document.body);
+      } finally {
+        document.body.removeEventListener("keydown", inner);
+      }
+      expect(play).not.toHaveBeenCalled();
+      expect(pause).not.toHaveBeenCalled();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("only the most recently registered handle is toggled", () => {
+    const isPausedA = { current: true };
+    const playA = vi.fn(() => {
+      isPausedA.current = false;
+    });
+    const pauseA = vi.fn(() => {
+      isPausedA.current = true;
+    });
+    const handleA = makeHandle({
+      play: playA,
+      pause: pauseA,
+      isPaused: () => isPausedA.current,
+    });
+
+    const isPausedB = { current: true };
+    const playB = vi.fn(() => {
+      isPausedB.current = false;
+    });
+    const pauseB = vi.fn(() => {
+      isPausedB.current = true;
+    });
+    const handleB = makeHandle({
+      play: playB,
+      pause: pauseB,
+      isPaused: () => isPausedB.current,
+    });
+
+    function Registrar(): ReactNode {
+      const a = useMemo(() => handleA, []);
+      const b = useMemo(() => handleB, []);
+      useRegisterPlayback("a", a);
+      useRegisterPlayback("b", b);
+      return null;
+    }
+
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    let root: Root;
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <PlaybackProvider>
+          <Registrar />
+        </PlaybackProvider>,
+      );
+    });
+    try {
+      dispatchSpaceOn(document.body);
+      // Most-recent (b) toggled; a untouched.
+      expect(playB).toHaveBeenCalledTimes(1);
+      expect(playA).not.toHaveBeenCalled();
+    } finally {
+      act(() => root.unmount());
+      container.remove();
+    }
   });
 });

--- a/packages/stagebook/src/components/playback/PlaybackProvider.tsx
+++ b/packages/stagebook/src/components/playback/PlaybackProvider.tsx
@@ -98,10 +98,31 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
       if (e.defaultPrevented) return;
       if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
       const target = e.target;
+      // Skip when the press belongs to a Space-activated interactive
+      // control: text inputs, form widgets, native buttons/links, ARIA
+      // buttons, etc. Otherwise the global handler would steal Space
+      // from a focused SubmitButton or radio option, breaking standard
+      // keyboard behavior.
       if (
         target instanceof HTMLElement &&
         target.closest(
-          "input, textarea, select, [contenteditable=''], [contenteditable='true']",
+          [
+            "input",
+            "textarea",
+            "select",
+            "button",
+            "summary",
+            "a[href]",
+            "[contenteditable='']",
+            "[contenteditable='true']",
+            "[role='button']",
+            "[role='checkbox']",
+            "[role='radio']",
+            "[role='switch']",
+            "[role='menuitem']",
+            "[role='tab']",
+            "[role='option']",
+          ].join(", "),
         )
       ) {
         return;

--- a/packages/stagebook/src/components/playback/PlaybackProvider.tsx
+++ b/packages/stagebook/src/components/playback/PlaybackProvider.tsx
@@ -16,6 +16,15 @@ interface PlaybackRegistry {
   handles: Map<string, PlaybackHandle>;
   register: (name: string, handle: PlaybackHandle) => void;
   unregister: (name: string) => void;
+  /** Mark `name` as the active player — the target of the global Space
+   *  handler when no focused element handles the press first. Components
+   *  call this on `mousedown` to attribute "what the user is interacting
+   *  with" so subsequent off-player Space presses still toggle the right
+   *  one. Unknown names are accepted (and silently fall back to the last
+   *  registered handle) so the caller doesn't have to guard. */
+  markActive: (name: string) => void;
+  /** Name passed to the most recent `markActive`, or null if never called. */
+  activeName: string | null;
 }
 
 const PlaybackContext = createContext<PlaybackRegistry | null>(null);
@@ -45,29 +54,47 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
     });
   }, []);
 
+  const [activeName, setActiveName] = useState<string | null>(null);
+  const markActive = useCallback((name: string) => {
+    setActiveName(name);
+  }, []);
+
   const value = useMemo(
-    () => ({ handles, register, unregister }),
-    [handles, register, unregister],
+    () => ({ handles, register, unregister, markActive, activeName }),
+    [handles, register, unregister, markActive, activeName],
   );
 
-  // Global Space → toggle most-recent registered handle (issue #300).
-  // The Timeline and MediaPlayer wrappers already handle Space when focused,
-  // but focus often lands on the page body (or another non-capturing element)
-  // after the user clicks "play" and then moves on — there, the browser's
-  // default Space=scroll fires and the page jumps. This window-level fallback
-  // catches Space anywhere on the page and routes it to the most recently
-  // mounted player, so the user's intent ("pause what's playing") works
+  // Global play/pause hotkeys → toggle the active player (issue #300).
+  // The Timeline and MediaPlayer wrappers already handle Space (and K)
+  // when focused, but focus often lands on the page body (or another
+  // non-capturing element) after the user clicks "play" and then moves
+  // on — there, the browser's default Space=scroll fires and the page
+  // jumps. This window-level fallback catches Space and K anywhere on
+  // the page so the user's intent ("pause what's playing") works
   // regardless of where focus happens to be.
+  //
+  // Scope is intentionally narrow — only the play/pause toggle keys.
+  // Seek/scrub keys (J, L, arrows, comma, period) stay focus-required
+  // because they overlap with page navigation and aren't subject to the
+  // same Space=scroll surprise.
+  //
+  // Target selection:
+  // - The "active" player (last one whose wrapper or sibling Timeline was
+  //   clicked, via `markActive`). This matches user intent on multi-player
+  //   pages: clicking on a player marks it as the hotkey target.
+  // - Falls back to the most recently registered handle when nothing has
+  //   been clicked yet, so a single-player page works without ceremony.
   //
   // Skip rules:
   // - Modifier keys: reserved for OS / app shortcuts.
-  // - Text inputs / contenteditable: Space is for typing.
+  // - Text inputs / contenteditable: Space and K are for typing.
   // - `defaultPrevented`: an inner handler (Timeline, MediaPlayer, button)
   //   already consumed the press; running again would double-toggle.
   useEffect(() => {
     if (handles.size === 0) return;
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== " ") return;
+      const isToggleKey = e.key === " " || e.key === "k" || e.key === "K";
+      if (!isToggleKey) return;
       if (e.defaultPrevented) return;
       if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
       const target = e.target;
@@ -79,18 +106,21 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
       ) {
         return;
       }
-      // Pick the most recently registered handle. Map iteration is
-      // insertion-ordered, so the last value is the freshest registration.
-      let last: PlaybackHandle | undefined;
-      for (const h of handles.values()) last = h;
-      if (!last) return;
+      let pick: PlaybackHandle | undefined =
+        activeName !== null ? handles.get(activeName) : undefined;
+      if (!pick) {
+        // Fallback: most recently registered handle. Map iteration is
+        // insertion-ordered, so the last value is the freshest.
+        for (const h of handles.values()) pick = h;
+      }
+      if (!pick) return;
       e.preventDefault();
-      if (last.isPaused()) last.play();
-      else last.pause();
+      if (pick.isPaused()) pick.play();
+      else pick.pause();
     };
     window.addEventListener("keydown", onKeyDown);
     return () => window.removeEventListener("keydown", onKeyDown);
-  }, [handles]);
+  }, [handles, activeName]);
 
   return (
     <PlaybackContext.Provider value={value}>
@@ -135,3 +165,31 @@ export function usePlayback(source: string): PlaybackHandle | undefined {
   const ctx = useContext(PlaybackContext);
   return ctx?.handles.get(source);
 }
+
+/**
+ * Returns a callback that marks a player as the active target for the
+ * global Space handler (#300). Call on user interaction (e.g. mousedown
+ * on the MediaPlayer wrapper or its sibling Timeline) so subsequent
+ * off-player Space presses pause/resume the right one.
+ *
+ * Safe to call without a PlaybackProvider — returns a no-op.
+ */
+export function useMarkActive(): (name: string) => void {
+  const ctx = useContext(PlaybackContext);
+  return ctx?.markActive ?? noop;
+}
+
+/**
+ * True when `name` is the active Space target *and* there's more than
+ * one player on the page, so callers know whether to render a subtle
+ * "this is what Space will toggle" indicator. Single-player pages always
+ * return false — the cue would be redundant noise there.
+ */
+export function useIsActiveSpaceTarget(name: string): boolean {
+  const ctx = useContext(PlaybackContext);
+  if (!ctx) return false;
+  if (ctx.handles.size <= 1) return false;
+  return ctx.activeName === name;
+}
+
+function noop() {}

--- a/packages/stagebook/src/components/playback/PlaybackProvider.tsx
+++ b/packages/stagebook/src/components/playback/PlaybackProvider.tsx
@@ -50,6 +50,48 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
     [handles, register, unregister],
   );
 
+  // Global Space → toggle most-recent registered handle (issue #300).
+  // The Timeline and MediaPlayer wrappers already handle Space when focused,
+  // but focus often lands on the page body (or another non-capturing element)
+  // after the user clicks "play" and then moves on — there, the browser's
+  // default Space=scroll fires and the page jumps. This window-level fallback
+  // catches Space anywhere on the page and routes it to the most recently
+  // mounted player, so the user's intent ("pause what's playing") works
+  // regardless of where focus happens to be.
+  //
+  // Skip rules:
+  // - Modifier keys: reserved for OS / app shortcuts.
+  // - Text inputs / contenteditable: Space is for typing.
+  // - `defaultPrevented`: an inner handler (Timeline, MediaPlayer, button)
+  //   already consumed the press; running again would double-toggle.
+  useEffect(() => {
+    if (handles.size === 0) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== " ") return;
+      if (e.defaultPrevented) return;
+      if (e.ctrlKey || e.metaKey || e.altKey || e.shiftKey) return;
+      const target = e.target;
+      if (
+        target instanceof HTMLElement &&
+        target.closest(
+          "input, textarea, select, [contenteditable=''], [contenteditable='true']",
+        )
+      ) {
+        return;
+      }
+      // Pick the most recently registered handle. Map iteration is
+      // insertion-ordered, so the last value is the freshest registration.
+      let last: PlaybackHandle | undefined;
+      for (const h of handles.values()) last = h;
+      if (!last) return;
+      e.preventDefault();
+      if (last.isPaused()) last.play();
+      else last.pause();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [handles]);
+
   return (
     <PlaybackContext.Provider value={value}>
       {children}


### PR DESCRIPTION
Closes #300.

## Summary
- `Timeline` and `MediaPlayer` already `preventDefault` on Space when focused, but the bug shows up when focus has drifted off the player (typically: user clicks "play", controls hide-on-play unmounts the focused button, focus falls back to body — now Space scrolls the page instead of pausing).
- `PlaybackProvider` now mounts a window-level `keydown` handler that toggles the most recently registered playback handle on bare Space, and `preventDefault`s the browser's scroll. It defers via `e.defaultPrevented` so existing focused handlers keep first dibs (no double-toggle), and skips text inputs / `[contenteditable]` / modifier-key combos so typing and OS shortcuts pass through.

## Test plan
- [x] `npx vitest run packages/stagebook/src/components/playback/` (11/11, including 9 new for #300)
- [x] `npx eslint` on changed files (clean)
- [ ] Visually verify in VS Code preview: stage with MediaPlayer + Timeline, click around to lose focus, then press Space — playback toggles, page does not scroll