### PR TITLE
Pre-hydration semantic checks (#321 step 1)

### DIFF
--- a/packages/stagebook/src/schemas/index.ts
+++ b/packages/stagebook/src/schemas/index.ts
@@ -105,6 +105,12 @@ export {
 } from "./storageKeyCollisions.js";
 
 export {
+  collectPreHydrationIssues,
+  type PreHydrationIssue,
+  type PreHydrationInput,
+} from "./preHydrationSemantic.js";
+
+export {
   resolvedElementSchema,
   resolvedStageSchema,
   resolvedIntroExitStepSchema,

--- a/packages/stagebook/src/schemas/preHydrationSemantic.test.ts
+++ b/packages/stagebook/src/schemas/preHydrationSemantic.test.ts
@@ -1,0 +1,301 @@
+import { describe, it, expect } from "vitest";
+import { collectPreHydrationIssues } from "./preHydrationSemantic.js";
+
+/**
+ * Pre-hydration semantic checks run on the merged source (root + imports)
+ * without expanding any templates. They catch a class of authoring errors
+ * that would otherwise throw a generic mid-hydration error far from the
+ * actual fix site, or silently pass and surprise the user at runtime.
+ *
+ * Scoped to two checks in this PR:
+ *   1. Unknown template name — every `template: X` invocation references
+ *      a template defined in this file or its imports
+ *   2. Circular template invocations — no template-A-invokes-B-invokes-A
+ *      cycles
+ *
+ * Parameterized invocation names (e.g. `template: ${arm}_pre`) are skipped
+ * — their concrete identity depends on call-site bindings that aren't
+ * resolved until hydration. Falsely flagging them as unknown would be
+ * worse than missing genuinely unresolvable ones, which hydration will
+ * surface in a clear way anyway.
+ *
+ * See #321 for the broader validation pipeline this is part of.
+ */
+
+describe("collectPreHydrationIssues", () => {
+  describe("unknown template invocations", () => {
+    it("returns no issues when every invocation resolves", () => {
+      const root = {
+        templates: [
+          {
+            name: "foo",
+            contentType: "treatment",
+            content: { name: "t", playerCount: 1, gameStages: [] },
+          },
+        ],
+        treatments: [{ template: "foo" }],
+      };
+      expect(collectPreHydrationIssues({ root })).toEqual([]);
+    });
+
+    it("flags an invocation whose name isn't defined anywhere", () => {
+      const root = {
+        templates: [
+          {
+            name: "foo",
+            contentType: "treatment",
+            content: { name: "t" },
+          },
+        ],
+        treatments: [{ template: "doesNotExist" }],
+      };
+      const issues = collectPreHydrationIssues({ root });
+      expect(issues).toHaveLength(1);
+      expect(issues[0].code).toBe("unknown-template");
+      expect(issues[0].message).toContain("doesNotExist");
+      expect(issues[0].path).toEqual(["treatments", 0, "template"]);
+    });
+
+    it("resolves a template defined in an imported file", () => {
+      const root = {
+        treatments: [{ template: "fromImport" }],
+      };
+      const importedTemplates = [
+        {
+          name: "fromImport",
+          contentType: "treatment",
+          content: { name: "t" },
+        },
+      ];
+      expect(collectPreHydrationIssues({ root, importedTemplates })).toEqual(
+        [],
+      );
+    });
+
+    it("flags an invocation when neither root nor imports define the name", () => {
+      const root = {
+        treatments: [{ template: "missing" }],
+      };
+      const importedTemplates = [
+        { name: "other", contentType: "treatment", content: { name: "t" } },
+      ];
+      const issues = collectPreHydrationIssues({ root, importedTemplates });
+      expect(issues).toHaveLength(1);
+      expect(issues[0].code).toBe("unknown-template");
+      expect(issues[0].message).toContain("missing");
+    });
+
+    it("skips parameterized invocations (name contains ${...})", () => {
+      // `template: ${arm}_pre` resolves at hydration time when `arm` is
+      // bound by broadcast or fields. The literal text doesn't match any
+      // defined template name, but it's not an error — it's a runtime
+      // dispatch. Flagging it here would false-positive on every
+      // broadcast-driven file.
+      const root = {
+        templates: [
+          {
+            name: "control_pre",
+            contentType: "elements",
+            content: [{ type: "submitButton" }],
+          },
+        ],
+        treatments: [
+          { template: "${arm}_pre", broadcast: { d0: [{ arm: "control" }] } },
+        ],
+      };
+      expect(collectPreHydrationIssues({ root })).toEqual([]);
+    });
+
+    it("finds invocations nested deep inside the source", () => {
+      const root = {
+        templates: [
+          {
+            name: "stageT",
+            contentType: "stage",
+            content: {
+              name: "s",
+              duration: 10,
+              elements: [{ template: "nestedMissing" }],
+            },
+          },
+        ],
+        treatments: [
+          {
+            name: "t",
+            playerCount: 1,
+            gameStages: [{ template: "stageT" }],
+          },
+        ],
+      };
+      const issues = collectPreHydrationIssues({ root });
+      expect(issues).toHaveLength(1);
+      expect(issues[0].code).toBe("unknown-template");
+      expect(issues[0].message).toContain("nestedMissing");
+    });
+
+    it("reports multiple unknown invocations separately", () => {
+      const root = {
+        treatments: [{ template: "missing1" }, { template: "missing2" }],
+      };
+      const issues = collectPreHydrationIssues({ root });
+      expect(issues).toHaveLength(2);
+      const names = issues.map((i) => i.message);
+      expect(names.some((m) => m.includes("missing1"))).toBe(true);
+      expect(names.some((m) => m.includes("missing2"))).toBe(true);
+    });
+  });
+
+  describe("circular template invocations", () => {
+    it("returns no issues for a non-cyclic call graph", () => {
+      const root = {
+        templates: [
+          {
+            name: "a",
+            contentType: "elements",
+            content: [{ template: "b" }],
+          },
+          {
+            name: "b",
+            contentType: "elements",
+            content: [{ type: "submitButton" }],
+          },
+        ],
+        treatments: [{ name: "t", playerCount: 1, gameStages: [] }],
+      };
+      expect(collectPreHydrationIssues({ root })).toEqual([]);
+    });
+
+    it("flags a direct self-invocation (A → A)", () => {
+      const root = {
+        templates: [
+          {
+            name: "a",
+            contentType: "elements",
+            content: [{ template: "a" }],
+          },
+        ],
+        treatments: [{ name: "t", playerCount: 1, gameStages: [] }],
+      };
+      const issues = collectPreHydrationIssues({ root });
+      expect(issues).toHaveLength(1);
+      expect(issues[0].code).toBe("circular-template");
+      expect(issues[0].message).toContain("a");
+    });
+
+    it("flags a two-step cycle (A → B → A)", () => {
+      const root = {
+        templates: [
+          {
+            name: "a",
+            contentType: "elements",
+            content: [{ template: "b" }],
+          },
+          {
+            name: "b",
+            contentType: "elements",
+            content: [{ template: "a" }],
+          },
+        ],
+        treatments: [{ name: "t", playerCount: 1, gameStages: [] }],
+      };
+      const issues = collectPreHydrationIssues({ root });
+      expect(issues.some((i) => i.code === "circular-template")).toBe(true);
+    });
+
+    it("flags a longer cycle (A → B → C → A)", () => {
+      const root = {
+        templates: [
+          {
+            name: "a",
+            contentType: "elements",
+            content: [{ template: "b" }],
+          },
+          {
+            name: "b",
+            contentType: "elements",
+            content: [{ template: "c" }],
+          },
+          {
+            name: "c",
+            contentType: "elements",
+            content: [{ template: "a" }],
+          },
+        ],
+        treatments: [{ name: "t", playerCount: 1, gameStages: [] }],
+      };
+      const issues = collectPreHydrationIssues({ root });
+      expect(issues.some((i) => i.code === "circular-template")).toBe(true);
+    });
+
+    it("does not flag diamond shapes (A → B, A → C, B → D, C → D)", () => {
+      // Same template invoked from multiple call sites isn't a cycle.
+      const root = {
+        templates: [
+          {
+            name: "a",
+            contentType: "elements",
+            content: [{ template: "b" }, { template: "c" }],
+          },
+          {
+            name: "b",
+            contentType: "elements",
+            content: [{ template: "d" }],
+          },
+          {
+            name: "c",
+            contentType: "elements",
+            content: [{ template: "d" }],
+          },
+          {
+            name: "d",
+            contentType: "elements",
+            content: [{ type: "submitButton" }],
+          },
+        ],
+        treatments: [{ name: "t", playerCount: 1, gameStages: [] }],
+      };
+      const cycles = collectPreHydrationIssues({ root }).filter(
+        (i) => i.code === "circular-template",
+      );
+      expect(cycles).toEqual([]);
+    });
+
+    it("skips cycles that go through parameterized invocations", () => {
+      // If A → ${x} is parameterized, we can't statically determine which
+      // template it resolves to. Treat as not part of the call graph for
+      // cycle detection — runtime errors will surface real cycles.
+      const root = {
+        templates: [
+          {
+            name: "a",
+            contentType: "elements",
+            content: [{ template: "${x}" }],
+          },
+        ],
+        treatments: [{ name: "t", playerCount: 1, gameStages: [] }],
+      };
+      const cycles = collectPreHydrationIssues({ root }).filter(
+        (i) => i.code === "circular-template",
+      );
+      expect(cycles).toEqual([]);
+    });
+  });
+
+  describe("malformed input", () => {
+    it("returns no issues for an empty object", () => {
+      expect(collectPreHydrationIssues({ root: {} })).toEqual([]);
+    });
+
+    it("ignores templates without a name (those are caught by the schema)", () => {
+      const root = {
+        templates: [{ contentType: "elements", content: [] }],
+        treatments: [{ template: "foo" }],
+      };
+      // The nameless template definition is malformed; the schema will
+      // flag that. We just shouldn't crash, and should still flag the
+      // unknown invocation.
+      const issues = collectPreHydrationIssues({ root });
+      expect(issues.some((i) => i.code === "unknown-template")).toBe(true);
+    });
+  });
+});

--- a/packages/stagebook/src/schemas/preHydrationSemantic.test.ts
+++ b/packages/stagebook/src/schemas/preHydrationSemantic.test.ts
@@ -260,6 +260,38 @@ describe("collectPreHydrationIssues", () => {
       expect(cycles).toEqual([]);
     });
 
+    it("anchors a cycle that exists entirely in imports to a position the editor can resolve", () => {
+      // When A → B → A is defined entirely inside imported templates and
+      // the root file doesn't invoke either, the diagnostic still needs
+      // a path that the editor's YAML AST mapper can convert to a
+      // position. Falling through to `["templates"]` would fail when
+      // the root has no `templates:` key; fall back to `["imports"]`
+      // (always present when imports are in play) instead.
+      const root = {
+        imports: ["./module.stagebook.yaml"],
+        treatments: [{ name: "t", playerCount: 1, gameStages: [] }],
+      };
+      const importedTemplates = [
+        {
+          name: "a",
+          contentType: "elements",
+          content: [{ template: "b" }],
+        },
+        {
+          name: "b",
+          contentType: "elements",
+          content: [{ template: "a" }],
+        },
+      ];
+      const cycles = collectPreHydrationIssues({
+        root,
+        importedTemplates,
+      }).filter((i) => i.code === "circular-template");
+      expect(cycles).toHaveLength(1);
+      // Anchor to a path that's actually present in the root.
+      expect(cycles[0].path[0]).toBe("imports");
+    });
+
     it("skips cycles that go through parameterized invocations", () => {
       // If A → ${x} is parameterized, we can't statically determine which
       // template it resolves to. Treat as not part of the call graph for
@@ -278,6 +310,34 @@ describe("collectPreHydrationIssues", () => {
         (i) => i.code === "circular-template",
       );
       expect(cycles).toEqual([]);
+    });
+  });
+
+  describe("imported template bodies", () => {
+    it("flags an imported template whose body invokes an undefined name", () => {
+      // An imported template `outer` whose body invokes a missing
+      // template would today fail at hydration with a generic error.
+      // The diagnostic anchors to the root's `imports:` line since
+      // that's the editable surface the user has when working in the
+      // root file.
+      const root = {
+        imports: ["./module.stagebook.yaml"],
+        treatments: [{ template: "outer" }],
+      };
+      const importedTemplates = [
+        {
+          name: "outer",
+          contentType: "elements",
+          content: [{ template: "missingFromImport" }],
+        },
+      ];
+      const issues = collectPreHydrationIssues({ root, importedTemplates });
+      const unknown = issues.filter((i) => i.code === "unknown-template");
+      expect(unknown).toHaveLength(1);
+      expect(unknown[0].message).toContain("missingFromImport");
+      // Anchor in the root file, not just `["templates"]` which doesn't
+      // exist when the root only declares `imports:`.
+      expect(unknown[0].path[0]).toBe("imports");
     });
   });
 

--- a/packages/stagebook/src/schemas/preHydrationSemantic.ts
+++ b/packages/stagebook/src/schemas/preHydrationSemantic.ts
@@ -1,0 +1,226 @@
+/**
+ * Pre-hydration semantic checks.
+ *
+ * Runs on the merged source (root file + loaded imports) before any
+ * template expansion. Catches a class of authoring errors that would
+ * otherwise:
+ *   - throw a generic mid-hydration error far from the actual fix site
+ *     ("Template not found"), or
+ *   - cause an infinite loop / stack overflow during hydration, or
+ *   - silently produce wrong output that surprises the user at runtime.
+ *
+ * In scope for this module:
+ *   1. Unknown template name — every `template: X` invocation references
+ *      a template defined in this file or its imports.
+ *   2. Circular template invocations — no template-A-invokes-B-invokes-A
+ *      cycles.
+ *
+ * Parameterized invocations (e.g. `template: ${arm}_pre`) are skipped:
+ * their concrete identity depends on call-site bindings that aren't
+ * known until hydration. Falsely flagging them would false-positive on
+ * every broadcast-driven file; conversely, a parameterized invocation
+ * that doesn't resolve at runtime surfaces as a clear hydration error.
+ *
+ * Position-free by design — issues carry JSON paths into the original
+ * source. The consumer (in-editor validator) maps those paths to YAML
+ * positions via its own AST mapper. Mirrors `validateReferences.ts`.
+ *
+ * See #321 for the broader validation pipeline this is part of.
+ */
+
+export type Path = (string | number)[];
+
+export interface PreHydrationIssue {
+  code: "unknown-template" | "circular-template";
+  message: string;
+  path: Path;
+}
+
+export interface PreHydrationInput {
+  /** Parsed root file object. */
+  root: Record<string, unknown>;
+  /** Templates contributed by imports (post-`resolveImports`), or empty. */
+  importedTemplates?: unknown[];
+}
+
+const FIELD_PLACEHOLDER_REGEX = /\$\{[a-zA-Z0-9_]+\}/;
+
+function hasFieldPlaceholder(s: string): boolean {
+  return FIELD_PLACEHOLDER_REGEX.test(s);
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function templateName(template: unknown): string | undefined {
+  if (!isRecord(template)) return undefined;
+  const name = template.name;
+  return typeof name === "string" && name.length > 0 ? name : undefined;
+}
+
+/** Walk `node` rooted at `path`, calling `visit` for every record. */
+function walkRecords(
+  node: unknown,
+  path: Path,
+  visit: (record: Record<string, unknown>, path: Path) => void,
+): void {
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => walkRecords(item, [...path, i], visit));
+    return;
+  }
+  if (!isRecord(node)) return;
+  visit(node, path);
+  for (const [key, value] of Object.entries(node)) {
+    walkRecords(value, [...path, key], visit);
+  }
+}
+
+export function collectPreHydrationIssues({
+  root,
+  importedTemplates = [],
+}: PreHydrationInput): PreHydrationIssue[] {
+  const issues: PreHydrationIssue[] = [];
+
+  // Build the set of known template names from root + imports. Both
+  // sources contribute equally; the host's import-loading + merging step
+  // (`resolveImports`) has already vetted for duplicates by the time we
+  // get here.
+  const rootTemplates = Array.isArray(root.templates) ? root.templates : [];
+  const knownNames = new Set<string>();
+  for (const tmpl of rootTemplates) {
+    const name = templateName(tmpl);
+    if (name !== undefined) knownNames.add(name);
+  }
+  for (const tmpl of importedTemplates) {
+    const name = templateName(tmpl);
+    if (name !== undefined) knownNames.add(name);
+  }
+
+  // Pass 1: every `template: X` invocation must resolve. Skip
+  // parameterized names (they're handled at hydration).
+  walkRecords(root, [], (record, path) => {
+    const tName = record.template;
+    if (typeof tName !== "string") return;
+    if (hasFieldPlaceholder(tName)) return;
+    if (knownNames.has(tName)) return;
+    issues.push({
+      code: "unknown-template",
+      message: `Template '${tName}' is not defined in this file or its imports.`,
+      path: [...path, "template"],
+    });
+  });
+
+  // Pass 2: cycle detection over the static call graph.
+  //
+  // For each template T, find every `template: X` invocation in T's
+  // body where X is a known concrete name. That's the edge T → X.
+  // Run depth-first search and emit one issue per detected cycle.
+  // Parameterized invocations don't contribute edges (we can't know
+  // their target statically).
+  const adjacency = new Map<string, Set<string>>();
+  const collectEdgesFor = (source: unknown): void => {
+    const from = templateName(source);
+    if (from === undefined) return;
+    const targets = new Set<string>();
+    const content = isRecord(source) ? source.content : undefined;
+    walkRecords(content, [], (record) => {
+      const tName = record.template;
+      if (typeof tName !== "string") return;
+      if (hasFieldPlaceholder(tName)) return;
+      if (!knownNames.has(tName)) return;
+      targets.add(tName);
+    });
+    adjacency.set(from, targets);
+  };
+  for (const source of rootTemplates) collectEdgesFor(source);
+  for (const source of importedTemplates) collectEdgesFor(source);
+
+  const reportedCycleSignatures = new Set<string>();
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const stack: string[] = [];
+
+  function dfs(node: string): void {
+    if (visited.has(node)) return;
+    if (visiting.has(node)) {
+      // Found a back edge — extract the cycle slice from the stack.
+      const cycleStart = stack.indexOf(node);
+      const cycle = stack.slice(cycleStart);
+      reportCycle(cycle);
+      return;
+    }
+    visiting.add(node);
+    stack.push(node);
+    const neighbors = adjacency.get(node);
+    if (neighbors) {
+      for (const n of neighbors) dfs(n);
+    }
+    stack.pop();
+    visiting.delete(node);
+    visited.add(node);
+  }
+
+  function reportCycle(cycle: string[]): void {
+    // Normalize the cycle so the same loop reported via different starts
+    // doesn't surface as multiple issues.
+    const sorted = [...cycle].sort();
+    const signature = sorted.join("→");
+    if (reportedCycleSignatures.has(signature)) return;
+    reportedCycleSignatures.add(signature);
+
+    // Locate the first edge in the cycle inside the root file so the
+    // diagnostic points at something the user can edit. If the cycle
+    // is entirely inside imported templates, fall back to the root
+    // file's first invocation of the first cycle node.
+    const head = cycle[0];
+    const next = cycle.length > 1 ? cycle[1] : cycle[0];
+    const cyclePath = locateCycleAnchorPath(root, head, next);
+
+    const description =
+      cycle.length === 1
+        ? `Template '${head}' invokes itself.`
+        : `Templates form an invocation cycle: ${[...cycle, head].join(" → ")}.`;
+    issues.push({
+      code: "circular-template",
+      message: `${description} Hydration would loop indefinitely — break the cycle by removing one of the invocations.`,
+      path: cyclePath,
+    });
+  }
+
+  for (const name of adjacency.keys()) dfs(name);
+
+  return issues;
+}
+
+/**
+ * Find a source path for a cycle diagnostic. Prefer a location in the
+ * root file (the user's editable surface) over imports.
+ */
+function locateCycleAnchorPath(
+  root: Record<string, unknown>,
+  head: string,
+  next: string,
+): Path {
+  let firstHeadInvocation: Path | undefined;
+  let edgeWithinHead: Path | undefined;
+
+  walkRecords(root, [], (record, path) => {
+    if (record.template === head && firstHeadInvocation === undefined) {
+      firstHeadInvocation = [...path, "template"];
+    }
+  });
+
+  const rootTemplates = Array.isArray(root.templates) ? root.templates : [];
+  rootTemplates.forEach((tmpl, i) => {
+    if (templateName(tmpl) !== head) return;
+    const content = isRecord(tmpl) ? tmpl.content : undefined;
+    walkRecords(content, [], (record, path) => {
+      if (record.template === next && edgeWithinHead === undefined) {
+        edgeWithinHead = ["templates", i, "content", ...path, "template"];
+      }
+    });
+  });
+
+  return edgeWithinHead ?? firstHeadInvocation ?? ["templates"];
+}

--- a/packages/stagebook/src/schemas/preHydrationSemantic.ts
+++ b/packages/stagebook/src/schemas/preHydrationSemantic.ts
@@ -97,8 +97,8 @@ export function collectPreHydrationIssues({
     if (name !== undefined) knownNames.add(name);
   }
 
-  // Pass 1: every `template: X` invocation must resolve. Skip
-  // parameterized names (they're handled at hydration).
+  // Pass 1a: every `template: X` invocation in the root must resolve.
+  // Skip parameterized names (they're handled at hydration).
   walkRecords(root, [], (record, path) => {
     const tName = record.template;
     if (typeof tName !== "string") return;
@@ -110,6 +110,39 @@ export function collectPreHydrationIssues({
       path: [...path, "template"],
     });
   });
+
+  // Pass 1b: same check inside imported template bodies. An imported
+  // template that invokes an undefined name would otherwise fail at
+  // hydration time with a generic error. Anchor the diagnostic to the
+  // root's `imports:` line (the editable surface from the root file's
+  // perspective). The user opens the imported file to fix the actual
+  // typo; the message includes the bad name plus the host template
+  // name to make navigation obvious.
+  const importsAnchor = rootAnchor(root);
+  const reportedFromImports = new Set<string>();
+  for (const tmpl of importedTemplates) {
+    const hostName = templateName(tmpl);
+    const content = isRecord(tmpl) ? tmpl.content : undefined;
+    walkRecords(content, [], (record) => {
+      const tName = record.template;
+      if (typeof tName !== "string") return;
+      if (hasFieldPlaceholder(tName)) return;
+      if (knownNames.has(tName)) return;
+      // De-dup so the same missing name invoked many times from
+      // imports doesn't produce N copies of the same diagnostic.
+      const dedupKey = `${hostName ?? "?"}→${tName}`;
+      if (reportedFromImports.has(dedupKey)) return;
+      reportedFromImports.add(dedupKey);
+      const hostDescription = hostName
+        ? ` inside imported template '${hostName}'`
+        : " inside an imported template";
+      issues.push({
+        code: "unknown-template",
+        message: `Template '${tName}'${hostDescription} is not defined in this file or its imports.`,
+        path: importsAnchor,
+      });
+    });
+  }
 
   // Pass 2: cycle detection over the static call graph.
   //
@@ -162,10 +195,11 @@ export function collectPreHydrationIssues({
   }
 
   function reportCycle(cycle: string[]): void {
-    // Normalize the cycle so the same loop reported via different starts
-    // doesn't surface as multiple issues.
-    const sorted = [...cycle].sort();
-    const signature = sorted.join("→");
+    // Normalize the cycle by rotating to start at the lexicographically
+    // smallest node. This preserves edge order (so A→B→C and A→C→B
+    // remain distinct cycles among the same node set) while collapsing
+    // the same cycle reported from different start points.
+    const signature = canonicalCycleSignature(cycle);
     if (reportedCycleSignatures.has(signature)) return;
     reportedCycleSignatures.add(signature);
 
@@ -194,8 +228,11 @@ export function collectPreHydrationIssues({
 }
 
 /**
- * Find a source path for a cycle diagnostic. Prefer a location in the
- * root file (the user's editable surface) over imports.
+ * Find a source path for a cycle diagnostic. Prefer the most specific
+ * location in the root file (the user's editable surface): an edge
+ * inside the root-defined `head` template if present, then any
+ * root-level invocation of `head`, then a stable always-present
+ * fallback (`imports:` if imports were used, else `templates:`).
  */
 function locateCycleAnchorPath(
   root: Record<string, unknown>,
@@ -222,5 +259,34 @@ function locateCycleAnchorPath(
     });
   });
 
-  return edgeWithinHead ?? firstHeadInvocation ?? ["templates"];
+  return edgeWithinHead ?? firstHeadInvocation ?? rootAnchor(root);
+}
+
+/**
+ * A stable, always-present path in the root for diagnostics that don't
+ * have a more precise location (e.g., cycles entirely inside imports,
+ * unknown invocations inside imported template bodies). Prefer
+ * `imports:` when present — it's the surface the user is editing when
+ * they brought the offending content into the file.
+ */
+function rootAnchor(root: Record<string, unknown>): Path {
+  if ("imports" in root) return ["imports"];
+  if ("templates" in root) return ["templates"];
+  return [];
+}
+
+/**
+ * Canonicalize a cycle by rotating so it starts at the smallest node
+ * name. Preserves edge order so genuinely different cycles among the
+ * same node set (e.g., A→B→C vs A→C→B in a graph with both pairs of
+ * edges) remain distinct.
+ */
+function canonicalCycleSignature(cycle: string[]): string {
+  if (cycle.length === 0) return "";
+  let minIndex = 0;
+  for (let i = 1; i < cycle.length; i++) {
+    if (cycle[i] < cycle[minIndex]) minIndex = i;
+  }
+  const rotated = [...cycle.slice(minIndex), ...cycle.slice(0, minIndex)];
+  return rotated.join("→");
 }


### PR DESCRIPTION
## Summary

First standalone piece of the #321 pipeline rewrite. New module `preHydrationSemantic.ts` runs two deterministic semantic checks on the merged source (root + imports) before any template expansion. No integration with the validator yet — that's the next PR in the sequence; this is just the helper + tests so future PRs can build on it without conflating concerns.

### What it catches

1. **Unknown template name** — every `template: X` invocation must reference a template defined in this file or its imports. Diagnostic points at the offending invocation. Today these surface as a generic mid-hydration `"Template not found"` error far from the actual fix site.

2. **Circular template invocations** — DFS over the static call graph (T → templates invoked in T's body, for every T) detects cycles and reports them once each. Self-invocation (A → A), two-step (A → B → A), longer cycles all caught. Diamond patterns (multiple paths to the same node, no cycle) correctly ignored. Today these cause infinite loops / stack overflows mid-hydration.

### What it deliberately skips

Parameterized invocations (e.g. `template: ${arm}_pre`) are excluded from both checks. Their concrete identity depends on call-site bindings that aren't known until hydration. Flagging them would false-positive on every broadcast-driven file; conversely a parameterized invocation that doesn't resolve at runtime still surfaces as a clear hydration error there.

### API shape

Mirrors `validateReferences.ts` — pure, position-free. Issues carry JSON paths into the source; the in-editor consumer maps them to YAML positions via its own AST mapper.

```ts
export function collectPreHydrationIssues({
  root,
  importedTemplates,
}: {
  root: Record<string, unknown>;
  importedTemplates?: unknown[];
}): PreHydrationIssue[];
```

`importedTemplates` accepts the post-`resolveImports` template list, so callers get the same merged view the rest of the pipeline uses.

## Test plan

- [x] 15 new tests covering both checks across the success/failure surface
- [x] Parameterized-skip case (template `${arm}_pre` doesn't trigger an unknown-name error)
- [x] Diamond non-cycle case (A → B, A → C, B → D, C → D — not a cycle)
- [x] 965 stagebook + 87 viewer + 201 vscode tests pass workspace-wide
- [x] Lint clean, format clean

## Relationship to #321

Step 4 of the eight-step pipeline laid out in #321. Standalone — no behavior change yet, no integration. Next PR will wire it into the editor validator alongside the diff orchestrator and the `globalProducedKeys` fallthrough removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)