### PR TITLE
Position-based storage-key fallback for unnamed audio/mediaPlayer/survey

### DIFF
--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -148,7 +148,13 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
         <AudioElement
           src={getAssetURL(element.file ?? "")}
           save={wrappedSave}
-          name={element.name ?? element.file}
+          // When `name:` is omitted, fall back to a position-based
+          // identifier (`<progressLabel>_<file>`) so two unnamed
+          // audios with the same file in different stages get
+          // distinct storage keys instead of silently overwriting
+          // each other. Researchers who do want a stable name
+          // across stages set `name:` explicitly.
+          name={element.name ?? `${progressLabel}_${element.file ?? ""}`}
         />
       );
 
@@ -287,7 +293,10 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
             : getAssetURL(rawCaptions);
       return (
         <MediaPlayer
-          name={String(element.name ?? rawURL)}
+          // Position-based fallback when `name:` is omitted — same
+          // intent as the audio case above: distinct storage keys
+          // for the same media used in different stages.
+          name={String(element.name ?? `${progressLabel}_${rawURL}`)}
           url={resolvedURL}
           save={wrappedSave}
           getElapsedTime={getElapsedTime}
@@ -371,7 +380,10 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
 
     case "survey": {
       const surveyName = element.surveyName ?? "";
-      const surveyKey = element.name ?? surveyName;
+      // Position-based fallback when `name:` is omitted — same
+      // intent as audio/mediaPlayer: distinct storage keys for the
+      // same survey used in different stages.
+      const surveyKey = element.name ?? `${progressLabel}_${surveyName}`;
       return (
         renderSurvey?.({
           surveyName,

--- a/packages/stagebook/src/schemas/storageKeyCollisions.test.ts
+++ b/packages/stagebook/src/schemas/storageKeyCollisions.test.ts
@@ -320,7 +320,9 @@ describe("collectStorageKeyCollisions", () => {
         },
       ],
     };
-    expect(collectStorageKeyCollisions(dataNamed)).toHaveLength(1);
+    const namedCollisions = collectStorageKeyCollisions(dataNamed);
+    expect(namedCollisions).toHaveLength(1);
+    expect(namedCollisions[0].key).toBe("mediaPlayer_intro");
 
     const dataUnnamed = {
       treatments: [
@@ -411,7 +413,9 @@ describe("collectStorageKeyCollisions", () => {
         },
       ],
     };
-    expect(collectStorageKeyCollisions(dataNamed)).toHaveLength(1);
+    const namedCollisions = collectStorageKeyCollisions(dataNamed);
+    expect(namedCollisions).toHaveLength(1);
+    expect(namedCollisions[0].key).toBe("survey_intake");
 
     const dataUnnamed = {
       treatments: [

--- a/packages/stagebook/src/schemas/storageKeyCollisions.test.ts
+++ b/packages/stagebook/src/schemas/storageKeyCollisions.test.ts
@@ -259,8 +259,32 @@ describe("collectStorageKeyCollisions", () => {
     expect(collectStorageKeyCollisions(data)).toEqual([]);
   });
 
-  it("derives keys for audio (name OR file fallback)", () => {
-    const data = {
+  it("flags audio collisions only when both elements are explicitly named", () => {
+    // Two unnamed audios sharing a file are NOT a collision —
+    // Element.tsx generates a position-based runtime key for unnamed
+    // audios so each occurrence gets a distinct storage key.
+    // Researchers opt in to cross-stage tracking by setting `name:`.
+    const dataNamed = {
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [
+            {
+              name: "stage1",
+              elements: [
+                { type: "audio", name: "bell", file: "intro.mp3" },
+                { type: "audio", name: "bell", file: "other.mp3" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    const namedCollisions = collectStorageKeyCollisions(dataNamed);
+    expect(namedCollisions).toHaveLength(1);
+    expect(namedCollisions[0].key).toBe("audio_bell");
+
+    const dataUnnamed = {
       treatments: [
         {
           name: "t1",
@@ -276,15 +300,29 @@ describe("collectStorageKeyCollisions", () => {
         },
       ],
     };
-    const collisions = collectStorageKeyCollisions(data);
-    expect(collisions).toHaveLength(1);
-    expect(collisions[0].key).toBe("audio_intro.mp3");
+    expect(collectStorageKeyCollisions(dataUnnamed)).toEqual([]);
   });
 
-  it("derives keys for mediaPlayer (name OR file fallback) — matches Element.tsx runtime", () => {
-    // Per Element.tsx:277, mediaPlayer falls back to the raw `file` field
-    // (NOT `url` — that field was renamed to `file` in #249).
-    const data = {
+  it("flags mediaPlayer collisions only when both elements are explicitly named", () => {
+    const dataNamed = {
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [
+            {
+              name: "stage1",
+              elements: [
+                { type: "mediaPlayer", name: "intro", file: "a.mp4" },
+                { type: "mediaPlayer", name: "intro", file: "b.mp4" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(collectStorageKeyCollisions(dataNamed)).toHaveLength(1);
+
+    const dataUnnamed = {
       treatments: [
         {
           name: "t1",
@@ -300,9 +338,7 @@ describe("collectStorageKeyCollisions", () => {
         },
       ],
     };
-    const collisions = collectStorageKeyCollisions(data);
-    expect(collisions).toHaveLength(1);
-    expect(collisions[0].key).toBe("mediaPlayer_intro.mp4");
+    expect(collectStorageKeyCollisions(dataUnnamed)).toEqual([]);
   });
 
   it("flags any two qualtrics elements in the same scope as colliding (fixed key)", () => {
@@ -358,8 +394,26 @@ describe("collectStorageKeyCollisions", () => {
     expect(collisions[0].paths).toHaveLength(2);
   });
 
-  it("derives keys for survey (name OR surveyName fallback)", () => {
-    const data = {
+  it("flags survey collisions only when both elements are explicitly named", () => {
+    const dataNamed = {
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [
+            {
+              name: "stage1",
+              elements: [
+                { type: "survey", name: "intake", surveyName: "TIPI" },
+                { type: "survey", name: "intake", surveyName: "Other" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(collectStorageKeyCollisions(dataNamed)).toHaveLength(1);
+
+    const dataUnnamed = {
       treatments: [
         {
           name: "t1",
@@ -375,9 +429,7 @@ describe("collectStorageKeyCollisions", () => {
         },
       ],
     };
-    const collisions = collectStorageKeyCollisions(data);
-    expect(collisions).toHaveLength(1);
-    expect(collisions[0].key).toBe("survey_TIPI");
+    expect(collectStorageKeyCollisions(dataUnnamed)).toEqual([]);
   });
 
   it("skips elements without a derivable storage key (unnamed prompts/submitButtons)", () => {

--- a/packages/stagebook/src/schemas/storageKeyCollisions.ts
+++ b/packages/stagebook/src/schemas/storageKeyCollisions.ts
@@ -19,8 +19,12 @@
  * per-element `name:` override (e.g. `name: pretest_q1` vs
  * `name: posttest_q1`) to disambiguate.
  *
- * Key derivation mirrors the save() calls in src/components/elements/.
- * Per-type rules:
+ * Key derivation mirrors the runtime `save()` calls. The `name` is
+ * computed in `Element.tsx` before each element dispatches; the actual
+ * `save()` invocation lives in the matching component under
+ * `src/components/elements/` (except surveys, which are rendered via
+ * the host-supplied `renderSurvey` slot — Element.tsx derives the key
+ * before handing off). Per-type rules:
  *
  *   audio        → checked when `name:` is set. Unnamed audios fall
  *                   back to a position-based key

--- a/packages/stagebook/src/schemas/storageKeyCollisions.ts
+++ b/packages/stagebook/src/schemas/storageKeyCollisions.ts
@@ -19,21 +19,37 @@
  * per-element `name:` override (e.g. `name: pretest_q1` vs
  * `name: posttest_q1`) to disambiguate.
  *
- * Key derivation mirrors the save() calls in src/components/elements/:
- *   audio        → `audio_${name ?? file}`
+ * Key derivation mirrors the save() calls in src/components/elements/.
+ * Per-type rules:
+ *
+ *   audio        → checked when `name:` is set. Unnamed audios fall
+ *                   back to a position-based key
+ *                   (`audio_<progressLabel>_<file>`) at runtime
+ *                   (Element.tsx:audio case), so two unnamed audios
+ *                   with the same file in different stages get
+ *                   distinct storage keys naturally.
  *   prompt       → `prompt_${name}` (runtime fallback uses progressLabel +
  *                   metadata, which isn't derivable from the YAML alone, so
  *                   we only check explicitly-named prompts)
- *   survey       → `survey_${name ?? surveyName}`
+ *   survey       → checked when `name:` is set. Unnamed surveys fall
+ *                   back to a position-based key at runtime, like audio.
  *   submitButton → `submitButton_${name}` (runtime fallback is progressLabel;
  *                   only checked when `name` is set)
- *   mediaPlayer  → `mediaPlayer_${name ?? file}` (runtime falls back to the
- *                   raw `file` field at Element.tsx:277, before URL resolution)
+ *   mediaPlayer  → checked when `name:` is set. Unnamed mediaPlayers fall
+ *                   back to a position-based key at runtime, like audio.
  *   qualtrics    → fixed key `qualtricsDataReady` (Qualtrics.tsx:50). Any
  *                   two qualtrics elements in the same scope collide
  *                   regardless of name/url, since the key is constant.
  *   timeline     → `timeline_${name}` (name is required by the schema)
  *   trackedLink  → `trackedLink_${name}` (name is required by the schema)
+ *
+ * Why the file/surveyName fallbacks aren't checked: a researcher who
+ * doesn't `name:` an audio is opting out of cross-stage data
+ * tracking — they just want the sound to play. The runtime gives
+ * each occurrence a unique position-derived key, so there's no
+ * silent overwrite to flag. Researchers who want stable cross-stage
+ * names set `name:` explicitly, at which point the collision
+ * detector kicks in.
  */
 
 export interface StorageKeyCollision {
@@ -57,23 +73,20 @@ function storageKeyFor(element: unknown): string | null {
   const el = element as Record<string, unknown>;
   if (typeof el.type !== "string") return null;
   const name = strField(el, "name");
-  let suffix: string | null;
   switch (el.type) {
+    // For these types, only check collisions when the researcher set
+    // `name:` explicitly. Unnamed elements get a position-based key
+    // at runtime (Element.tsx prepends `progressLabel`), so there's
+    // no collision to flag — opt in to cross-stage tracking by
+    // naming.
     case "audio":
-      suffix = name ?? strField(el, "file");
-      break;
     case "survey":
-      suffix = name ?? strField(el, "surveyName");
-      break;
     case "mediaPlayer":
-      suffix = name ?? strField(el, "file");
-      break;
     case "prompt":
     case "submitButton":
     case "timeline":
     case "trackedLink":
-      suffix = name;
-      break;
+      return name ? `${el.type}_${name}` : null;
     case "qualtrics":
       // Qualtrics writes to a fixed key regardless of element identity, so
       // any two qualtrics elements in the same scope collide. Return a
@@ -82,7 +95,6 @@ function storageKeyFor(element: unknown): string | null {
     default:
       return null;
   }
-  return suffix ? `${el.type}_${suffix}` : null;
 }
 
 function scanElements(


### PR DESCRIPTION
## Summary

Cherry-pick of the runtime + collision-detector portion of #316. The preview-error-surfacing portion of that PR was superseded by #322; this is the remaining piece — the one that drops `pilot_3.stagebook.yaml`'s duplicate-storage-key errors from 440 → 0.

### What changes

**1. Runtime: position-based fallback for unnamed elements** ([packages/stagebook/src/components/Element.tsx](packages/stagebook/src/components/Element.tsx))

When `name:` is omitted on an audio / mediaPlayer / survey element, the runtime now derives the storage key as `${progressLabel}_${file or surveyName}` instead of just `${file or surveyName}`. Two unnamed plays of the same audio in different stages get distinct storage keys naturally — no silent overwrite, both saved.

Named elements unchanged. Researchers opt in to cross-stage tracking by setting `name:` explicitly.

**2. Collision detector: stop flagging file-fallback keys** ([packages/stagebook/src/schemas/storageKeyCollisions.ts](packages/stagebook/src/schemas/storageKeyCollisions.ts))

The detector previously flagged collisions whenever two audio/mediaPlayer/survey elements shared `file:` or `surveyName:` without an explicit `name:`. Now it only flags collisions on the explicit-`name` path. The reasoning:

- An unnamed audio is opting out of cross-stage tracking — the researcher just wants the sound to play.
- The runtime guarantees uniqueness via the position fallback above, so there's no silent overwrite to surface.
- Named collisions (e.g. two `name: bell` audios) still fire as before.

## Test plan

- [x] All 1238 tests pass (950 stagebook + 87 viewer + 201 vscode)
- [x] `pilot_3.stagebook.yaml` opens without the 440 duplicate-storage-key errors
- [x] Existing collision-detector tests updated to cover both the named-still-collides and unnamed-no-longer-collides cases
- [x] Workspace lint + format clean
- [ ] Manual smoke test: preview pilot_3 in VS Code; treatments render; counter_bell plays in both stages

## Relationship to #316

PR #316 bundled this fix with several other validation-infrastructure changes (post-fill banner, reference walker, expand-preview wiring, import-suppression heuristic). Those other changes are being redone properly as part of the larger #321 pipeline rewrite, so this PR cherry-picks just the part that's standalone and useful right now. PR #316 can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)