### PR TITLE
Strict per-treatment unreachable-reference check (#321 step 3)

### DIFF
--- a/packages/stagebook/src/schemas/findUnreachableReferences.test.ts
+++ b/packages/stagebook/src/schemas/findUnreachableReferences.test.ts
@@ -280,6 +280,95 @@ describe("findUnreachableReferences", () => {
     });
   });
 
+  describe("uninvoked-template producer", () => {
+    it("flags a reference to a key produced only by a template that no treatment invokes", () => {
+      // The template `unused` defines `prompt name: lonely`. No
+      // treatment invokes the template, so `lonely` is unreachable
+      // from any participant. Treatment A references it →
+      // unreachable-reference diagnostic.
+      //
+      // `fillTemplates` strips `templates:` from its output, so the
+      // hydrated tree alone doesn't carry the template's keys. The
+      // orchestrator (`runValidationDiff`) passes the merged template
+      // list explicitly via the `templates` option so this case
+      // becomes detectable.
+      const hydrated = {
+        introSequences: [
+          {
+            name: "i",
+            introSteps: [{ name: "s", elements: [{ type: "submitButton" }] }],
+          },
+        ],
+        treatments: [
+          {
+            name: "A",
+            playerCount: 1,
+            gameStages: [
+              {
+                name: "g",
+                duration: 10,
+                elements: [
+                  { type: "display", reference: "self.prompt.lonely" },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const templates = [
+        {
+          name: "unused",
+          contentType: "element",
+          content: {
+            type: "prompt",
+            name: "lonely",
+            file: "lonely.prompt.md",
+          },
+        },
+      ];
+      const issues = findUnreachableReferences(hydrated, { templates });
+      expect(issues).toHaveLength(1);
+      expect(issues[0].message).toContain("prompt.lonely");
+      expect(issues[0].path[0]).toBe("treatments");
+      expect(issues[0].path[1]).toBe(0);
+    });
+
+    it("without passing templates, an uninvoked-template producer's key looks like a typo and is left to the schema", () => {
+      // Same setup as above but no templates passed. The function
+      // can't see the producer, so it can't distinguish "unreachable
+      // via uninvoked template" from "pure typo" — the latter is the
+      // schema's responsibility, so we don't emit. Documents the
+      // contract: callers that want full coverage must pass merged
+      // templates.
+      const hydrated = {
+        introSequences: [
+          {
+            name: "i",
+            introSteps: [{ name: "s", elements: [{ type: "submitButton" }] }],
+          },
+        ],
+        treatments: [
+          {
+            name: "A",
+            playerCount: 1,
+            gameStages: [
+              {
+                name: "g",
+                duration: 10,
+                elements: [
+                  { type: "display", reference: "self.prompt.lonely" },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      expect(findUnreachableReferences(hydrated)).toEqual([]);
+    });
+  });
+
   describe("multiple treatments with separate scopes", () => {
     it("flags only the consumer treatment, not the producer treatment", () => {
       const hydrated = {

--- a/packages/stagebook/src/schemas/findUnreachableReferences.test.ts
+++ b/packages/stagebook/src/schemas/findUnreachableReferences.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect } from "vitest";
+import { findUnreachableReferences } from "./findUnreachableReferences.js";
+
+/**
+ * Strict per-treatment reachable-keys check, applied to a hydrated
+ * treatment file (templates expanded into their invocation sites).
+ *
+ * The check covers what the schema's existing `validateReferences`
+ * silently passes via the `globalProducedKeys` fallthrough:
+ *
+ *   - Cross-treatment leaks (producer in another treatment)
+ *   - Producer in a template that this treatment doesn't invoke
+ *   - Producer in a template that another treatment invokes
+ *
+ * All three look the same at runtime — the consumer's participant
+ * never traverses the producer — and all three produce the same
+ * diagnostic class ("not reachable from this treatment"). Three
+ * sub-cases collapsed into one message; users don't need a
+ * prescriptive hint to find the bug.
+ *
+ * Caveat: only sound on the HYDRATED form, where each treatment's
+ * `producedAt` is complete. Running on raw source would false-
+ * positive on legitimate template-injected references.
+ */
+
+describe("findUnreachableReferences", () => {
+  describe("happy path", () => {
+    it("returns no issues when every reference resolves within its treatment", () => {
+      const hydrated = {
+        introSequences: [
+          {
+            name: "i",
+            introSteps: [
+              {
+                name: "s",
+                elements: [
+                  { type: "prompt", file: "intro.prompt.md", name: "consent" },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+        ],
+        treatments: [
+          {
+            name: "t",
+            playerCount: 1,
+            gameStages: [
+              {
+                name: "g",
+                duration: 10,
+                elements: [
+                  {
+                    type: "display",
+                    reference: "self.prompt.consent",
+                  },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      expect(findUnreachableReferences(hydrated)).toEqual([]);
+    });
+  });
+
+  describe("cross-treatment leaks", () => {
+    it("flags a reference produced only by another treatment", () => {
+      const hydrated = {
+        introSequences: [
+          {
+            name: "i",
+            introSteps: [
+              {
+                name: "s",
+                elements: [{ type: "submitButton" }],
+              },
+            ],
+          },
+        ],
+        treatments: [
+          {
+            name: "A",
+            playerCount: 1,
+            gameStages: [
+              {
+                name: "g",
+                duration: 10,
+                elements: [
+                  {
+                    type: "display",
+                    reference: "self.prompt.bOnly",
+                  },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+          {
+            name: "B",
+            playerCount: 1,
+            gameStages: [
+              {
+                name: "g",
+                duration: 10,
+                elements: [
+                  {
+                    type: "prompt",
+                    name: "bOnly",
+                    file: "b.prompt.md",
+                  },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const issues = findUnreachableReferences(hydrated);
+      // Treatment A's reference is unreachable; Treatment B doesn't
+      // reference anything from outside, so no leak there.
+      expect(issues).toHaveLength(1);
+      expect(issues[0].message).toContain("prompt.bOnly");
+      expect(issues[0].path[0]).toBe("treatments");
+      expect(issues[0].path[1]).toBe(0); // treatment A
+    });
+  });
+
+  describe("self-reachable cases that must not fire", () => {
+    it("does not flag a reference to a producer in the same treatment's earlier stage", () => {
+      // Same treatment, earlier stage → reachable. The forward-ref
+      // rank check is the schema's job; the strict check just
+      // requires the producer to be in the reachable set.
+      const hydrated = {
+        introSequences: [
+          {
+            name: "i",
+            introSteps: [{ name: "s", elements: [{ type: "submitButton" }] }],
+          },
+        ],
+        treatments: [
+          {
+            name: "t",
+            playerCount: 1,
+            gameStages: [
+              {
+                name: "stage1",
+                duration: 10,
+                elements: [
+                  {
+                    type: "prompt",
+                    name: "earlyAnswer",
+                    file: "q.prompt.md",
+                  },
+                  { type: "submitButton" },
+                ],
+              },
+              {
+                name: "stage2",
+                duration: 10,
+                elements: [
+                  {
+                    type: "display",
+                    reference: "self.prompt.earlyAnswer",
+                  },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      expect(findUnreachableReferences(hydrated)).toEqual([]);
+    });
+
+    it("does not flag a reference to an intro-step producer", () => {
+      const hydrated = {
+        introSequences: [
+          {
+            name: "i",
+            introSteps: [
+              {
+                name: "consent",
+                elements: [
+                  { type: "prompt", name: "consent", file: "c.prompt.md" },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+        ],
+        treatments: [
+          {
+            name: "t",
+            playerCount: 1,
+            gameStages: [
+              {
+                name: "g",
+                duration: 10,
+                elements: [
+                  { type: "display", reference: "self.prompt.consent" },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      expect(findUnreachableReferences(hydrated)).toEqual([]);
+    });
+
+    it("does not flag external references (entryUrl, participantInfo, etc.)", () => {
+      const hydrated = {
+        introSequences: [
+          {
+            name: "i",
+            introSteps: [{ name: "s", elements: [{ type: "submitButton" }] }],
+          },
+        ],
+        treatments: [
+          {
+            name: "t",
+            playerCount: 1,
+            gameStages: [
+              {
+                name: "g",
+                duration: 10,
+                elements: [
+                  {
+                    type: "display",
+                    reference: "entryUrl.params.PROLIFIC_PID",
+                  },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      expect(findUnreachableReferences(hydrated)).toEqual([]);
+    });
+  });
+
+  describe("not duplicating the schema's typo check", () => {
+    it("does NOT flag references that no producer exists for (schema already handles)", () => {
+      // The schema's existing reference checker emits an
+      // "unknown reference" error when the key isn't in
+      // globalProducedKeys. We rely on the schema for that diagnostic
+      // and only emit for references that ARE in globalProducedKeys
+      // but not reachable from this treatment — avoids duplicates.
+      const hydrated = {
+        introSequences: [
+          {
+            name: "i",
+            introSteps: [{ name: "s", elements: [{ type: "submitButton" }] }],
+          },
+        ],
+        treatments: [
+          {
+            name: "t",
+            playerCount: 1,
+            gameStages: [
+              {
+                name: "g",
+                duration: 10,
+                elements: [
+                  {
+                    type: "display",
+                    reference: "self.prompt.totallyMadeUp",
+                  },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      expect(findUnreachableReferences(hydrated)).toEqual([]);
+    });
+  });
+
+  describe("multiple treatments with separate scopes", () => {
+    it("flags only the consumer treatment, not the producer treatment", () => {
+      const hydrated = {
+        introSequences: [
+          {
+            name: "i",
+            introSteps: [{ name: "s", elements: [{ type: "submitButton" }] }],
+          },
+        ],
+        treatments: [
+          {
+            name: "A",
+            playerCount: 1,
+            gameStages: [
+              {
+                name: "g",
+                duration: 10,
+                elements: [
+                  { type: "display", reference: "self.prompt.bOnly" },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+          {
+            name: "B",
+            playerCount: 1,
+            gameStages: [
+              {
+                name: "g",
+                duration: 10,
+                elements: [
+                  { type: "display", reference: "self.prompt.aOnly" },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+          {
+            name: "C",
+            playerCount: 1,
+            gameStages: [
+              {
+                name: "g",
+                duration: 10,
+                elements: [
+                  { type: "prompt", name: "aOnly", file: "a.prompt.md" },
+                  { type: "prompt", name: "bOnly", file: "b.prompt.md" },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const issues = findUnreachableReferences(hydrated);
+      // Both A's ref to bOnly and B's ref to aOnly are unreachable
+      // — those keys are produced only in C.
+      expect(issues).toHaveLength(2);
+      const treatmentIndices = issues.map((i) => i.path[1]);
+      expect(treatmentIndices).toContain(0); // A
+      expect(treatmentIndices).toContain(1); // B
+      expect(treatmentIndices).not.toContain(2); // C produces both
+    });
+  });
+
+  describe("malformed input", () => {
+    it("returns an empty array for non-object input", () => {
+      expect(findUnreachableReferences(null)).toEqual([]);
+      expect(findUnreachableReferences(undefined)).toEqual([]);
+      expect(findUnreachableReferences("not an object")).toEqual([]);
+      expect(findUnreachableReferences([])).toEqual([]);
+    });
+
+    it("returns an empty array for an empty treatment file", () => {
+      expect(findUnreachableReferences({})).toEqual([]);
+    });
+  });
+});

--- a/packages/stagebook/src/schemas/findUnreachableReferences.ts
+++ b/packages/stagebook/src/schemas/findUnreachableReferences.ts
@@ -4,7 +4,6 @@ import {
   STAGE_PRODUCED_REF_TYPES,
   collectStepKeys,
   collectKeysFromAny,
-  collectProducedKeys,
   enumerateStepSites,
 } from "./validateReferences.js";
 import { getReferenceKeyAndPath } from "../utils/reference.js";
@@ -47,23 +46,38 @@ function toArray(v: unknown): unknown[] {
   return Array.isArray(v) ? v : [];
 }
 
+export interface FindUnreachableReferencesOptions {
+  /**
+   * Template definitions (post-`resolveImports` merge) to include in
+   * `globalProducedKeys`. Required for the "producer is in an
+   * uninvoked template" sub-case — `fillTemplates` strips
+   * `templates:` from its output, so the hydrated form alone doesn't
+   * carry them. The orchestrator (`runValidationDiff`) computes the
+   * merged list and passes it here.
+   */
+  templates?: unknown[];
+}
+
 export function findUnreachableReferences(
   hydratedTreatmentFile: unknown,
+  options: FindUnreachableReferencesOptions = {},
 ): ZodIssue[] {
   if (!isRecord(hydratedTreatmentFile)) return [];
 
   const issues: ZodIssue[] = [];
   const introSequences = toArray(hydratedTreatmentFile.introSequences);
   const treatments = toArray(hydratedTreatmentFile.treatments);
-  const templates = toArray(hydratedTreatmentFile.templates);
+  const templates = toArray(options.templates);
 
   // Intro keys are shared across treatments (every treatment can read
-  // intro-phase data). Build once.
+  // intro-phase data). Build once. `collectStepKeys` iterates over a
+  // step's elements; `collectProducedKeys` operates on a single
+  // element, so it's the wrong granularity for a step.
   const introProducedKeys = new Set<string>();
   for (const seq of introSequences) {
     if (!isRecord(seq)) continue;
     for (const step of toArray(seq.introSteps)) {
-      collectProducedKeys(step, introProducedKeys);
+      for (const key of collectStepKeys(step)) introProducedKeys.add(key);
     }
   }
 

--- a/packages/stagebook/src/schemas/findUnreachableReferences.ts
+++ b/packages/stagebook/src/schemas/findUnreachableReferences.ts
@@ -1,0 +1,161 @@
+import type { ZodIssue } from "zod";
+import { z } from "zod";
+import {
+  STAGE_PRODUCED_REF_TYPES,
+  collectStepKeys,
+  collectKeysFromAny,
+  collectProducedKeys,
+  enumerateStepSites,
+} from "./validateReferences.js";
+import { getReferenceKeyAndPath } from "../utils/reference.js";
+import { formatReference } from "./reference.js";
+
+/**
+ * Strict per-treatment reachable-keys reference check, applied to a
+ * hydrated treatment file (templates expanded into their invocation
+ * sites). Catches what the schema's existing reference checker
+ * silently passes via its `globalProducedKeys` fallthrough:
+ *
+ *   - Cross-treatment leaks (producer in another treatment)
+ *   - Producer in a template that this treatment doesn't invoke
+ *   - Producer in a template another treatment invokes
+ *
+ * All three are runtime-equivalent (the consumer's participant never
+ * traverses the producer) and collapse to a single diagnostic class —
+ * "reference doesn't match any element in this treatment." No
+ * prescriptive sub-message about which sub-case is involved; that
+ * would risk mis-directing the fix.
+ *
+ * To avoid duplicating the schema's "unknown reference" diagnostic,
+ * the check only emits when the reference IS produced somewhere in
+ * the file (just not reachable from this treatment). Pure typos —
+ * keys produced nowhere — are left to the schema's existing pass.
+ *
+ * Only sound on the HYDRATED form. Per-treatment producedAt on raw
+ * source is incomplete (templates not expanded) and would false-
+ * positive on legitimate template-injected references.
+ *
+ * See #321 for the broader pipeline; this is the rung-3-strict piece
+ * the diff orchestrator calls.
+ */
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function toArray(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+
+export function findUnreachableReferences(
+  hydratedTreatmentFile: unknown,
+): ZodIssue[] {
+  if (!isRecord(hydratedTreatmentFile)) return [];
+
+  const issues: ZodIssue[] = [];
+  const introSequences = toArray(hydratedTreatmentFile.introSequences);
+  const treatments = toArray(hydratedTreatmentFile.treatments);
+  const templates = toArray(hydratedTreatmentFile.templates);
+
+  // Intro keys are shared across treatments (every treatment can read
+  // intro-phase data). Build once.
+  const introProducedKeys = new Set<string>();
+  for (const seq of introSequences) {
+    if (!isRecord(seq)) continue;
+    for (const step of toArray(seq.introSteps)) {
+      collectProducedKeys(step, introProducedKeys);
+    }
+  }
+
+  // globalProducedKeys: union over everything (incl. templates and
+  // other treatments). Used to filter out pure typos so we don't
+  // duplicate the schema's unknown-reference diagnostic.
+  const globalProducedKeys = new Set<string>(introProducedKeys);
+  for (const treatment of treatments) {
+    if (!isRecord(treatment)) continue;
+    for (const stage of toArray(treatment.gameStages)) {
+      for (const key of collectStepKeys(stage)) globalProducedKeys.add(key);
+    }
+    for (const step of toArray(treatment.exitSequence)) {
+      for (const key of collectStepKeys(step)) globalProducedKeys.add(key);
+    }
+  }
+  for (const tmpl of templates) {
+    if (!isRecord(tmpl)) continue;
+    collectKeysFromAny(tmpl.content, globalProducedKeys);
+  }
+
+  // Per-treatment reachable check.
+  treatments.forEach((treatment, treatmentIdx) => {
+    if (!isRecord(treatment)) return;
+
+    // Build this treatment's reachable keys: intro keys + own
+    // gameStages + own exitSequence. (Templates have already been
+    // expanded into the appropriate stages by hydration, so their
+    // produced keys appear naturally in this treatment's stage walk.)
+    const reachable = new Set<string>(introProducedKeys);
+    const stages = toArray(treatment.gameStages);
+    for (const stage of stages) {
+      for (const key of collectStepKeys(stage)) reachable.add(key);
+    }
+    for (const step of toArray(treatment.exitSequence)) {
+      for (const key of collectStepKeys(step)) reachable.add(key);
+    }
+
+    // Walk every reference site in this treatment's stages and exit
+    // (intro sites belong to their own sequence scope, not the
+    // treatment — they're validated by the intro-pass elsewhere).
+    const allSites = [
+      ...stages.flatMap((stage, stageIdx) =>
+        enumerateStepSites(stage, [
+          "treatments",
+          treatmentIdx,
+          "gameStages",
+          stageIdx,
+        ]),
+      ),
+      ...toArray(treatment.exitSequence).flatMap((step, stepIdx) =>
+        enumerateStepSites(step, [
+          "treatments",
+          treatmentIdx,
+          "exitSequence",
+          stepIdx,
+        ]),
+      ),
+    ];
+
+    for (const site of allSites) {
+      // External sources (entryUrl, participantInfo, …) always
+      // resolve at runtime, no check needed.
+      if (!STAGE_PRODUCED_REF_TYPES.has(site.reference.source)) continue;
+
+      let referenceKey: string;
+      try {
+        ({ referenceKey } = getReferenceKeyAndPath(site.reference));
+      } catch {
+        // Malformed reference — schema's other validators handle it.
+        continue;
+      }
+
+      // In this treatment's reachable set → schema's existing rank
+      // check will validate forward-reference semantics. Nothing for
+      // us to add.
+      if (reachable.has(referenceKey)) continue;
+
+      // Not produced anywhere in the file → schema's existing
+      // unknown-reference check will flag it. Don't duplicate.
+      if (!globalProducedKeys.has(referenceKey)) continue;
+
+      // Produced somewhere in the file but not reachable from this
+      // treatment. Real bug — emit.
+      const refStr = formatReference(site.reference);
+      issues.push({
+        code: z.ZodIssueCode.custom,
+        path: site.path,
+        message: `Reference "${refStr}" doesn't match any element in this treatment. The storage key "${referenceKey}" exists elsewhere in the file (another treatment, or a template this treatment doesn't invoke), but participants only traverse one treatment's stages — references must resolve within the treatment that uses them.`,
+      });
+    }
+  });
+
+  return issues;
+}

--- a/packages/stagebook/src/schemas/index.ts
+++ b/packages/stagebook/src/schemas/index.ts
@@ -117,6 +117,8 @@ export {
   type ValidationDiffResult,
 } from "./runValidationDiff.js";
 
+export { findUnreachableReferences } from "./findUnreachableReferences.js";
+
 export {
   resolvedElementSchema,
   resolvedStageSchema,

--- a/packages/stagebook/src/schemas/runValidationDiff.test.ts
+++ b/packages/stagebook/src/schemas/runValidationDiff.test.ts
@@ -369,6 +369,70 @@ treatments:
     });
   });
 
+  describe("unreachableReferences bucket", () => {
+    it("populates unreachableReferences for cross-treatment leaks the schema silently passes", () => {
+      // Treatment A references a key only Treatment B produces. The
+      // schema's existing reference check falls through to
+      // globalProducedKeys (silent pass), so neither sourceIssues nor
+      // hydratedIssues catches it. The orchestrator's strict per-
+      // treatment check (rung-3-strict, no fallthrough) does.
+      const source = `introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+treatments:
+  - name: A
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: display
+            reference: self.prompt.bOnly
+          - type: submitButton
+  - name: B
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: prompt
+            name: bOnly
+            file: b.prompt.md
+          - type: submitButton
+`;
+      const result = runValidationDiff({ source });
+      expect(result.hydrationError).toBeNull();
+      // Schema's pass through with fallthrough — no source/hydrated
+      // unknown-reference issues for the leak.
+      const leakInSourceIssues = result.sourceIssues.some((i) =>
+        i.message.includes("prompt.bOnly"),
+      );
+      const leakInHydratedIssues = result.hydratedIssues.some((i) =>
+        i.message.includes("prompt.bOnly"),
+      );
+      expect(leakInSourceIssues).toBe(false);
+      expect(leakInHydratedIssues).toBe(false);
+      // But the strict check catches it.
+      expect(result.unreachableReferences).toHaveLength(1);
+      expect(result.unreachableReferences[0].message).toContain("prompt.bOnly");
+      expect(result.unreachableReferences[0].path[0]).toBe("treatments");
+      expect(result.unreachableReferences[0].path[1]).toBe(0);
+    });
+
+    it("returns an empty unreachableReferences on hydration failure", () => {
+      const result = runValidationDiff({
+        source: `treatments:
+  - template: doesNotExist
+`,
+      });
+      expect(result.hydrationError).not.toBeNull();
+      expect(result.unreachableReferences).toEqual([]);
+    });
+  });
+
   describe("imports field validation", () => {
     it("flags a non-string entry in `imports:` (matched in both passes)", () => {
       // The schema models `imports:` as `z.array(z.string().min(1))`.

--- a/packages/stagebook/src/schemas/runValidationDiff.ts
+++ b/packages/stagebook/src/schemas/runValidationDiff.ts
@@ -266,7 +266,12 @@ export function runValidationDiff({
   // Strict per-treatment reachable-keys check, only sound on the
   // hydrated form. Catches what the schema's existing reference
   // checker silently passes via globalProducedKeys fallthrough.
-  const unreachableReferences = findUnreachableReferences(expanded);
+  // Pass the merged templates explicitly — fillTemplates strips
+  // `templates:` from its output, so the hydrated form alone doesn't
+  // carry them, and we'd miss producer-in-uninvoked-template leaks.
+  const unreachableReferences = findUnreachableReferences(expanded, {
+    templates: mergedTemplates ?? [],
+  });
 
   return {
     hydrationError: null,

--- a/packages/stagebook/src/schemas/runValidationDiff.ts
+++ b/packages/stagebook/src/schemas/runValidationDiff.ts
@@ -2,6 +2,7 @@ import type { ZodIssue } from "zod";
 import { parse as parseYaml } from "yaml";
 import { fillTemplates } from "../templates/fillTemplates.js";
 import { safeParseTreatmentFile } from "./safeParseTreatmentFile.js";
+import { findUnreachableReferences } from "./findUnreachableReferences.js";
 
 /**
  * Diff-based validation orchestrator.
@@ -102,6 +103,17 @@ export interface ValidationDiffResult {
   sourceOnly: ZodIssue[];
   /** Issues only in the hydrated pass — revealed by expansion. */
   hydratedOnly: ZodIssue[];
+  /**
+   * Cross-treatment / unreachable-reference issues from the strict
+   * per-treatment check on the hydrated form. Catches what the
+   * schema's existing reference checker silently passes via the
+   * `globalProducedKeys` fallthrough — references to keys produced
+   * elsewhere in the file but not reachable from the consuming
+   * treatment. Confidently real bugs (no false-positives by
+   * construction); display as errors. See
+   * `findUnreachableReferences.ts` for the rule details.
+   */
+  unreachableReferences: ZodIssue[];
 }
 
 /**
@@ -143,6 +155,7 @@ export function runValidationDiff({
     matched: [],
     sourceOnly: [],
     hydratedOnly: [],
+    unreachableReferences: [],
   };
 
   let parsed: unknown;
@@ -225,6 +238,7 @@ export function runValidationDiff({
       matched: [],
       sourceOnly: [],
       hydratedOnly: [],
+      unreachableReferences: [],
     };
   }
 
@@ -249,6 +263,11 @@ export function runValidationDiff({
     hydratedIssues,
   );
 
+  // Strict per-treatment reachable-keys check, only sound on the
+  // hydrated form. Catches what the schema's existing reference
+  // checker silently passes via globalProducedKeys fallthrough.
+  const unreachableReferences = findUnreachableReferences(expanded);
+
   return {
     hydrationError: null,
     sourceIssues,
@@ -256,6 +275,7 @@ export function runValidationDiff({
     matched,
     sourceOnly,
     hydratedOnly,
+    unreachableReferences,
   };
 }
 

--- a/packages/stagebook/src/schemas/validateReferences.ts
+++ b/packages/stagebook/src/schemas/validateReferences.ts
@@ -82,7 +82,7 @@ const RANK_GAME_BASE = 1;
  *  layout, …). We leave `discussion.*` refs alone rather than risk a
  *  false-positive "doesn't match any discussion element" on valid
  *  references. Forward-ref and unknown-ref checks both skip them. */
-const STAGE_PRODUCED_REF_TYPES = new Set([
+export const STAGE_PRODUCED_REF_TYPES = new Set([
   "prompt",
   "survey",
   "submitButton",
@@ -424,7 +424,7 @@ function validateTreatment({
 // Reference-site enumeration
 // ---------------------------------------------------------------------------
 
-interface RefSite {
+export interface RefSite {
   /** The reference, normalized to its structured form (#240). */
   reference: ReferenceType;
   kind: ReferenceKind;
@@ -444,7 +444,7 @@ interface RefSite {
  *  operator object, or a single leaf — `walkConditionLeaves` flattens
  *  the tree and yields each leaf with its absolute path.
  */
-function enumerateStepSites(
+export function enumerateStepSites(
   step: unknown,
   stepPath: (string | number)[],
 ): RefSite[] {
@@ -674,7 +674,7 @@ function pathTraversesNonAllOperator(path: (string | number)[]): boolean {
 
 /** Collect every storage key produced by the elements inside a single step
  *  (stage or intro/exit step). */
-function collectStepKeys(step: unknown): Set<string> {
+export function collectStepKeys(step: unknown): Set<string> {
   const keys = new Set<string>();
   if (!isRecord(step)) return keys;
   for (const el of toArray(step.elements)) {
@@ -690,7 +690,7 @@ function collectStepKeys(step: unknown): Set<string> {
  *  because template shapes are flexible and we just want "every key that
  *  could come out of this template."
  */
-function collectKeysFromAny(node: unknown, acc: Set<string>): void {
+export function collectKeysFromAny(node: unknown, acc: Set<string>): void {
   if (typeof node !== "object" || node === null) return;
   if (Array.isArray(node)) {
     for (const item of node) collectKeysFromAny(item, acc);
@@ -707,7 +707,7 @@ function collectKeysFromAny(node: unknown, acc: Set<string>): void {
 /** Map an element to its storage key (or keys) and add them to `acc`.
  *  The key conventions mirror `getReferenceKeyAndPath` so lookups line up.
  */
-function collectProducedKeys(element: unknown, acc: Set<string>): void {
+export function collectProducedKeys(element: unknown, acc: Set<string>): void {
   if (!isRecord(element)) return;
   const type = element.type;
   const name = element.name;


### PR DESCRIPTION
## Summary

Third standalone piece of the #321 pipeline rewrite. New module `findUnreachableReferences.ts` implements the strict per-treatment reachable-keys check that the schema's existing `validateReferences` silently passes via its `globalProducedKeys` fallthrough.

Library-only, not wired into the editor yet (Phase 5). The diff orchestrator from #327 grows a new output bucket `unreachableReferences`.

## What the schema currently misses

For each reference in a treatment, the schema's checker walks down:

1. Producer in this treatment's `producedAt` → rank check
2. Producer in `laterPhaseKeys` → cross-phase forward-ref error
3. Producer in `globalProducedKeys` (anywhere in the file) → **silent pass**
4. Otherwise → unknown-reference error

Rung 3 masks three distinct runtime bugs that all look the same to a participant (the producer is never traversed):

- Cross-treatment leak (producer in another treatment)
- Producer in a template the consumer doesn't invoke
- Producer in a template another treatment invokes

## What this PR adds

`findUnreachableReferences(hydratedTreatmentFile)` does rung 3 strictly. It emits an issue when the reference's key is in `globalProducedKeys` but not in **this treatment's reachable set** (intros + this treatment's gameStages + this treatment's exit, with templates already expanded into those positions).

It doesn't duplicate the schema's existing diagnostics:
- Pure typos (key produced nowhere) → schema handles
- Forward references within a treatment → schema's rank check handles
- Cross-phase forward refs → schema's existing check handles
- The strict rung-3 case → **this function**

## Single diagnostic class, not three

I considered three distinct messages (cross-treatment vs uninvoked-template vs nowhere-at-all) but they'd be prescriptive in ways that risk mis-directing the fix. One message says "this reference doesn't match any element in this treatment" plus the storage key — the user has the whole picture and can investigate without the validator guessing.

## Only sound on hydrated form

Per-treatment `producedAt` on raw source is incomplete (templates not expanded), so applying strict rules pre-fill would false-positive on legitimate template-injected references. The function should only be called on the hydrated form, which `runValidationDiff` already produces.

## Touchpoints

- [`validateReferences.ts`](packages/stagebook/src/schemas/validateReferences.ts): export `RefSite`, `STAGE_PRODUCED_REF_TYPES`, `enumerateStepSites`, `collectStepKeys`, `collectKeysFromAny`, `collectProducedKeys` for reuse. **Schema behavior unchanged** — existing reference check still runs with fallthrough, just like before.
- [`findUnreachableReferences.ts`](packages/stagebook/src/schemas/findUnreachableReferences.ts) (new): the strict check + 9 unit tests
- [`runValidationDiff.ts`](packages/stagebook/src/schemas/runValidationDiff.ts): add `unreachableReferences` to `ValidationDiffResult`; orchestrator calls the new function after hydration
- [`runValidationDiff.test.ts`](packages/stagebook/src/schemas/runValidationDiff.test.ts): 2 new tests demonstrating the bucket
- `schemas/index.ts`: export the new function

## Test plan

- [x] 9 new tests in `findUnreachableReferences.test.ts` covering happy path, cross-treatment leak, same-treatment earlier-stage (no false positive), intro producer (no false positive), external sources (no false positive), schema-typo-not-duplicated, multi-treatment per-scope, and malformed input edge cases
- [x] 2 new tests in `runValidationDiff.test.ts` showing the orchestrator routes leaks into `unreachableReferences` (not source/hydrated/matched/sourceOnly/hydratedOnly) and returns empty on hydration failure
- [x] All 974 stagebook + 87 viewer + 201 vscode tests pass
- [x] Lint clean, format clean

## Relationship to #321

Step 3 of the eight-step pipeline. Builds on #324 (pre-hydration semantic) and #327 (diff orchestrator). Next PR (Phase 5) wires the full orchestrator — including this new bucket — into the editor's async `validateTreatmentFile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)