### PR TITLE
Position-prefixed reference grammar (#298) — breaking change

### DIFF
--- a/apps/viewer/src/lib/references.test.ts
+++ b/apps/viewer/src/lib/references.test.ts
@@ -9,12 +9,12 @@ describe("extractStageReferences", () => {
         name: "q2",
         file: "prompts/q2.prompt.md",
         conditions: [
-          { reference: "prompt.q1", comparator: "equals", value: "yes" },
+          { reference: "self.prompt.q1", comparator: "equals", value: "yes" },
         ],
       },
     ];
     const refs = extractStageReferences(elements);
-    expect(refs).toContain("prompt.q1");
+    expect(refs).toContain("self.prompt.q1");
   });
 
   it("extracts display element references", () => {
@@ -22,12 +22,11 @@ describe("extractStageReferences", () => {
       {
         type: "display" as const,
         name: "showVote",
-        reference: "prompt.vote",
-        position: "0",
+        reference: "0.prompt.vote",
       },
     ];
     const refs = extractStageReferences(elements);
-    expect(refs).toContain("prompt.vote");
+    expect(refs).toContain("0.prompt.vote");
   });
 
   it("extracts multiple references and deduplicates", () => {
@@ -37,10 +36,10 @@ describe("extractStageReferences", () => {
         name: "q2",
         file: "prompts/q2.prompt.md",
         conditions: [
-          { reference: "prompt.q1", comparator: "equals", value: "yes" },
-          { reference: "prompt.q1", comparator: "equals", value: "no" },
+          { reference: "self.prompt.q1", comparator: "equals", value: "yes" },
+          { reference: "self.prompt.q1", comparator: "equals", value: "no" },
           {
-            reference: "survey.TIPI.result.score",
+            reference: "self.survey.TIPI.result.score",
             comparator: "isAbove",
             value: 3,
           },
@@ -49,11 +48,11 @@ describe("extractStageReferences", () => {
       {
         type: "display" as const,
         name: "d1",
-        reference: "prompt.q1",
+        reference: "self.prompt.q1",
       },
     ];
     const refs = extractStageReferences(elements);
-    expect(refs).toEqual(["prompt.q1", "survey.TIPI.result.score"]);
+    expect(refs).toEqual(["self.prompt.q1", "self.survey.TIPI.result.score"]);
   });
 
   it("returns empty array for elements with no references", () => {

--- a/apps/vscode/src/lib/semanticTokens.test.ts
+++ b/apps/vscode/src/lib/semanticTokens.test.ts
@@ -42,12 +42,12 @@ describe("computeSemanticTokens", () => {
   describe("reference strings", () => {
     it("highlights reference values after 'reference:' key", () => {
       const src = `conditions:
-  - reference: prompt.q1
+  - reference: self.prompt.q1
     comparator: exists`;
       const tokens = computeSemanticTokens(src);
       const refTokens = tokens.filter((t) => t.tokenType === "variable");
       expect(refTokens).toHaveLength(1);
-      expect(refTokens[0]).toMatchObject({ text: "prompt.q1" });
+      expect(refTokens[0]).toMatchObject({ text: "self.prompt.q1" });
     });
   });
 
@@ -283,15 +283,15 @@ duration: 300`;
     });
 
     it("aligns token for double-quoted reference", () => {
-      const src = `reference: "prompt.q1"`;
+      const src = `reference: "self.prompt.q1"`;
       const tokens = computeSemanticTokens(src);
       const refTokens = tokens.filter((t) => t.tokenType === "variable");
       expect(refTokens).toHaveLength(1);
       expect(refTokens[0]).toMatchObject({
         line: 0,
         startCol: 12,
-        length: 9,
-        text: "prompt.q1",
+        length: "self.prompt.q1".length,
+        text: "self.prompt.q1",
       });
     });
 
@@ -518,7 +518,7 @@ treatments:
           - type: prompt
             file: prompts/q1.prompt.md
             conditions:
-              - reference: prompt.consent
+              - reference: self.prompt.consent
                 comparator: equals
                 value: "yes"
           - type: submitButton`;

--- a/apps/vscode/src/lib/semanticTokens.ts
+++ b/apps/vscode/src/lib/semanticTokens.ts
@@ -290,8 +290,11 @@ export function computeSemanticTokens(source: string): SemanticToken[] {
             typeof value.value === "string" &&
             scalarSrc
           ) {
-            const refType = value.value.split(".")[0];
-            if (referenceTypeSet.has(refType)) {
+            // Per #298, references are position-prefixed:
+            // `<position>.<source>.<...>`. Source is the second segment.
+            const segments = value.value.split(".");
+            const refType = segments[1];
+            if (refType && referenceTypeSet.has(refType)) {
               addToken(scalarSrc.offset, scalarSrc.text, "variable");
             }
           } else if (

--- a/examples/annotated-walkthrough/walkthrough.treatments.yaml
+++ b/examples/annotated-walkthrough/walkthrough.treatments.yaml
@@ -1,8 +1,3 @@
-# Annotated walkthrough — a Stagebook syntax tour.
-# See README.md for the big-picture overview. The `notes:` fields below
-# describe each stage/element/template and are surfaced in the viewer
-# sidebar; short inline comments flag syntax particulars.
-
 templates:
   - name: studyTreatment
     contentType: treatment
@@ -17,37 +12,22 @@ templates:
       `contentType: treatment` tells the validator which schema to apply
       to `content`.
     content:
-      # `${topic}` and `${topicLabel}` come from the broadcast axis at
-      # the bottom of the file. After expansion `${topic}` becomes e.g.
-      # "remote_work" and `${topicLabel}` becomes "remote work policies".
       name: Annotated walkthrough - ${topicLabel}
       notes: A two-person text discussion about ${topicLabel}, annotated as a syntax tour.
       playerCount: 2
-
-      # `groupComposition` defines per-position eligibility conditions
-      # on data captured during the intro. (Player-level blocks don't
-      # carry `notes:`, so the explanatory commentary for this block
-      # lives here as a YAML comment.) Absolute cutoff on the
-      # familiarity slider: scores ≥ 50 → position 0 ("Familiar"); scores
-      # < 50 → position 1 ("Newcomer"). Stagebook defines the contract;
-      # matching happens in the host's lobby. Hosts that enforce strict
-      # threshold matching will fail to form a group when both
-      # participants fall on the same side of the cutoff — the
-      # intentional cost of threshold-based composition there.
       groupComposition:
         - position: 0
           title: Familiar
           conditions:
-            - reference: prompt.familiarity
+            - reference: self.prompt.familiarity
               comparator: isAtLeast
               value: 50
         - position: 1
           title: Newcomer
           conditions:
-            - reference: prompt.familiarity
+            - reference: self.prompt.familiarity
               comparator: isBelow
               value: 50
-
       gameStages:
         - name: ${topic}_initial
           duration: 90
@@ -65,8 +45,6 @@ templates:
                 Visible for 0–10s via `hideTime: 10`. Acts as a short
                 orientation screen before the real prompt appears.
             - type: prompt
-              # `name:` makes this response addressable as
-              # `prompt.${topic}_initial` in later references.
               name: ${topic}_initial
               file: prompts/topic_${topic}.prompt.md
               displayTime: 10
@@ -79,7 +57,6 @@ templates:
               buttonText: Submit my position
               displayTime: 10
               notes: Hidden for the first 10s so participants read the orientation before they can advance.
-
         - name: ${topic}_discussion
           duration: 300
           notes: |
@@ -93,7 +70,10 @@ templates:
             chatType: text
             showNickname: true
             showTitle: true
-            reactionEmojisAvailable: ["👍", "🤔", "❓"]
+            reactionEmojisAvailable:
+              - 👍
+              - 🤔
+              - ❓
           elements:
             - type: prompt
               file: prompts/discussion_guide.prompt.md
@@ -113,7 +93,6 @@ templates:
               buttonText: End discussion
               displayTime: 60
               notes: Hidden for the first 60s so participants engage before they can bail out.
-
         - name: ${topic}_reflection
           duration: 120
           notes: |
@@ -126,42 +105,34 @@ templates:
             question.
           elements:
             - type: display
-              reference: prompt.${topic}_initial
-              position: 1
-              showToPositions: [0]
+              reference: 1.prompt.${topic}_initial
+              showToPositions:
+                - 0
               notes: Shows position 1's initial response to position 0.
             - type: display
-              reference: prompt.${topic}_initial
-              position: 0
-              showToPositions: [1]
+              reference: 0.prompt.${topic}_initial
+              showToPositions:
+                - 1
               notes: Shows position 0's initial response to position 1.
-
             - type: separator
               style: thick
-
             - type: prompt
               name: ${topic}_post
               file: prompts/post_position.prompt.md
-
             - type: prompt
               name: ${topic}_changed
               file: prompts/post_changed.prompt.md
-
             - type: prompt
               file: prompts/post_consensus.prompt.md
               conditions:
-                # String-shorthand reference (the most common form).
-                - reference: prompt.${topic}_changed
-                  position: 0
+                - reference: 0.prompt.${topic}_changed
                   comparator: exists
-                # Same reference, written in the structured form (#240).
-                # Equivalent to `prompt.${topic}_changed` — `path: [value]`
-                # makes the implicit `value` default explicit.
                 - reference:
+                    position: '1'
                     source: prompt
                     name: ${topic}_changed
-                    path: [value]
-                  position: 1
+                    path:
+                      - value
                   comparator: exists
               notes: |
                 Conditional element — only appears once *both* players
@@ -175,9 +146,7 @@ templates:
                 both reference shapes — string sugar (`prompt.foo`) and
                 the structured `{source, name, path}` form (#240) — at
                 the same site; either parses to the same internal shape.
-
             - type: submitButton
-
       exitSequence:
         - name: Debrief
           notes: Per-treatment, solo exit step. Runs after the game stages but before any treatment-wide exit survey.
@@ -198,7 +167,6 @@ templates:
             - type: qualtrics
               name: exit_qualtrics
               url: https://example.qualtrics.com/jfe/form/SV_example
-
 introSequences:
   - name: onboarding
     notes: |
@@ -215,12 +183,9 @@ introSequences:
             notes: Informational `noResponse` prompt — text only, no input collected.
           - type: submitButton
             buttonText: I consent
-
       - name: Familiarity
         elements:
           - type: prompt
-            # `name:` here is what makes this slider addressable by
-            # `groupComposition` above as `prompt.familiarity`.
             name: familiarity
             file: prompts/familiarity.prompt.md
             notes: |
@@ -228,19 +193,12 @@ introSequences:
               `groupComposition` uses (`prompt.familiarity`) to split
               participants into positions.
           - type: submitButton
-
       - name: Personality
         elements:
           - type: survey
             surveyName: TIPI
             name: pre_TIPI
             notes: Platform-coupled survey element — the host platform renders the Ten-Item Personality Inventory. Skeleton placeholder in the viewer.
-
-# Two treatments are generated from one template by broadcasting over
-# the `d0` axis below. The viewer offers them side-by-side in the
-# treatment picker; each row supplies a different value for `${topic}`
-# and `${topicLabel}`, which fan out through every `${topic}`
-# placeholder inside `studyTreatment`.
 treatments:
   - template: studyTreatment
     broadcast:

--- a/examples/prisoners-dilemma/prisoners-dilemma.treatments.yaml
+++ b/examples/prisoners-dilemma/prisoners-dilemma.treatments.yaml
@@ -1,9 +1,3 @@
-# Prisoner's Dilemma — a 2-player simultaneous-choice example.
-# Two treatments share a single round template: a one-shot game and a
-# 3-round repeated game. Each round = one choice stage + one outcome
-# stage; the outcome stage uses condition leaves with `comparator: equals`
-# to render the right outcome card per (P0 × P1) choice combination.
-
 templates:
   - name: roundTemplate
     contentType: stages
@@ -30,7 +24,6 @@ templates:
           - type: timer
           - type: submitButton
             buttonText: Lock in choice
-
       - name: round_${roundN}_outcome
         duration: 30
         notes: |
@@ -42,107 +35,83 @@ templates:
           into one element per perspective so the same prompt file can
           serve "you were exploited" for whoever cooperated.
         elements:
-          # Show partner's choice — asymmetric per position.
           - type: display
-            reference: prompt.choice_round_${roundN}
-            position: 1
-            showToPositions: [0]
+            reference: 1.prompt.choice_round_${roundN}
+            showToPositions:
+              - 0
             notes: Position 0 sees position 1's choice.
           - type: display
-            reference: prompt.choice_round_${roundN}
-            position: 0
-            showToPositions: [1]
+            reference: 0.prompt.choice_round_${roundN}
+            showToPositions:
+              - 1
             notes: Position 1 sees position 0's choice.
-
           - type: separator
-
-          # Both cooperated → both see the same card.
           - type: prompt
             file: prompts/outcome_both_cooperated.prompt.md
             conditions:
-              - reference: prompt.choice_round_${roundN}
-                position: 0
+              - reference: 0.prompt.choice_round_${roundN}
                 comparator: equals
                 value: Cooperate
-              - reference: prompt.choice_round_${roundN}
-                position: 1
+              - reference: 1.prompt.choice_round_${roundN}
                 comparator: equals
                 value: Cooperate
             notes: Flat-array conditions are AND-combined — only renders when *both* positions chose Cooperate.
-
-          # Both defected → both see the same card.
           - type: prompt
             file: prompts/outcome_both_defected.prompt.md
             conditions:
-              - reference: prompt.choice_round_${roundN}
-                position: 0
+              - reference: 0.prompt.choice_round_${roundN}
                 comparator: equals
                 value: Defect
-              - reference: prompt.choice_round_${roundN}
-                position: 1
+              - reference: 1.prompt.choice_round_${roundN}
                 comparator: equals
                 value: Defect
-
-          # Asymmetric: position 0 cooperated, position 1 defected.
-          # Each side sees a different card; we instantiate the same
-          # prompt file twice with mirrored `showToPositions` /
-          # `position` selectors.
           - type: prompt
             file: prompts/outcome_you_cooperated_they_defected.prompt.md
-            showToPositions: [0]
+            showToPositions:
+              - 0
             conditions:
-              - reference: prompt.choice_round_${roundN}
-                position: 0
+              - reference: 0.prompt.choice_round_${roundN}
                 comparator: equals
                 value: Cooperate
-              - reference: prompt.choice_round_${roundN}
-                position: 1
+              - reference: 1.prompt.choice_round_${roundN}
                 comparator: equals
                 value: Defect
           - type: prompt
             file: prompts/outcome_you_defected_they_cooperated.prompt.md
-            showToPositions: [1]
+            showToPositions:
+              - 1
             conditions:
-              - reference: prompt.choice_round_${roundN}
-                position: 0
+              - reference: 0.prompt.choice_round_${roundN}
                 comparator: equals
                 value: Cooperate
-              - reference: prompt.choice_round_${roundN}
-                position: 1
+              - reference: 1.prompt.choice_round_${roundN}
                 comparator: equals
                 value: Defect
-
-          # Asymmetric: position 0 defected, position 1 cooperated. Mirror
-          # of the block above.
           - type: prompt
             file: prompts/outcome_you_defected_they_cooperated.prompt.md
-            showToPositions: [0]
+            showToPositions:
+              - 0
             conditions:
-              - reference: prompt.choice_round_${roundN}
-                position: 0
+              - reference: 0.prompt.choice_round_${roundN}
                 comparator: equals
                 value: Defect
-              - reference: prompt.choice_round_${roundN}
-                position: 1
+              - reference: 1.prompt.choice_round_${roundN}
                 comparator: equals
                 value: Cooperate
           - type: prompt
             file: prompts/outcome_you_cooperated_they_defected.prompt.md
-            showToPositions: [1]
+            showToPositions:
+              - 1
             conditions:
-              - reference: prompt.choice_round_${roundN}
-                position: 0
+              - reference: 0.prompt.choice_round_${roundN}
                 comparator: equals
                 value: Defect
-              - reference: prompt.choice_round_${roundN}
-                position: 1
+              - reference: 1.prompt.choice_round_${roundN}
                 comparator: equals
                 value: Cooperate
-
           - type: submitButton
             displayTime: 5
             buttonText: Continue
-
 treatments:
   - name: Prisoners Dilemma one-shot
     notes: |
@@ -161,7 +130,6 @@ treatments:
             name: reflection
             file: prompts/feedback.prompt.md
           - type: submitButton
-
   - name: Prisoners Dilemma 3-round repeated
     notes: |
       Same round structure repeated three times via broadcast. Each
@@ -185,7 +153,6 @@ treatments:
             name: reflection
             file: prompts/feedback.prompt.md
           - type: submitButton
-
 introSequences:
   - name: orientation
     notes: Solo intro — both players read the rules independently before being matched.

--- a/examples/ultimatum-game/ultimatum-game.treatments.yaml
+++ b/examples/ultimatum-game/ultimatum-game.treatments.yaml
@@ -1,10 +1,3 @@
-# Ultimatum Game — a 2-player asymmetric example.
-# Position 0 is the Proposer (offers a slice of $10); position 1 is the
-# Responder (accepts or rejects). Roles are assigned via
-# `groupComposition` from a multipleChoice in the intro. The two game
-# stages and the outcome stage demonstrate position-based asymmetric
-# content via `showToPositions` and cross-player `display` elements.
-
 treatments:
   - name: Ultimatum Game
     notes: |
@@ -15,26 +8,19 @@ treatments:
       and responder are working from the same stage but seeing
       different content.
     playerCount: 2
-
-    # `groupComposition` matches participants into seats based on the
-    # role-preference response captured in the intro. If both
-    # participants pick the same role the host's matching policy
-    # decides who gets which seat — Stagebook only specifies the
-    # contract.
     groupComposition:
       - position: 0
         title: Proposer
         conditions:
-          - reference: prompt.role_preference
+          - reference: self.prompt.role_preference
             comparator: equals
             value: Proposer
       - position: 1
         title: Responder
         conditions:
-          - reference: prompt.role_preference
+          - reference: self.prompt.role_preference
             comparator: equals
             value: Responder
-
     gameStages:
       - name: offer
         duration: 60
@@ -44,26 +30,23 @@ treatments:
           and a Ready button. Both must submit before the stage advances,
           so the responder is naturally held while the proposer thinks.
         elements:
-          # Proposer-only: the actual offer slider.
           - type: prompt
             name: offer
             file: prompts/offer.prompt.md
-            showToPositions: [0]
+            showToPositions:
+              - 0
             notes: |
               `showToPositions: [0]` restricts this prompt to the
               proposer. The response is named `offer`, so it is
               addressable as `prompt.offer` from the responder's
               `display` element on the next stage.
-
-          # Responder-only: a "wait" view.
           - type: prompt
             file: prompts/responder_waiting.prompt.md
-            showToPositions: [1]
-
+            showToPositions:
+              - 1
           - type: timer
           - type: submitButton
             buttonText: Ready
-
       - name: decision
         duration: 60
         notes: |
@@ -73,11 +56,10 @@ treatments:
           deciding" notice plus a `display` of their own offer as a
           recap. Both submit; stage advances when both are in.
         elements:
-          # Proposer-only: recap of the offer they made + waiting message.
           - type: display
-            reference: prompt.offer
-            position: 0
-            showToPositions: [0]
+            reference: 0.prompt.offer
+            showToPositions:
+              - 0
             notes: |
               Same `display` element used for the recap and the
               cross-player view — `position: 0` selects the
@@ -86,14 +68,12 @@ treatments:
               for the cross-player variant.)
           - type: prompt
             file: prompts/proposer_waiting.prompt.md
-            showToPositions: [0]
-
-          # Responder-only: cross-player display of the offer + decide
-          # prompt.
+            showToPositions:
+              - 0
           - type: display
-            reference: prompt.offer
-            position: 0
-            showToPositions: [1]
+            reference: 0.prompt.offer
+            showToPositions:
+              - 1
             notes: |
               Cross-player `display` — `position: 0` reads the
               proposer's response; `showToPositions: [1]` renders
@@ -101,12 +81,11 @@ treatments:
           - type: prompt
             name: decision
             file: prompts/decision.prompt.md
-            showToPositions: [1]
-
+            showToPositions:
+              - 1
           - type: timer
           - type: submitButton
             buttonText: Submit
-
       - name: outcome
         duration: 30
         notes: |
@@ -116,32 +95,24 @@ treatments:
           position 1 selects accepted vs. rejected.
         elements:
           - type: display
-            reference: prompt.offer
-            position: 0
+            reference: 0.prompt.offer
             notes: Both positions see the offer value. No `showToPositions` defaults to all.
-
           - type: separator
-
           - type: prompt
             file: prompts/outcome_accepted.prompt.md
             conditions:
-              - reference: prompt.decision
-                position: 1
+              - reference: 1.prompt.decision
                 comparator: equals
                 value: Accept
-
           - type: prompt
             file: prompts/outcome_rejected.prompt.md
             conditions:
-              - reference: prompt.decision
-                position: 1
+              - reference: 1.prompt.decision
                 comparator: equals
                 value: Reject
-
           - type: submitButton
             displayTime: 5
             buttonText: Continue
-
     exitSequence:
       - name: Reflection
         elements:
@@ -149,7 +120,6 @@ treatments:
             name: reflection
             file: prompts/feedback.prompt.md
           - type: submitButton
-
 introSequences:
   - name: orientation
     notes: |
@@ -162,7 +132,6 @@ introSequences:
             file: prompts/instructions.prompt.md
           - type: submitButton
             buttonText: Continue
-
       - name: Role preference
         elements:
           - type: prompt

--- a/packages/stagebook/src/components/Element.ct.tsx
+++ b/packages/stagebook/src/components/Element.ct.tsx
@@ -92,8 +92,7 @@ test.describe("Element router dispatch", () => {
       <MockStageRenderer
         stage={singleElementStage({
           type: "display",
-          reference: "prompt.answer",
-          position: "player",
+          reference: "self.prompt.answer",
         })}
         stateValues={{ "prompt.answer": "Hello from display" }}
       />,
@@ -145,7 +144,7 @@ test.describe("Element router dispatch", () => {
           url: "https://upenn.qualtrics.com/jfe/form/SV_test",
           urlParams: [
             { key: "condition", value: "topicA" },
-            { key: "answer", reference: "prompt.myQ" },
+            { key: "answer", reference: "self.prompt.myQ" },
           ],
         })}
         stateValues={{ "prompt.myQ": "yes" }}

--- a/packages/stagebook/src/components/Element.ct.tsx
+++ b/packages/stagebook/src/components/Element.ct.tsx
@@ -94,7 +94,7 @@ test.describe("Element router dispatch", () => {
           type: "display",
           reference: "self.prompt.answer",
         })}
-        stateValues={{ "prompt.answer": "Hello from display" }}
+        stateValues={{ "self.prompt.answer": "Hello from display" }}
       />,
     );
     await expect(component).toContainText("Hello from display");
@@ -147,7 +147,7 @@ test.describe("Element router dispatch", () => {
             { key: "answer", reference: "self.prompt.myQ" },
           ],
         })}
-        stateValues={{ "prompt.myQ": "yes" }}
+        stateValues={{ "self.prompt.myQ": "yes" }}
       />,
     );
     const src = await component.locator("iframe").getAttribute("src");

--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -47,7 +47,9 @@ function resolveParams(
             : String(param.value as string | number | boolean),
       };
     }
-    const values = resolve(param.reference, param.position);
+    // Per #298 the position is part of the reference itself; the
+    // sibling `param.position` field is removed.
+    const values = resolve(param.reference);
     const picked = values.find((v) => v !== undefined);
     return {
       key: param.key,
@@ -150,23 +152,36 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
       );
 
     case "display": {
-      const ref = element.reference ?? `prompt.${element.name}`;
-      const values = resolve(ref, element.position);
-      // Always render a stable dotted-string for `data-reference`
-      // regardless of whether the treatment authored a string or
-      // structured ref (and regardless of whether the host parsed it
-      // into structured form before passing it in). Downstream tooling
-      // that scrapes the attribute keeps the familiar dotted shape.
+      // Per #298, the position is part of the reference itself —
+      // `0.prompt.foo.value`, `all.prompt.recall.value`, etc. The
+      // Display element no longer takes a sibling `position:` field
+      // (the position is parsed out by the resolver and passed to the
+      // host via `get()`).
+      const ref = element.reference ?? `self.prompt.${String(element.name)}`;
+      const values = resolve(ref);
+      // Render a stable dotted-string for `data-reference` so
+      // downstream tooling that scrapes the attribute sees the
+      // familiar prefixed-dotted shape.
       const refString =
         typeof ref === "string"
           ? parseDottedReference(ref).ok
             ? ref
             : ref // malformed strings pass through verbatim
           : formatReference(ref);
+      // Extract the position from the (parsed) reference for layout
+      // hints — Display uses it to decide between single-value and
+      // per-participant rendering.
+      let positionForLayout: number | string | undefined;
+      if (typeof ref === "string") {
+        const parsed = parseDottedReference(ref);
+        if (parsed.ok) positionForLayout = parsed.value.position;
+      } else {
+        positionForLayout = ref.position;
+      }
       return (
         <Display
           reference={refString}
-          position={element.position}
+          position={positionForLayout}
           values={values}
         />
       );
@@ -210,9 +225,11 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
       const promptName =
         element.name ?? `${progressLabel}_${metadata.name ?? element.file}`;
 
-      // Read current value from state
-      const scope = element.shared ? "shared" : "player";
-      const currentValues = resolve(`prompt.${promptName}`, scope);
+      // Read current value from state. Position comes from the
+      // reference itself per #298 — `shared.prompt.X` for shared
+      // prompts, `self.prompt.X` for player-scoped.
+      const scope = element.shared ? "shared" : "self";
+      const currentValues = resolve(`${scope}.prompt.${promptName}`);
       const currentValue = currentValues[0];
 
       return (

--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -29,12 +29,13 @@ function resolveParams(
         key: string;
         value?: unknown;
         // After #240, references can be either the dotted-string sugar
-        // or the structured `{source, name?, path?}` form.
+        // or the structured `{position, source, name?, path?}` form.
+        // Per #298 position lives inside the reference; the pre-#298
+        // sibling `position:` field is gone.
         reference?: string | ReferenceType;
-        position?: string;
       }>
     | undefined,
-  resolve: (ref: string | ReferenceType, pos?: string) => unknown[],
+  resolve: (ref: string | ReferenceType) => unknown[],
 ): ResolvedParam[] {
   if (!urlParams) return [];
   return urlParams.map((param) => {
@@ -154,30 +155,25 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
     case "display": {
       // Per #298, the position is part of the reference itself —
       // `0.prompt.foo.value`, `all.prompt.recall.value`, etc. The
-      // Display element no longer takes a sibling `position:` field
-      // (the position is parsed out by the resolver and passed to the
-      // host via `get()`).
+      // Display element no longer takes a sibling `position:` field;
+      // the position is parsed out of the reference and used for
+      // layout hints. The resolver handles the same parsing internally
+      // when resolving values.
       const ref = element.reference ?? `self.prompt.${String(element.name)}`;
       const values = resolve(ref);
-      // Render a stable dotted-string for `data-reference` so
-      // downstream tooling that scrapes the attribute sees the
-      // familiar prefixed-dotted shape.
-      const refString =
-        typeof ref === "string"
-          ? parseDottedReference(ref).ok
-            ? ref
-            : ref // malformed strings pass through verbatim
-          : formatReference(ref);
-      // Extract the position from the (parsed) reference for layout
-      // hints — Display uses it to decide between single-value and
-      // per-participant rendering.
-      let positionForLayout: number | string | undefined;
+      // Parse once, derive both the canonical dotted-string form (for
+      // `data-reference`) and the position (for layout) from the same
+      // structured shape.
+      let parsed: ReferenceType | null = null;
       if (typeof ref === "string") {
-        const parsed = parseDottedReference(ref);
-        if (parsed.ok) positionForLayout = parsed.value.position;
+        const r = parseDottedReference(ref);
+        if (r.ok) parsed = r.value;
       } else {
-        positionForLayout = ref.position;
+        parsed = ref;
       }
+      const refString = parsed ? formatReference(parsed) : (ref as string); // malformed pass-through
+      const positionForLayout =
+        parsed === null ? undefined : String(parsed.position);
       return (
         <Display
           reference={refString}

--- a/packages/stagebook/src/components/StagebookProvider.test.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.test.tsx
@@ -123,7 +123,6 @@ describe("StagebookProvider + useStagebookContext", () => {
 function renderUseResolve(
   reference: string,
   ctx: StagebookContext,
-  position?: string,
 ): {
   result: { current: unknown[] };
   unmount: () => void;
@@ -133,7 +132,7 @@ function renderUseResolve(
   let root: Root;
 
   function Harness(): ReactNode {
-    result.current = useResolve(reference, position);
+    result.current = useResolve(reference);
     return null;
   }
 
@@ -159,9 +158,11 @@ describe("Provider-level resolve (get → resolve pipeline)", () => {
     ]);
     const ctx = createMockContext({ get });
 
-    const { result, unmount } = renderUseResolve("prompt.q1", ctx);
+    // Per #298 the position is part of the reference itself. `self.X`
+    // maps to the host's "player" scope at the get() boundary.
+    const { result, unmount } = renderUseResolve("self.prompt.q1", ctx);
 
-    expect(get).toHaveBeenCalledWith("prompt_q1", undefined);
+    expect(get).toHaveBeenCalledWith("prompt_q1", "player");
     expect(result.current).toEqual(["yes"]);
     unmount();
   });
@@ -171,61 +172,44 @@ describe("Provider-level resolve (get → resolve pipeline)", () => {
     const ctx = createMockContext({ get });
 
     const { result, unmount } = renderUseResolve(
-      "survey.TIPI.result.score",
+      "self.survey.TIPI.result.score",
       ctx,
     );
 
-    expect(get).toHaveBeenCalledWith("survey_TIPI", undefined);
+    expect(get).toHaveBeenCalledWith("survey_TIPI", "player");
     expect(result.current).toEqual([4.5]);
     unmount();
   });
 
-  test("passes 'shared' scope through to get verbatim", () => {
+  test("passes 'shared' position prefix through to get verbatim", () => {
     const get = vi.fn(() => []);
     const ctx = createMockContext({ get });
 
-    const { unmount } = renderUseResolve("prompt.q1", ctx, "shared");
+    const { unmount } = renderUseResolve("shared.prompt.q1", ctx);
 
     expect(get).toHaveBeenCalledWith("prompt_q1", "shared");
     unmount();
   });
 
-  test("passes a numeric slot-index scope through to get verbatim", () => {
-    // After #238, condition leaves can target a specific slot via a
-    // numeric position (rendered to string at this boundary). The
-    // host's get() receives the string unchanged.
+  test("passes a numeric slot-index prefix through to get verbatim", () => {
+    // Numeric slot index is rendered to a string at the get()
+    // boundary so the host receives a uniform string scope arg.
     const get = vi.fn(() => []);
     const ctx = createMockContext({ get });
 
-    const { unmount } = renderUseResolve("prompt.q1", ctx, "0");
+    const { unmount } = renderUseResolve("0.prompt.q1", ctx);
 
     expect(get).toHaveBeenCalledWith("prompt_q1", "0");
     unmount();
   });
 
-  test("forwards `all` scope to get (display.position: all is still kept)", () => {
-    // `display.position` (and trackedLink/qualtrics urlParams via
-    // `positionSelectorSchema`) still allow `"all"` after #238 —
-    // only condition leaves were narrowed. The runtime forwards
+  test("forwards `all` prefix to get (multi-participant list)", () => {
+    // `all.X` returns one value per participant; the runtime forwards
     // `"all"` verbatim to the host's get().
     const get = vi.fn(() => []);
     const ctx = createMockContext({ get });
 
-    const { unmount } = renderUseResolve("prompt.q1", ctx, "all");
-
-    expect(get).toHaveBeenCalledWith("prompt_q1", "all");
-    unmount();
-  });
-
-  test("normalizes `any` scope to `all` before forwarding to get", () => {
-    // `display.position: "any"` and `"all"` share the same storage
-    // shape (one value per participant); the "any-of" semantics is
-    // applied at the consumer. Stagebook normalizes here so hosts
-    // only need to handle `"all"`.
-    const get = vi.fn(() => []);
-    const ctx = createMockContext({ get });
-
-    const { unmount } = renderUseResolve("prompt.q1", ctx, "any");
+    const { unmount } = renderUseResolve("all.prompt.q1", ctx);
 
     expect(get).toHaveBeenCalledWith("prompt_q1", "all");
     unmount();
@@ -236,7 +220,7 @@ describe("Provider-level resolve (get → resolve pipeline)", () => {
     const get = vi.fn(() => [{ name: "q1" }]);
     const ctx = createMockContext({ get });
 
-    const { result, unmount } = renderUseResolve("prompt.q1", ctx);
+    const { result, unmount } = renderUseResolve("self.prompt.q1", ctx);
 
     expect(result.current).toEqual([]);
     unmount();
@@ -253,7 +237,7 @@ describe("Provider-level resolve (get → resolve pipeline)", () => {
     ]);
     const ctx = createMockContext({ get });
 
-    const { result, unmount } = renderUseResolve("prompt.q1", ctx, "0");
+    const { result, unmount } = renderUseResolve("0.prompt.q1", ctx);
 
     expect(result.current).toEqual(["a", "b"]);
     unmount();

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -7,10 +7,24 @@ import React, {
   useRef,
 } from "react";
 import type { DiscussionType, ReferenceType } from "../schemas/treatment.js";
+import { parseDottedReference } from "../schemas/reference.js";
 import {
   getReferenceKeyAndPath,
   getNestedValueByPath,
 } from "../utils/reference.js";
+
+/**
+ * Normalise a reference to its structured form so callers can branch on
+ * `.position` without re-parsing. Throws if the string is invalid.
+ */
+function parseToStructuredRef(
+  reference: string | ReferenceType,
+): ReferenceType {
+  if (typeof reference !== "string") return reference;
+  const parsed = parseDottedReference(reference);
+  if (!parsed.ok) throw new Error(parsed.message);
+  return parsed.value;
+}
 
 // --------------- StagebookContext Interface ---------------
 
@@ -122,9 +136,10 @@ export interface StagebookContext {
 
 interface InternalStagebookContext extends StagebookContext {
   // After #240, callers can pass either the dotted-string sugar
-  // (`prompt.foo`) or the structured form
-  // (`{ source: "prompt", name: "foo" }`).
-  resolve(reference: string | ReferenceType, position?: string): unknown[];
+  // (`0.prompt.foo`, `self.entryUrl.params.x`) or the structured form
+  // (`{ position: 0, source: "prompt", name: "foo" }`). After #298 the
+  // position is part of the reference — the resolver extracts it.
+  resolve(reference: string | ReferenceType): unknown[];
 }
 
 const StagebookReactContext = createContext<InternalStagebookContext | null>(
@@ -141,26 +156,26 @@ export function StagebookProvider({
   children: React.ReactNode;
 }) {
   const resolve = React.useCallback(
-    (reference: string | ReferenceType, position?: string): unknown[] => {
+    (reference: string | ReferenceType): unknown[] => {
       let referenceKey: string;
       let path: string[];
+      let position: number | string;
       try {
-        ({ referenceKey, path } = getReferenceKeyAndPath(reference));
+        const parsed = parseToStructuredRef(reference);
+        position = parsed.position;
+        ({ referenceKey, path } = getReferenceKeyAndPath(parsed));
       } catch {
         console.error(
           `Invalid reference: ${typeof reference === "string" ? `"${reference}"` : JSON.stringify(reference)}`,
         );
         return [];
       }
-      // After #238, *condition* leaves only emit `"shared"` /
-      // `"player"` / numeric-slot positions. But other DSL sites still
-      // use `positionSelectorSchema`, which kept `"all"` and `"any"`
-      // — `display.position`, `trackedLink.urlParams[].position`, and
-      // `qualtrics.urlParams[].position` all read via `resolve()` and
-      // can pass `"all"` or `"any"` here. Storage scope is the same
-      // for both (the host returns one value per participant), so we
-      // normalize `"any"` to `"all"` before calling the host.
-      const storageScope = position === "any" ? "all" : position;
+      // The position selector is now part of the reference (#298). The
+      // host's `get(key, scope)` accepts `"shared"`, `"all"`, or a
+      // numeric-slot index as a string. `"self"` maps to the current
+      // participant's storage — passed as `"player"` to the host for
+      // backward compatibility with the existing get() contract.
+      const storageScope = position === "self" ? "player" : String(position);
       const rawValues = value.get(referenceKey, storageScope);
       return rawValues
         .map((v) => getNestedValueByPath(v, path))
@@ -194,12 +209,9 @@ export function useStagebookContext(): InternalStagebookContext {
   return ctx;
 }
 
-export function useResolve(
-  reference: string | ReferenceType,
-  position?: string,
-): unknown[] {
+export function useResolve(reference: string | ReferenceType): unknown[] {
   const { resolve } = useStagebookContext();
-  return resolve(reference, position);
+  return resolve(reference);
 }
 
 export function useSave(): StagebookContext["save"] {

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -164,10 +164,17 @@ export function StagebookProvider({
         const parsed = parseToStructuredRef(reference);
         position = parsed.position;
         ({ referenceKey, path } = getReferenceKeyAndPath(parsed));
-      } catch {
-        console.error(
-          `Invalid reference: ${typeof reference === "string" ? `"${reference}"` : JSON.stringify(reference)}`,
-        );
+      } catch (err) {
+        // Surface the underlying parser/migration message so authors
+        // can act on it (e.g. the "missing position prefix" hint from
+        // #298 or the `urlParams` → `entryUrl.params` migration hint
+        // from #246).
+        const refStr =
+          typeof reference === "string"
+            ? `"${reference}"`
+            : JSON.stringify(reference);
+        const why = err instanceof Error ? err.message : String(err);
+        console.error(`Invalid reference: ${refStr} — ${why}`);
         return [];
       }
       // The position selector is now part of the reference (#298). The

--- a/packages/stagebook/src/components/conditions/StageConditionGate.ct.tsx
+++ b/packages/stagebook/src/components/conditions/StageConditionGate.ct.tsx
@@ -18,10 +18,9 @@ test.describe("StageConditionGate (#183)", () => {
           duration: 60,
           conditions: [
             {
-              reference: "survey.continueVote.result.keepGoing",
+              reference: "shared.survey.continueVote.result.keepGoing",
               comparator: "equals",
               value: "yes",
-              position: "shared",
             },
           ],
           elements,
@@ -48,10 +47,9 @@ test.describe("StageConditionGate (#183)", () => {
           duration: 60,
           conditions: [
             {
-              reference: "survey.continueVote.result.keepGoing",
+              reference: "shared.survey.continueVote.result.keepGoing",
               comparator: "equals",
               value: "yes",
-              position: "shared",
             },
           ],
           elements,
@@ -83,10 +81,9 @@ test.describe("StageConditionGate (#183)", () => {
           duration: 60,
           conditions: [
             {
-              reference: "survey.continueVote.result.keepGoing",
+              reference: "shared.survey.continueVote.result.keepGoing",
               comparator: "equals",
               value: "yes",
-              position: "shared",
             },
           ],
           elements,
@@ -112,9 +109,8 @@ test.describe("StageConditionGate (#183)", () => {
           duration: 60,
           conditions: [
             {
-              reference: "submitButton.speedSubmit",
+              reference: "shared.submitButton.speedSubmit",
               comparator: "doesNotExist",
-              position: "shared",
             },
           ],
           elements: [{ type: "submitButton" as const, name: "speedSubmit" }],

--- a/packages/stagebook/src/components/conditions/StageConditionGate.ct.tsx
+++ b/packages/stagebook/src/components/conditions/StageConditionGate.ct.tsx
@@ -26,7 +26,7 @@ test.describe("StageConditionGate (#183)", () => {
           elements,
         }}
         stateValues={{
-          "survey.continueVote.result.keepGoing": "yes",
+          "shared.survey.continueVote.result.keepGoing": "yes",
         }}
       />,
     );
@@ -55,7 +55,7 @@ test.describe("StageConditionGate (#183)", () => {
           elements,
         }}
         stateValues={{
-          "survey.continueVote.result.keepGoing": "no",
+          "shared.survey.continueVote.result.keepGoing": "no",
         }}
       />,
     );

--- a/packages/stagebook/src/components/testing/MockStageRenderer.tsx
+++ b/packages/stagebook/src/components/testing/MockStageRenderer.tsx
@@ -19,7 +19,12 @@ export interface MockStageRendererProps {
   playerCount?: number;
   isSubmitted?: boolean;
   elapsedTime?: number;
-  /** Key-value map of DSL reference string → extracted value (e.g., "prompt.answer" → "yes") */
+  /**
+   * Key-value map of DSL reference string → extracted value
+   * (e.g., `"self.prompt.answer" → "yes"`). Per #298 the reference
+   * needs a position prefix; the prefix itself is discarded when
+   * computing the storage key, so any valid prefix works.
+   */
   stateValues?: Record<string, unknown>;
   /**
    * Host advancement hook for stage-level conditions (#183). Default

--- a/packages/stagebook/src/schemas/reference.ts
+++ b/packages/stagebook/src/schemas/reference.ts
@@ -72,6 +72,12 @@ const referencePathSchema = z.array(z.string().min(1));
  */
 export const positionSelectorSchema = z.union([
   z.number().int().nonnegative(),
+  // YAML may quote stringified integers (`position: '1'`); coerce to
+  // canonical number form so consumers see one type.
+  z
+    .string()
+    .regex(/^\d+$/, "numeric position selector must be a non-negative integer")
+    .transform((s) => Number(s)),
   z.enum(["self", "shared", "all"]),
 ]);
 export type PositionSelectorType = z.infer<typeof positionSelectorSchema>;
@@ -107,7 +113,7 @@ export const externalReferenceSchema = z
           code: z.ZodIssueCode.custom,
           path: ["path"],
           message:
-            "entryUrl references must use the `params` subpath: `<position>.entryUrl.params.<key>`. (Other entryUrl subpaths like `path`, `host`, `href` are reserved for future use.)",
+            "entryUrl references must use the `params` subpath: e.g. `self.entryUrl.params.<key>`. (Other entryUrl subpaths like `path`, `host`, `href` are reserved for future use.)",
         });
       }
     }
@@ -176,6 +182,17 @@ export function parseDottedReference(
 
   const positionResult = parsePositionToken(positionToken);
   if (!positionResult.ok) {
+    // Legacy `urlParams.<key>` was renamed to `entryUrl.params.<key>`
+    // in #246. Surface the migration hint even when the position prefix
+    // is also missing — the renamed source + missing prefix together
+    // is the most common compound migration error.
+    if (positionToken === "urlParams") {
+      const key = source ? [source, ...rest].join(".") : "<key>";
+      return {
+        ok: false,
+        message: `\`urlParams\` reference source was renamed to \`entryUrl.params\` (#246). Use \`self.entryUrl.params.${key}\` instead.`,
+      };
+    }
     // Help authors migrating from pre-#298 references where the first
     // segment was a source enum.
     if (

--- a/packages/stagebook/src/schemas/reference.ts
+++ b/packages/stagebook/src/schemas/reference.ts
@@ -1,21 +1,26 @@
 /**
- * Reference schemas (#240, #246).
+ * Reference schemas (#240, #246, #298).
  *
  * A reference identifies a value somewhere in the study state. There are two
  * kinds: **named** sources (`prompt`, `survey`, …) whose data is keyed by
  * a researcher-chosen `name`, and **external** sources (`entryUrl`,
  * `participantInfo`, …) supplied by the host as a singleton.
  *
+ * Per #298, every reference begins with an explicit **position selector** —
+ * `<integer>`, `self`, `shared`, or `all`. The position selector is part of
+ * the reference (where to find the value), not a separate field.
+ *
  * References can be written two ways:
- *   - **String shorthand** (the original syntax) — `prompt.familiarity`,
- *     `entryUrl.params.condition`, `survey.TIPI.responses.q1`.
- *   - **Structured object** — `{ source: "prompt", name: "familiarity" }`,
- *     `{ source: "entryUrl", path: ["params", "condition"] }`. Same
- *     expressivity plus the ability to override defaults that the dotted
+ *   - **String shorthand** (the original syntax) — `0.prompt.familiarity`,
+ *     `self.entryUrl.params.condition`, `1.survey.TIPI.responses.q1`,
+ *     `all.prompt.recall.value`.
+ *   - **Structured object** — `{ position: 0, source: "prompt", name: "familiarity" }`,
+ *     `{ position: "self", source: "entryUrl", path: ["params", "condition"] }`.
+ *     Same expressivity plus the ability to override defaults that the dotted
  *     form bakes in.
  *
  * The string shorthand is parsed into the structured form, so downstream
- * code only ever sees `{source, name?, path?}` shapes.
+ * code only ever sees `{position, source, name?, path?}` shapes.
  *
  * Lives in its own module (not `treatment.ts`) so the cross-stage walker
  * `validateReferences.ts` can import the parser without creating a circular
@@ -52,8 +57,28 @@ export type ExternalSource = z.infer<typeof externalSourceEnum>;
 
 const referencePathSchema = z.array(z.string().min(1));
 
+/**
+ * Position selector for a reference (#298). Either a non-negative integer
+ * slot index, or one of the named selectors:
+ *   - `self` — the current participant's value
+ *   - `shared` — group-shared state
+ *   - `all` — multi-participant list (one entry per participant)
+ *
+ * The pre-#298 `any` selector is removed; existential quantification
+ * across participants belongs in the boolean-tree `any:` operator.
+ *
+ * The pre-#298 `player` selector is removed; `self` replaces it (same
+ * semantic, clearer name, single canonical spelling).
+ */
+export const positionSelectorSchema = z.union([
+  z.number().int().nonnegative(),
+  z.enum(["self", "shared", "all"]),
+]);
+export type PositionSelectorType = z.infer<typeof positionSelectorSchema>;
+
 export const namedReferenceSchema = z
   .object({
+    position: positionSelectorSchema,
     source: namedSourceEnum,
     name: nameSchema,
     path: referencePathSchema.optional(),
@@ -63,6 +88,7 @@ export type NamedReferenceType = z.infer<typeof namedReferenceSchema>;
 
 export const externalReferenceSchema = z
   .object({
+    position: positionSelectorSchema,
     source: externalSourceEnum,
     path: referencePathSchema.nonempty({
       message: "External-source references require a non-empty `path`.",
@@ -81,7 +107,7 @@ export const externalReferenceSchema = z
           code: z.ZodIssueCode.custom,
           path: ["path"],
           message:
-            "entryUrl references must use the `params` subpath: `entryUrl.params.<key>`. (Other entryUrl subpaths like `path`, `host`, `href` are reserved for future use.)",
+            "entryUrl references must use the `params` subpath: `<position>.entryUrl.params.<key>`. (Other entryUrl subpaths like `path`, `host`, `href` are reserved for future use.)",
         });
       }
     }
@@ -99,12 +125,36 @@ const ALL_SOURCES = [
   ...namedSourceEnum.options,
   ...externalSourceEnum.options,
 ] as const;
+const POSITION_SELECTOR_NAMES: ReadonlySet<string> = new Set([
+  "self",
+  "shared",
+  "all",
+]);
+
+function parsePositionToken(
+  token: string,
+): { ok: true; position: PositionSelectorType } | { ok: false } {
+  if (POSITION_SELECTOR_NAMES.has(token)) {
+    return { ok: true, position: token as PositionSelectorType };
+  }
+  // Numeric position. Use a tight regex so leading-zero / decimal / sign
+  // forms don't accidentally parse as positions; canonical positions are
+  // bare non-negative integers.
+  if (/^[0-9]+$/.test(token)) {
+    return { ok: true, position: Number(token) };
+  }
+  return { ok: false };
+}
 
 /**
  * Parse a dotted-string reference into its structured form. Returns either
  * `{ ok: true, value }` or `{ ok: false, message }`. Used by the schema
  * (string-shorthand sugar) AND by `getReferenceKeyAndPath` when a runtime
  * caller passes a string instead of the structured form.
+ *
+ * Per #298, the first segment is a required position selector
+ * (`<integer>`, `self`, `shared`, `all`). The second segment is the source
+ * enum.
  *
  * The result is then re-validated against the structured schemas
  * (`namedReferenceSchema` / `externalReferenceSchema`) so the string-shorthand
@@ -116,10 +166,41 @@ export function parseDottedReference(
   str: string,
 ): { ok: true; value: ReferenceType } | { ok: false; message: string } {
   const segments = str.split(".");
-  const [source, ...rest] = segments;
-  if (!source) {
-    return { ok: false, message: "Reference must include a source." };
+  if (segments.length < 2) {
+    return {
+      ok: false,
+      message: `Reference must include a position prefix and a source, e.g. \`self.prompt.elementName\` or \`0.prompt.elementName\`. Got "${str}".`,
+    };
   }
+  const [positionToken, source, ...rest] = segments;
+
+  const positionResult = parsePositionToken(positionToken);
+  if (!positionResult.ok) {
+    // Help authors migrating from pre-#298 references where the first
+    // segment was a source enum.
+    if (
+      NAMED_SOURCES.has(positionToken) ||
+      EXTERNAL_SOURCES.has(positionToken)
+    ) {
+      return {
+        ok: false,
+        message: `Reference "${str}" is missing a position prefix. After #298, every reference starts with a position selector — \`self\`, \`shared\`, \`all\`, or a non-negative integer slot index. Try \`self.${str}\` for the current participant's value.`,
+      };
+    }
+    return {
+      ok: false,
+      message: `Reference "${str}" must start with a position selector (\`self\`, \`shared\`, \`all\`, or a non-negative integer). Got "${positionToken}".`,
+    };
+  }
+  const position = positionResult.position;
+
+  if (!source) {
+    return {
+      ok: false,
+      message: `Reference "${str}" is missing a source after the position prefix.`,
+    };
+  }
+
   // Legacy `urlParams.<key>` was renamed to `entryUrl.params.<key>` in
   // #246 to disambiguate from the unrelated `urlParams:` element field
   // (outgoing params on trackedLink / qualtrics). Surface a clear hint
@@ -129,7 +210,7 @@ export function parseDottedReference(
     const key = rest.length > 0 ? rest.join(".") : "<key>";
     return {
       ok: false,
-      message: `\`urlParams\` reference source was renamed to \`entryUrl.params\` (#246). Use \`entryUrl.params.${key}\` instead of \`urlParams.${key}\`.`,
+      message: `\`urlParams\` reference source was renamed to \`entryUrl.params\` (#246). Use \`<position>.entryUrl.params.${key}\` instead.`,
     };
   }
   if (NAMED_SOURCES.has(source)) {
@@ -137,13 +218,13 @@ export function parseDottedReference(
     if (name === undefined || name.length < 1) {
       return {
         ok: false,
-        message: `A name must be provided, e.g. '${source}.elementName'.`,
+        message: `A name must be provided, e.g. '<position>.${source}.elementName'.`,
       };
     }
     const candidate =
       path.length > 0
-        ? { source: source as NamedSource, name, path }
-        : { source: source as NamedSource, name };
+        ? { position, source: source as NamedSource, name, path }
+        : { position, source: source as NamedSource, name };
     const parsed = namedReferenceSchema.safeParse(candidate);
     if (!parsed.success) {
       return {
@@ -157,10 +238,11 @@ export function parseDottedReference(
     if (rest.length < 1) {
       return {
         ok: false,
-        message: `A path must be provided, e.g. '${source}.fieldName'.`,
+        message: `A path must be provided, e.g. '<position>.${source}.fieldName'.`,
       };
     }
     const candidate = {
+      position,
       source: source as ExternalSource,
       path: rest as [string, ...string[]],
     };
@@ -187,12 +269,13 @@ export function parseDottedReference(
  * familiar dotted form.
  */
 export function formatReference(ref: ReferenceType): string {
+  const positionStr = String(ref.position);
   if ("name" in ref) {
     return ref.path && ref.path.length > 0
-      ? `${ref.source}.${ref.name}.${ref.path.join(".")}`
-      : `${ref.source}.${ref.name}`;
+      ? `${positionStr}.${ref.source}.${ref.name}.${ref.path.join(".")}`
+      : `${positionStr}.${ref.source}.${ref.name}`;
   }
-  return `${ref.source}.${ref.path.join(".")}`;
+  return `${positionStr}.${ref.source}.${ref.path.join(".")}`;
 }
 
 const stringReferenceSchema = z.string().transform((str, ctx) => {
@@ -209,13 +292,13 @@ const stringReferenceSchema = z.string().transform((str, ctx) => {
 
 /**
  * Reference field schema — accepts either:
- *   - the dotted-string sugar (`prompt.foo`, `entryUrl.params.condition`)
- *   - the structured `{ source, name?, path? }` object form
+ *   - the dotted-string sugar (`0.prompt.foo`, `self.entryUrl.params.condition`)
+ *   - the structured `{ position, source, name?, path? }` object form
  *
  * Output is always the structured form (the string-sugar branch transforms
- * to the same shape). Validation: named sources require `name` and forbid
- * empty `path` segments; external sources forbid `name` and require a
- * non-empty `path`.
+ * to the same shape). Validation: position is required (#298); named sources
+ * require `name` and forbid empty `path` segments; external sources forbid
+ * `name` and require a non-empty `path`.
  */
 export const referenceSchema = z.union([
   namedReferenceSchema,

--- a/packages/stagebook/src/schemas/reference.ts
+++ b/packages/stagebook/src/schemas/reference.ts
@@ -143,10 +143,10 @@ function parsePositionToken(
   if (POSITION_SELECTOR_NAMES.has(token)) {
     return { ok: true, position: token as PositionSelectorType };
   }
-  // Numeric position. Use a tight regex so leading-zero / decimal / sign
-  // forms don't accidentally parse as positions; canonical positions are
-  // bare non-negative integers.
-  if (/^[0-9]+$/.test(token)) {
+  // Numeric position. Canonical form: non-negative integer with no
+  // leading zeros (`0`, `1`, `12`). Reject `01`, `007`, etc. so two
+  // distinct token strings can't normalize to the same selector.
+  if (/^(0|[1-9]\d*)$/.test(token)) {
     return { ok: true, position: Number(token) };
   }
   return { ok: false };

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -16,7 +16,6 @@ import {
   displayTimeSchema,
   hideTimeSchema,
   positionSchema,
-  positionSelectorSchema,
   showToPositionsSchema,
   hideFromPositionsSchema,
   discussionSchema,
@@ -29,18 +28,12 @@ import {
 
 // Leaf shape of a resolved condition: reference + comparator + optional
 // value, no template placeholders. Boolean-tree operators (#235) are
-// described separately below.
+// described separately below. After #298 the position lives inside the
+// reference; the sibling `position:` field is removed (mirrors
+// `baseConditionSchema` in treatment.ts).
 const resolvedLeafConditionSchema = z
   .object({
     reference: referenceSchema,
-    // `position` is a pure read selector after #238 — `all`/`any`
-    // moved to the boolean-tree operators (#235), `percentAgreement`
-    // was pulled out entirely. Mirrors `baseConditionSchema.position`
-    // in treatment.ts.
-    position: z
-      .enum(["shared", "player"])
-      .or(z.number().nonnegative().int())
-      .optional(),
     comparator: z.enum([
       "exists",
       "doesNotExist",
@@ -139,7 +132,6 @@ const resolvedElementBaseSchema = z.object({
   displayText: z.string().optional(),
   helperText: z.string().optional(),
   reference: z.string().optional(),
-  position: positionSelectorSchema.optional(),
   surveyName: z.string().optional(),
   startTime: z.number().optional(),
   endTime: z.number().optional(),
@@ -152,7 +144,6 @@ const resolvedElementBaseSchema = z.object({
         key: z.string(),
         value: z.union([z.string(), z.number(), z.boolean()]).optional(),
         reference: z.string().optional(),
-        position: positionSelectorSchema.optional(),
       }),
     )
     .optional(),

--- a/packages/stagebook/src/schemas/safeParseTreatmentFile.test.ts
+++ b/packages/stagebook/src/schemas/safeParseTreatmentFile.test.ts
@@ -242,7 +242,7 @@ describe("safeParseTreatmentFile — condition unrecognized keys", () => {
         type: "submitButton",
         conditions: [
           {
-            reference: "prompt.something",
+            reference: "self.prompt.something",
             comparator: "equals",
             value: "ok",
             val: 3,
@@ -260,7 +260,7 @@ describe("safeParseTreatmentFile — condition unrecognized keys", () => {
     );
     expect(issue).toBeDefined();
     expect(issue!.message).toBe(
-      "Unrecognized key 'val' on condition with comparator 'equals'. Did you mean 'value'? Valid keys: reference, position, comparator, value",
+      "Unrecognized key 'val' on condition with comparator 'equals'. Did you mean 'value'? Valid keys: reference, comparator, value",
     );
   });
 });

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -24,14 +24,14 @@ import { resolvedTreatmentSchema } from "./resolved.js";
 
 // ----------- Reference Schema ------------
 test("reference with valid prompt", () => {
-  const reference = "prompt.namedPrompt";
+  const reference = "self.prompt.namedPrompt";
   const result = referenceSchema.safeParse(reference);
   if (!result.success) console.log(result.error);
   expect(result.success).toBe(true);
 });
 
 test("reference with valid survey", () => {
-  const reference = "survey.namedSurvey.results.namedResult";
+  const reference = "self.survey.namedSurvey.results.namedResult";
   const result = referenceSchema.safeParse(reference);
   if (!result.success) console.log(result.error);
   expect(result.success).toBe(true);
@@ -54,35 +54,35 @@ test("reference prompt with no name", () => {
 });
 
 test("reference survey with no path is now valid (named source — path is optional, #240)", () => {
-  const reference = "survey.namedSurvey";
+  const reference = "self.survey.namedSurvey";
   const result = referenceSchema.safeParse(reference);
   if (!result.success) console.log(result.error);
   expect(result.success).toBe(true);
 });
 
 test("reference tracked link with name", () => {
-  const reference = "trackedLink.followUp.events";
+  const reference = "self.trackedLink.followUp.events";
   const result = referenceSchema.safeParse(reference);
   if (!result.success) console.log(result.error);
   expect(result.success).toBe(true);
 });
 
 test("reference timeline with name", () => {
-  const reference = "timeline.storySegment";
+  const reference = "self.timeline.storySegment";
   const result = referenceSchema.safeParse(reference);
   if (!result.success) console.log(result.error);
   expect(result.success).toBe(true);
 });
 
 test("reference timeline with nested path", () => {
-  const reference = "timeline.storySegment.0.start";
+  const reference = "self.timeline.storySegment.0.start";
   const result = referenceSchema.safeParse(reference);
   if (!result.success) console.log(result.error);
   expect(result.success).toBe(true);
 });
 
 test("reference timeline with no name", () => {
-  const reference = "timeline";
+  const reference = "self.timeline";
   const result = referenceSchema.safeParse(reference);
   if (!result.success)
     console.log(result.error.message, "\npath:", result.error.path);
@@ -96,8 +96,7 @@ test("reference timeline with no name", () => {
 
 test("validCondition", () => {
   const condition = {
-    reference: "prompt.namedPrompt",
-    position: 1,
+    reference: "1.prompt.namedPrompt",
     comparator: "equals",
     value: "value",
   };
@@ -147,14 +146,12 @@ test("prompt element validation", () => {
     file: "projects/example/testDisplay00.prompt.md",
     conditions: [
       {
-        reference: "prompt.namedPrompt",
-        position: 1,
+        reference: "1.prompt.namedPrompt",
         comparator: "equals",
         value: "value",
       },
       {
-        reference: "prompt.namedPrompt",
-        position: 2,
+        reference: "2.prompt.namedPrompt",
         comparator: "equals",
         value: "value2",
       },
@@ -189,14 +186,12 @@ test("multiple elements validation", () => {
       file: "projects/example/testDisplay01.prompt.md",
       conditions: [
         {
-          reference: "prompt.namedPrompt",
-          position: 1,
+          reference: "1.prompt.namedPrompt",
           comparator: "equals",
           value: "value",
         },
         {
-          reference: "prompt.namedPrompt",
-          position: 2,
+          reference: "2.prompt.namedPrompt",
           comparator: "equals",
           value: "value2",
         },
@@ -219,8 +214,7 @@ test("tracked link element validation", () => {
         { key: "token", value: "abc123" },
         {
           key: "name",
-          reference: "prompt.namedPrompt",
-          position: "player",
+          reference: "self.prompt.namedPrompt",
         },
       ],
     },
@@ -285,7 +279,7 @@ test("validate entire file", () => {
                 file: "projects/example/testDisplay00.prompt.md",
                 conditions: [
                   {
-                    reference: "prompt.introNamedPrompt",
+                    reference: "self.prompt.introNamedPrompt",
                     comparator: "equals",
                     value: "value",
                   },
@@ -319,14 +313,12 @@ test("validate entire file", () => {
                 file: "projects/example/testDisplay00.prompt.md",
                 conditions: [
                   {
-                    reference: "prompt.namedPrompt",
-                    position: 1,
+                    reference: "1.prompt.namedPrompt",
                     comparator: "equals",
                     value: "value",
                   },
                   {
-                    reference: "prompt.namedPrompt",
-                    position: 2,
+                    reference: "2.prompt.namedPrompt",
                     comparator: "equals",
                     value: "value2",
                   },
@@ -338,14 +330,12 @@ test("validate entire file", () => {
                 file: "projects/example/testDisplay01.prompt.md",
                 conditions: [
                   {
-                    reference: "prompt.namedPrompt",
-                    position: 1,
+                    reference: "1.prompt.namedPrompt",
                     comparator: "equals",
                     value: "value",
                   },
                   {
-                    reference: "prompt.namedPrompt",
-                    position: 2,
+                    reference: "2.prompt.namedPrompt",
                     comparator: "equals",
                     value: "value2",
                   },
@@ -421,9 +411,8 @@ test("discussion with conditions is valid", () => {
     showTitle: true,
     conditions: [
       {
-        reference: "prompt.setupChoice",
+        reference: "0.prompt.setupChoice",
         comparator: "equals",
-        position: 0,
         value: "HTML",
       },
     ],
@@ -440,13 +429,12 @@ test("discussion with multiple conditions is valid", () => {
     showTitle: true,
     conditions: [
       {
-        reference: "prompt.setupChoice",
+        reference: "0.prompt.setupChoice",
         comparator: "equals",
-        position: 0,
         value: "HTML",
       },
       {
-        reference: "survey.priorRound.responses.consensus",
+        reference: "self.survey.priorRound.responses.consensus",
         comparator: "doesNotEqual",
         value: "yes",
       },
@@ -1456,10 +1444,9 @@ test("stageSchema accepts stage-level conditions with a cross-client position", 
     duration: 120,
     conditions: [
       {
-        reference: "survey.continueVote.responses.keepGoing",
+        reference: "shared.survey.continueVote.responses.keepGoing",
         comparator: "equals",
         value: "yes",
-        position: "shared",
       },
     ],
     elements: [{ type: "submitButton" }],
@@ -1468,60 +1455,23 @@ test("stageSchema accepts stage-level conditions with a cross-client position", 
   expect(result.success).toBe(true);
 });
 
-test("stageSchema rejects stage-level conditions with the dropped aggregator position 'all' (#238)", () => {
-  // `position: "all"` is no longer a valid leaf value — fan-out
-  // moved to the boolean-tree operators (#235). Authors migrate via
-  // `all: [{position: 0, ...}, {position: 1, ...}]`.
+test("stageSchema accepts stage-level conditions with `all.X` reference (cross-client list, #298)", () => {
+  // After #298, `all.X` is a list-returning reference (one entry per
+  // participant). It's cross-client safe — every client resolves the
+  // same list — so it's allowed at game-stage level.
   const result = stageSchema.safeParse({
     name: "r2",
     duration: 120,
     conditions: [
       {
-        reference: "survey.continueVote.responses.keepGoing",
+        reference: "all.survey.continueVote.responses.keepGoing",
         comparator: "equals",
         value: "yes",
-        position: "all",
       },
     ],
     elements: [{ type: "submitButton" }],
   });
-  expect(result.success).toBe(false);
-});
-
-test("stageSchema rejects stage-level conditions with the dropped aggregator position 'any' (#238)", () => {
-  const result = stageSchema.safeParse({
-    name: "r2",
-    duration: 120,
-    conditions: [
-      {
-        reference: "survey.continueVote.responses.keepGoing",
-        comparator: "equals",
-        value: "yes",
-        position: "any",
-      },
-    ],
-    elements: [{ type: "submitButton" }],
-  });
-  expect(result.success).toBe(false);
-});
-
-test("stageSchema rejects stage-level conditions with the dropped aggregator position 'percentAgreement' (#238)", () => {
-  // `percentAgreement` was pulled out entirely — no migration; a
-  // future countables/aggregates family will cover its use cases.
-  const result = stageSchema.safeParse({
-    name: "r2",
-    duration: 120,
-    conditions: [
-      {
-        reference: "survey.continueVote.responses.keepGoing",
-        comparator: "isAtLeast",
-        value: 60,
-        position: "percentAgreement",
-      },
-    ],
-    elements: [{ type: "submitButton" }],
-  });
-  expect(result.success).toBe(false);
+  expect(result.success).toBe(true);
 });
 
 test("stageSchema accepts the boolean-tree migration of `position: all` — `all:` operator with explicit slot-index leaves", () => {
@@ -1534,16 +1484,14 @@ test("stageSchema accepts the boolean-tree migration of `position: all` — `all
     conditions: {
       all: [
         {
-          reference: "survey.continueVote.responses.keepGoing",
+          reference: "0.survey.continueVote.responses.keepGoing",
           comparator: "equals",
           value: "yes",
-          position: 0,
         },
         {
-          reference: "survey.continueVote.responses.keepGoing",
+          reference: "1.survey.continueVote.responses.keepGoing",
           comparator: "equals",
           value: "yes",
-          position: 1,
         },
       ],
     },
@@ -1553,16 +1501,19 @@ test("stageSchema accepts the boolean-tree migration of `position: all` — `all
   expect(result.success).toBe(true);
 });
 
-test("stageSchema rejects stage-level conditions with default position (implicit player)", () => {
+test("stageSchema rejects stage-level conditions with `self` position prefix (#298)", () => {
+  // After #298, position is part of the reference itself. `self.X` at
+  // a game-stage condition would desync (one client sees this player's
+  // value, another sees their own); rejected with a cross-client
+  // migration hint.
   const result = stageSchema.safeParse({
     name: "r2",
     duration: 120,
     conditions: [
       {
-        reference: "prompt.vote",
+        reference: "self.prompt.vote",
         comparator: "equals",
         value: "yes",
-        // no position → defaults to per-player, would desync
       },
     ],
     elements: [{ type: "submitButton" }],
@@ -1570,32 +1521,9 @@ test("stageSchema rejects stage-level conditions with default position (implicit
   expect(result.success).toBe(false);
   if (!result.success) {
     const issue = result.error.issues.find(
-      (i) => i.path.join(".") === "conditions.0.position",
+      (i) => i.path.join(".") === "conditions.0.reference",
     );
-    expect(issue?.message).toMatch(/cross-client position/);
-  }
-});
-
-test("stageSchema rejects stage-level conditions with explicit position: player", () => {
-  const result = stageSchema.safeParse({
-    name: "r2",
-    duration: 120,
-    conditions: [
-      {
-        reference: "prompt.vote",
-        comparator: "equals",
-        value: "yes",
-        position: "player",
-      },
-    ],
-    elements: [{ type: "submitButton" }],
-  });
-  expect(result.success).toBe(false);
-  if (!result.success) {
-    const issue = result.error.issues.find(
-      (i) => i.path.join(".") === "conditions.0.position",
-    );
-    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/cross-client position prefix/);
   }
 });
 
@@ -1605,7 +1533,7 @@ test("introExitStepSchema allows stage-level conditions with any position, inclu
     conditions: [
       // Intro/exit is per-participant — default (player) position is fine
       {
-        reference: "entryUrl.params.showOptionalInfo",
+        reference: "self.entryUrl.params.showOptionalInfo",
         comparator: "equals",
         value: "true",
       },
@@ -1616,82 +1544,24 @@ test("introExitStepSchema allows stage-level conditions with any position, inclu
   expect(result.success).toBe(true);
 });
 
-test("stageSchema rejects element-level conditions with the dropped position 'percentAgreement' (#238)", () => {
-  // `percentAgreement` was the numeric-aggregate read selector before
-  // #238; it was pulled out entirely (no migration). Element-level
-  // conditions, like stage-level, now reject it as an invalid enum
-  // value. Authors with existing percentAgreement conditions need to
-  // either rewrite as explicit per-player checks or drop the
-  // condition pending the future countables/aggregates family.
-  const result = stageSchema.safeParse({
-    name: "r2",
-    duration: 120,
-    elements: [
-      {
-        type: "prompt",
-        file: "p.prompt.md",
-        conditions: [
-          {
-            reference: "survey.vote.result.x",
-            comparator: "isAtLeast",
-            value: 60,
-            position: "percentAgreement",
-          },
-        ],
-      },
-      { type: "submitButton" },
-    ],
-  });
-  expect(result.success).toBe(false);
-});
+// Tests for the pre-#298 dropped position selectors (`all`, `any`,
+// `percentAgreement` as leaf-position values) are removed in favor of
+// the position-prefixed reference grammar. The relevant rejections now
+// surface as either invalid-reference errors (parser rejects unknown
+// position selectors) or game-stage forbid-self errors (see below).
 
-test("introExitStepSchema rejects the dropped position 'percentAgreement' (#238)", () => {
-  const result = introExitStepSchema.safeParse({
-    name: "debrief",
-    conditions: [
-      {
-        reference: "survey.feedback.result.x",
-        comparator: "isAtLeast",
-        value: 60,
-        position: "percentAgreement",
-      },
-    ],
-    elements: [{ type: "submitButton" }],
-  });
-  expect(result.success).toBe(false);
-});
-
-test("introExitStepSchema rejects the dropped aggregator positions 'all' / 'any' (#238)", () => {
-  for (const dropped of ["all", "any"] as const) {
-    const result = introExitStepSchema.safeParse({
-      name: "debrief",
-      conditions: [
-        {
-          reference: "prompt.q",
-          comparator: "equals",
-          value: "yes",
-          position: dropped,
-        },
-      ],
-      elements: [{ type: "submitButton" }],
-    });
-    expect(result.success).toBe(false);
-  }
-});
-
-test("game-stage forbidSelfPosition error message points at the boolean-tree migration recipe (#238)", () => {
-  // The error message that fires when an author writes a per-player
-  // position on a game stage now suggests the `all:` / `any:` operator
-  // migration rather than mentioning the dropped aggregator values.
+test("game-stage forbid-self error message points at the boolean-tree migration recipe (#298)", () => {
+  // When an author writes `self.X` at a game stage, the desync-prevention
+  // rule fires with a message suggesting the `all:` / `any:` operator
+  // migration with explicit slot indices.
   const result = stageSchema.safeParse({
     name: "r2",
     duration: 120,
     conditions: [
       {
-        reference: "prompt.vote",
+        reference: "self.prompt.vote",
         comparator: "equals",
         value: "yes",
-        position: "player",
       },
     ],
     elements: [{ type: "submitButton" }],
@@ -1699,10 +1569,9 @@ test("game-stage forbidSelfPosition error message points at the boolean-tree mig
   expect(result.success).toBe(false);
   if (!result.success) {
     const issue = result.error.issues.find(
-      (i) => i.path.join(".") === "conditions.0.position",
+      (i) => i.path.join(".") === "conditions.0.reference",
     );
-    expect(issue?.message).toMatch(/cross-client position \(shared/);
-    expect(issue?.message).not.toMatch(/percentAgreement/);
+    expect(issue?.message).toMatch(/cross-client position prefix/);
     expect(issue?.message).toMatch(/`all:` or `any:` operator/);
   }
 });
@@ -1710,7 +1579,7 @@ test("game-stage forbidSelfPosition error message points at the boolean-tree mig
 // ----------- Boolean condition tree (#235) ------------
 
 const leaf = (value: string) => ({
-  reference: "prompt.q",
+  reference: "self.prompt.q",
   comparator: "equals" as const,
   value,
 });
@@ -1781,7 +1650,7 @@ test("conditionsSchema rejects extra keys on operator object", () => {
   // `{all: [...], reference: ...}` etc. as ambiguous shapes.
   const result = conditionsSchema.safeParse({
     all: [leaf("a")],
-    reference: "prompt.q",
+    reference: "self.prompt.q",
   });
   expect(result.success).toBe(false);
 });
@@ -1833,14 +1702,12 @@ test("stageSchema accepts boolean-tree conditions", () => {
     conditions: {
       any: [
         {
-          reference: "prompt.consent",
-          position: 0,
+          reference: "0.prompt.consent",
           comparator: "equals",
           value: "yes",
         },
         {
-          reference: "prompt.consent",
-          position: 1,
+          reference: "1.prompt.consent",
           comparator: "equals",
           value: "yes",
         },
@@ -1860,7 +1727,7 @@ test("validateConditionRules recurses into operator branches (game-stage forbidS
     conditions: {
       any: [
         {
-          reference: "prompt.q",
+          reference: "self.prompt.q",
           comparator: "equals",
           value: "yes",
           // position omitted — defaults to "player", forbidden at
@@ -1997,7 +1864,9 @@ test("template: contentType 'conditions' validates a condition array", () => {
   const result = templateSchema.safeParse({
     name: "wantsToProceed",
     contentType: "conditions",
-    content: [{ reference: "prompt.q1", comparator: "equals", value: "yes" }],
+    content: [
+      { reference: "self.prompt.q1", comparator: "equals", value: "yes" },
+    ],
   });
   expect(result.success).toBe(true);
 });
@@ -2190,16 +2059,16 @@ test("validElementTypes does not include talkMeter or sharedNotepad", async () =
 // ----------- entryUrl rename (#246) ------------
 
 test("entryUrl.params.<key> string reference is accepted", () => {
-  const result = referenceSchema.safeParse("entryUrl.params.condition");
+  const result = referenceSchema.safeParse("self.entryUrl.params.condition");
   expect(result.success).toBe(true);
 });
 
 test("entryUrl bare-key string reference is rejected (`params` subpath required)", () => {
-  const result = referenceSchema.safeParse("entryUrl.condition");
+  const result = referenceSchema.safeParse("self.entryUrl.condition");
   expect(result.success).toBe(false);
   if (!result.success) {
     const message = result.error.issues.map((i) => i.message).join("\n");
-    expect(message).toContain("entryUrl.params");
+    expect(message).toContain("self.entryUrl.params");
   }
 });
 
@@ -2208,28 +2077,31 @@ test("legacy urlParams.<key> string reference is rejected with a migration hint"
   expect(result.success).toBe(false);
   if (!result.success) {
     const message = result.error.issues.map((i) => i.message).join("\n");
-    expect(message).toContain("entryUrl.params");
+    expect(message).toContain("self.entryUrl.params");
   }
 });
 
-test("structured `{source: entryUrl, path: [params, key]}` is accepted", () => {
+test("structured `{position, source: entryUrl, path: [params, key]}` is accepted", () => {
   const result = referenceSchema.safeParse({
+    position: "self",
     source: "entryUrl",
     path: ["params", "condition"],
   });
   expect(result.success).toBe(true);
 });
 
-test("structured `{source: entryUrl, path: [<key>]}` is rejected", () => {
+test("structured `{position, source: entryUrl, path: [<key>]}` is rejected", () => {
   const result = referenceSchema.safeParse({
+    position: "self",
     source: "entryUrl",
     path: ["condition"],
   });
   expect(result.success).toBe(false);
 });
 
-test("structured `{source: entryUrl, name: ...}` is rejected (external sources forbid name)", () => {
+test("structured `{position, source: entryUrl, name: ...}` is rejected (external sources forbid name)", () => {
   const result = referenceSchema.safeParse({
+    position: "self",
     source: "entryUrl",
     name: "condition",
     path: ["params", "x"],
@@ -2324,7 +2196,7 @@ test("top-level conditions accepts a ${field} placeholder (#284)", () => {
 
 test("top-level conditions still accepts an array literal (no regression)", () => {
   const result = conditionsSchema.safeParse([
-    { reference: "prompt.q1", comparator: "exists" },
+    { reference: "self.prompt.q1", comparator: "exists" },
   ]);
   expect(result.success).toBe(true);
 });

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -7,11 +7,14 @@ import {
   namedSourceEnum,
   externalSourceEnum,
   referenceSchema,
+  parseDottedReference,
+  positionSelectorSchema,
   type ReferenceType,
   type NamedReferenceType,
   type ExternalReferenceType,
   type NamedSource,
   type ExternalSource,
+  type PositionSelectorType,
 } from "./reference.js";
 
 // Re-exports so consumers' existing imports from `./treatment.js` keep
@@ -21,11 +24,13 @@ export {
   namedSourceEnum,
   externalSourceEnum,
   referenceSchema,
+  positionSelectorSchema,
   type ReferenceType,
   type NamedReferenceType,
   type ExternalReferenceType,
   type NamedSource,
   type ExternalSource,
+  type PositionSelectorType,
 };
 export { parseDottedReference, formatReference } from "./reference.js";
 
@@ -192,11 +197,10 @@ export type HideTimeType = z.infer<typeof hideTimeSchema>;
 export const positionSchema = z.number().int().nonnegative();
 export type PositionType = z.infer<typeof positionSchema>;
 
-export const positionSelectorSchema = z
-  .enum(["shared", "player", "all", "any"])
-  .or(positionSchema)
-  .default("player");
-export type PositionSelectorType = z.infer<typeof positionSelectorSchema>;
+// Position selector for *references* lives in `reference.ts` after #298 —
+// re-exported via the schemas barrel. Reference-using sites no longer
+// have a sibling `position:` field; the position is part of the reference
+// itself (e.g. `0.prompt.recall.value`).
 
 export const showToPositionsSchema = z
   .array(positionSchema, {
@@ -563,18 +567,12 @@ function altTemplateContext<T extends z.ZodTypeAny>(baseSchema: T) {
 
 const baseConditionSchema = z
   .object({
+    // After #298 the position selector is part of the reference itself
+    // (e.g. `0.prompt.X.value`, `self.entryUrl.params.condition`).
+    // The pre-#298 sibling `position:` field is removed; the
+    // game-stage rule that forbade `player`/`self` references at the
+    // stage level reads the position from the parsed reference now.
     reference: referenceSchema,
-    // `position` on a condition leaf is a pure read selector (#238):
-    // where to read the referenced value from. Cross-player aggregation
-    // (`all` / `any`) lives in the boolean-tree operators (#235); the
-    // numeric `percentAgreement` aggregator was pulled out entirely
-    // (no migration — see issue #238 for context). The game-stage
-    // `forbidSelfPosition` rule (below) still rejects default/explicit
-    // `player` at the game-stage level for the same desync reason.
-    position: z
-      .enum(["shared", "player"])
-      .or(z.number().nonnegative().int())
-      .optional(),
   })
   .strict();
 
@@ -790,10 +788,12 @@ export const conditionSchema = conditionNodeSchema;
 // they would evaluate to a different result on each participant's client
 // — causing one participant to skip a stage while the other renders it.
 // Intro/exit steps are per-participant and have no such constraint.
-const GAME_STAGE_FORBIDDEN_POSITIONS = new Set([
-  "player",
-  "self", // not in the schema today but guard against future additions
-]);
+//
+// After #298 the position lives inside the reference itself, so this
+// check inspects the parsed reference's `position` field. The forbidden
+// selector is `self` (formerly `player`); numeric indices and `shared`
+// are cross-client safe; `all` returns a list and is also safe.
+const GAME_STAGE_FORBIDDEN_POSITIONS = new Set(["self"]);
 
 /**
  * Validate that every `type: "timeline"` element's `source` names a
@@ -909,33 +909,55 @@ function validateConditionRules(
   // Leaf condition: apply the per-leaf rules. The path prefix already
   // points at the condition's location.
   const c = node as {
-    position?: unknown;
+    reference?: unknown;
     comparator?: unknown;
     value?: unknown;
   };
 
   // Game-stage conditions must evaluate identically on every client or
-  // they'll desync (one player skips, the other renders). The default
-  // position is "player", which reads this participant's own data — so
-  // we reject both missing and explicitly "player". After #238 the
-  // cross-client read selectors are `shared` or a numeric slot index;
-  // cross-player aggregation lives in the boolean-tree operators (#235).
-  if (
-    options.forbidSelfPosition &&
-    (c.position === undefined ||
-      (typeof c.position === "string" &&
-        GAME_STAGE_FORBIDDEN_POSITIONS.has(c.position)))
-  ) {
-    const shown =
-      c.position === undefined
-        ? "(default: player)"
-        : `"${String(c.position)}"`;
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: [...pathPrefix, "position"],
-      message: `${options.contextLabel} conditions must use a cross-client position (shared, or a numeric slot index) — got ${shown}. Per-player positions would let one participant skip the stage while the other renders it. For per-player aggregation, wrap leaves in an \`all:\` or \`any:\` operator with explicit slot-index leaves.`,
-    });
+  // they'll desync (one player skips, the other renders). After #298
+  // the position lives inside the reference itself; we extract it and
+  // reject `self` (per-participant). Numeric slot indices, `shared`,
+  // and `all` are cross-client safe.
+  if (options.forbidSelfPosition) {
+    const refPosition = extractReferencePosition(c.reference);
+    if (
+      typeof refPosition === "string" &&
+      GAME_STAGE_FORBIDDEN_POSITIONS.has(refPosition)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [...pathPrefix, "reference"],
+        message: `${options.contextLabel} conditions must use a cross-client position prefix on the reference (\`shared\`, a numeric slot index, or \`all\`) — got \`self\`. Per-participant references would let one participant skip the stage while the other renders it. For per-participant aggregation, wrap leaves in an \`all:\` or \`any:\` operator with explicit slot-index references.`,
+      });
+    }
   }
+}
+
+/**
+ * Extract the position selector from a reference field, regardless of
+ * whether the reference is in dotted-string form or already structured.
+ * Returns `undefined` if the position can't be determined (e.g., the
+ * reference is invalid or a template placeholder).
+ */
+function extractReferencePosition(
+  reference: unknown,
+): number | string | undefined {
+  if (typeof reference === "string") {
+    const parsed = parseDottedReference(reference);
+    if (parsed.ok) return parsed.value.position;
+    return undefined;
+  }
+  if (
+    reference &&
+    typeof reference === "object" &&
+    "position" in reference &&
+    (typeof (reference as { position: unknown }).position === "string" ||
+      typeof (reference as { position: unknown }).position === "number")
+  ) {
+    return (reference as { position: number | string }).position;
+  }
+  return undefined;
 }
 
 // Field-level conditions schema (#235): accepts either a flat array
@@ -1088,8 +1110,11 @@ const imageSchema = elementBaseSchema
 const displaySchema = elementBaseSchema
   .extend({
     type: z.literal("display"),
+    // Per #298 the position is part of the reference itself
+    // (e.g. `all.prompt.recall.value` to render every participant's
+    // value, `0.prompt.notes.value` to render position 0's). The
+    // pre-#298 sibling `position:` field is removed.
     reference: referenceSchema,
-    position: positionSelectorSchema,
   })
   .strict();
 
@@ -1274,8 +1299,8 @@ const trackedLinkParamSchema = z
     value: z
       .union([z.string(), z.number(), z.boolean(), fieldPlaceholderSchema])
       .optional(),
+    // Per #298 the position is part of the reference itself.
     reference: referenceSchema.optional(),
-    position: positionSelectorSchema.optional(),
   })
   .strict()
   .superRefine((data, ctx) => {

--- a/packages/stagebook/src/schemas/validateReferences.test.ts
+++ b/packages/stagebook/src/schemas/validateReferences.test.ts
@@ -79,10 +79,9 @@ describe("Rule 1 — no forward references", () => {
           duration: 60,
           conditions: [
             {
-              reference: "prompt.laterAnswer",
+              reference: "shared.prompt.laterAnswer",
               comparator: "equals",
               value: "yes",
-              position: "shared",
             },
           ],
           elements: [{ type: "submitButton" }],
@@ -121,7 +120,7 @@ describe("Rule 1 — no forward references", () => {
               type: "submitButton",
               conditions: [
                 {
-                  reference: "prompt.laterAnswer",
+                  reference: "self.prompt.laterAnswer",
                   comparator: "equals",
                   value: "yes",
                 },
@@ -159,7 +158,7 @@ describe("Rule 1 — no forward references", () => {
           name: "s1",
           duration: 60,
           elements: [
-            { type: "display", reference: "prompt.laterAnswer" },
+            { type: "display", reference: "self.prompt.laterAnswer" },
             { type: "submitButton" },
           ],
         },
@@ -198,7 +197,9 @@ describe("Rule 1 — no forward references", () => {
               name: "signup",
               url: "https://example.org",
               displayText: "Go",
-              urlParams: [{ key: "answer", reference: "prompt.laterAnswer" }],
+              urlParams: [
+                { key: "answer", reference: "self.prompt.laterAnswer" },
+              ],
             },
           ],
         },
@@ -235,7 +236,7 @@ describe("Rule 1 — no forward references", () => {
             {
               type: "qualtrics",
               url: "https://upenn.qualtrics.com/jfe/form/SV_x",
-              urlParams: [{ key: "x", reference: "prompt.laterAnswer" }],
+              urlParams: [{ key: "x", reference: "self.prompt.laterAnswer" }],
             },
           ],
         },
@@ -274,10 +275,9 @@ describe("Rule 1 — no forward references", () => {
             showTitle: false,
             conditions: [
               {
-                reference: "prompt.laterAnswer",
+                reference: "shared.prompt.laterAnswer",
                 comparator: "equals",
                 value: "yes",
-                position: "shared",
               },
             ],
           },
@@ -314,7 +314,7 @@ describe("Rule 1 — no forward references", () => {
           title: "Confederate",
           conditions: [
             {
-              reference: "prompt.gameStageAnswer",
+              reference: "self.prompt.gameStageAnswer",
               comparator: "equals",
               value: "yes",
             },
@@ -325,7 +325,7 @@ describe("Rule 1 — no forward references", () => {
           title: "Participant",
           conditions: [
             {
-              reference: "prompt.gameStageAnswer",
+              reference: "self.prompt.gameStageAnswer",
               comparator: "doesNotEqual",
               value: "yes",
             },
@@ -373,7 +373,7 @@ describe("Rule 1 — no forward references", () => {
           title: "D",
           conditions: [
             {
-              reference: "prompt.partyAffiliation",
+              reference: "self.prompt.partyAffiliation",
               comparator: "equals",
               value: "democrat",
             },
@@ -384,7 +384,7 @@ describe("Rule 1 — no forward references", () => {
           title: "R",
           conditions: [
             {
-              reference: "prompt.partyAffiliation",
+              reference: "self.prompt.partyAffiliation",
               comparator: "equals",
               value: "republican",
             },
@@ -405,7 +405,7 @@ describe("Rule 1 — no forward references", () => {
           name: "welcome",
           conditions: [
             {
-              reference: "prompt.gameAnswer",
+              reference: "self.prompt.gameAnswer",
               comparator: "equals",
               value: "yes",
             },
@@ -440,7 +440,7 @@ describe("Rule 1 — no forward references", () => {
         {
           name: "welcome",
           elements: [
-            { type: "display", reference: "prompt.gameAnswer" },
+            { type: "display", reference: "self.prompt.gameAnswer" },
             { type: "submitButton" },
           ],
         },
@@ -479,7 +479,7 @@ describe("Rule 1 — no forward references", () => {
           elements: [
             {
               type: "display",
-              reference: "survey.MySurvey.result.answer",
+              reference: "self.survey.MySurvey.result.answer",
             },
             { type: "submitButton" },
           ],
@@ -512,16 +512,15 @@ describe("Rule 1 — no forward references", () => {
           duration: 60,
           conditions: [
             {
-              reference: "entryUrl.params.cohort",
+              reference: "shared.entryUrl.params.cohort",
               comparator: "equals",
               value: "a",
-              position: "shared",
             },
           ],
           elements: [
             {
               type: "display",
-              reference: "participantInfo.playerId",
+              reference: "self.participantInfo.playerId",
             },
             { type: "submitButton" },
           ],
@@ -548,10 +547,9 @@ describe("Rule 1 — no forward references", () => {
           duration: 60,
           conditions: [
             {
-              reference: "prompt.early",
+              reference: "shared.prompt.early",
               comparator: "equals",
               value: "yes",
-              position: "shared",
             },
           ],
           elements: [{ type: "submitButton" }],
@@ -579,10 +577,9 @@ describe("Rule 1 — no forward references", () => {
           name: "debrief",
           conditions: [
             {
-              reference: "prompt.main",
+              reference: "shared.prompt.main",
               comparator: "equals",
               value: "yes",
-              position: "shared",
             },
           ],
           elements: [{ type: "submitButton" }],
@@ -620,7 +617,7 @@ describe("Unknown-reference detection", () => {
               type: "submitButton",
               conditions: [
                 {
-                  reference: "timeline.storySegment2",
+                  reference: "self.timeline.storySegment2",
                   comparator: "exists",
                 },
               ],
@@ -646,10 +643,9 @@ describe("Unknown-reference detection", () => {
           duration: 60,
           conditions: [
             {
-              reference: "prompt.nonexistent",
+              reference: "shared.prompt.nonexistent",
               comparator: "equals",
               value: "yes",
-              position: "shared",
             },
           ],
           elements: [{ type: "submitButton" }],
@@ -705,7 +701,7 @@ describe("Unknown-reference detection", () => {
               elements: [
                 {
                   type: "display",
-                  reference: "prompt.templatedPrompt",
+                  reference: "self.prompt.templatedPrompt",
                 },
                 { type: "submitButton" },
               ],
@@ -735,7 +731,7 @@ describe("Unknown-reference detection", () => {
               type: "submitButton",
               conditions: [
                 {
-                  reference: "discussion.someRoom.messages",
+                  reference: "self.discussion.someRoom.messages",
                   comparator: "exists",
                 },
               ],
@@ -757,7 +753,7 @@ describe("Unknown-reference detection", () => {
           elements: [
             {
               type: "display",
-              reference: "entryUrl.params.neverDeclared",
+              reference: "self.entryUrl.params.neverDeclared",
             },
             { type: "submitButton" },
           ],
@@ -778,9 +774,8 @@ describe("Rule 2 — stage-level always-skip-at-load (current-stage refs only)",
           duration: 60,
           conditions: [
             {
-              reference: "submitButton.speedSubmit",
+              reference: "shared.submitButton.speedSubmit",
               comparator: "doesNotExist",
-              position: "shared",
             },
           ],
           elements: [{ type: "submitButton", name: "speedSubmit" }],
@@ -799,9 +794,8 @@ describe("Rule 2 — stage-level always-skip-at-load (current-stage refs only)",
           duration: 60,
           conditions: [
             {
-              reference: "submitButton.s",
+              reference: "shared.submitButton.s",
               comparator: "exists",
-              position: "shared",
             },
           ],
           elements: [{ type: "submitButton", name: "s" }],
@@ -825,10 +819,9 @@ describe("Rule 2 — stage-level always-skip-at-load (current-stage refs only)",
           duration: 60,
           conditions: [
             {
-              reference: "prompt.currentAnswer",
+              reference: "shared.prompt.currentAnswer",
               comparator: "equals",
               value: "yes",
-              position: "shared",
             },
           ],
           elements: [
@@ -869,7 +862,7 @@ describe("Rule 2 — stage-level always-skip-at-load (current-stage refs only)",
               type: "submitButton",
               conditions: [
                 {
-                  reference: "prompt.currentAnswer",
+                  reference: "self.prompt.currentAnswer",
                   comparator: "equals",
                   value: "yes",
                 },
@@ -895,7 +888,7 @@ describe("Rule 2 — stage-level always-skip-at-load (current-stage refs only)",
               name: "currentAnswer",
               file: "c.prompt.md",
             },
-            { type: "display", reference: "prompt.currentAnswer" },
+            { type: "display", reference: "self.prompt.currentAnswer" },
             { type: "submitButton" },
           ],
         },
@@ -922,7 +915,7 @@ describe("Rule 2 — stage-level always-skip-at-load (current-stage refs only)",
               name: "link",
               url: "https://example.org",
               displayText: "Go",
-              urlParams: [{ key: "a", reference: "prompt.currentAnswer" }],
+              urlParams: [{ key: "a", reference: "self.prompt.currentAnswer" }],
             },
           ],
         },
@@ -947,10 +940,9 @@ describe("Rule 2 with boolean-tree operators (#235)", () => {
           duration: 60,
           conditions: [
             {
-              reference: "prompt.q",
+              reference: "shared.prompt.q",
               comparator: "equals",
               value: "yes",
-              position: "shared",
             },
           ],
           elements: [
@@ -976,10 +968,9 @@ describe("Rule 2 with boolean-tree operators (#235)", () => {
           conditions: {
             all: [
               {
-                reference: "prompt.q",
+                reference: "shared.prompt.q",
                 comparator: "equals",
                 value: "yes",
-                position: "shared",
               },
             ],
           } as unknown as Record<string, unknown>[],
@@ -1011,16 +1002,14 @@ describe("Rule 2 with boolean-tree operators (#235)", () => {
           conditions: {
             any: [
               {
-                reference: "prompt.q",
+                reference: "shared.prompt.q",
                 comparator: "equals",
                 value: "yes",
-                position: "shared",
               },
               {
-                reference: "prompt.r",
+                reference: "shared.prompt.r",
                 comparator: "equals",
                 value: "yes",
-                position: "shared",
               },
             ],
           } as unknown as Record<string, unknown>[],
@@ -1051,10 +1040,9 @@ describe("Rule 2 with boolean-tree operators (#235)", () => {
           conditions: {
             none: [
               {
-                reference: "prompt.q",
+                reference: "shared.prompt.q",
                 comparator: "equals",
                 value: "yes",
-                position: "shared",
               },
             ],
           } as unknown as Record<string, unknown>[],
@@ -1083,10 +1071,9 @@ describe("Rule 2 with boolean-tree operators (#235)", () => {
               {
                 any: [
                   {
-                    reference: "prompt.q",
+                    reference: "shared.prompt.q",
                     comparator: "equals",
                     value: "yes",
-                    position: "shared",
                   },
                 ],
               },
@@ -1116,10 +1103,9 @@ describe("treatmentFileSchema surfaces walker issues via superRefine (red-squigg
           duration: 60,
           conditions: [
             {
-              reference: "prompt.later",
+              reference: "shared.prompt.later",
               comparator: "equals",
               value: "yes",
-              position: "shared",
             },
           ],
           elements: [{ type: "submitButton" }],

--- a/packages/stagebook/src/utils/evaluateConditions.test.ts
+++ b/packages/stagebook/src/utils/evaluateConditions.test.ts
@@ -8,7 +8,7 @@ describe("evaluateCondition", () => {
     test("all values satisfy equals", () => {
       expect(
         evaluateCondition(
-          { reference: "prompt.q1", comparator: "equals", value: "yes" },
+          { reference: "self.prompt.q1", comparator: "equals", value: "yes" },
           ["yes", "yes", "yes"],
         ),
       ).toBe(true);
@@ -17,7 +17,7 @@ describe("evaluateCondition", () => {
     test("fails if any value doesn't satisfy", () => {
       expect(
         evaluateCondition(
-          { reference: "prompt.q1", comparator: "equals", value: "yes" },
+          { reference: "self.prompt.q1", comparator: "equals", value: "yes" },
           ["yes", "no", "yes"],
         ),
       ).toBe(false);
@@ -26,7 +26,7 @@ describe("evaluateCondition", () => {
     test("single value satisfies", () => {
       expect(
         evaluateCondition(
-          { reference: "prompt.q1", comparator: "isAbove", value: 5 },
+          { reference: "self.prompt.q1", comparator: "isAbove", value: 5 },
           [10],
         ),
       ).toBe(true);
@@ -39,7 +39,7 @@ describe("evaluateCondition", () => {
       // "exists" to appear before any prompt was answered.)
       expect(
         evaluateCondition(
-          { reference: "prompt.q1", comparator: "equals", value: "yes" },
+          { reference: "self.prompt.q1", comparator: "equals", value: "yes" },
           [],
         ),
       ).toBe(false);
@@ -47,30 +47,35 @@ describe("evaluateCondition", () => {
 
     test("exists comparator", () => {
       expect(
-        evaluateCondition({ reference: "prompt.q1", comparator: "exists" }, [
-          "some value",
-        ]),
+        evaluateCondition(
+          { reference: "self.prompt.q1", comparator: "exists" },
+          ["some value"],
+        ),
       ).toBe(true);
     });
 
     test("exists fails for undefined", () => {
       expect(
-        evaluateCondition({ reference: "prompt.q1", comparator: "exists" }, [
-          undefined,
-        ]),
+        evaluateCondition(
+          { reference: "self.prompt.q1", comparator: "exists" },
+          [undefined],
+        ),
       ).toBe(false);
     });
 
     test("exists fails for empty array (nothing exists)", () => {
       expect(
-        evaluateCondition({ reference: "prompt.q1", comparator: "exists" }, []),
+        evaluateCondition(
+          { reference: "self.prompt.q1", comparator: "exists" },
+          [],
+        ),
       ).toBe(false);
     });
 
     test("doesNotExist passes for empty array", () => {
       expect(
         evaluateCondition(
-          { reference: "prompt.q1", comparator: "doesNotExist" },
+          { reference: "self.prompt.q1", comparator: "doesNotExist" },
           [],
         ),
       ).toBe(true);
@@ -95,8 +100,7 @@ describe("evaluateCondition", () => {
       expect(
         evaluateCondition(
           {
-            reference: "prompt.q1",
-            position: "any",
+            reference: "all.prompt.q1",
             comparator: "equals",
             value: "yes",
           },
@@ -114,8 +118,7 @@ describe("evaluateCondition", () => {
       expect(
         evaluateCondition(
           {
-            reference: "prompt.q1",
-            position: "percentAgreement",
+            reference: "self.prompt.q1",
             comparator: "isAtLeast",
             value: 80,
           },
@@ -129,7 +132,11 @@ describe("evaluateCondition", () => {
     test("doesNotEqual with undefined lhs returns true", () => {
       expect(
         evaluateCondition(
-          { reference: "prompt.q1", comparator: "doesNotEqual", value: "x" },
+          {
+            reference: "self.prompt.q1",
+            comparator: "doesNotEqual",
+            value: "x",
+          },
           [undefined],
         ),
       ).toBe(true);
@@ -139,7 +146,7 @@ describe("evaluateCondition", () => {
       expect(
         evaluateCondition(
           {
-            reference: "prompt.q1",
+            reference: "self.prompt.q1",
             comparator: "includes",
             value: "world",
           },
@@ -152,7 +159,7 @@ describe("evaluateCondition", () => {
       expect(
         evaluateCondition(
           {
-            reference: "prompt.q1",
+            reference: "self.prompt.q1",
             comparator: "isOneOf",
             value: ["a", "b", "c"],
           },
@@ -177,8 +184,8 @@ describe("evaluateConditions", () => {
   test("single condition met", () => {
     expect(
       evaluateConditions(
-        [{ reference: "prompt.q1", comparator: "equals", value: "yes" }],
-        mockResolve({ "prompt.q1": ["yes"] }),
+        [{ reference: "self.prompt.q1", comparator: "equals", value: "yes" }],
+        mockResolve({ "self.prompt.q1": ["yes"] }),
       ),
     ).toBe(true);
   });
@@ -186,8 +193,8 @@ describe("evaluateConditions", () => {
   test("single condition not met", () => {
     expect(
       evaluateConditions(
-        [{ reference: "prompt.q1", comparator: "equals", value: "yes" }],
-        mockResolve({ "prompt.q1": ["no"] }),
+        [{ reference: "self.prompt.q1", comparator: "equals", value: "yes" }],
+        mockResolve({ "self.prompt.q1": ["no"] }),
       ),
     ).toBe(false);
   });
@@ -196,10 +203,10 @@ describe("evaluateConditions", () => {
     expect(
       evaluateConditions(
         [
-          { reference: "prompt.q1", comparator: "equals", value: "yes" },
-          { reference: "prompt.q2", comparator: "isAbove", value: 5 },
+          { reference: "self.prompt.q1", comparator: "equals", value: "yes" },
+          { reference: "self.prompt.q2", comparator: "isAbove", value: 5 },
         ],
-        mockResolve({ "prompt.q1": ["yes"], "prompt.q2": [10] }),
+        mockResolve({ "self.prompt.q1": ["yes"], "self.prompt.q2": [10] }),
       ),
     ).toBe(true);
   });
@@ -208,10 +215,10 @@ describe("evaluateConditions", () => {
     expect(
       evaluateConditions(
         [
-          { reference: "prompt.q1", comparator: "equals", value: "yes" },
-          { reference: "prompt.q2", comparator: "isAbove", value: 5 },
+          { reference: "self.prompt.q1", comparator: "equals", value: "yes" },
+          { reference: "self.prompt.q2", comparator: "isAbove", value: 5 },
         ],
-        mockResolve({ "prompt.q1": ["yes"], "prompt.q2": [3] }),
+        mockResolve({ "self.prompt.q1": ["yes"], "self.prompt.q2": [3] }),
       ),
     ).toBe(false);
   });
@@ -223,7 +230,13 @@ describe("evaluateConditions", () => {
     // gated on "exists" to appear before any prompt was answered.)
     expect(
       evaluateConditions(
-        [{ reference: "prompt.missing", comparator: "equals", value: "yes" }],
+        [
+          {
+            reference: "self.prompt.missing",
+            comparator: "equals",
+            value: "yes",
+          },
+        ],
         mockResolve({}),
       ),
     ).toBe(false);
@@ -232,7 +245,7 @@ describe("evaluateConditions", () => {
   test("exists on missing reference fails", () => {
     expect(
       evaluateConditions(
-        [{ reference: "prompt.missing", comparator: "exists" }],
+        [{ reference: "self.prompt.missing", comparator: "exists" }],
         mockResolve({}),
       ),
     ).toBe(false);
@@ -241,49 +254,39 @@ describe("evaluateConditions", () => {
   test("doesNotExist on missing reference passes", () => {
     expect(
       evaluateConditions(
-        [{ reference: "prompt.missing", comparator: "doesNotExist" }],
+        [{ reference: "self.prompt.missing", comparator: "doesNotExist" }],
         mockResolve({}),
       ),
     ).toBe(true);
   });
 
-  // ----- Positional comparators by name (issue #232) -----
+  // ----- Positional comparators by name (issue #232, updated for #298) -----
   //
-  // `position: shared`, `position: "0"`, `position: "1"` are host-resolver
-  // concerns — stagebook itself doesn't know what "shared" or numeric
-  // positions mean, it just forwards the position string through to the
-  // host's `resolve(reference, position)` callback. These tests pin the
-  // forwarding contract (so deliberation-empirica-style hosts can rely on
-  // it) and confirm that once values come back, the comparator runs with
-  // default `all` semantics — every returned value must satisfy.
+  // After #298, position is part of the reference string (`shared.X`,
+  // `0.X`, `1.X`, `self.X`). Stagebook just forwards the reference to
+  // the host's `resolve(reference)` callback; the host's resolver
+  // parses out the position and looks up the right slot. These tests
+  // pin the forwarding contract and confirm comparator semantics on
+  // the resolved values.
 
-  // A position-aware resolver that returns different values for the same
-  // reference depending on the position string. Modeled on the kind of
-  // resolver a multi-position host would supply.
-  const resolveByPosition = (
-    table: Record<string, Record<string, unknown[]>>,
-  ) => {
-    return (reference: string, position?: string) => {
-      const key = position ?? "__default";
-      return table[reference]?.[key] ?? [];
-    };
+  // A position-aware resolver: maps the full position-prefixed reference
+  // to its values. Models a host that's parsed the prefix and routed to
+  // the right scope.
+  const resolveByReference = (table: Record<string, unknown[]>) => {
+    return (reference: string) => table[reference] ?? [];
   };
 
-  test("position: shared — forwards the string and uses the resolved value", () => {
-    const resolve = resolveByPosition({
-      "prompt.flag": {
-        shared: ["yes"],
-        "0": ["no"],
-        "1": ["maybe"],
-      },
+  test("position: shared — forwards the reference and uses the resolved value", () => {
+    const resolve = resolveByReference({
+      "shared.prompt.flag": ["yes"],
+      "0.prompt.flag": ["no"],
+      "1.prompt.flag": ["maybe"],
     });
-    // Resolving with `position: "shared"` returns ["yes"], which equals "yes".
     expect(
       evaluateConditions(
         [
           {
-            reference: "prompt.flag",
-            position: "shared",
+            reference: "shared.prompt.flag",
             comparator: "equals",
             value: "yes",
           },
@@ -294,18 +297,15 @@ describe("evaluateConditions", () => {
   });
 
   test("position: shared — failure case (shared value doesn't match)", () => {
-    const resolve = resolveByPosition({
-      "prompt.flag": {
-        shared: ["no"],
-        "0": ["yes"],
-      },
+    const resolve = resolveByReference({
+      "shared.prompt.flag": ["no"],
+      "0.prompt.flag": ["yes"],
     });
     expect(
       evaluateConditions(
         [
           {
-            reference: "prompt.flag",
-            position: "shared",
+            reference: "shared.prompt.flag",
             comparator: "equals",
             value: "yes",
           },
@@ -316,54 +316,34 @@ describe("evaluateConditions", () => {
   });
 
   test("position: 0 — resolves to the position-0 player's value", () => {
-    const resolve = resolveByPosition({
-      "prompt.q": {
-        "0": ["red"],
-        "1": ["blue"],
-      },
+    const resolve = resolveByReference({
+      "0.prompt.q": ["red"],
+      "1.prompt.q": ["blue"],
     });
     expect(
       evaluateConditions(
-        [
-          {
-            reference: "prompt.q",
-            position: "0",
-            comparator: "equals",
-            value: "red",
-          },
-        ],
+        [{ reference: "0.prompt.q", comparator: "equals", value: "red" }],
         resolve,
       ),
     ).toBe(true);
-    // Failure case: position 0's value is "red", not "blue".
     expect(
       evaluateConditions(
-        [
-          {
-            reference: "prompt.q",
-            position: "0",
-            comparator: "equals",
-            value: "blue",
-          },
-        ],
+        [{ reference: "0.prompt.q", comparator: "equals", value: "blue" }],
         resolve,
       ),
     ).toBe(false);
   });
 
   test("position: 1 — resolves to the position-1 player's value", () => {
-    const resolve = resolveByPosition({
-      "prompt.q": {
-        "0": ["red"],
-        "1": ["blue"],
-      },
+    const resolve = resolveByReference({
+      "0.prompt.q": ["red"],
+      "1.prompt.q": ["blue"],
     });
     expect(
       evaluateConditions(
         [
           {
-            reference: "prompt.q",
-            position: "1",
+            reference: "1.prompt.q",
             comparator: "equals",
             value: "blue",
           },
@@ -375,8 +355,7 @@ describe("evaluateConditions", () => {
       evaluateConditions(
         [
           {
-            reference: "prompt.q",
-            position: "1",
+            reference: "1.prompt.q",
             comparator: "equals",
             value: "red",
           },
@@ -386,42 +365,25 @@ describe("evaluateConditions", () => {
     ).toBe(false);
   });
 
-  test("position string is forwarded to resolver verbatim (spy)", () => {
-    // Hosts implement `resolve` and can interpret any position string —
-    // stagebook's only contract is to pass it through. Verify with a spy.
-    const calls: { reference: string; position: string | undefined }[] = [];
-    const resolve = (reference: string, position?: string) => {
-      calls.push({ reference, position });
+  test("reference string is forwarded to resolver verbatim (spy)", () => {
+    // After #298, the position is embedded in the reference. The
+    // resolver takes only the reference; hosts parse out the position.
+    // Verify with a spy that each leaf's reference reaches the resolver
+    // unchanged.
+    const calls: string[] = [];
+    const resolve = (reference: string) => {
+      calls.push(reference);
       return ["x"];
     };
     evaluateConditions(
       [
-        {
-          reference: "prompt.q",
-          position: "shared",
-          comparator: "equals",
-          value: "x",
-        },
-        {
-          reference: "prompt.q",
-          position: "0",
-          comparator: "equals",
-          value: "x",
-        },
-        {
-          reference: "prompt.q",
-          // position omitted — resolver receives undefined.
-          comparator: "equals",
-          value: "x",
-        },
+        { reference: "shared.prompt.q", comparator: "equals", value: "x" },
+        { reference: "0.prompt.q", comparator: "equals", value: "x" },
+        { reference: "self.prompt.q", comparator: "equals", value: "x" },
       ],
       resolve,
     );
-    expect(calls).toEqual([
-      { reference: "prompt.q", position: "shared" },
-      { reference: "prompt.q", position: "0" },
-      { reference: "prompt.q", position: undefined },
-    ]);
+    expect(calls).toEqual(["shared.prompt.q", "0.prompt.q", "self.prompt.q"]);
   });
 });
 
@@ -442,10 +404,10 @@ describe("evaluateConditions — boolean tree (#235)", () => {
     });
 
     test("single leaf in array", () => {
-      const resolve = makeResolve({ "prompt.q": ["yes"] });
+      const resolve = makeResolve({ "self.prompt.q": ["yes"] });
       expect(
         evaluateConditions(
-          [{ reference: "prompt.q", comparator: "equals", value: "yes" }],
+          [{ reference: "self.prompt.q", comparator: "equals", value: "yes" }],
           resolve,
         ),
       ).toBe(true);
@@ -453,14 +415,14 @@ describe("evaluateConditions — boolean tree (#235)", () => {
 
     test("multiple leaves AND together", () => {
       const resolve = makeResolve({
-        "prompt.a": ["x"],
-        "prompt.b": ["y"],
+        "self.prompt.a": ["x"],
+        "self.prompt.b": ["y"],
       });
       expect(
         evaluateConditions(
           [
-            { reference: "prompt.a", comparator: "equals", value: "x" },
-            { reference: "prompt.b", comparator: "equals", value: "y" },
+            { reference: "self.prompt.a", comparator: "equals", value: "x" },
+            { reference: "self.prompt.b", comparator: "equals", value: "y" },
           ],
           resolve,
         ),
@@ -469,14 +431,14 @@ describe("evaluateConditions — boolean tree (#235)", () => {
 
     test("any leaf failing makes the array false", () => {
       const resolve = makeResolve({
-        "prompt.a": ["x"],
-        "prompt.b": ["wrong"],
+        "self.prompt.a": ["x"],
+        "self.prompt.b": ["wrong"],
       });
       expect(
         evaluateConditions(
           [
-            { reference: "prompt.a", comparator: "equals", value: "x" },
-            { reference: "prompt.b", comparator: "equals", value: "y" },
+            { reference: "self.prompt.a", comparator: "equals", value: "x" },
+            { reference: "self.prompt.b", comparator: "equals", value: "y" },
           ],
           resolve,
         ),
@@ -487,15 +449,15 @@ describe("evaluateConditions — boolean tree (#235)", () => {
   describe("all operator", () => {
     test("all children true → true", () => {
       const resolve = makeResolve({
-        "prompt.a": ["x"],
-        "prompt.b": ["y"],
+        "self.prompt.a": ["x"],
+        "self.prompt.b": ["y"],
       });
       expect(
         evaluateConditions(
           {
             all: [
-              { reference: "prompt.a", comparator: "equals", value: "x" },
-              { reference: "prompt.b", comparator: "equals", value: "y" },
+              { reference: "self.prompt.a", comparator: "equals", value: "x" },
+              { reference: "self.prompt.b", comparator: "equals", value: "y" },
             ],
           },
           resolve,
@@ -505,15 +467,15 @@ describe("evaluateConditions — boolean tree (#235)", () => {
 
     test("any child false → false", () => {
       const resolve = makeResolve({
-        "prompt.a": ["x"],
-        "prompt.b": ["wrong"],
+        "self.prompt.a": ["x"],
+        "self.prompt.b": ["wrong"],
       });
       expect(
         evaluateConditions(
           {
             all: [
-              { reference: "prompt.a", comparator: "equals", value: "x" },
-              { reference: "prompt.b", comparator: "equals", value: "y" },
+              { reference: "self.prompt.a", comparator: "equals", value: "x" },
+              { reference: "self.prompt.b", comparator: "equals", value: "y" },
             ],
           },
           resolve,
@@ -530,8 +492,8 @@ describe("evaluateConditions — boolean tree (#235)", () => {
         evaluateConditions(
           {
             all: [
-              { reference: "prompt.a", comparator: "equals", value: "x" },
-              { reference: "prompt.b", comparator: "equals", value: "y" },
+              { reference: "self.prompt.a", comparator: "equals", value: "x" },
+              { reference: "self.prompt.b", comparator: "equals", value: "y" },
             ],
           },
           resolve,
@@ -543,15 +505,15 @@ describe("evaluateConditions — boolean tree (#235)", () => {
   describe("any operator", () => {
     test("at least one child true → true", () => {
       const resolve = makeResolve({
-        "prompt.a": ["wrong"],
-        "prompt.b": ["y"],
+        "self.prompt.a": ["wrong"],
+        "self.prompt.b": ["y"],
       });
       expect(
         evaluateConditions(
           {
             any: [
-              { reference: "prompt.a", comparator: "equals", value: "x" },
-              { reference: "prompt.b", comparator: "equals", value: "y" },
+              { reference: "self.prompt.a", comparator: "equals", value: "x" },
+              { reference: "self.prompt.b", comparator: "equals", value: "y" },
             ],
           },
           resolve,
@@ -561,15 +523,15 @@ describe("evaluateConditions — boolean tree (#235)", () => {
 
     test("all children false → false", () => {
       const resolve = makeResolve({
-        "prompt.a": ["wrong"],
-        "prompt.b": ["wrong"],
+        "self.prompt.a": ["wrong"],
+        "self.prompt.b": ["wrong"],
       });
       expect(
         evaluateConditions(
           {
             any: [
-              { reference: "prompt.a", comparator: "equals", value: "x" },
-              { reference: "prompt.b", comparator: "equals", value: "y" },
+              { reference: "self.prompt.a", comparator: "equals", value: "x" },
+              { reference: "self.prompt.b", comparator: "equals", value: "y" },
             ],
           },
           resolve,
@@ -583,8 +545,8 @@ describe("evaluateConditions — boolean tree (#235)", () => {
         evaluateConditions(
           {
             any: [
-              { reference: "prompt.a", comparator: "equals", value: "x" },
-              { reference: "prompt.b", comparator: "equals", value: "y" },
+              { reference: "self.prompt.a", comparator: "equals", value: "x" },
+              { reference: "self.prompt.b", comparator: "equals", value: "y" },
             ],
           },
           resolve,
@@ -596,15 +558,15 @@ describe("evaluateConditions — boolean tree (#235)", () => {
   describe("none operator (the case that requires tri-state)", () => {
     test("all children false → true", () => {
       const resolve = makeResolve({
-        "prompt.a": ["wrong"],
-        "prompt.b": ["wrong"],
+        "self.prompt.a": ["wrong"],
+        "self.prompt.b": ["wrong"],
       });
       expect(
         evaluateConditions(
           {
             none: [
-              { reference: "prompt.a", comparator: "equals", value: "x" },
-              { reference: "prompt.b", comparator: "equals", value: "y" },
+              { reference: "self.prompt.a", comparator: "equals", value: "x" },
+              { reference: "self.prompt.b", comparator: "equals", value: "y" },
             ],
           },
           resolve,
@@ -614,15 +576,15 @@ describe("evaluateConditions — boolean tree (#235)", () => {
 
     test("any child true → false", () => {
       const resolve = makeResolve({
-        "prompt.a": ["x"],
-        "prompt.b": ["wrong"],
+        "self.prompt.a": ["x"],
+        "self.prompt.b": ["wrong"],
       });
       expect(
         evaluateConditions(
           {
             none: [
-              { reference: "prompt.a", comparator: "equals", value: "x" },
-              { reference: "prompt.b", comparator: "equals", value: "y" },
+              { reference: "self.prompt.a", comparator: "equals", value: "x" },
+              { reference: "self.prompt.b", comparator: "equals", value: "y" },
             ],
           },
           resolve,
@@ -642,8 +604,8 @@ describe("evaluateConditions — boolean tree (#235)", () => {
         evaluateConditions(
           {
             none: [
-              { reference: "prompt.a", comparator: "equals", value: "x" },
-              { reference: "prompt.b", comparator: "equals", value: "y" },
+              { reference: "self.prompt.a", comparator: "equals", value: "x" },
+              { reference: "self.prompt.b", comparator: "equals", value: "y" },
             ],
           },
           resolve,
@@ -652,13 +614,13 @@ describe("evaluateConditions — boolean tree (#235)", () => {
     });
 
     test("one child known false, one unknown → undefined → false", () => {
-      const resolve = makeResolve({ "prompt.a": ["wrong"] });
+      const resolve = makeResolve({ "self.prompt.a": ["wrong"] });
       expect(
         evaluateConditions(
           {
             none: [
-              { reference: "prompt.a", comparator: "equals", value: "x" },
-              { reference: "prompt.b", comparator: "equals", value: "y" },
+              { reference: "self.prompt.a", comparator: "equals", value: "x" },
+              { reference: "self.prompt.b", comparator: "equals", value: "y" },
             ],
           },
           resolve,
@@ -681,7 +643,11 @@ describe("evaluateConditions — boolean tree (#235)", () => {
             all: [
               {
                 none: [
-                  { reference: "prompt.a", comparator: "equals", value: "x" },
+                  {
+                    reference: "self.prompt.a",
+                    comparator: "equals",
+                    value: "x",
+                  },
                 ],
               },
             ],
@@ -696,15 +662,23 @@ describe("evaluateConditions — boolean tree (#235)", () => {
       // [undefined] → undefined → boundary false. The known-true child
       // inside the inner `all` does not "leak out" because the
       // surrounding `all` didn't reach a definitive answer.
-      const resolve = makeResolve({ "prompt.a": ["x"] });
+      const resolve = makeResolve({ "self.prompt.a": ["x"] });
       expect(
         evaluateConditions(
           {
             any: [
               {
                 all: [
-                  { reference: "prompt.a", comparator: "equals", value: "x" },
-                  { reference: "prompt.b", comparator: "equals", value: "y" },
+                  {
+                    reference: "self.prompt.a",
+                    comparator: "equals",
+                    value: "x",
+                  },
+                  {
+                    reference: "self.prompt.b",
+                    comparator: "equals",
+                    value: "y",
+                  },
                 ],
               },
             ],
@@ -718,9 +692,9 @@ describe("evaluateConditions — boolean tree (#235)", () => {
   describe("nested operators", () => {
     test("(A or B) and C", () => {
       const resolve = makeResolve({
-        "prompt.a": ["wrong"],
-        "prompt.b": ["yes"],
-        "prompt.c": ["go"],
+        "self.prompt.a": ["wrong"],
+        "self.prompt.b": ["yes"],
+        "self.prompt.c": ["go"],
       });
       expect(
         evaluateConditions(
@@ -728,11 +702,19 @@ describe("evaluateConditions — boolean tree (#235)", () => {
             all: [
               {
                 any: [
-                  { reference: "prompt.a", comparator: "equals", value: "yes" },
-                  { reference: "prompt.b", comparator: "equals", value: "yes" },
+                  {
+                    reference: "self.prompt.a",
+                    comparator: "equals",
+                    value: "yes",
+                  },
+                  {
+                    reference: "self.prompt.b",
+                    comparator: "equals",
+                    value: "yes",
+                  },
                 ],
               },
-              { reference: "prompt.c", comparator: "equals", value: "go" },
+              { reference: "self.prompt.c", comparator: "equals", value: "go" },
             ],
           },
           resolve,
@@ -742,9 +724,9 @@ describe("evaluateConditions — boolean tree (#235)", () => {
 
     test("array root with nested operator inside", () => {
       const resolve = makeResolve({
-        "prompt.a": ["yes"],
-        "prompt.b": ["no"],
-        "prompt.c": ["yes"],
+        "self.prompt.a": ["yes"],
+        "self.prompt.b": ["no"],
+        "self.prompt.c": ["yes"],
       });
       // Top-level array (implicit all): each item must hold.
       // Item 1: leaf "prompt.a == yes" → true
@@ -753,11 +735,19 @@ describe("evaluateConditions — boolean tree (#235)", () => {
       expect(
         evaluateConditions(
           [
-            { reference: "prompt.a", comparator: "equals", value: "yes" },
+            { reference: "self.prompt.a", comparator: "equals", value: "yes" },
             {
               any: [
-                { reference: "prompt.b", comparator: "equals", value: "yes" },
-                { reference: "prompt.c", comparator: "equals", value: "yes" },
+                {
+                  reference: "self.prompt.b",
+                  comparator: "equals",
+                  value: "yes",
+                },
+                {
+                  reference: "self.prompt.c",
+                  comparator: "equals",
+                  value: "yes",
+                },
               ],
             },
           ],
@@ -770,9 +760,9 @@ describe("evaluateConditions — boolean tree (#235)", () => {
       // `none` of [all(A,B), C] — true when neither (A and B) nor C
       // holds.
       const resolve = makeResolve({
-        "prompt.a": ["yes"],
-        "prompt.b": ["no"], // (a and b) is false
-        "prompt.c": ["no"], // c is false
+        "self.prompt.a": ["yes"],
+        "self.prompt.b": ["no"], // (a and b) is false
+        "self.prompt.c": ["no"], // c is false
       });
       expect(
         evaluateConditions(
@@ -780,11 +770,23 @@ describe("evaluateConditions — boolean tree (#235)", () => {
             none: [
               {
                 all: [
-                  { reference: "prompt.a", comparator: "equals", value: "yes" },
-                  { reference: "prompt.b", comparator: "equals", value: "yes" },
+                  {
+                    reference: "self.prompt.a",
+                    comparator: "equals",
+                    value: "yes",
+                  },
+                  {
+                    reference: "self.prompt.b",
+                    comparator: "equals",
+                    value: "yes",
+                  },
                 ],
               },
-              { reference: "prompt.c", comparator: "equals", value: "yes" },
+              {
+                reference: "self.prompt.c",
+                comparator: "equals",
+                value: "yes",
+              },
             ],
           },
           resolve,
@@ -795,20 +797,20 @@ describe("evaluateConditions — boolean tree (#235)", () => {
 
   describe("single leaf at root", () => {
     test("single leaf object (not in array) — true case", () => {
-      const resolve = makeResolve({ "prompt.q": ["yes"] });
+      const resolve = makeResolve({ "self.prompt.q": ["yes"] });
       expect(
         evaluateConditions(
-          { reference: "prompt.q", comparator: "equals", value: "yes" },
+          { reference: "self.prompt.q", comparator: "equals", value: "yes" },
           resolve,
         ),
       ).toBe(true);
     });
 
     test("single leaf object — false case", () => {
-      const resolve = makeResolve({ "prompt.q": ["no"] });
+      const resolve = makeResolve({ "self.prompt.q": ["no"] });
       expect(
         evaluateConditions(
-          { reference: "prompt.q", comparator: "equals", value: "yes" },
+          { reference: "self.prompt.q", comparator: "equals", value: "yes" },
           resolve,
         ),
       ).toBe(false);

--- a/packages/stagebook/src/utils/evaluateConditions.ts
+++ b/packages/stagebook/src/utils/evaluateConditions.ts
@@ -1,11 +1,10 @@
 import { compare, type Comparator } from "./compare.js";
 
-/** A single leaf condition: a reference + comparator + optional value,
- *  with optional cross-player aggregation via `position`. This is what
- *  the boolean tree's operator branches eventually bottom out at. */
+/** A single leaf condition: a reference + comparator + optional value.
+ *  After #298, the position is part of the reference itself (e.g.
+ *  `0.prompt.X.value`); the sibling `position:` field is removed. */
 export interface Condition {
   reference: string;
-  position?: string;
   comparator: string;
   value?: unknown;
 }
@@ -66,12 +65,12 @@ function isNoneNode(n: unknown): n is { none: ConditionNode[] } {
  * is available (so operators above can know the leaf is "unknown"
  * rather than "false"); returns `true`/`false` otherwise.
  *
- * After #238, `position` on a leaf is a pure read selector
- * (`"shared"` / `"player"` / numeric slot index, default `"player"`).
- * The host's `resolve(reference, position)` callback returns the
- * relevant value(s) for that selector. Cross-player aggregation
- * (`all` / `any`) lives in the boolean-tree operators (#235);
- * `percentAgreement` was pulled out entirely.
+ * After #298, the position is part of the reference itself
+ * (`0.prompt.X.value`, `self.entryUrl.params.x`, etc.). The host's
+ * `resolve(reference)` callback parses out the position and returns
+ * the relevant value(s). Cross-player aggregation (`all` / `any`)
+ * lives in the boolean-tree operators (#235); `percentAgreement`
+ * was pulled out entirely.
  *
  * Semantics: every returned value must satisfy the comparator; the
  * loop short-circuits on a definite false, propagates undefined when
@@ -120,7 +119,7 @@ function evaluateLeafTriState(
  */
 function evaluateNode(
   node: ConditionNode,
-  resolve: (reference: string, position?: string) => unknown[],
+  resolve: (reference: string) => unknown[],
 ): TriState {
   if (isAllNode(node)) {
     let anyUnknown = false;
@@ -149,8 +148,8 @@ function evaluateNode(
     }
     return anyUnknown ? undefined : true;
   }
-  // Leaf
-  const values = resolve(node.reference, node.position);
+  // Leaf — position is part of the reference itself per #298.
+  const values = resolve(node.reference);
   return evaluateLeafTriState(node, values);
 }
 
@@ -181,7 +180,7 @@ export function evaluateCondition(
  */
 export function evaluateConditions(
   conditions: ConditionNode[] | ConditionNode | undefined | null,
-  resolve: (reference: string, position?: string) => unknown[],
+  resolve: (reference: string) => unknown[],
 ): boolean {
   if (conditions === undefined || conditions === null) return true;
   if (Array.isArray(conditions)) {

--- a/packages/stagebook/src/utils/reference.test.ts
+++ b/packages/stagebook/src/utils/reference.test.ts
@@ -5,37 +5,39 @@ import { getReferenceKeyAndPath, getNestedValueByPath } from "./reference.js";
 
 describe("getReferenceKeyAndPath", () => {
   test("survey reference", () => {
-    const result = getReferenceKeyAndPath("survey.bigFive.result.score");
+    const result = getReferenceKeyAndPath("self.survey.bigFive.result.score");
     expect(result.referenceKey).toBe("survey_bigFive");
     expect(result.path).toEqual(["result", "score"]);
   });
 
   test("submitButton reference", () => {
-    const result = getReferenceKeyAndPath("submitButton.continue.time");
+    const result = getReferenceKeyAndPath("self.submitButton.continue.time");
     expect(result.referenceKey).toBe("submitButton_continue");
     expect(result.path).toEqual(["time"]);
   });
 
   test("qualtrics reference", () => {
-    const result = getReferenceKeyAndPath("qualtrics.mySurvey.responses.Q1");
+    const result = getReferenceKeyAndPath(
+      "self.qualtrics.mySurvey.responses.Q1",
+    );
     expect(result.referenceKey).toBe("qualtrics_mySurvey");
     expect(result.path).toEqual(["responses", "Q1"]);
   });
 
   test("prompt reference defaults path to ['value']", () => {
-    const result = getReferenceKeyAndPath("prompt.myQuestion");
+    const result = getReferenceKeyAndPath("self.prompt.myQuestion");
     expect(result.referenceKey).toBe("prompt_myQuestion");
     expect(result.path).toEqual(["value"]);
   });
 
   test("trackedLink reference", () => {
-    const result = getReferenceKeyAndPath("trackedLink.followUp.events");
+    const result = getReferenceKeyAndPath("self.trackedLink.followUp.events");
     expect(result.referenceKey).toBe("trackedLink_followUp");
     expect(result.path).toEqual(["events"]);
   });
 
   test("entryUrl.params reference (renamed from urlParams in #246)", () => {
-    const result = getReferenceKeyAndPath("entryUrl.params.condition");
+    const result = getReferenceKeyAndPath("self.entryUrl.params.condition");
     expect(result.referenceKey).toBe("entryUrl");
     expect(result.path).toEqual(["params", "condition"]);
   });
@@ -47,13 +49,13 @@ describe("getReferenceKeyAndPath", () => {
   });
 
   test("connectionInfo reference", () => {
-    const result = getReferenceKeyAndPath("connectionInfo.country");
+    const result = getReferenceKeyAndPath("self.connectionInfo.country");
     expect(result.referenceKey).toBe("connectionInfo");
     expect(result.path).toEqual(["country"]);
   });
 
   test("browserInfo reference", () => {
-    const result = getReferenceKeyAndPath("browserInfo.name");
+    const result = getReferenceKeyAndPath("self.browserInfo.name");
     expect(result.referenceKey).toBe("browserInfo");
     expect(result.path).toEqual(["name"]);
   });
@@ -62,51 +64,51 @@ describe("getReferenceKeyAndPath", () => {
     // participantInfo uses the same flat-namespace pattern as connectionInfo
     // and browserInfo — stored under a single `participantInfo` key with
     // the field addressed via the nested path.
-    const result = getReferenceKeyAndPath("participantInfo.name");
+    const result = getReferenceKeyAndPath("self.participantInfo.name");
     expect(result.referenceKey).toBe("participantInfo");
     expect(result.path).toEqual(["name"]);
   });
 
   test("participantInfo reference with deep path", () => {
-    const result = getReferenceKeyAndPath("participantInfo.sampleId.raw");
+    const result = getReferenceKeyAndPath("self.participantInfo.sampleId.raw");
     expect(result.referenceKey).toBe("participantInfo");
     expect(result.path).toEqual(["sampleId", "raw"]);
   });
 
   test("timeline reference", () => {
-    const result = getReferenceKeyAndPath("timeline.myAnnotations");
+    const result = getReferenceKeyAndPath("self.timeline.myAnnotations");
     expect(result.referenceKey).toBe("timeline_myAnnotations");
     expect(result.path).toEqual([]);
   });
 
   test("discussion reference (now namespaced as `discussion_<name>` per #240)", () => {
-    const result = getReferenceKeyAndPath("discussion.main.messageCount");
+    const result = getReferenceKeyAndPath("self.discussion.main.messageCount");
     expect(result.referenceKey).toBe("discussion_main");
     expect(result.path).toEqual(["messageCount"]);
   });
 
   test("throws on invalid reference type", () => {
-    expect(() => getReferenceKeyAndPath("duck.quack")).toThrow(
+    expect(() => getReferenceKeyAndPath("self.duck.quack")).toThrow(
       'Invalid reference source "duck"',
     );
   });
 
   test("throws on missing name segment", () => {
-    expect(() => getReferenceKeyAndPath("survey")).toThrow();
+    expect(() => getReferenceKeyAndPath("self.survey")).toThrow();
   });
 
   test("throws on missing path segment for external sources", () => {
     // External-source references require at least one path segment.
-    expect(() => getReferenceKeyAndPath("participantInfo")).toThrow(
+    expect(() => getReferenceKeyAndPath("self.participantInfo")).toThrow(
       "A path must be provided",
     );
-    expect(() => getReferenceKeyAndPath("connectionInfo")).toThrow(
+    expect(() => getReferenceKeyAndPath("self.connectionInfo")).toThrow(
       "A path must be provided",
     );
-    expect(() => getReferenceKeyAndPath("browserInfo")).toThrow(
+    expect(() => getReferenceKeyAndPath("self.browserInfo")).toThrow(
       "A path must be provided",
     );
-    expect(() => getReferenceKeyAndPath("entryUrl")).toThrow(
+    expect(() => getReferenceKeyAndPath("self.entryUrl")).toThrow(
       "A path must be provided",
     );
   });
@@ -115,7 +117,7 @@ describe("getReferenceKeyAndPath", () => {
     // The `params` subpath check on `entryUrl` lives in
     // `externalReferenceSchema.superRefine` and runs through
     // `parseDottedReference`'s post-validation.
-    expect(() => getReferenceKeyAndPath("entryUrl.condition")).toThrow(
+    expect(() => getReferenceKeyAndPath("self.entryUrl.condition")).toThrow(
       /entryUrl\.params/,
     );
   });
@@ -162,14 +164,14 @@ describe("getReferenceKeyAndPath", () => {
   });
 
   test("string and structured forms produce equivalent output", () => {
-    expect(getReferenceKeyAndPath("survey.TIPI.responses.q1")).toEqual(
+    expect(getReferenceKeyAndPath("self.survey.TIPI.responses.q1")).toEqual(
       getReferenceKeyAndPath({
         source: "survey",
         name: "TIPI",
         path: ["responses", "q1"],
       }),
     );
-    expect(getReferenceKeyAndPath("entryUrl.params.PROLIFIC_PID")).toEqual(
+    expect(getReferenceKeyAndPath("self.entryUrl.params.PROLIFIC_PID")).toEqual(
       getReferenceKeyAndPath({
         source: "entryUrl",
         path: ["params", "PROLIFIC_PID"],

--- a/scripts/codemod-298-ts.mjs
+++ b/scripts/codemod-298-ts.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+/**
+ * Sister script to `codemod-298.mjs` for TypeScript fixtures.
+ *
+ * Operates on .ts/.tsx files via regex. Handles the two patterns that
+ * cover ~95% of in-tree fixtures:
+ *
+ *   1. Object literal with `reference: "X.Y..."` and a sibling
+ *      `position: <value>` (any order, on adjacent or nearby lines):
+ *        → prepend the position to the reference; delete the position line.
+ *
+ *   2. Object literal with `reference: "X.Y..."` and no sibling position:
+ *        → prepend `self.` to the reference.
+ *
+ * The first transformation runs object-literal-aware (matched by the
+ * smallest enclosing `{...}`); the second is a global regex over
+ * unmatched references.
+ *
+ * Skips:
+ *   - References whose first segment is already a position selector.
+ *   - References whose first segment isn't a recognized source enum
+ *     (treats those as opaque strings — likely template fragments or
+ *     test data, not actual references).
+ *
+ * Usage:
+ *   node scripts/codemod-298-ts.mjs path/to/file.ts [...more]
+ *   node scripts/codemod-298-ts.mjs --check path/to/file.ts
+ */
+import * as fs from "node:fs";
+
+const SOURCES = [
+  "prompt",
+  "survey",
+  "submitButton",
+  "qualtrics",
+  "timeline",
+  "trackedLink",
+  "discussion",
+  "aggregate",
+  "entryUrl",
+  "connectionInfo",
+  "browserInfo",
+  "participantInfo",
+];
+const SOURCE_PATTERN = SOURCES.join("|");
+const POSITION_PATTERN = String.raw`(?:\d+|"(?:self|shared|all|player|any)"|self|shared|all|player|any)`;
+
+function normalizePos(raw) {
+  // Strip surrounding quotes if any
+  const v = raw.replace(/^"(.*)"$/, "$1");
+  if (v === "player" || v === "self") return "self";
+  if (v === "any") return "all";
+  if (/^\d+$/.test(v)) return v;
+  if (v === "shared" || v === "all") return v;
+  return "self";
+}
+
+/** Find the matching close brace for the open brace at `start`. Returns
+ *  index of the close brace, or -1 if unmatched. Naive — doesn't handle
+ *  string escapes, but TS fixtures rarely have braces inside strings.
+ */
+function findMatchingClose(src, start) {
+  let depth = 1;
+  let i = start + 1;
+  let inSingle = false;
+  let inDouble = false;
+  let inBacktick = false;
+  while (i < src.length) {
+    const c = src[i];
+    const prev = src[i - 1];
+    if (!inDouble && !inBacktick && c === "'" && prev !== "\\") inSingle = !inSingle;
+    else if (!inSingle && !inBacktick && c === '"' && prev !== "\\") inDouble = !inDouble;
+    else if (!inSingle && !inDouble && c === "`" && prev !== "\\") inBacktick = !inBacktick;
+    else if (!inSingle && !inDouble && !inBacktick) {
+      if (c === "{") depth++;
+      else if (c === "}") {
+        depth--;
+        if (depth === 0) return i;
+      }
+    }
+    i++;
+  }
+  return -1;
+}
+
+/** Find each `reference: "..."` occurrence and find its enclosing `{...}`
+ *  to look for a sibling `position:`. Returns array of edit operations.
+ */
+function planEdits(src) {
+  const edits = [];
+  // Match `reference: "X.Y..."` — must look like a reference (first
+  // segment is a known source). Captures the full match and the
+  // reference string content.
+  const refRegex = new RegExp(
+    `reference:\\s*"((${SOURCE_PATTERN})(?:\\.[^"\\s]+)+)"`,
+    "g",
+  );
+  let m;
+  while ((m = refRegex.exec(src)) !== null) {
+    const refStartInMatch = m[0].indexOf('"');
+    const refStart = m.index + refStartInMatch + 1;
+    const refEnd = refStart + m[1].length;
+    const refStr = m[1];
+
+    // Look for the smallest enclosing `{` to scan its body for a
+    // sibling `position:`. Walk backward to find an unmatched `{`.
+    let braceIdx = -1;
+    let depth = 0;
+    for (let i = m.index - 1; i >= 0; i--) {
+      const c = src[i];
+      if (c === "}") depth++;
+      else if (c === "{") {
+        if (depth === 0) {
+          braceIdx = i;
+          break;
+        }
+        depth--;
+      }
+    }
+    if (braceIdx === -1) {
+      // Couldn't find enclosing object — fall back to "prepend self."
+      edits.push({
+        kind: "prefix",
+        refStart,
+        refEnd,
+        original: refStr,
+        replacement: `self.${refStr}`,
+      });
+      continue;
+    }
+    const closeIdx = findMatchingClose(src, braceIdx);
+    if (closeIdx === -1) {
+      edits.push({
+        kind: "prefix",
+        refStart,
+        refEnd,
+        original: refStr,
+        replacement: `self.${refStr}`,
+      });
+      continue;
+    }
+    const body = src.slice(braceIdx + 1, closeIdx);
+    // Look for a sibling `position:` inside this object body. Only
+    // direct children — skip nested objects.
+    const siblingPosition = findSiblingPosition(body);
+    if (siblingPosition) {
+      const position = normalizePos(siblingPosition.value);
+      edits.push({
+        kind: "prefix",
+        refStart,
+        refEnd,
+        original: refStr,
+        replacement: `${position}.${refStr}`,
+      });
+      // Compute absolute position of the position-line for deletion
+      const posLineStart = braceIdx + 1 + siblingPosition.lineStart;
+      const posLineEnd = braceIdx + 1 + siblingPosition.lineEnd;
+      edits.push({
+        kind: "deleteLine",
+        start: posLineStart,
+        end: posLineEnd,
+      });
+    } else {
+      edits.push({
+        kind: "prefix",
+        refStart,
+        refEnd,
+        original: refStr,
+        replacement: `self.${refStr}`,
+      });
+    }
+  }
+  return edits;
+}
+
+/** Within an object body (between `{` and `}`), find a top-level
+ *  (depth-0) `position:` field. Returns `{ value, lineStart, lineEnd }`
+ *  with offsets relative to the body, or null. */
+function findSiblingPosition(body) {
+  let depth = 0;
+  let inSingle = false;
+  let inDouble = false;
+  let inBacktick = false;
+  let i = 0;
+  while (i < body.length) {
+    const c = body[i];
+    const prev = body[i - 1];
+    if (!inDouble && !inBacktick && c === "'" && prev !== "\\") inSingle = !inSingle;
+    else if (!inSingle && !inBacktick && c === '"' && prev !== "\\") inDouble = !inDouble;
+    else if (!inSingle && !inDouble && c === "`" && prev !== "\\") inBacktick = !inBacktick;
+    else if (!inSingle && !inDouble && !inBacktick) {
+      if (c === "{" || c === "[") depth++;
+      else if (c === "}" || c === "]") depth--;
+      else if (depth === 0 && body.slice(i, i + 9).match(/^position\s*:/)) {
+        // Found a top-level position. Capture the value (literal or
+        // string) up to the next `,` or end of body.
+        const valueStart = body.indexOf(":", i) + 1;
+        let valueEnd = valueStart;
+        let vDepth = 0;
+        while (valueEnd < body.length) {
+          const vc = body[valueEnd];
+          if (vc === "{" || vc === "[") vDepth++;
+          else if (vc === "}" || vc === "]") vDepth--;
+          else if (vc === "," && vDepth === 0) break;
+          valueEnd++;
+        }
+        const value = body.slice(valueStart, valueEnd).trim();
+
+        // Find the line bounds — start at the previous `\n` (or 0),
+        // end at the next `\n` after the value (or body end).
+        let lineStart = i;
+        while (lineStart > 0 && body[lineStart - 1] !== "\n") lineStart--;
+        let lineEnd = valueEnd;
+        if (body[lineEnd] === ",") lineEnd++;
+        while (lineEnd < body.length && body[lineEnd] !== "\n") lineEnd++;
+        if (body[lineEnd] === "\n") lineEnd++;
+
+        return { value, lineStart, lineEnd };
+      }
+    }
+    i++;
+  }
+  return null;
+}
+
+function applyEdits(src, edits) {
+  // Sort by start position descending so earlier edits don't shift
+  // later edits' offsets.
+  const all = edits
+    .map((e) =>
+      e.kind === "prefix"
+        ? { start: e.refStart, end: e.refEnd, replacement: e.replacement }
+        : { start: e.start, end: e.end, replacement: "" },
+    )
+    .sort((a, b) => b.start - a.start);
+  let out = src;
+  for (const e of all) {
+    out = out.slice(0, e.start) + e.replacement + out.slice(e.end);
+  }
+  return out;
+}
+
+function processFile(filePath, checkOnly) {
+  const original = fs.readFileSync(filePath, "utf-8");
+  const edits = planEdits(original);
+  if (edits.length === 0) {
+    return { filePath, changed: false };
+  }
+  const updated = applyEdits(original, edits);
+  if (updated === original) {
+    return { filePath, changed: false };
+  }
+  if (!checkOnly) {
+    fs.writeFileSync(filePath, updated, "utf-8");
+  }
+  return { filePath, changed: true };
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const checkOnly = argv.includes("--check");
+  const files = argv.filter((a) => !a.startsWith("--"));
+  if (files.length === 0) {
+    console.error("Usage: codemod-298-ts.mjs [--check] file.ts [file2.ts ...]");
+    process.exit(2);
+  }
+  let anyChanged = false;
+  for (const f of files) {
+    if (!fs.existsSync(f)) {
+      console.error(`Skipping missing file: ${f}`);
+      continue;
+    }
+    const r = processFile(f, checkOnly);
+    if (r.changed) {
+      anyChanged = true;
+      console.log(`${checkOnly ? "[needs migration]" : "[migrated]"} ${f}`);
+    } else {
+      console.log(`[unchanged] ${f}`);
+    }
+  }
+  if (checkOnly && anyChanged) process.exit(1);
+}
+
+main();

--- a/scripts/codemod-298.mjs
+++ b/scripts/codemod-298.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * Codemod for #298 — position-prefixed reference grammar.
+ *
+ * Migrates a treatment YAML file from the pre-#298 reference grammar
+ * (sibling `position:` fields, refs like `prompt.X.value`) to the new
+ * grammar (refs like `0.prompt.X.value`, `self.prompt.X.value`).
+ *
+ * Heuristic transformation operating on parsed YAML:
+ *
+ * 1. For each condition leaf with `{ reference, position?, comparator, ... }`:
+ *    - Prepend the position prefix to `reference:` (`self` if absent,
+ *      `player` ↔ `self`, `any` ↔ `all`, integer index, `shared`, `all`).
+ *    - Delete the sibling `position:` field.
+ *
+ * 2. For each `display` element with `{ reference, position?, ... }`:
+ *    - Same as above; position folds into the reference string.
+ *
+ * 3. For each urlParam (`trackedLink.urlParams[]`, `qualtrics.urlParams[]`)
+ *    with `{ reference?, position?, ... }`:
+ *    - Same.
+ *
+ * 4. For bare reference strings already in dotted form, prepend `self.`
+ *    if the first segment is a known source (and not already a position
+ *    selector).
+ *
+ * Limitations:
+ * - Operates on parsed YAML, so YAML comments and formatting are not
+ *   preserved. Authors using significant comments should diff carefully.
+ * - Doesn't recurse into template `content:` if the content shape isn't
+ *   a recognizable element/condition tree — those edges may need a
+ *   manual touch-up.
+ *
+ * Usage:
+ *   node scripts/codemod-298.mjs path/to/study.treatments.yaml [...more files]
+ *   node scripts/codemod-298.mjs --check path/to/study.treatments.yaml   # exit 1 if changes needed, no write
+ *
+ * For test fixtures embedded in TypeScript, the same transformation
+ * applies but you'll need to run it on YAML, then port back. Or do the
+ * fixtures by hand — they're typically small.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import yaml from "js-yaml";
+
+const KNOWN_NAMED_SOURCES = new Set([
+  "prompt",
+  "survey",
+  "submitButton",
+  "qualtrics",
+  "timeline",
+  "trackedLink",
+  "discussion",
+  "aggregate", // for forward-compat with #299
+]);
+const KNOWN_EXTERNAL_SOURCES = new Set([
+  "entryUrl",
+  "connectionInfo",
+  "browserInfo",
+  "participantInfo",
+]);
+const POSITION_NAMES = new Set(["self", "shared", "all"]);
+
+function isPositionToken(token) {
+  if (POSITION_NAMES.has(token)) return true;
+  return /^[0-9]+$/.test(token);
+}
+
+/** Map a pre-#298 position value to the post-#298 position selector. */
+function normalizePositionValue(p) {
+  if (p === undefined || p === null) return "self";
+  if (typeof p === "number") return String(p);
+  if (typeof p === "string") {
+    if (p === "player" || p === "self") return "self";
+    if (p === "any") return "all";
+    if (p === "shared" || p === "all") return p;
+    if (/^[0-9]+$/.test(p)) return p;
+  }
+  return "self";
+}
+
+/** Add a position prefix to a string reference, or leave it alone if it
+ *  already has one. */
+function prefixReferenceString(refStr, position) {
+  if (typeof refStr !== "string") return refStr;
+  const segments = refStr.split(".");
+  if (segments.length === 0) return refStr;
+  // Already prefixed?
+  if (isPositionToken(segments[0])) return refStr;
+  // Leading segment is a recognized source — prepend the position.
+  if (
+    KNOWN_NAMED_SOURCES.has(segments[0]) ||
+    KNOWN_EXTERNAL_SOURCES.has(segments[0])
+  ) {
+    return `${position}.${refStr}`;
+  }
+  // Unrecognized leading segment — leave as-is and let validation
+  // produce a clearer error than this codemod could.
+  return refStr;
+}
+
+/** Apply the migration to a structured reference object form. */
+function migrateStructuredRef(ref, position) {
+  if (!ref || typeof ref !== "object") return ref;
+  if ("position" in ref) return ref; // already migrated
+  return { position, ...ref };
+}
+
+let touched = false;
+
+/** Walk an arbitrary object/array tree, applying #298 transformations
+ *  at every recognizable site. Mutates in place. */
+function walk(node) {
+  if (Array.isArray(node)) {
+    for (const item of node) walk(item);
+    return;
+  }
+  if (!node || typeof node !== "object") return;
+
+  // Leaf condition / display element / urlParam: any object with both
+  // `reference` and `position`, OR a `reference` whose string lacks a
+  // position prefix.
+  if ("reference" in node) {
+    const position = normalizePositionValue(node.position);
+    if (typeof node.reference === "string") {
+      const before = node.reference;
+      node.reference = prefixReferenceString(node.reference, position);
+      if (node.reference !== before) touched = true;
+    } else if (node.reference && typeof node.reference === "object") {
+      const before = JSON.stringify(node.reference);
+      node.reference = migrateStructuredRef(node.reference, position);
+      if (JSON.stringify(node.reference) !== before) touched = true;
+    }
+    if ("position" in node) {
+      delete node.position;
+      touched = true;
+    }
+  }
+
+  // Recurse into all child values (we don't know which keys carry
+  // nested refs without coupling to the schema; walking everything is
+  // the easiest correct option).
+  for (const key of Object.keys(node)) {
+    walk(node[key]);
+  }
+}
+
+function processFile(filePath, checkOnly) {
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const doc = yaml.load(raw);
+  touched = false;
+  walk(doc);
+  if (!touched) {
+    return { filePath, changed: false };
+  }
+  if (checkOnly) {
+    return { filePath, changed: true };
+  }
+  const out = yaml.dump(doc, { lineWidth: 1000 });
+  fs.writeFileSync(filePath, out, "utf-8");
+  return { filePath, changed: true };
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const checkOnly = argv.includes("--check");
+  const files = argv.filter((a) => !a.startsWith("--"));
+  if (files.length === 0) {
+    console.error(
+      "Usage: codemod-298.mjs [--check] file.yaml [file2.yaml ...]",
+    );
+    process.exit(2);
+  }
+
+  let anyChanged = false;
+  for (const f of files) {
+    if (!fs.existsSync(f)) {
+      console.error(`Skipping missing file: ${f}`);
+      continue;
+    }
+    const result = processFile(path.resolve(f), checkOnly);
+    if (result.changed) {
+      anyChanged = true;
+      console.log(
+        `${checkOnly ? "[needs migration]" : "[migrated]"} ${result.filePath}`,
+      );
+    } else {
+      console.log(`[unchanged] ${result.filePath}`);
+    }
+  }
+
+  if (checkOnly && anyChanged) process.exit(1);
+}
+
+main();


### PR DESCRIPTION
Closes #298.

## Summary

Every reference now begins with an explicit position selector — `<integer>`, `self`, `shared`, or `all`. The pre-#298 implicit-self default and the sibling `position:` field at every read site are removed.

## Before / after

```yaml
# Before
- reference: prompt.recall.value
  position: 0
  comparator: equals
  value: red

# After
- reference: 0.prompt.recall.value
  comparator: equals
  value: red
```

```yaml
# Aggregate inputs become symmetric (the design motivation)
operator: countUnique
inputs:
  - 0.prompt.recall.value
  - 1.prompt.recall.value
  - 2.prompt.recall.value
  - 3.prompt.recall.value
```

## Schema changes

- `parseDottedReference` requires position prefix as first segment.
- `namedReferenceSchema` and `externalReferenceSchema` get a required `position:` field.
- `formatReference` includes the prefix.
- `positionSelectorSchema` moved to `reference.ts`; vocabulary is `<integer>` / `self` / `shared` / `all`. `any` and `player` are removed (`any:` operator covers existential quantification; `self` replaces `player` as the canonical name).
- Sibling `position:` field removed from condition leaves, display elements, and trackedLink/qualtrics urlParams. Same removals in `resolved.ts`.
- Game-stage forbid-self rule reads from the parsed reference; rejects `self.X` with a cross-client migration hint.

## Resolver / runtime

- `StagebookProvider`'s `resolve(reference)` extracts position from the reference and maps `self` → `"player"` at the host's `get(key, scope)` boundary (backward-compat with the existing get contract).
- `useResolve` simplified to single arg.
- `evaluateConditions` Condition interface no longer has a sibling `position:` field.
- vscode `semanticTokens.ts` highlighter updated to inspect the second segment (the source enum, after the position prefix).

## Migration story

Mostly mechanical. Two codemod scripts shipped in `scripts/`:

- `codemod-298.mjs` — YAML codemod. Folds sibling `position:` into the reference; prepends `self.` for un-prefixed refs.
- `codemod-298-ts.mjs` — TS-fixture codemod with brace-aware sibling detection.

All four example studies migrated. All in-tree test fixtures (~10 test files across stagebook, viewer, vscode) migrated. ~12 obsolete tests deleted (the `position: 'all' / 'any' / 'percentAgreement'` rejection scenarios don't exist post-#298).

## Schema permissiveness for YAML quirks

`positionSelectorSchema` accepts `z.string().regex(/^\d+$/)` and coerces to a number. YAML often quotes integer-valued positions (`position: '1'`) — coercion gives one canonical type downstream.

The `urlParams.<key>` legacy migration hint (#246) is preserved when the renamed source appears with a missing position prefix — the compound migration error.

## Test plan

- [x] `npm test` — stagebook 880 / viewer 85 / vscode 189 — all pass.
- [x] `npm run lint` — clean.
- [x] `npx prettier --check` — clean.
- [x] Manual: ran codemod against all four example studies; all parse and validate cleanly post-migration.

## External-study migration

External consumers (e.g. `exaptation`, `backchannel-manipulation`) run `node scripts/codemod-298.mjs path/to/study.treatments.yaml` to migrate. The codemod is idempotent and handles both un-prefixed refs and sibling-position folding.

## Migration steps for `deliberation-lab` (consuming repo)

After this PR merges and a new stagebook release ships:

1. **Bump the `stagebook` dependency** in `client/package.json` and `server/package.json` to the new release (≥ 0.10.0 or whatever the release vehicle is — this is a major-version-flavored breaking change).

2. **Run the codemod over treatment YAML files**:
   ```bash
   cd ../deliberation-lab
   node ../stagebook/scripts/codemod-298.mjs      demos/annotated_demo/demo.treatments.yaml      playwright/e2e/smoke/fixtures/study.treatments.yaml      playwright/e2e/video/fixtures/study.treatments.yaml      playwright/e2e/api-driven/fixtures/study.treatments.yaml      playwright/e2e/multi/fixtures/study.treatments.yaml      playwright/e2e/solo/fixtures/study.treatments.yaml
   ```
   Diff each file before committing — YAML formatting will reflow (the codemod uses js-yaml's dumper, so comments/blank lines may shift). Spot-check that references read cleanly after the prefix.

3. **Run the TS-fixture codemod over server/client code that builds treatment objects programmatically** (mostly tests):
   ```bash
   node ../stagebook/scripts/codemod-298-ts.mjs      $(grep -rl 'reference: "' server/src client/src playwright | grep -v node_modules)
   ```
   Then hand-review — the TS codemod is regex-based and may leave a few edge cases on multi-line objects.

4. **No changes needed to `client/src/components/stagebookAdapter/helpers.js`** — the adapter's `get(key, scope)` already accepts the scope strings stagebook now passes (`"player"`, `"shared"`, `"all"`, numeric strings). Stagebook's resolver maps `self` → `"player"` at the get() boundary for backward compat with the existing contract.

5. **Spot-check tests**: the adapter tests in `helpers.test.js` shouldn't need changes since they exercise the host-side `get(key, scope)` API directly. The stagebook-internal renaming of `position:` doesn't reach them.

6. **Run the test suite** to catch any references missed by the codemods.

If anything fails validation post-migration, the new parser produces explicit error messages pointing at the position-prefix migration (e.g., `Reference "prompt.X" is missing a position prefix. Try \`self.prompt.X\`...`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
