### PR TITLE
Regression test for intro-producer / collectProducedKeys bug (#321 follow-up)

### DIFF
--- a/packages/stagebook/src/schemas/findUnreachableReferences.test.ts
+++ b/packages/stagebook/src/schemas/findUnreachableReferences.test.ts
@@ -369,6 +369,80 @@ describe("findUnreachableReferences", () => {
     });
   });
 
+  describe("intro keys participate in globalProducedKeys (regression test)", () => {
+    it("treats an intro-produced key as reachable when an uninvoked template also produces the same key", () => {
+      // Distinguishing test for the introProducedKeys-built-with-wrong-
+      // granularity bug. Both "key reachable via intro" and "key not
+      // in globalProducedKeys" produce a no-issue outcome for a simple
+      // intro-producer scenario, so the simpler test can't tell the
+      // two paths apart. This setup forces the distinction:
+      //
+      //   - Intro produces `prompt.dual`
+      //   - A template (uninvoked) ALSO produces `prompt.dual`
+      //   - Treatment A references `prompt.dual`
+      //
+      // Correct behavior (intro keys collected properly):
+      //   - introProducedKeys = {prompt.dual}
+      //   - A's reachable set includes prompt.dual via intro
+      //   - No issue emitted
+      //
+      // Buggy behavior (introProducedKeys was empty):
+      //   - introProducedKeys = {}
+      //   - globalProducedKeys = {prompt.dual} (via the template)
+      //   - A's reachable set does NOT include prompt.dual
+      //   - The reference is "produced in globalProducedKeys but not
+      //     reachable" → wrongly emits unreachable
+      //
+      // So this test fails with the bug and passes after the fix —
+      // exactly the regression discriminator the simple intro-
+      // producer test couldn't provide.
+      const hydrated = {
+        introSequences: [
+          {
+            name: "i",
+            introSteps: [
+              {
+                name: "s",
+                elements: [
+                  { type: "prompt", name: "dual", file: "dual.prompt.md" },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+        ],
+        treatments: [
+          {
+            name: "A",
+            playerCount: 1,
+            gameStages: [
+              {
+                name: "g",
+                duration: 10,
+                elements: [
+                  { type: "display", reference: "self.prompt.dual" },
+                  { type: "submitButton" },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+      const templates = [
+        {
+          name: "alsoDual",
+          contentType: "element",
+          content: {
+            type: "prompt",
+            name: "dual",
+            file: "dual.prompt.md",
+          },
+        },
+      ];
+      expect(findUnreachableReferences(hydrated, { templates })).toEqual([]);
+    });
+  });
+
   describe("multiple treatments with separate scopes", () => {
     it("flags only the consumer treatment, not the producer treatment", () => {
       const hydrated = {


### PR DESCRIPTION
## Summary

PR #328 originally had a bug — `introProducedKeys` was built by calling `collectProducedKeys(step, …)`, which is the wrong granularity (it operates on a single element and skips anything that isn't an element). The fix landed in commit 0b23ebb on #328, but the existing tests didn't distinguish the buggy and fixed code paths.

This PR adds the missing regression test. It would have caught the bug before fixing it, and now locks in the fix against future regressions.

## Why the original tests missed it

The simple intro-producer test:
- Intro produces `prompt.consent`
- Treatment references `self.prompt.consent`
- Expected: no issue emitted

Both the buggy and fixed paths produce **the same outcome** ("no issue emitted") via different internal mechanisms:

- **Bug:** `introProducedKeys` empty, `globalProducedKeys` also missing intro keys → reference falls into the "key produced nowhere → schema handles" early-out → no issue
- **Fix:** `introProducedKeys` populated, treatment's reachable set includes the key → no issue

A negative-only assertion can't tell those two paths apart.

## The discriminating test

To force the function to choose between the two paths, the new test sets up:
- Intro produces `prompt.dual`
- An uninvoked template **also** produces `prompt.dual`
- Treatment A references `prompt.dual`

Now:
- **Bug:** `introProducedKeys` = {}, `globalProducedKeys` = {prompt.dual} (via the uninvoked template) → A's reachable set lacks the key → function wrongly emits unreachable
- **Fix:** `introProducedKeys` = {prompt.dual} → A's reachable set contains the key → no issue

I confirmed by temporarily reverting the fix locally: the new test fails. With the fix in place, all 12 tests pass.

## Test plan

- [x] All 12 `findUnreachableReferences.test.ts` tests pass
- [x] All 201 vscode + 87 viewer + 975 stagebook tests pass workspace-wide
- [x] Format clean, lint clean
- [x] Manually verified the test fails on the reverted (buggy) code

## Why this is a separate PR

#328 was merged before this regression test could land in the same PR. Small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)