### PR TITLE
Release v0.9.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13396,10 +13396,11 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.9.4",
+      "version": "0.9.7",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",
+        "js-yaml": "^4.1.0",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1"
       },
@@ -13425,7 +13426,6 @@
         "zod": "^3.23.0"
       },
       "peerDependencies": {
-        "js-yaml": ">=4",
         "react": ">=18",
         "react-dom": ">=18",
         "zod": ">=3.23"

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Adds the \`Select\` form component + \`dropdown\` prompt type (#181, PR #319). Researchers can now use \`type: dropdown\` in prompt files for a compact single-choice picker, useful for long option lists (countries, languages, many-step Likert) where \`multipleChoice\`'s stack of radio buttons would be noisy. Host platforms gain a stagebook-themed \`Select\` primitive that retires parallel local \`<select>\` implementations.

## Test plan

- [x] CI green on #319
- [ ] Cut GitHub release after merge to trigger npm-publish