### PR TITLE
Surface real errors from preview and expand commands (#321 repros 1 & 2)

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -20,14 +20,10 @@ import {
   parseFilePathCompletionContext,
 } from "./lib/filePathCompletion";
 import {
-  fillTemplates,
-  getReferencedAssets,
-  parseTreatmentYaml as parseStagebookYaml,
-  resolveImportPath,
-  resolveImports,
-  treatmentFileSchema,
-  type ParsedFile,
-} from "stagebook";
+  parseTreatmentSource,
+  type ParseResult,
+} from "./lib/parseTreatmentSource";
+import { getReferencedAssets } from "stagebook";
 
 const diagnosticCollection =
   vscode.languages.createDiagnosticCollection("stagebook");
@@ -597,107 +593,27 @@ function getNonce(): string {
 /**
  * Parse a Stagebook treatment file for the preview command.
  *
- * After #277, this loads any `imports:` declared in the file (and
- * transitively in those imports) using vscode's filesystem API, then
- * merges every imported file's `templates:` into the root file's
- * templates list with path rewriting (per template, relative to the
- * file it was declared in). The merged result is then template-
- * expanded via `fillTemplates` and schema-validated.
- *
- * Async because import loading goes through `vscode.workspace.fs`.
- * Returns `null` on any failure (parse, missing import, validation)
- * — the caller surfaces a generic "could not parse" message and
- * leaves precise diagnostics to the in-editor validator.
+ * Thin VS Code-side shim that wraps `parseTreatmentSource` (the pure,
+ * testable core) with a `loadImport` callback backed by
+ * `vscode.workspace.fs`. The shim returns the structured result
+ * unchanged — callers surface the `message` field on failure rather
+ * than the previous generic "could not parse" notification (the root
+ * cause of #321 Repro 1, which silently swallowed all six failure
+ * modes in this function).
  */
-async function parseTreatmentForPreview(source: string, rootDir: vscode.Uri) {
-  let rootParse: ReturnType<typeof parseStagebookYaml>;
-  try {
-    rootParse = parseStagebookYaml(source);
-  } catch {
-    return null;
-  }
-  const root = rootParse.parsed as ParsedFile;
-
-  // Imports loading loop. The host owns the loop (per #277's
-  // design); stagebook's helpers handle path canonicalization
-  // (`resolveImportPath`) and merging (`resolveImports`).
-  const loaded = new Map<string, ParsedFile>();
-  const queue: string[] = rootParse.imports.map((p) =>
-    // The root file's own path is the parent for resolving its imports.
-    // Using a fictional `root.stagebook.yaml` here gives the right
-    // relative behavior because `resolveImportPath` only uses the
-    // parent's directory portion.
-    resolveImportPath("root.stagebook.yaml", p),
-  );
+async function parseTreatmentForPreview(
+  source: string,
+  rootDir: vscode.Uri,
+): Promise<ParseResult> {
   const decoder = new TextDecoder();
-  while (queue.length > 0) {
-    const importPath = queue.shift()!;
-    if (loaded.has(importPath)) continue;
-    const importUri = vscode.Uri.joinPath(rootDir, importPath);
-    let bytes: Uint8Array;
-    try {
-      bytes = await vscode.workspace.fs.readFile(importUri);
-    } catch {
-      // Import file not found / unreadable. Could surface a real
-      // diagnostic here in a follow-up; for now the preview just
-      // refuses to render.
-      return null;
-    }
-    let importedParse: ReturnType<typeof parseStagebookYaml>;
-    try {
-      importedParse = parseStagebookYaml(decoder.decode(bytes));
-    } catch {
-      return null;
-    }
-    loaded.set(importPath, importedParse.parsed as ParsedFile);
-    for (const next of importedParse.imports) {
-      queue.push(resolveImportPath(importPath, next));
-    }
-  }
-
-  // Merge templates with per-file path rewriting.
-  let mergedTemplates: unknown[];
-  try {
-    mergedTemplates = resolveImports({ main: root, files: loaded });
-  } catch {
-    return null;
-  }
-
-  // Strip `imports:` from the root and replace `templates:` with the
-  // merged set. This is what the schema/runtime expects (no imports
-  // in the post-fill world).
-  //
-  // Re-attach `templates:` whenever the root explicitly had it,
-  // even if the merged array is empty — preserves the schema's
-  // rejection of `templates: []` in the root (an authoring error
-  // that would otherwise be silently masked by stripping the key).
-  const rootHadTemplates = "templates" in root;
-  const { imports: _imports, templates: _origTemplates, ...rest } = root;
-  void _imports;
-  void _origTemplates;
-  const merged: Record<string, unknown> = { ...rest };
-  if (mergedTemplates.length > 0 || rootHadTemplates) {
-    merged.templates = mergedTemplates;
-  }
-
-  // Template expansion (existing pipeline).
-  let expanded: Record<string, unknown> = merged;
-  if (mergedTemplates.length > 0) {
-    try {
-      const { result } = fillTemplates({
-        obj: merged,
-        templates: mergedTemplates,
-        allowUnresolved: true,
-      });
-      expanded = result as Record<string, unknown>;
-    } catch {
-      return null;
-    }
-  }
-
-  const parsed = treatmentFileSchema.safeParse(expanded);
-  if (!parsed.success) return null;
-  return parsed.data;
+  return parseTreatmentSource({
+    source,
+    loadImport: async (importPath: string) => {
+      const importUri = vscode.Uri.joinPath(rootDir, importPath);
+      const bytes = await vscode.workspace.fs.readFile(importUri);
+      return decoder.decode(bytes);
+    },
+  });
 }
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -814,8 +730,8 @@ export function activate(context: vscode.ExtensionContext): void {
   // Register stage preview webview command
   let previewPanel: vscode.WebviewPanel | undefined;
   // Mutable state updated on each command invocation — avoids stale closures
-  let currentTreatment: Awaited<ReturnType<typeof parseTreatmentForPreview>> =
-    null;
+  type CurrentTreatment = Extract<ParseResult, { ok: true }>["data"] | null;
+  let currentTreatment: CurrentTreatment = null;
   let currentTreatmentUri: vscode.Uri | undefined;
   let currentTreatmentDir: vscode.Uri | undefined;
   let currentWorkspaceRootFsPath: string | undefined;
@@ -830,13 +746,17 @@ export function activate(context: vscode.ExtensionContext): void {
 
       const source = editor.document.getText();
       const previewRootDir = vscode.Uri.joinPath(editor.document.uri, "..");
-      currentTreatment = await parseTreatmentForPreview(source, previewRootDir);
-      if (!currentTreatment) {
+      const parseResult = await parseTreatmentForPreview(
+        source,
+        previewRootDir,
+      );
+      if (!parseResult.ok) {
         vscode.window.showErrorMessage(
-          "Could not parse treatment file for preview.",
+          `Could not preview treatment: ${parseResult.message}`,
         );
         return;
       }
+      currentTreatment = parseResult.data;
 
       const workspaceFolder =
         vscode.workspace.getWorkspaceFolder(editor.document.uri) ??
@@ -900,17 +820,17 @@ export function activate(context: vscode.ExtensionContext): void {
             try {
               const doc =
                 await vscode.workspace.openTextDocument(currentTreatmentUri);
-              const parsed = await parseTreatmentForPreview(
+              const refreshResult = await parseTreatmentForPreview(
                 doc.getText(),
                 treatmentDir,
               );
-              if (!parsed) {
+              if (!refreshResult.ok) {
                 vscode.window.showErrorMessage(
-                  "Refresh failed: could not parse treatment file.",
+                  `Refresh failed: ${refreshResult.message}`,
                 );
                 return;
               }
-              currentTreatment = parsed;
+              currentTreatment = refreshResult.data;
               // Panel may have been disposed while we were awaiting above.
               if (!previewPanel) return;
               const baseUri = panel.webview
@@ -918,7 +838,7 @@ export function activate(context: vscode.ExtensionContext): void {
                 .toString();
               panel.webview.postMessage({
                 type: "treatment",
-                treatmentFile: parsed,
+                treatmentFile: refreshResult.data,
                 introIndex: 0,
                 treatmentIndex: 0,
                 webviewBaseUri: baseUri,

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -10,7 +10,7 @@ import {
   computeSemanticTokens,
   type SemanticTokenType,
 } from "./lib/semanticTokens";
-import { expandAndValidate } from "./lib/expandAndValidate";
+import { expandAndValidateWithImports } from "./lib/expandAndValidate";
 import { findClosestMatch } from "./lib/levenshtein";
 import { UnrecognizedKeyQuickFixProvider } from "./lib/unrecognizedKeyQuickFix";
 import { isWithinWorkspace, relativizePath } from "./lib/filePaths";
@@ -408,7 +408,7 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
 
   constructor(private readonly diagnostics: vscode.DiagnosticCollection) {}
 
-  provideTextDocumentContent(uri: vscode.Uri): string {
+  async provideTextDocumentContent(uri: vscode.Uri): Promise<string> {
     const sourceUri = vscode.Uri.parse(decodeURIComponent(uri.query));
     const sourceDoc = vscode.workspace.textDocuments.find(
       (d) => d.uri.toString() === sourceUri.toString(),
@@ -418,7 +418,20 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
       return "# Source document not found. Please reopen the preview.";
     }
 
-    const result = expandAndValidate(sourceDoc.getText());
+    // Use the imports-aware expander so cross-file `template:` invocations
+    // resolve in the preview (per #321 Repro 2 — without imports loaded
+    // here, the preview surfaces a misleading "Template not found" error
+    // for templates defined in module files).
+    const sourceDir = vscode.Uri.joinPath(sourceUri, "..");
+    const decoder = new TextDecoder();
+    const result = await expandAndValidateWithImports({
+      source: sourceDoc.getText(),
+      loadImport: async (importPath: string) => {
+        const importUri = vscode.Uri.joinPath(sourceDir, importPath);
+        const bytes = await vscode.workspace.fs.readFile(importUri);
+        return decoder.decode(bytes);
+      },
+    });
     if (result.expandError) {
       this.diagnostics.delete(uri);
       const commentedError = result.expandError

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -472,12 +472,26 @@ class ExpandedTemplatesProvider implements vscode.TextDocumentContentProvider {
       key,
       setTimeout(() => {
         this.refreshTimers.delete(key);
-        const expandedUri = vscode.Uri.parse(
-          `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${encodeURIComponent(sourceUri.toString())}`,
-        );
-        this._onDidChange.fire(expandedUri);
+        this.fireChangeForSource(sourceUri);
       }, DEBOUNCE_MS),
     );
+  }
+
+  /**
+   * Fire the change event immediately (no debounce) for the expanded
+   * preview corresponding to `sourceUri`. Used by the command handler
+   * right after the expanded document is opened, to force VS Code to
+   * re-fetch the content. Diagnostics set during the very first
+   * `provideTextDocumentContent` call don't attach to the editor's
+   * squiggle layer (the doc isn't fully open yet); a second fetch after
+   * the document is visible makes them appear without waiting for the
+   * user to edit the source.
+   */
+  fireChangeForSource(sourceUri: vscode.Uri): void {
+    const expandedUri = vscode.Uri.parse(
+      `${EXPANDED_SCHEME}:${sourceUri.path} (expanded)?${encodeURIComponent(sourceUri.toString())}`,
+    );
+    this._onDidChange.fire(expandedUri);
   }
 
   dispose(): void {
@@ -722,6 +736,15 @@ export function activate(context: vscode.ExtensionContext): void {
         // source treatment files (element types, comparators, template
         // variables, schema keywords).
         await vscode.languages.setTextDocumentLanguage(doc, "stagebookYaml");
+        // Force a re-fetch of the content now that the document is fully
+        // open. Diagnostics attached during the very first
+        // `provideTextDocumentContent` call don't appear in the editor
+        // until a subsequent fetch happens (the doc wasn't fully open
+        // yet, so VS Code didn't wire them to the squiggle layer). The
+        // second fetch hits the warmed-up pipeline (~60ms on pilot_3)
+        // and surfaces the diagnostics immediately instead of waiting
+        // for the user to edit the source file.
+        expandedProvider.fireChangeForSource(sourceUri);
       },
     ),
   );

--- a/apps/vscode/src/lib/expandAndValidate.ts
+++ b/apps/vscode/src/lib/expandAndValidate.ts
@@ -1,4 +1,8 @@
-import { expandTreatmentSource, type ExpandOptions } from "./expandTreatment";
+import {
+  expandTreatmentSource,
+  expandTreatmentSourceWithImports,
+  type ExpandOptions,
+} from "./expandTreatment";
 import { validateTreatmentSource } from "./validateTreatment";
 import type { Diagnostic } from "./types";
 
@@ -33,7 +37,38 @@ export function expandAndValidate(
   options?: ExpandOptions,
 ): ExpandAndValidateResult {
   const expanded = expandTreatmentSource(source, options);
+  return finishExpandAndValidate(expanded);
+}
 
+/**
+ * Like `expandAndValidate`, but loads `imports:` through the supplied
+ * callback before expanding. Used by the "View Expanded Templates"
+ * provider so the expanded preview reflects the actual cross-file
+ * resolution (per #321 Repro 2).
+ */
+export async function expandAndValidateWithImports({
+  source,
+  loadImport,
+  options,
+}: {
+  source: string;
+  loadImport: (importPath: string) => Promise<string>;
+  options?: ExpandOptions;
+}): Promise<ExpandAndValidateResult> {
+  const expanded = await expandTreatmentSourceWithImports({
+    source,
+    loadImport,
+    options,
+  });
+  return finishExpandAndValidate(expanded);
+}
+
+function finishExpandAndValidate(expanded: {
+  yaml: string;
+  fullYaml: string;
+  error: string | null;
+  truncated: boolean;
+}): ExpandAndValidateResult {
   if (expanded.error) {
     return {
       yaml: expanded.yaml,
@@ -42,9 +77,7 @@ export function expandAndValidate(
       diagnostics: [],
     };
   }
-
   const { diagnostics } = validateTreatmentSource(expanded.fullYaml);
-
   return {
     yaml: expanded.yaml,
     truncated: expanded.truncated,

--- a/apps/vscode/src/lib/expandTreatment.test.ts
+++ b/apps/vscode/src/lib/expandTreatment.test.ts
@@ -191,6 +191,18 @@ treatments:
       expect(result.error).toContain("not found");
       expect(result.yaml).toBe("");
     });
+
+    // Repro 2 from #321: today, when the file has no root-level `templates:`
+    // key, the expander short-circuits and returns the source unchanged —
+    // even when the file invokes a template that no one has defined. The
+    // user sees their input echoed back and can't tell expansion is broken.
+    it("returns an error for an unresolved invocation when no templates key is present (#321 Repro 2)", () => {
+      const src = `treatments:
+  - template: foo`;
+      const result = expandTreatmentSource(src);
+      expect(result.error).toContain("not found");
+      expect(result.yaml).toBe("");
+    });
   });
 
   describe("unresolved placeholders", () => {

--- a/apps/vscode/src/lib/expandTreatment.test.ts
+++ b/apps/vscode/src/lib/expandTreatment.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { expandTreatmentSource } from "./expandTreatment";
+import {
+  expandTreatmentSource,
+  expandTreatmentSourceWithImports,
+} from "./expandTreatment";
 
 describe("expandTreatmentSource", () => {
   describe("no templates", () => {
@@ -275,6 +278,72 @@ treatments:
 ${broadcastItems}`;
       const result = expandTreatmentSource(src, { maxBroadcastProduct: 100 });
       expect(result.error).toContain("Broadcast expansion would produce");
+      expect(result.yaml).toBe("");
+    });
+  });
+
+  describe("expandTreatmentSourceWithImports", () => {
+    const loaderFromMap = (files: Record<string, string>) => {
+      // resolveImportPath normalizes paths (strips `./`), so be tolerant
+      // of both forms when looking up the fixture.
+      return async (path: string): Promise<string> => {
+        const normalized = path.replace(/^\.\//, "");
+        const content = files[path] ?? files[normalized] ?? files[`./${path}`];
+        if (content === undefined) {
+          throw new Error(`Mock loader: no entry for ${path}`);
+        }
+        return content;
+      };
+    };
+
+    it("resolves a template defined in an imported module (#321 Repro 2 — full fix)", async () => {
+      const source = `imports:
+  - ./module.stagebook.yaml
+
+treatments:
+  - template: makeTreatment`;
+      const moduleSrc = `templates:
+  - name: makeTreatment
+    contentType: treatment
+    content:
+      name: t
+      playerCount: 1
+      gameStages:
+        - name: s
+          duration: 10
+          elements:
+            - type: submitButton
+`;
+      const result = await expandTreatmentSourceWithImports({
+        source,
+        loadImport: loaderFromMap({
+          "./module.stagebook.yaml": moduleSrc,
+        }),
+      });
+      expect(result.error).toBeNull();
+      expect(result.yaml).toContain("name: t");
+      expect(result.yaml).toContain("type: submitButton");
+      // Templates key should be stripped from the expanded output.
+      expect(result.yaml).not.toMatch(/^templates:/m);
+    });
+
+    it("returns an import-read error when an import file is missing", async () => {
+      const source = `imports:
+  - ./missing.stagebook.yaml
+
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: s
+        duration: 10
+        elements:
+          - type: submitButton`;
+      const result = await expandTreatmentSourceWithImports({
+        source,
+        loadImport: loaderFromMap({}),
+      });
+      expect(result.error).toContain("missing.stagebook.yaml");
       expect(result.yaml).toBe("");
     });
   });

--- a/apps/vscode/src/lib/expandTreatment.ts
+++ b/apps/vscode/src/lib/expandTreatment.ts
@@ -122,19 +122,19 @@ export function expandTreatmentSource(
     return { yaml: "", fullYaml: "", error: sizeError, truncated: false };
   }
 
-  // Expand templates
+  // Always pass through fillTemplates so unresolved `template:` invocations
+  // always surface as a "Template not found" error, even when there are
+  // zero root-level templates (the common case once #277 imports landed —
+  // see #321 Repro 2). The previous `templates.length > 0` gate silently
+  // returned the source unchanged in that case.
   let expanded: Record<string, unknown>;
   try {
-    if (templates.length > 0) {
-      const { result } = fillTemplates({
-        obj: record,
-        templates,
-        allowUnresolved: true,
-      });
-      expanded = result as Record<string, unknown>;
-    } else {
-      expanded = { ...record };
-    }
+    const { result } = fillTemplates({
+      obj: record,
+      templates,
+      allowUnresolved: true,
+    });
+    expanded = result as Record<string, unknown>;
   } catch (e) {
     return {
       yaml: "",

--- a/apps/vscode/src/lib/expandTreatment.ts
+++ b/apps/vscode/src/lib/expandTreatment.ts
@@ -1,5 +1,6 @@
 import { fillTemplates } from "stagebook";
 import { parse, stringify } from "yaml";
+import { loadAndMergeImports } from "./loadAndMergeImports";
 
 const DEFAULT_MAX_LINES = 5000;
 const DEFAULT_MAX_BROADCAST = 10000;
@@ -175,4 +176,51 @@ export function expandTreatmentSource(
   }
 
   return { yaml, fullYaml: yaml, error: null, truncated: false };
+}
+
+/**
+ * Like `expandTreatmentSource`, but loads `imports:` through the supplied
+ * callback before expanding. Returns the same `ExpandResult` shape — the
+ * caller can't tell whether imports were involved.
+ *
+ * Used by the "View Expanded Templates" provider so the expanded preview
+ * shows the actual resolution of cross-file template invocations (the
+ * second half of #321 Repro 2; without imports loaded, the expander
+ * surfaces "Template not found" for templates that live in module files).
+ *
+ * Import-loading errors (missing/unreadable file, malformed YAML in an
+ * import, merge failure) are surfaced in the result's `error` field so
+ * the preview shows them as commented banners — same channel as
+ * expansion errors.
+ */
+export async function expandTreatmentSourceWithImports({
+  source,
+  loadImport,
+  options,
+}: {
+  source: string;
+  loadImport: (importPath: string) => Promise<string>;
+  options?: ExpandOptions;
+}): Promise<ExpandResult> {
+  const loadResult = await loadAndMergeImports({ source, loadImport });
+  if (!loadResult.ok) {
+    return {
+      yaml: "",
+      fullYaml: "",
+      error: loadResult.message,
+      truncated: false,
+    };
+  }
+  let mergedYaml: string;
+  try {
+    mergedYaml = stringify(loadResult.merged, { indent: 2, lineWidth: 0 });
+  } catch (e) {
+    return {
+      yaml: "",
+      fullYaml: "",
+      error: `YAML serialization failed: ${e instanceof Error ? e.message : String(e)}`,
+      truncated: false,
+    };
+  }
+  return expandTreatmentSource(mergedYaml, options);
 }

--- a/apps/vscode/src/lib/loadAndMergeImports.ts
+++ b/apps/vscode/src/lib/loadAndMergeImports.ts
@@ -102,10 +102,11 @@ export async function loadAndMergeImports({
   }
 
   // Strip `imports:` from the root and replace `templates:` with the
-  // merged set. Re-attach `templates:` whenever the root explicitly had
-  // it, even if the merged array is empty — preserves the schema's
-  // rejection of `templates: []` in the root (an authoring error that
-  // would otherwise be silently masked by stripping the key).
+  // merged set. Note: `fillTemplates` strips `templates:` from its walk
+  // input before expanding, so the merged value is effectively only
+  // passed to `fillTemplates` via its separate `templates` parameter.
+  // Attaching it back on `merged` is documentation: the post-load shape
+  // mirrors what a file with inline templates would look like.
   const rootHadTemplates = "templates" in root;
   const { imports: _imports, templates: _origTemplates, ...rest } = root;
   void _imports;

--- a/apps/vscode/src/lib/loadAndMergeImports.ts
+++ b/apps/vscode/src/lib/loadAndMergeImports.ts
@@ -1,0 +1,123 @@
+import {
+  parseTreatmentYaml as parseStagebookYaml,
+  resolveImportPath,
+  resolveImports,
+  type ParsedFile,
+} from "stagebook";
+
+export type LoadFailureStage =
+  | "parse"
+  | "import-read"
+  | "import-parse"
+  | "resolve";
+
+export type LoadAndMergeResult =
+  | {
+      ok: true;
+      /** Root object with `imports:` stripped and `templates:` replaced
+       *  by the merged set. Schema/expander-ready. */
+      merged: Record<string, unknown>;
+      /** The merged templates list (also embedded in `merged.templates`). */
+      templates: unknown[];
+    }
+  | { ok: false; stage: LoadFailureStage; message: string };
+
+/**
+ * Parse a treatment source, walk its `imports:` tree via the supplied
+ * loader, and merge every imported file's `templates:` into the root.
+ *
+ * Shared by `parseTreatmentSource` (which then runs `fillTemplates` +
+ * schema validation) and `expandTreatmentSourceWithImports` (which
+ * runs the expander for the "View Expanded Templates" command). Both
+ * paths previously diverged: one knew about imports, the other didn't.
+ * See #321 Repro 2.
+ *
+ * `loadImport` is the host's bridge to its filesystem; in VS Code it
+ * wraps `vscode.workspace.fs`, in tests it can be a Map-based mock.
+ */
+export async function loadAndMergeImports({
+  source,
+  loadImport,
+}: {
+  source: string;
+  loadImport: (importPath: string) => Promise<string>;
+}): Promise<LoadAndMergeResult> {
+  let rootParse: ReturnType<typeof parseStagebookYaml>;
+  try {
+    rootParse = parseStagebookYaml(source);
+  } catch (e) {
+    return {
+      ok: false,
+      stage: "parse",
+      message: `YAML parse error: ${errorMessage(e)}`,
+    };
+  }
+  const root = rootParse.parsed as ParsedFile;
+
+  // The root file's own path is the parent for resolving its imports.
+  // A fictional `root.stagebook.yaml` works because `resolveImportPath`
+  // only uses the parent's directory portion.
+  const loaded = new Map<string, ParsedFile>();
+  const queue: string[] = rootParse.imports.map((p) =>
+    resolveImportPath("root.stagebook.yaml", p),
+  );
+  while (queue.length > 0) {
+    const importPath = queue.shift()!;
+    if (loaded.has(importPath)) continue;
+    let contents: string;
+    try {
+      contents = await loadImport(importPath);
+    } catch (e) {
+      return {
+        ok: false,
+        stage: "import-read",
+        message: `Could not read import file '${importPath}': ${errorMessage(e)}`,
+      };
+    }
+    let importedParse: ReturnType<typeof parseStagebookYaml>;
+    try {
+      importedParse = parseStagebookYaml(contents);
+    } catch (e) {
+      return {
+        ok: false,
+        stage: "import-parse",
+        message: `YAML parse error in import '${importPath}': ${errorMessage(e)}`,
+      };
+    }
+    loaded.set(importPath, importedParse.parsed as ParsedFile);
+    for (const next of importedParse.imports) {
+      queue.push(resolveImportPath(importPath, next));
+    }
+  }
+
+  let mergedTemplates: unknown[];
+  try {
+    mergedTemplates = resolveImports({ main: root, files: loaded });
+  } catch (e) {
+    return {
+      ok: false,
+      stage: "resolve",
+      message: `Could not merge imports: ${errorMessage(e)}`,
+    };
+  }
+
+  // Strip `imports:` from the root and replace `templates:` with the
+  // merged set. Re-attach `templates:` whenever the root explicitly had
+  // it, even if the merged array is empty — preserves the schema's
+  // rejection of `templates: []` in the root (an authoring error that
+  // would otherwise be silently masked by stripping the key).
+  const rootHadTemplates = "templates" in root;
+  const { imports: _imports, templates: _origTemplates, ...rest } = root;
+  void _imports;
+  void _origTemplates;
+  const merged: Record<string, unknown> = { ...rest };
+  if (mergedTemplates.length > 0 || rootHadTemplates) {
+    merged.templates = mergedTemplates;
+  }
+
+  return { ok: true, merged, templates: mergedTemplates };
+}
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/apps/vscode/src/lib/parseTreatmentSource.test.ts
+++ b/apps/vscode/src/lib/parseTreatmentSource.test.ts
@@ -133,6 +133,53 @@ treatments:
       expect(result.message).toContain("broken.stagebook.yaml");
     });
 
+    it("returns resolve failure when an import duplicates a template name from the root", async () => {
+      // `resolveImports` throws when a template name is defined twice
+      // across the root + imports tree. The pipeline maps that to the
+      // `resolve` stage. Surfaces as a precise message rather than
+      // letting the duplicate quietly win one definition over the other.
+      const source = `imports:
+  - ./module.stagebook.yaml
+
+templates:
+  - name: dup
+    contentType: treatment
+    content:
+      name: t
+      playerCount: 1
+      gameStages:
+        - name: s
+          duration: 10
+          elements:
+            - type: submitButton
+
+treatments:
+  - template: dup
+`;
+      const moduleSrc = `templates:
+  - name: dup
+    contentType: treatment
+    content:
+      name: t2
+      playerCount: 1
+      gameStages:
+        - name: s
+          duration: 10
+          elements:
+            - type: submitButton
+`;
+      const result = await parseTreatmentSource({
+        source,
+        loadImport: loaderFromMap({
+          "./module.stagebook.yaml": moduleSrc,
+        }),
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.stage).toBe("resolve");
+      expect(result.message).toContain("dup");
+    });
+
     it("returns hydration failure when a template invocation cannot be resolved", async () => {
       const source = `imports:
   - ./module.stagebook.yaml

--- a/apps/vscode/src/lib/parseTreatmentSource.test.ts
+++ b/apps/vscode/src/lib/parseTreatmentSource.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, expect } from "vitest";
+import { parseTreatmentSource } from "./parseTreatmentSource";
+
+/**
+ * Tests for the host-agnostic source parser/expander/validator that backs
+ * the VS Code preview command. The same helper is also the testable core
+ * for the larger validation pipeline in #321.
+ *
+ * Each failure path returns a structured `{ ok: false, stage, message }`
+ * result so callers can surface specific error text instead of a generic
+ * "could not parse" notification (the previous behavior, which masked all
+ * six failure modes and was the root cause of #321 Repro 1).
+ */
+const loaderFromMap = (files: Record<string, string>) => {
+  return async (path: string): Promise<string> => {
+    const normalized = path.replace(/^\.\//, "");
+    const content = files[path] ?? files[normalized] ?? files[`./${path}`];
+    if (content === undefined) {
+      throw new Error(`Mock loader: no entry for ${path}`);
+    }
+    return content;
+  };
+};
+
+const validTreatment = `treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: s
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+
+describe("parseTreatmentSource", () => {
+  describe("success", () => {
+    it("returns ok with the parsed treatment when the source is valid", async () => {
+      const result = await parseTreatmentSource({
+        source: validTreatment,
+        loadImport: loaderFromMap({}),
+      });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.data).toBeDefined();
+    });
+
+    it("loads imports and merges their templates", async () => {
+      const source = `imports:
+  - ./module.stagebook.yaml
+
+treatments:
+  - template: makeTreatment
+`;
+      const moduleSrc = `templates:
+  - name: makeTreatment
+    contentType: treatment
+    content:
+      name: t
+      playerCount: 1
+      gameStages:
+        - name: s
+          duration: 10
+          elements:
+            - type: submitButton
+`;
+      const result = await parseTreatmentSource({
+        source,
+        loadImport: loaderFromMap({
+          "./module.stagebook.yaml": moduleSrc,
+        }),
+      });
+      expect(result.ok).toBe(true);
+    });
+  });
+
+  describe("structured failures", () => {
+    it("returns parse failure when the root YAML is malformed", async () => {
+      const result = await parseTreatmentSource({
+        source: "[[[invalid",
+        loadImport: loaderFromMap({}),
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.stage).toBe("parse");
+      expect(result.message).toMatch(/yaml|parse/i);
+    });
+
+    it("returns import-read failure when an imported file is missing (#321 Repro 1)", async () => {
+      const source = `imports:
+  - ./does-not-exist.stagebook.yaml
+
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: s
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+      const result = await parseTreatmentSource({
+        source,
+        loadImport: loaderFromMap({}),
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.stage).toBe("import-read");
+      expect(result.message).toContain("does-not-exist.stagebook.yaml");
+    });
+
+    it("returns import-parse failure when an imported file has malformed YAML", async () => {
+      const source = `imports:
+  - ./broken.stagebook.yaml
+
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: s
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+      const result = await parseTreatmentSource({
+        source,
+        loadImport: loaderFromMap({
+          "./broken.stagebook.yaml": "[[[malformed",
+        }),
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.stage).toBe("import-parse");
+      expect(result.message).toContain("broken.stagebook.yaml");
+    });
+
+    it("returns hydration failure when a template invocation cannot be resolved", async () => {
+      const source = `imports:
+  - ./module.stagebook.yaml
+
+treatments:
+  - template: doesNotExist
+`;
+      const moduleSrc = `templates:
+  - name: someOtherTemplate
+    contentType: treatment
+    content:
+      name: t
+      playerCount: 1
+      gameStages:
+        - name: s
+          duration: 10
+          elements:
+            - type: submitButton
+`;
+      const result = await parseTreatmentSource({
+        source,
+        loadImport: loaderFromMap({
+          "./module.stagebook.yaml": moduleSrc,
+        }),
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.stage).toBe("hydration");
+      expect(result.message).toContain("doesNotExist");
+    });
+
+    it("returns schema failure when the hydrated form violates the schema", async () => {
+      // Hydrated form: playerCount is a string, which violates the schema.
+      const source = `treatments:
+  - name: t
+    playerCount: notANumber
+    gameStages:
+      - name: s
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+      const result = await parseTreatmentSource({
+        source,
+        loadImport: loaderFromMap({}),
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.stage).toBe("schema");
+      expect(result.message.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("transitive imports", () => {
+    it("loads imports recursively through the tree", async () => {
+      const source = `imports:
+  - ./a.stagebook.yaml
+
+treatments:
+  - template: fromB
+`;
+      const a = `imports:
+  - ./b.stagebook.yaml
+`;
+      const b = `templates:
+  - name: fromB
+    contentType: treatment
+    content:
+      name: t
+      playerCount: 1
+      gameStages:
+        - name: s
+          duration: 10
+          elements:
+            - type: submitButton
+`;
+      const result = await parseTreatmentSource({
+        source,
+        loadImport: loaderFromMap({
+          "./a.stagebook.yaml": a,
+          "./b.stagebook.yaml": b,
+        }),
+      });
+      expect(result.ok).toBe(true);
+    });
+  });
+});

--- a/apps/vscode/src/lib/parseTreatmentSource.ts
+++ b/apps/vscode/src/lib/parseTreatmentSource.ts
@@ -1,7 +1,7 @@
 import {
   fillTemplates,
   treatmentFileSchema,
-  type TreatmentFile,
+  type TreatmentFileType,
 } from "stagebook";
 import {
   loadAndMergeImports,
@@ -22,7 +22,7 @@ import {
 export type ParseFailureStage = LoadFailureStage | "hydration" | "schema";
 
 export type ParseResult =
-  | { ok: true; data: TreatmentFile }
+  | { ok: true; data: TreatmentFileType }
   | { ok: false; stage: ParseFailureStage; message: string };
 
 /**

--- a/apps/vscode/src/lib/parseTreatmentSource.ts
+++ b/apps/vscode/src/lib/parseTreatmentSource.ts
@@ -1,0 +1,172 @@
+import {
+  fillTemplates,
+  parseTreatmentYaml as parseStagebookYaml,
+  resolveImportPath,
+  resolveImports,
+  treatmentFileSchema,
+  type ParsedFile,
+  type TreatmentFile,
+} from "stagebook";
+
+/**
+ * Stage at which parsing/expanding/validating failed.
+ *
+ * - `parse`         — root YAML parse failed
+ * - `import-read`   — an imported file couldn't be read by `loadImport`
+ * - `import-parse`  — an imported file's YAML parse failed
+ * - `resolve`       — `resolveImports` threw while merging templates
+ * - `hydration`     — `fillTemplates` threw (most commonly: template name
+ *                     not defined in this file or its imports)
+ * - `schema`        — the hydrated form failed schema validation
+ */
+export type ParseFailureStage =
+  | "parse"
+  | "import-read"
+  | "import-parse"
+  | "resolve"
+  | "hydration"
+  | "schema";
+
+export type ParseResult =
+  | { ok: true; data: TreatmentFile }
+  | { ok: false; stage: ParseFailureStage; message: string };
+
+/**
+ * Host-agnostic core of the treatment-file preview pipeline. Parses the
+ * root source, loads its imports (transitively), merges them, runs
+ * `fillTemplates`, and validates against `treatmentFileSchema`.
+ *
+ * Each failure mode returns `{ ok: false, stage, message }` rather than
+ * a null/undefined so callers can surface specific text instead of a
+ * generic "could not parse" notification. This replaces the previous
+ * behavior of `parseTreatmentForPreview` in extension.ts which silently
+ * swallowed every error — the root cause of #321 Repro 1.
+ *
+ * `loadImport` is the host's bridge to its filesystem. In VS Code it
+ * wraps `vscode.workspace.fs.readFile`; in tests it's a Map-based mock.
+ * Throw or reject on failure; the caller will tag it as `import-read`.
+ *
+ * See #321 for the broader validation pipeline this is part of.
+ */
+export async function parseTreatmentSource({
+  source,
+  loadImport,
+}: {
+  source: string;
+  loadImport: (importPath: string) => Promise<string>;
+}): Promise<ParseResult> {
+  let rootParse: ReturnType<typeof parseStagebookYaml>;
+  try {
+    rootParse = parseStagebookYaml(source);
+  } catch (e) {
+    return {
+      ok: false,
+      stage: "parse",
+      message: `YAML parse error: ${errorMessage(e)}`,
+    };
+  }
+  const root = rootParse.parsed as ParsedFile;
+
+  // The root file's own path is the parent for resolving its imports.
+  // Using a fictional `root.stagebook.yaml` here gives the right relative
+  // behavior because `resolveImportPath` only uses the parent's directory.
+  const loaded = new Map<string, ParsedFile>();
+  const queue: string[] = rootParse.imports.map((p) =>
+    resolveImportPath("root.stagebook.yaml", p),
+  );
+  while (queue.length > 0) {
+    const importPath = queue.shift()!;
+    if (loaded.has(importPath)) continue;
+    let contents: string;
+    try {
+      contents = await loadImport(importPath);
+    } catch (e) {
+      return {
+        ok: false,
+        stage: "import-read",
+        message: `Could not read import file '${importPath}': ${errorMessage(e)}`,
+      };
+    }
+    let importedParse: ReturnType<typeof parseStagebookYaml>;
+    try {
+      importedParse = parseStagebookYaml(contents);
+    } catch (e) {
+      return {
+        ok: false,
+        stage: "import-parse",
+        message: `YAML parse error in import '${importPath}': ${errorMessage(e)}`,
+      };
+    }
+    loaded.set(importPath, importedParse.parsed as ParsedFile);
+    for (const next of importedParse.imports) {
+      queue.push(resolveImportPath(importPath, next));
+    }
+  }
+
+  let mergedTemplates: unknown[];
+  try {
+    mergedTemplates = resolveImports({ main: root, files: loaded });
+  } catch (e) {
+    return {
+      ok: false,
+      stage: "resolve",
+      message: `Could not merge imports: ${errorMessage(e)}`,
+    };
+  }
+
+  // Strip `imports:` from the root and replace `templates:` with the merged
+  // set. Re-attach `templates:` whenever the root explicitly had it, even
+  // if the merged array is empty — preserves the schema's rejection of
+  // `templates: []` in the root (an authoring error that would otherwise
+  // be silently masked by stripping the key).
+  const rootHadTemplates = "templates" in root;
+  const { imports: _imports, templates: _origTemplates, ...rest } = root;
+  void _imports;
+  void _origTemplates;
+  const merged: Record<string, unknown> = { ...rest };
+  if (mergedTemplates.length > 0 || rootHadTemplates) {
+    merged.templates = mergedTemplates;
+  }
+
+  // Always pass through fillTemplates, even when there are zero templates,
+  // so unresolved `template:` invocations always surface as a real
+  // "Template not found" error. (Per #321 Repro 2: the previous
+  // `templates.length > 0` gate let invocations silently pass through.)
+  let expanded: Record<string, unknown>;
+  try {
+    const { result } = fillTemplates({
+      obj: merged,
+      templates: mergedTemplates,
+      allowUnresolved: true,
+    });
+    expanded = result as Record<string, unknown>;
+  } catch (e) {
+    return {
+      ok: false,
+      stage: "hydration",
+      message: `Template expansion failed: ${errorMessage(e)}`,
+    };
+  }
+
+  const parsed = treatmentFileSchema.safeParse(expanded);
+  if (!parsed.success) {
+    const firstIssue = parsed.error.issues[0];
+    const message = firstIssue
+      ? `Schema validation failed at ${formatPath(firstIssue.path)}: ${firstIssue.message}`
+      : "Schema validation failed";
+    return { ok: false, stage: "schema", message };
+  }
+  return { ok: true, data: parsed.data };
+}
+
+function errorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+function formatPath(p: (string | number)[]): string {
+  if (p.length === 0) return "(root)";
+  return p
+    .map((seg) => (typeof seg === "number" ? `[${seg}]` : seg))
+    .join(".")
+    .replace(/\.\[/g, "[");
+}

--- a/apps/vscode/src/lib/parseTreatmentSource.ts
+++ b/apps/vscode/src/lib/parseTreatmentSource.ts
@@ -1,12 +1,12 @@
 import {
   fillTemplates,
-  parseTreatmentYaml as parseStagebookYaml,
-  resolveImportPath,
-  resolveImports,
   treatmentFileSchema,
-  type ParsedFile,
   type TreatmentFile,
 } from "stagebook";
+import {
+  loadAndMergeImports,
+  type LoadFailureStage,
+} from "./loadAndMergeImports";
 
 /**
  * Stage at which parsing/expanding/validating failed.
@@ -19,22 +19,16 @@ import {
  *                     not defined in this file or its imports)
  * - `schema`        — the hydrated form failed schema validation
  */
-export type ParseFailureStage =
-  | "parse"
-  | "import-read"
-  | "import-parse"
-  | "resolve"
-  | "hydration"
-  | "schema";
+export type ParseFailureStage = LoadFailureStage | "hydration" | "schema";
 
 export type ParseResult =
   | { ok: true; data: TreatmentFile }
   | { ok: false; stage: ParseFailureStage; message: string };
 
 /**
- * Host-agnostic core of the treatment-file preview pipeline. Parses the
- * root source, loads its imports (transitively), merges them, runs
- * `fillTemplates`, and validates against `treatmentFileSchema`.
+ * Host-agnostic core of the treatment-file preview pipeline. Loads imports
+ * (via the supplied callback), merges them, runs `fillTemplates`, and
+ * validates against `treatmentFileSchema`.
  *
  * Each failure mode returns `{ ok: false, stage, message }` rather than
  * a null/undefined so callers can surface specific text instead of a
@@ -55,78 +49,8 @@ export async function parseTreatmentSource({
   source: string;
   loadImport: (importPath: string) => Promise<string>;
 }): Promise<ParseResult> {
-  let rootParse: ReturnType<typeof parseStagebookYaml>;
-  try {
-    rootParse = parseStagebookYaml(source);
-  } catch (e) {
-    return {
-      ok: false,
-      stage: "parse",
-      message: `YAML parse error: ${errorMessage(e)}`,
-    };
-  }
-  const root = rootParse.parsed as ParsedFile;
-
-  // The root file's own path is the parent for resolving its imports.
-  // Using a fictional `root.stagebook.yaml` here gives the right relative
-  // behavior because `resolveImportPath` only uses the parent's directory.
-  const loaded = new Map<string, ParsedFile>();
-  const queue: string[] = rootParse.imports.map((p) =>
-    resolveImportPath("root.stagebook.yaml", p),
-  );
-  while (queue.length > 0) {
-    const importPath = queue.shift()!;
-    if (loaded.has(importPath)) continue;
-    let contents: string;
-    try {
-      contents = await loadImport(importPath);
-    } catch (e) {
-      return {
-        ok: false,
-        stage: "import-read",
-        message: `Could not read import file '${importPath}': ${errorMessage(e)}`,
-      };
-    }
-    let importedParse: ReturnType<typeof parseStagebookYaml>;
-    try {
-      importedParse = parseStagebookYaml(contents);
-    } catch (e) {
-      return {
-        ok: false,
-        stage: "import-parse",
-        message: `YAML parse error in import '${importPath}': ${errorMessage(e)}`,
-      };
-    }
-    loaded.set(importPath, importedParse.parsed as ParsedFile);
-    for (const next of importedParse.imports) {
-      queue.push(resolveImportPath(importPath, next));
-    }
-  }
-
-  let mergedTemplates: unknown[];
-  try {
-    mergedTemplates = resolveImports({ main: root, files: loaded });
-  } catch (e) {
-    return {
-      ok: false,
-      stage: "resolve",
-      message: `Could not merge imports: ${errorMessage(e)}`,
-    };
-  }
-
-  // Strip `imports:` from the root and replace `templates:` with the merged
-  // set. Re-attach `templates:` whenever the root explicitly had it, even
-  // if the merged array is empty — preserves the schema's rejection of
-  // `templates: []` in the root (an authoring error that would otherwise
-  // be silently masked by stripping the key).
-  const rootHadTemplates = "templates" in root;
-  const { imports: _imports, templates: _origTemplates, ...rest } = root;
-  void _imports;
-  void _origTemplates;
-  const merged: Record<string, unknown> = { ...rest };
-  if (mergedTemplates.length > 0 || rootHadTemplates) {
-    merged.templates = mergedTemplates;
-  }
+  const loadResult = await loadAndMergeImports({ source, loadImport });
+  if (!loadResult.ok) return loadResult;
 
   // Always pass through fillTemplates, even when there are zero templates,
   // so unresolved `template:` invocations always surface as a real
@@ -135,8 +59,8 @@ export async function parseTreatmentSource({
   let expanded: Record<string, unknown>;
   try {
     const { result } = fillTemplates({
-      obj: merged,
-      templates: mergedTemplates,
+      obj: loadResult.merged,
+      templates: loadResult.templates,
       allowUnresolved: true,
     });
     expanded = result as Record<string, unknown>;


### PR DESCRIPTION
## Summary

Two reproducible bugs in the VS Code extension's preview pipeline both have the same root cause: silent fallbacks that mask whatever's actually wrong. Both fixes are independent of the larger validator-architecture rework planned in #321.

### Repro 1: silent preview failure

`parseTreatmentForPreview` had six failure paths (root parse, import read, import parse, `resolveImports`, `fillTemplates`, schema validation) and silently returned `null` on all of them. The caller showed a generic *"Could not parse treatment file for preview."* notification. The user had no signal about which stage failed or why.

**Before:** generic notification, no detail.
**After:** specific message, e.g. *"Could not preview treatment: Could not read import file './missing.stagebook.yaml': ..."*, *"Could not preview treatment: Template expansion failed: Template 'doesNotExist' not found"*, etc.

Extracted the import-loading + expand + validate logic into a pure, testable helper ([apps/vscode/src/lib/parseTreatmentSource.ts](apps/vscode/src/lib/parseTreatmentSource.ts)) with a `loadImport` callback, so each failure mode can be unit-tested without the `vscode` runtime. The VS Code shim in [extension.ts](apps/vscode/src/extension.ts) is now ~15 lines wrapping `vscode.workspace.fs.readFile`. Both call sites surface the structured message verbatim.

### Repro 2: expanded view returns source unchanged

`expandTreatmentSource` gated the call to `fillTemplates` on `templates.length > 0`. When a file declares `imports:` but no root-level `templates:` key, this skipped expansion entirely — even when there were unresolved `template:` invocations. The user saw their source echoed back as "expanded" output with no indication the resolution had failed.

**Before:** "View Expanded Templates" returns the source unchanged.
**After:** Returns the actual expansion, or surfaces a real "Template not found" diagnostic if the invocation can't resolve.

Dropped the gate at [expandTreatment.ts:128](apps/vscode/src/lib/expandTreatment.ts#L128). `fillTemplates` always runs now.

## Relationship to #321

These are the two concrete repros documented at the top of #321. Fixing them in a focused PR unblocks anyone running into them today; the larger graceful-degrade pipeline (async validator, pre-hydration semantic checks, diff orchestrator, rule changes in `validateReferences`, doc updates, static sweep) remains scheduled for a follow-up PR against the same issue.

## Test plan

- [x] New `parseTreatmentSource.test.ts` covers all six failure modes (parse, import-read, import-parse, resolve, hydration, schema) plus success and transitive imports
- [x] New `expandTreatmentSource` test for Repro 2 (unresolved invocation with no root `templates:` key)
- [x] All 198 vscode tests pass; all 950 stagebook tests pass; all 87 viewer tests pass
- [x] Workspace `npm run lint` clean; Prettier clean
- [x] Extension builds (`npm run build` in apps/vscode)
- [ ] Manual smoke test in VS Code: open `pilot_3.stagebook.yaml`, run Preview Stage, verify a specific error appears (not the generic one)
- [ ] Manual smoke test in VS Code: open `_preview_.stagebook.yaml`, run View Expanded Templates, verify the expansion contains the resolved `demographics_questions` content (or a real error if the module is broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)