### PR TITLE
Position-based fallback for unnamed audio/mediaPlayer/survey + post-fill error surfacing

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -487,9 +487,11 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
       return `# Template expansion error:\n${commentedError}`;
     }
 
-    // Attach schema-validation diagnostics to the expanded preview URI.
-    // Positions reference the full expanded YAML; diagnostics past the
-    // truncation line still appear in the Problems panel.
+    // Schedule diagnostic-attachment for after VS Code has opened the
+    // document for this URI. Setting them synchronously inside this
+    // content-provider call is unreliable: VS Code can drop the
+    // diagnostics during document creation. setTimeout(0) defers
+    // until after the open completes.
     const vscodeDiagnostics = result.diagnostics.map((d) => {
       const diag = new vscode.Diagnostic(
         toVscodeRange(d.range),
@@ -499,7 +501,9 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
       diag.source = "stagebook";
       return diag;
     });
-    this.diagnostics.set(uri, vscodeDiagnostics);
+    setTimeout(() => {
+      this.diagnostics.set(uri, vscodeDiagnostics);
+    }, 0);
 
     return result.yaml;
   }

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -487,11 +487,12 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
       return `# Template expansion error:\n${commentedError}`;
     }
 
-    // Schedule diagnostic-attachment for after VS Code has opened the
-    // document for this URI. Setting them synchronously inside this
-    // content-provider call is unreliable: VS Code can drop the
-    // diagnostics during document creation. setTimeout(0) defers
-    // until after the open completes.
+    // Attach schema-validation diagnostics to the expanded preview URI.
+    // The close handler in extension.ts deliberately skips deleting
+    // diagnostics for the EXPANDED scheme so they survive the close-and-
+    // reopen that `setTextDocumentLanguage` triggers in the expand
+    // command — without that exception, diagnostics set here would be
+    // immediately wiped.
     const vscodeDiagnostics = result.diagnostics.map((d) => {
       const diag = new vscode.Diagnostic(
         toVscodeRange(d.range),
@@ -501,9 +502,7 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
       diag.source = "stagebook";
       return diag;
     });
-    setTimeout(() => {
-      this.diagnostics.set(uri, vscodeDiagnostics);
-    }, 0);
+    this.diagnostics.set(uri, vscodeDiagnostics);
 
     return result.yaml;
   }
@@ -1124,7 +1123,15 @@ export function activate(context: vscode.ExtensionContext): void {
       if (timer) clearTimeout(timer);
       debounceTimers.delete(key);
       validationVersions.delete(key);
-      diagnosticCollection.delete(document.uri);
+      // Diagnostics for expanded-preview virtual documents are owned by
+      // ExpandedTemplatesProvider — don't delete them here, because
+      // `setTextDocumentLanguage` (called from the expand command after
+      // showTextDocument) closes-and-reopens the document, which would
+      // otherwise wipe the diagnostics the provider just set. Source
+      // file diagnostics get cleared as before.
+      if (document.uri.scheme !== EXPANDED_SCHEME) {
+        diagnosticCollection.delete(document.uri);
+      }
     }),
   );
 }

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -173,6 +173,18 @@ function expandedFormBannerDiagnostic(
   const result = expandAndValidate(source);
 
   if (result.expandError) {
+    // If the file declares `imports:` and the error is a missing-
+    // template lookup, it's almost certainly because the validator
+    // (sync, no fs access) couldn't load the imported module that
+    // defines the template. Suppress the false-positive banner —
+    // the Preview Treatment command (async, uses vscode.workspace.fs)
+    // does the real check.
+    if (
+      hasImports(source) &&
+      /Template ".*" not found/.test(result.expandError)
+    ) {
+      return null;
+    }
     const diag = new vscode.Diagnostic(
       new vscode.Range(0, 0, 0, 1),
       `Stagebook: template expansion failed — ${result.expandError}\n\nRun "Stagebook: Preview Expanded Templates" to investigate.`,
@@ -192,6 +204,23 @@ function expandedFormBannerDiagnostic(
   );
   diag.source = "stagebook";
   return diag;
+}
+
+/**
+ * Quick check whether the source declares any `imports:` entries.
+ * Used to suppress the post-fill banner's false-positive
+ * "template not found" errors when the missing template is
+ * almost certainly defined in an unloaded import. Done by parsing
+ * the YAML rather than regex-matching the source so we don't
+ * confuse a comment or a string value for a top-level field.
+ */
+function hasImports(source: string): boolean {
+  try {
+    const { imports } = parseStagebookYaml(source);
+    return imports.length > 0;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -27,6 +27,7 @@ import {
   resolveImports,
   treatmentFileSchema,
   type ParsedFile,
+  type TreatmentFileType,
 } from "stagebook";
 
 const diagnosticCollection =
@@ -121,6 +122,21 @@ function validateTreatmentFile(document: vscode.TextDocument): void {
     return diag;
   });
 
+  // Post-fill banner. The source schema (`treatmentFileSchema`) is
+  // permissive enough to accept un-expanded template invocations
+  // (via `altTemplateContext`), so collisions / structural errors
+  // hidden inside template-expanded content don't surface in the
+  // squiggle pass above. Run a single expand+validate pass and, if
+  // it produces additional diagnostics, surface a single banner at
+  // line 1 directing the researcher to the expand command — where
+  // the expanded YAML's diagnostics are anchored to natural
+  // expanded-line positions and easy to navigate. Mapping post-fill
+  // paths back to source positions is genuinely hard (templates
+  // multiply structure); the expand-preview pivot sidesteps it
+  // entirely.
+  const banner = expandedFormBannerDiagnostic(source);
+  if (banner) vscodeDiagnostics.push(banner);
+
   diagnosticCollection.set(document.uri, vscodeDiagnostics);
 
   // File existence checking (async — updates diagnostics after stat)
@@ -137,6 +153,45 @@ function validateTreatmentFile(document: vscode.TextDocument): void {
       version,
     );
   }
+}
+
+/**
+ * Quick check whether the file's *expanded* form has issues the
+ * source-level validator missed. Returns a single line-1 diagnostic
+ * pointing the researcher at the expand-preview command, or null if
+ * the expanded form is clean.
+ *
+ * Intentionally does NOT load `imports:` (the lib helpers are sync
+ * and live without filesystem access). Files using imports will
+ * get a banner only for issues in the inline templates / treatments;
+ * import-side issues surface when the researcher actually runs the
+ * preview commands.
+ */
+function expandedFormBannerDiagnostic(
+  source: string,
+): vscode.Diagnostic | null {
+  const result = expandAndValidate(source);
+
+  if (result.expandError) {
+    const diag = new vscode.Diagnostic(
+      new vscode.Range(0, 0, 0, 1),
+      `Stagebook: template expansion failed — ${result.expandError}\n\nRun "Stagebook: Preview Expanded Templates" to investigate.`,
+      vscode.DiagnosticSeverity.Error,
+    );
+    diag.source = "stagebook";
+    return diag;
+  }
+
+  if (result.diagnostics.length === 0) return null;
+
+  const count = result.diagnostics.length;
+  const diag = new vscode.Diagnostic(
+    new vscode.Range(0, 0, 0, 1),
+    `Stagebook: ${count} validation issue${count === 1 ? "" : "s"} in this file's expanded form. Run "Stagebook: Preview Expanded Templates" to see them at their expanded-line positions.`,
+    vscode.DiagnosticSeverity.Warning,
+  );
+  diag.source = "stagebook";
+  return diag;
 }
 
 /**
@@ -594,6 +649,10 @@ function getNonce(): string {
   return nonce;
 }
 
+type PreviewResult =
+  | { ok: true; data: TreatmentFileType }
+  | { ok: false; error: string };
+
 /**
  * Parse a Stagebook treatment file for the preview command.
  *
@@ -605,16 +664,24 @@ function getNonce(): string {
  * expanded via `fillTemplates` and schema-validated.
  *
  * Async because import loading goes through `vscode.workspace.fs`.
- * Returns `null` on any failure (parse, missing import, validation)
- * — the caller surfaces a generic "could not parse" message and
- * leaves precise diagnostics to the in-editor validator.
+ * Returns `{ ok: false, error }` on any failure (parse, missing
+ * import, validation) so the caller can surface the actual error to
+ * the user — falling back to a generic "could not parse" message
+ * loses too much signal, especially for schema-validation failures
+ * with hundreds of issues spread across the file.
  */
-async function parseTreatmentForPreview(source: string, rootDir: vscode.Uri) {
+async function parseTreatmentForPreview(
+  source: string,
+  rootDir: vscode.Uri,
+): Promise<PreviewResult> {
   let rootParse: ReturnType<typeof parseStagebookYaml>;
   try {
     rootParse = parseStagebookYaml(source);
-  } catch {
-    return null;
+  } catch (err) {
+    return {
+      ok: false,
+      error: `YAML parse failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
   }
   const root = rootParse.parsed as ParsedFile;
 
@@ -637,17 +704,20 @@ async function parseTreatmentForPreview(source: string, rootDir: vscode.Uri) {
     let bytes: Uint8Array;
     try {
       bytes = await vscode.workspace.fs.readFile(importUri);
-    } catch {
-      // Import file not found / unreadable. Could surface a real
-      // diagnostic here in a follow-up; for now the preview just
-      // refuses to render.
-      return null;
+    } catch (err) {
+      return {
+        ok: false,
+        error: `Could not read imported file "${importPath}": ${err instanceof Error ? err.message : String(err)}`,
+      };
     }
     let importedParse: ReturnType<typeof parseStagebookYaml>;
     try {
       importedParse = parseStagebookYaml(decoder.decode(bytes));
-    } catch {
-      return null;
+    } catch (err) {
+      return {
+        ok: false,
+        error: `YAML parse failed in imported file "${importPath}": ${err instanceof Error ? err.message : String(err)}`,
+      };
     }
     loaded.set(importPath, importedParse.parsed as ParsedFile);
     for (const next of importedParse.imports) {
@@ -659,8 +729,11 @@ async function parseTreatmentForPreview(source: string, rootDir: vscode.Uri) {
   let mergedTemplates: unknown[];
   try {
     mergedTemplates = resolveImports({ main: root, files: loaded });
-  } catch {
-    return null;
+  } catch (err) {
+    return {
+      ok: false,
+      error: `Import resolution failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
   }
 
   // Strip `imports:` from the root and replace `templates:` with the
@@ -690,14 +763,34 @@ async function parseTreatmentForPreview(source: string, rootDir: vscode.Uri) {
         allowUnresolved: true,
       });
       expanded = result as Record<string, unknown>;
-    } catch {
-      return null;
+    } catch (err) {
+      return {
+        ok: false,
+        error: `Template expansion failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
     }
   }
 
   const parsed = treatmentFileSchema.safeParse(expanded);
-  if (!parsed.success) return null;
-  return parsed.data;
+  if (!parsed.success) {
+    const issues = parsed.error.issues;
+    const summary = issues
+      .slice(0, 3)
+      .map(
+        (i) =>
+          `  • ${i.path.length > 0 ? i.path.join(".") : "(root)"} — ${i.message}`,
+      )
+      .join("\n");
+    const moreNote =
+      issues.length > 3 ? `\n…and ${issues.length - 3} more.` : "";
+    return {
+      ok: false,
+      error:
+        `Validation failed (${issues.length} issue${issues.length === 1 ? "" : "s"}). ` +
+        `Run "Stagebook: Preview Expanded Templates" to see them at their expanded-form positions.\n\n${summary}${moreNote}`,
+    };
+  }
+  return { ok: true, data: parsed.data };
 }
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -814,8 +907,7 @@ export function activate(context: vscode.ExtensionContext): void {
   // Register stage preview webview command
   let previewPanel: vscode.WebviewPanel | undefined;
   // Mutable state updated on each command invocation — avoids stale closures
-  let currentTreatment: Awaited<ReturnType<typeof parseTreatmentForPreview>> =
-    null;
+  let currentTreatment: TreatmentFileType | null = null;
   let currentTreatmentUri: vscode.Uri | undefined;
   let currentTreatmentDir: vscode.Uri | undefined;
   let currentWorkspaceRootFsPath: string | undefined;
@@ -830,13 +922,20 @@ export function activate(context: vscode.ExtensionContext): void {
 
       const source = editor.document.getText();
       const previewRootDir = vscode.Uri.joinPath(editor.document.uri, "..");
-      currentTreatment = await parseTreatmentForPreview(source, previewRootDir);
-      if (!currentTreatment) {
+      const previewResult = await parseTreatmentForPreview(
+        source,
+        previewRootDir,
+      );
+      if (!previewResult.ok) {
         vscode.window.showErrorMessage(
-          "Could not parse treatment file for preview.",
+          `Preview failed.\n\n${previewResult.error}`,
+          {
+            modal: true,
+          },
         );
         return;
       }
+      currentTreatment = previewResult.data;
 
       const workspaceFolder =
         vscode.workspace.getWorkspaceFolder(editor.document.uri) ??
@@ -900,17 +999,18 @@ export function activate(context: vscode.ExtensionContext): void {
             try {
               const doc =
                 await vscode.workspace.openTextDocument(currentTreatmentUri);
-              const parsed = await parseTreatmentForPreview(
+              const refreshResult = await parseTreatmentForPreview(
                 doc.getText(),
                 treatmentDir,
               );
-              if (!parsed) {
+              if (!refreshResult.ok) {
                 vscode.window.showErrorMessage(
-                  "Refresh failed: could not parse treatment file.",
+                  `Refresh failed.\n\n${refreshResult.error}`,
+                  { modal: true },
                 );
                 return;
               }
-              currentTreatment = parsed;
+              currentTreatment = refreshResult.data;
               // Panel may have been disposed while we were awaiting above.
               if (!previewPanel) return;
               const baseUri = panel.webview
@@ -918,7 +1018,7 @@ export function activate(context: vscode.ExtensionContext): void {
                 .toString();
               panel.webview.postMessage({
                 type: "treatment",
-                treatmentFile: parsed,
+                treatmentFile: refreshResult.data,
                 introIndex: 0,
                 treatmentIndex: 0,
                 webviewBaseUri: baseUri,

--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -148,7 +148,13 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
         <AudioElement
           src={getAssetURL(element.file ?? "")}
           save={wrappedSave}
-          name={element.name ?? element.file}
+          // When `name:` is omitted, fall back to a position-based
+          // identifier (`<progressLabel>_<file>`) so two unnamed
+          // audios with the same file in different stages get
+          // distinct storage keys instead of silently overwriting
+          // each other. Researchers who do want a stable name
+          // across stages set `name:` explicitly.
+          name={element.name ?? `${progressLabel}_${element.file ?? ""}`}
         />
       );
 
@@ -287,7 +293,10 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
             : getAssetURL(rawCaptions);
       return (
         <MediaPlayer
-          name={String(element.name ?? rawURL)}
+          // Position-based fallback when `name:` is omitted — same
+          // intent as the audio case above: distinct storage keys
+          // for the same media used in different stages.
+          name={String(element.name ?? `${progressLabel}_${rawURL}`)}
           url={resolvedURL}
           save={wrappedSave}
           getElapsedTime={getElapsedTime}
@@ -371,7 +380,10 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
 
     case "survey": {
       const surveyName = element.surveyName ?? "";
-      const surveyKey = element.name ?? surveyName;
+      // Position-based fallback when `name:` is omitted — same
+      // intent as audio/mediaPlayer: distinct storage keys for the
+      // same survey used in different stages.
+      const surveyKey = element.name ?? `${progressLabel}_${surveyName}`;
       return (
         renderSurvey?.({
           surveyName,

--- a/packages/stagebook/src/schemas/storageKeyCollisions.test.ts
+++ b/packages/stagebook/src/schemas/storageKeyCollisions.test.ts
@@ -259,8 +259,32 @@ describe("collectStorageKeyCollisions", () => {
     expect(collectStorageKeyCollisions(data)).toEqual([]);
   });
 
-  it("derives keys for audio (name OR file fallback)", () => {
-    const data = {
+  it("flags audio collisions only when both elements are explicitly named", () => {
+    // Two unnamed audios sharing a file are NOT a collision —
+    // Element.tsx generates a position-based runtime key for unnamed
+    // audios so each occurrence gets a distinct storage key.
+    // Researchers opt in to cross-stage tracking by setting `name:`.
+    const dataNamed = {
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [
+            {
+              name: "stage1",
+              elements: [
+                { type: "audio", name: "bell", file: "intro.mp3" },
+                { type: "audio", name: "bell", file: "other.mp3" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const namedCollisions = collectStorageKeyCollisions(dataNamed);
+    expect(namedCollisions).toHaveLength(1);
+    expect(namedCollisions[0].key).toBe("audio_bell");
+
+    const dataUnnamed = {
       treatments: [
         {
           name: "t1",
@@ -276,15 +300,29 @@ describe("collectStorageKeyCollisions", () => {
         },
       ],
     };
-    const collisions = collectStorageKeyCollisions(data);
-    expect(collisions).toHaveLength(1);
-    expect(collisions[0].key).toBe("audio_intro.mp3");
+    expect(collectStorageKeyCollisions(dataUnnamed)).toEqual([]);
   });
 
-  it("derives keys for mediaPlayer (name OR file fallback) — matches Element.tsx runtime", () => {
-    // Per Element.tsx:277, mediaPlayer falls back to the raw `file` field
-    // (NOT `url` — that field was renamed to `file` in #249).
-    const data = {
+  it("flags mediaPlayer collisions only when both elements are explicitly named", () => {
+    const dataNamed = {
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [
+            {
+              name: "stage1",
+              elements: [
+                { type: "mediaPlayer", name: "intro", file: "a.mp4" },
+                { type: "mediaPlayer", name: "intro", file: "b.mp4" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(collectStorageKeyCollisions(dataNamed)).toHaveLength(1);
+
+    const dataUnnamed = {
       treatments: [
         {
           name: "t1",
@@ -300,9 +338,7 @@ describe("collectStorageKeyCollisions", () => {
         },
       ],
     };
-    const collisions = collectStorageKeyCollisions(data);
-    expect(collisions).toHaveLength(1);
-    expect(collisions[0].key).toBe("mediaPlayer_intro.mp4");
+    expect(collectStorageKeyCollisions(dataUnnamed)).toEqual([]);
   });
 
   it("flags any two qualtrics elements in the same scope as colliding (fixed key)", () => {
@@ -358,8 +394,26 @@ describe("collectStorageKeyCollisions", () => {
     expect(collisions[0].paths).toHaveLength(2);
   });
 
-  it("derives keys for survey (name OR surveyName fallback)", () => {
-    const data = {
+  it("flags survey collisions only when both elements are explicitly named", () => {
+    const dataNamed = {
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [
+            {
+              name: "stage1",
+              elements: [
+                { type: "survey", name: "intake", surveyName: "TIPI" },
+                { type: "survey", name: "intake", surveyName: "Other" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(collectStorageKeyCollisions(dataNamed)).toHaveLength(1);
+
+    const dataUnnamed = {
       treatments: [
         {
           name: "t1",
@@ -375,9 +429,7 @@ describe("collectStorageKeyCollisions", () => {
         },
       ],
     };
-    const collisions = collectStorageKeyCollisions(data);
-    expect(collisions).toHaveLength(1);
-    expect(collisions[0].key).toBe("survey_TIPI");
+    expect(collectStorageKeyCollisions(dataUnnamed)).toEqual([]);
   });
 
   it("skips elements without a derivable storage key (unnamed prompts/submitButtons)", () => {

--- a/packages/stagebook/src/schemas/storageKeyCollisions.ts
+++ b/packages/stagebook/src/schemas/storageKeyCollisions.ts
@@ -19,21 +19,37 @@
  * per-element `name:` override (e.g. `name: pretest_q1` vs
  * `name: posttest_q1`) to disambiguate.
  *
- * Key derivation mirrors the save() calls in src/components/elements/:
- *   audio        → `audio_${name ?? file}`
+ * Key derivation mirrors the save() calls in src/components/elements/.
+ * Per-type rules:
+ *
+ *   audio        → checked when `name:` is set. Unnamed audios fall
+ *                   back to a position-based key
+ *                   (`audio_<progressLabel>_<file>`) at runtime
+ *                   (Element.tsx:audio case), so two unnamed audios
+ *                   with the same file in different stages get
+ *                   distinct storage keys naturally.
  *   prompt       → `prompt_${name}` (runtime fallback uses progressLabel +
  *                   metadata, which isn't derivable from the YAML alone, so
  *                   we only check explicitly-named prompts)
- *   survey       → `survey_${name ?? surveyName}`
+ *   survey       → checked when `name:` is set. Unnamed surveys fall
+ *                   back to a position-based key at runtime, like audio.
  *   submitButton → `submitButton_${name}` (runtime fallback is progressLabel;
  *                   only checked when `name` is set)
- *   mediaPlayer  → `mediaPlayer_${name ?? file}` (runtime falls back to the
- *                   raw `file` field at Element.tsx:277, before URL resolution)
+ *   mediaPlayer  → checked when `name:` is set. Unnamed mediaPlayers fall
+ *                   back to a position-based key at runtime, like audio.
  *   qualtrics    → fixed key `qualtricsDataReady` (Qualtrics.tsx:50). Any
  *                   two qualtrics elements in the same scope collide
  *                   regardless of name/url, since the key is constant.
  *   timeline     → `timeline_${name}` (name is required by the schema)
  *   trackedLink  → `trackedLink_${name}` (name is required by the schema)
+ *
+ * Why the file/surveyName fallbacks aren't checked: a researcher who
+ * doesn't `name:` an audio is opting out of cross-stage data
+ * tracking — they just want the sound to play. The runtime gives
+ * each occurrence a unique position-derived key, so there's no
+ * silent overwrite to flag. Researchers who want stable cross-stage
+ * names set `name:` explicitly, at which point the collision
+ * detector kicks in.
  */
 
 export interface StorageKeyCollision {
@@ -57,23 +73,20 @@ function storageKeyFor(element: unknown): string | null {
   const el = element as Record<string, unknown>;
   if (typeof el.type !== "string") return null;
   const name = strField(el, "name");
-  let suffix: string | null;
   switch (el.type) {
+    // For these types, only check collisions when the researcher set
+    // `name:` explicitly. Unnamed elements get a position-based key
+    // at runtime (Element.tsx prepends `progressLabel`), so there's
+    // no collision to flag — opt in to cross-stage tracking by
+    // naming.
     case "audio":
-      suffix = name ?? strField(el, "file");
-      break;
     case "survey":
-      suffix = name ?? strField(el, "surveyName");
-      break;
     case "mediaPlayer":
-      suffix = name ?? strField(el, "file");
-      break;
     case "prompt":
     case "submitButton":
     case "timeline":
     case "trackedLink":
-      suffix = name;
-      break;
+      return name ? `${el.type}_${name}` : null;
     case "qualtrics":
       // Qualtrics writes to a fixed key regardless of element identity, so
       // any two qualtrics elements in the same scope collide. Return a
@@ -82,7 +95,6 @@ function storageKeyFor(element: unknown): string | null {
     default:
       return null;
   }
-  return suffix ? `${el.type}_${suffix}` : null;
 }
 
 function scanElements(

--- a/packages/stagebook/src/schemas/validateReferences.ts
+++ b/packages/stagebook/src/schemas/validateReferences.ts
@@ -235,7 +235,84 @@ export function validateTreatmentFileReferences(
     });
   });
 
+  // Templates: walk every template's content for reference sites and
+  // flag any with concrete (placeholder-free) references that don't
+  // resolve against `globalProducedKeys`. This catches typos in
+  // template definitions that would otherwise only surface after
+  // expansion (when the template is invoked from a treatment).
+  // References containing `${...}` placeholders are deferred — they
+  // resolve at fill time and we can't predict the resolved name.
+  templates.forEach((tmpl, tmplIdx) => {
+    if (!isRecord(tmpl)) return;
+    const tmplPath = ["templates", tmplIdx, "content"];
+    for (const site of walkTemplateContentRefSites(tmpl.content, tmplPath)) {
+      if (referenceContainsPlaceholder(site.reference)) continue;
+      // Pass empty producedAt and no rank/phase context — rank-based
+      // checks (forward references, always-skip-at-load) don't apply
+      // inside template definitions; only the unknown-reference rule
+      // is meaningful here, and applyRules handles that as a fall-
+      // through when producedAt has no entry for the key.
+      applyRules({
+        site,
+        enclosingRank: 0,
+        producedAt: new Map(),
+        issues,
+        globalProducedKeys,
+        phaseLabel: "template",
+      });
+    }
+  });
+
   return issues;
+}
+
+/**
+ * Recursively walk a template's `content:` value and yield every
+ * reference site contained within. Templates can have content of
+ * many shapes (treatment / stages / stage / elements / etc.), so
+ * the walker descends into nested objects/arrays and calls
+ * `enumerateStepSites` at each step-shaped object it finds.
+ *
+ * Skips keys that `enumerateStepSites` already walks
+ * (`elements`, `conditions`, `urlParams`, `reference`) to avoid
+ * double-emitting reference sites at the same path.
+ */
+const REF_SKIP_KEYS = new Set([
+  "elements",
+  "conditions",
+  "urlParams",
+  "reference",
+]);
+
+function* walkTemplateContentRefSites(
+  content: unknown,
+  pathPrefix: (string | number)[],
+): Generator<RefSite> {
+  if (content === null || content === undefined) return;
+  if (Array.isArray(content)) {
+    for (let i = 0; i < content.length; i++) {
+      yield* walkTemplateContentRefSites(content[i], [...pathPrefix, i]);
+    }
+    return;
+  }
+  if (!isRecord(content)) return;
+
+  // Treat any object as potentially step-shaped — enumerateStepSites
+  // produces nothing if there are no `conditions:` or `elements:`.
+  yield* enumerateStepSites(content, pathPrefix);
+
+  // Recurse into nested structure, skipping the keys already covered
+  // by enumerateStepSites.
+  for (const [key, value] of Object.entries(content)) {
+    if (REF_SKIP_KEYS.has(key)) continue;
+    yield* walkTemplateContentRefSites(value, [...pathPrefix, key]);
+  }
+}
+
+function referenceContainsPlaceholder(ref: ReferenceType): boolean {
+  // Re-render to dotted form and check for `${...}` — covers
+  // placeholders in source/name/path segments alike.
+  return formatReference(ref).includes("${");
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/stagebook/src/schemas/validateReferences.ts
+++ b/packages/stagebook/src/schemas/validateReferences.ts
@@ -237,9 +237,18 @@ export function validateTreatmentFileReferences(
 
   // Templates: walk every template's content for reference sites and
   // flag any with concrete (placeholder-free) references that don't
-  // resolve against `globalProducedKeys`. This catches typos in
-  // template definitions that would otherwise only surface after
-  // expansion (when the template is invoked from a treatment).
+  // resolve against `globalProducedKeys`. Catches typos in template
+  // definitions that would otherwise only surface after expansion.
+  //
+  // We use the source-walked `globalProducedKeys` (which includes
+  // every template's content via `collectKeysFromAny`), NOT the
+  // hydrated form. Reasoning: templates may be defined but not
+  // currently invoked (e.g., commented-out broadcast, work-in-progress
+  // arms). The source-walked set treats them as "available", which is
+  // the right call — we don't want to flag references to elements
+  // inside a template that the researcher hasn't yet wired up to a
+  // live invocation.
+  //
   // References containing `${...}` placeholders are deferred — they
   // resolve at fill time and we can't predict the resolved name.
   templates.forEach((tmpl, tmplIdx) => {
@@ -247,11 +256,6 @@ export function validateTreatmentFileReferences(
     const tmplPath = ["templates", tmplIdx, "content"];
     for (const site of walkTemplateContentRefSites(tmpl.content, tmplPath)) {
       if (referenceContainsPlaceholder(site.reference)) continue;
-      // Pass empty producedAt and no rank/phase context — rank-based
-      // checks (forward references, always-skip-at-load) don't apply
-      // inside template definitions; only the unknown-reference rule
-      // is meaningful here, and applyRules handles that as a fall-
-      // through when producedAt has no entry for the key.
       applyRules({
         site,
         enclosingRank: 0,
@@ -313,6 +317,43 @@ function referenceContainsPlaceholder(ref: ReferenceType): boolean {
   // Re-render to dotted form and check for `${...}` — covers
   // placeholders in source/name/path segments alike.
   return formatReference(ref).includes("${");
+}
+
+/**
+ * Returns true if `referenceKey` matches any `globalProducedKeys`
+ * entry that contains `${...}` placeholders, treating each
+ * placeholder as a wildcard `[a-zA-Z0-9_]+` segment.
+ *
+ * Handles the prefix-extension convention (see
+ * docs/researcher/templates.md): a template that produces an
+ * element with `name: ${prefix}_q1` lands in the produced-keys
+ * set as the literal `prompt_${prefix}_q1`. A reference at a
+ * caller site that resolved the prefix concretely
+ * (`self.prompt.intake_q1`) needs to match the placeholder
+ * pattern, not the literal.
+ */
+function anyPlaceholderKeyMatches(
+  referenceKey: string,
+  globalProducedKeys: Set<string>,
+): boolean {
+  for (const producedKey of globalProducedKeys) {
+    if (!producedKey.includes("${")) continue;
+    const pattern =
+      "^" +
+      escapeRegex(producedKey).replace(
+        // After escapeRegex, `${name}` becomes `\$\{name\}`. Match
+        // that escaped form and replace with the wildcard.
+        /\\\$\\\{[a-zA-Z0-9_]+\\\}/g,
+        "[a-zA-Z0-9_]+",
+      ) +
+      "$";
+    if (new RegExp(pattern).test(referenceKey)) return true;
+  }
+  return false;
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 // ---------------------------------------------------------------------------
@@ -671,7 +712,20 @@ function applyRules({
     // treatment (concrete stages or templates). Almost always a typo on
     // the element name (e.g. `timeline.storySegment2` when the actual
     // element is `storySegment`).
-    if (globalProducedKeys && !globalProducedKeys.has(referenceKey)) {
+    //
+    // Wildcard fallback: a producing template may use `${prefix}` in its
+    // element names (e.g. `prompt_${prefix}_age`), which lands in
+    // `globalProducedKeys` literally. A concrete reference at a call
+    // site (e.g. `self.prompt.intake_age`, where the caller invoked
+    // the template with `prefix: intake`) won't match the literal —
+    // but it WOULD match a regex built by treating `${...}` as a
+    // wildcard. Accept those, since flagging would be a false
+    // positive on the prefix-extension convention (templates.md).
+    if (
+      globalProducedKeys &&
+      !globalProducedKeys.has(referenceKey) &&
+      !anyPlaceholderKeyMatches(referenceKey, globalProducedKeys)
+    ) {
       issues.push({
         path: site.path,
         message: `Reference "${refStr}" doesn't match any ${refType} element in the treatment. Check the name — no element produces the storage key "${referenceKey}".`,


### PR DESCRIPTION
## Summary

Hits two related authoring-UX problems surfaced by a real-world file (`dialogue-levers/pilot_3.stagebook.yaml`):

1. The file has 220+ treatments, most playing the same unnamed `counter_bell.mp3` audio in two stages. The runtime gave both occurrences the same storage key (`audio_<file>` fallback), and the validator flagged 440 collision errors. The researcher didn't actually want save data for the bell — they just wanted the sound to play.

2. The preview command silently swallowed those 440 errors and showed a generic "Could not parse treatment file for preview." popup, leaving no actionable path forward.

## What changed

### Position-based runtime key for unnamed elements

`Element.tsx` now generates the runtime name as `${progressLabel}_${file}` (or `${progressLabel}_${surveyName}` for surveys) when `name:` is omitted. So two unnamed plays of the same sound in different stages get distinct storage keys naturally — no collision, both saved. Researchers opt in to cross-stage tracking by setting `name:` explicitly.

Affects audio, mediaPlayer, survey. Named elements unchanged.

### Storage-key collision detector relaxed

`storageKeyCollisions.ts` no longer flags collisions on the file-fallback key. For audio/mediaPlayer/survey, the detector returns null when `name:` is absent — researchers who don't name are opting out of cross-stage tracking; the runtime guarantees uniqueness via the position fallback. Two `name: bell` audios still collide as expected.

### Preview popup surfaces real errors

`parseTreatmentForPreview` now returns `{ ok: false, error }` with a specific message instead of `null`:
- YAML parse failure: includes the parser's error
- Import file not found: includes the canonical path
- Template expansion failure: includes the engine's error
- Schema validation failure: shows the first 3 issues with paths, plus a count of remaining ones

Both initial-preview and refresh paths show the result via `showErrorMessage(..., { modal: true })`.

### In-editor banner for post-fill validation issues

`validateTreatmentFile` now adds a single line-1 banner diagnostic when the file's expanded form has issues:

> "Stagebook: 440 validation issues in this file's expanded form. Run \"Stagebook: Preview Expanded Templates\" to see them at their expanded-line positions."

The expand-templates virtual document already runs full post-fill validation and attaches diagnostics to the virtual URI with positions naturally mapped to the expanded text. The banner just tells the researcher where to look — sidesteps the sourcemap-back-to-source problem entirely (templates multiply structure; mapping post-fill paths to source positions is hard).

If template expansion itself fails, the banner surfaces the error message directly with severity Error.

## Test plan

- [x] `pilot_3.stagebook.yaml` now parses cleanly (was 440 errors → 0)
- [x] 1221 tests pass across all workspaces (945 stagebook + 87 viewer + 189 vscode)
- [x] Updated collision detector tests cover both the named-still-collides and unnamed-no-longer-collides cases
- [x] Builds clean
- [x] VS Code extension reinstalled locally; preview popup now shows specific errors with line/path

## Out of scope (future work)

- Source-position squiggles for individual post-fill issues (sourcemapping post-fill paths back to source). Banner + expand-preview gives users a clear path to investigate; precise source squiggles would need fillTemplates instrumentation to track provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)