### PR TITLE
Wire diff orchestrator into editor validator (#321 step 5)

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -106,16 +106,50 @@ async function validateTreatmentFile(
 
   const source = document.getText();
   const rootDir = vscode.Uri.joinPath(document.uri, "..");
+  const workspaceFolder =
+    vscode.workspace.getWorkspaceFolder(document.uri) ??
+    vscode.workspace.workspaceFolders?.[0];
   const decoder = new TextDecoder();
 
-  const result = await validateTreatmentWithDiff({
-    source,
-    loadImport: async (importPath: string) => {
-      const importUri = vscode.Uri.joinPath(rootDir, importPath);
-      const bytes = await vscode.workspace.fs.readFile(importUri);
-      return decoder.decode(bytes);
-    },
-  });
+  // `validateTreatmentFile` runs fire-and-forget from the debounced
+  // validator; any uncaught rejection becomes an unhandled-promise
+  // warning that destabilizes the extension host. Catch everything
+  // and surface as a top-of-file diagnostic so the editor stays
+  // responsive.
+  let result;
+  try {
+    result = await validateTreatmentWithDiff({
+      source,
+      loadImport: async (importPath: string) => {
+        // Boundary guard: `resolveImportPath` can produce paths that
+        // start with `..` (legal for `./..` declarations in source)
+        // or even absolute paths. Without an explicit check,
+        // `vscode.workspace.fs.readFile` would happily read arbitrary
+        // files outside the workspace on every edit. Refuse those
+        // outright so validation can never trigger an unbounded read.
+        const importUri = vscode.Uri.joinPath(rootDir, importPath);
+        if (
+          workspaceFolder &&
+          !isWithinWorkspace(importUri.fsPath, workspaceFolder.uri.fsPath)
+        ) {
+          throw new Error(`Import path escapes workspace: ${importPath}`);
+        }
+        const bytes = await vscode.workspace.fs.readFile(importUri);
+        return decoder.decode(bytes);
+      },
+    });
+  } catch (e) {
+    if (validationVersions.get(uriKey) !== version) return;
+    const message = e instanceof Error ? e.message : String(e);
+    const fallback = new vscode.Diagnostic(
+      new vscode.Range(0, 0, 0, 1),
+      `Stagebook validator failed unexpectedly: ${message}`,
+      vscode.DiagnosticSeverity.Error,
+    );
+    fallback.source = "stagebook";
+    diagnosticCollection.set(document.uri, [fallback]);
+    return;
+  }
 
   // Stale-version guard: if another edit fired while we were awaiting,
   // discard this result rather than clobbering the newer one.

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -1,9 +1,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
-import {
-  validateTreatmentSource,
-  type Diagnostic,
-} from "./lib/validateTreatment";
+import { type Diagnostic } from "./lib/validateTreatment";
+import { validateTreatmentWithDiff } from "./lib/validateTreatmentDiff";
 import { validatePromptSource } from "./lib/validatePrompt";
 import { pathToRange } from "./lib/yamlPositionMap";
 import {
@@ -99,13 +97,29 @@ function toVscodeRange(range: Diagnostic["range"]): vscode.Range {
   );
 }
 
-function validateTreatmentFile(document: vscode.TextDocument): void {
+async function validateTreatmentFile(
+  document: vscode.TextDocument,
+): Promise<void> {
   const uriKey = document.uri.toString();
   const version = (validationVersions.get(uriKey) ?? 0) + 1;
   validationVersions.set(uriKey, version);
 
   const source = document.getText();
-  const result = validateTreatmentSource(source);
+  const rootDir = vscode.Uri.joinPath(document.uri, "..");
+  const decoder = new TextDecoder();
+
+  const result = await validateTreatmentWithDiff({
+    source,
+    loadImport: async (importPath: string) => {
+      const importUri = vscode.Uri.joinPath(rootDir, importPath);
+      const bytes = await vscode.workspace.fs.readFile(importUri);
+      return decoder.decode(bytes);
+    },
+  });
+
+  // Stale-version guard: if another edit fired while we were awaiting,
+  // discard this result rather than clobbering the newer one.
+  if (validationVersions.get(uriKey) !== version) return;
 
   const vscodeDiagnostics = result.diagnostics.map((d) => {
     const diag = new vscode.Diagnostic(

--- a/apps/vscode/src/lib/validateTreatmentDiff.test.ts
+++ b/apps/vscode/src/lib/validateTreatmentDiff.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect } from "vitest";
+import { validateTreatmentWithDiff } from "./validateTreatmentDiff";
+
+/**
+ * Editor-side wrapper around the diff orchestrator. Verifies that:
+ *
+ *   - Real bugs (matched) surface as errors with source positions
+ *   - Cross-treatment leaks surface (unreachableReferences)
+ *   - Templating artifacts (sourceOnly) surface as warnings
+ *   - Hydrated-only issues are NOT surfaced on the source (the
+ *     expanded preview is their home)
+ *   - YAML parse failures still surface
+ *   - Import-load failures surface as top-of-file errors
+ *
+ * `loadImport` is mocked with a Map for hermetic tests.
+ */
+
+const loaderFromMap = (files: Record<string, string>) => {
+  return async (path: string): Promise<string> => {
+    const normalized = path.replace(/^\.\//, "");
+    const content = files[path] ?? files[normalized] ?? files[`./${path}`];
+    if (content === undefined) {
+      throw new Error(`Mock loader: no entry for ${path}`);
+    }
+    return content;
+  };
+};
+
+const noImports = loaderFromMap({});
+
+describe("validateTreatmentWithDiff", () => {
+  describe("happy path", () => {
+    it("returns no diagnostics for a clean treatment", async () => {
+      const source = `introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+      const result = await validateTreatmentWithDiff({
+        source,
+        loadImport: noImports,
+      });
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+
+  describe("cross-treatment reference leaks (unreachableReferences)", () => {
+    it("surfaces a leak as an error on the consuming treatment's source line", async () => {
+      const source = `introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+treatments:
+  - name: A
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: display
+            reference: self.prompt.bOnly
+          - type: submitButton
+  - name: B
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: prompt
+            name: bOnly
+            file: b.prompt.md
+          - type: submitButton
+`;
+      const result = await validateTreatmentWithDiff({
+        source,
+        loadImport: noImports,
+      });
+      const leakErrors = result.diagnostics.filter(
+        (d) =>
+          d.severity === "error" &&
+          d.message.includes("prompt.bOnly") &&
+          d.message.toLowerCase().includes("doesn't match"),
+      );
+      expect(leakErrors).toHaveLength(1);
+      // The path resolves cleanly in source (no templates in this
+      // file), so the range is the reference site, not a fallback
+      // to top-of-file.
+      expect(leakErrors[0].range).not.toBeNull();
+      expect(leakErrors[0].range!.startLine).toBeGreaterThan(0);
+    });
+  });
+
+  describe("templating artifacts (sourceOnly → warning)", () => {
+    it("downgrades the intro-step advancement-element refinement to warning when a template provides it", async () => {
+      const source = `templates:
+  - name: advanceBtn
+    contentType: elements
+    content:
+      - type: submitButton
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - template: advanceBtn
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+      const result = await validateTreatmentWithDiff({
+        source,
+        loadImport: noImports,
+      });
+      // The advancement-element rule fires source-only. The orchestrator
+      // classifies it as sourceOnly. We surface as warning (not error).
+      const advancementDiags = result.diagnostics.filter((d) =>
+        d.message.toLowerCase().includes("advancement element"),
+      );
+      expect(advancementDiags.length).toBeGreaterThan(0);
+      expect(advancementDiags.every((d) => d.severity === "warning")).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("imports failure surfaces at top of file", () => {
+    it("surfaces import-read failure as an error at line 0", async () => {
+      const source = `imports:
+  - ./missing.stagebook.yaml
+
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+      const result = await validateTreatmentWithDiff({
+        source,
+        loadImport: noImports,
+      });
+      const importErr = result.diagnostics.find(
+        (d) => d.severity === "error" && d.message.includes("missing"),
+      );
+      expect(importErr).toBeDefined();
+      expect(importErr!.range?.startLine).toBe(0);
+    });
+  });
+
+  describe("hydration failure surfaces at top of file", () => {
+    it("flags an unresolved template invocation", async () => {
+      const source = `treatments:
+  - template: doesNotExist
+`;
+      const result = await validateTreatmentWithDiff({
+        source,
+        loadImport: noImports,
+      });
+      // Pre-hydration semantic catches this first ("template doesn't
+      // exist") — and that's better than the generic hydration error.
+      // Either form is acceptable for the user.
+      const surfaced = result.diagnostics.find((d) =>
+        d.message.includes("doesNotExist"),
+      );
+      expect(surfaced).toBeDefined();
+      expect(surfaced!.severity).toBe("error");
+    });
+  });
+
+  describe("pre-hydration semantic (circular templates)", () => {
+    it("flags a self-invocation cycle", async () => {
+      const source = `templates:
+  - name: loopy
+    contentType: elements
+    content:
+      - template: loopy
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+      const result = await validateTreatmentWithDiff({
+        source,
+        loadImport: noImports,
+      });
+      const cycle = result.diagnostics.find((d) =>
+        d.message.toLowerCase().includes("invokes itself"),
+      );
+      expect(cycle).toBeDefined();
+      expect(cycle!.severity).toBe("error");
+    });
+  });
+
+  describe("YAML parse errors are preserved", () => {
+    it("surfaces a YAML duplicate-key warning at the offending line", async () => {
+      const source = `treatments:
+  - name: t
+    playerCount: 1
+    playerCount: 2
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+`;
+      const result = await validateTreatmentWithDiff({
+        source,
+        loadImport: noImports,
+      });
+      const dup = result.diagnostics.find((d) =>
+        d.message.toLowerCase().includes("unique"),
+      );
+      expect(dup).toBeDefined();
+    });
+  });
+});

--- a/apps/vscode/src/lib/validateTreatmentDiff.test.ts
+++ b/apps/vscode/src/lib/validateTreatmentDiff.test.ts
@@ -220,6 +220,93 @@ treatments:
     });
   });
 
+  describe("avoids double-reporting same failure", () => {
+    it("short-circuits before import loading when YAML is malformed (no generic top-of-file dup)", async () => {
+      // Malformed YAML — `extractYamlErrors` already emits a precise
+      // line/col diagnostic. Running the import loader would just emit
+      // an additional `YAML parse error: ...` at line 0, doubling the
+      // user's noise for one root cause.
+      const result = await validateTreatmentWithDiff({
+        source: "[[[invalid",
+        loadImport: noImports,
+      });
+      // The generic top-of-file "YAML parse error:" from
+      // loadAndMergeImports must not appear — only the precise
+      // line/col diagnostics from extractYamlErrors.
+      const genericTopOfFile = result.diagnostics.find(
+        (d) =>
+          d.range?.startLine === 0 && d.message.startsWith("YAML parse error:"),
+      );
+      expect(genericTopOfFile).toBeUndefined();
+    });
+
+    it("suppresses generic hydration error when pre-hydration semantic already explained it", async () => {
+      // A `template:` invocation that doesn't resolve produces an
+      // "unknown template" error from pre-hydration. Hydration also
+      // fails (since fillTemplates throws), but the generic
+      // "Template expansion failed" message is redundant — the
+      // specific pre-hydration error already named the missing
+      // template.
+      const source = `treatments:
+  - template: doesNotExist
+`;
+      const result = await validateTreatmentWithDiff({
+        source,
+        loadImport: noImports,
+      });
+      const errs = result.diagnostics.filter((d) => d.severity === "error");
+      // The specific "Template 'doesNotExist' is not defined" diagnostic
+      // is present.
+      expect(errs.some((d) => d.message.includes("doesNotExist"))).toBe(true);
+      // The generic "Template expansion failed" is NOT also present.
+      expect(
+        errs.some((d) => d.message.toLowerCase().includes("expansion failed")),
+      ).toBe(false);
+    });
+  });
+
+  describe("unrecognized-key quick-fix range", () => {
+    it("emits unrecognized-key issues with a key-token range (not value range)", async () => {
+      // `surveryName` (typo) should produce an unrecognized-key
+      // diagnostic. The range should land on the key token so the
+      // UnrecognizedKeyQuickFixProvider's `replace(range, suggestion)`
+      // correctly renames the key.
+      const source = `introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: survey
+            surveryName: TIPI
+          - type: submitButton
+`;
+      const result = await validateTreatmentWithDiff({
+        source,
+        loadImport: noImports,
+      });
+      const unrecognized = result.diagnostics.find((d) =>
+        d.message.toLowerCase().includes("unrecognized key"),
+      );
+      expect(unrecognized).toBeDefined();
+      // The range should be on the `surveryName` line.
+      const lines = source.split("\n");
+      const keyLine = lines.findIndex((l) => l.includes("surveryName:"));
+      expect(unrecognized!.range?.startLine).toBe(keyLine);
+      // And specifically on the key token, not the value. The column
+      // should match the position of 's' in 'surveryName'.
+      const colInLine = lines[keyLine].indexOf("surveryName");
+      expect(unrecognized!.range?.startCol).toBe(colInLine);
+    });
+  });
+
   describe("YAML parse errors are preserved", () => {
     it("surfaces a YAML duplicate-key warning at the offending line", async () => {
       const source = `treatments:

--- a/apps/vscode/src/lib/validateTreatmentDiff.ts
+++ b/apps/vscode/src/lib/validateTreatmentDiff.ts
@@ -56,10 +56,14 @@ export async function validateTreatmentWithDiff({
   // YAML syntax + duplicate-key warnings (existing behavior, preserved
   // so we don't regress on noise-level diagnostics the orchestrator
   // doesn't cover).
-  for (const err of extractYamlErrors(source)) {
+  const yamlErrors = extractYamlErrors(source);
+  let hasYamlParseError = false;
+  for (const err of yamlErrors) {
+    const isDuplicateKey = err.message.match(/unique|duplicate/i);
+    if (!isDuplicateKey) hasYamlParseError = true;
     diagnostics.push({
       message: err.message,
-      severity: err.message.match(/unique|duplicate/i) ? "warning" : "error",
+      severity: isDuplicateKey ? "warning" : "error",
       range: {
         startLine: err.line,
         startCol: err.col,
@@ -73,6 +77,14 @@ export async function validateTreatmentWithDiff({
   // routed to a source position.
   const mapper = createPositionMapper(source);
   const parsedObj = mapper.toJSON();
+
+  // Short-circuit on YAML parse errors. `extractYamlErrors` already
+  // surfaced precise line/col diagnostics; running the import loader
+  // and orchestrator on malformed YAML would produce a duplicate
+  // top-of-file error ("YAML parse error: ...") plus a parade of
+  // downstream "couldn't expand" / "schema rejected" noise that's
+  // already explained by the parse failure.
+  if (hasYamlParseError) return { diagnostics, parsedObj };
 
   // Load imports asynchronously.
   const loadResult = await loadAndMergeImports({ source, loadImport });
@@ -117,13 +129,18 @@ export async function validateTreatmentWithDiff({
   const diff = runValidationDiff({ source, importedTemplates });
 
   if (diff.hydrationError) {
-    // Hydration failed. Top-of-file error; skip the diff buckets
-    // (they're empty anyway when hydration fails).
-    diagnostics.push({
-      message: diff.hydrationError,
-      severity: "error",
-      range: { startLine: 0, startCol: 0, endLine: 0, endCol: 1 },
-    });
+    // Hydration failed. If pre-hydration semantic already explained
+    // why (e.g., "Template 'foo' is not defined"), the generic
+    // hydration error is redundant noise — pre-hydration is the more
+    // specific diagnostic. Otherwise surface the hydration error at
+    // top of file so the user has *something*.
+    if (preHydration.length === 0) {
+      diagnostics.push({
+        message: diff.hydrationError,
+        severity: "error",
+        range: { startLine: 0, startCol: 0, endLine: 0, endCol: 1 },
+      });
+    }
     return { diagnostics, parsedObj };
   }
 
@@ -133,7 +150,7 @@ export async function validateTreatmentWithDiff({
     diagnostics.push({
       message: appendPathIfMissing(issue),
       severity: "error",
-      range: resolveOrWalkUp(mapper, issue.path),
+      range: resolveIssueRange(mapper, issue),
     });
   }
 
@@ -144,7 +161,7 @@ export async function validateTreatmentWithDiff({
     diagnostics.push({
       message: appendPathIfMissing(issue),
       severity: "error",
-      range: resolveOrWalkUp(mapper, issue.path),
+      range: resolveIssueRange(mapper, issue),
     });
   }
 
@@ -158,11 +175,42 @@ export async function validateTreatmentWithDiff({
     diagnostics.push({
       message: appendPathIfMissing(issue),
       severity: "warning",
-      range: resolveOrWalkUp(mapper, issue.path),
+      range: resolveIssueRange(mapper, issue),
     });
   }
 
   return { diagnostics, parsedObj };
+}
+
+/**
+ * Resolve a Zod issue to a source range, with special handling for
+ * the unrecognized-key issues rewritten by `safeParseTreatmentFile`.
+ *
+ * Those issues carry `params.badKey` and the path ends at the
+ * offending key string; the existing UnrecognizedKeyQuickFixProvider
+ * expects a key-token range so its `replace(diagnostic.range,
+ * suggestion)` correctly renames the key (rather than replacing the
+ * value). Mirrors the logic in `validateTreatmentSource`.
+ */
+function resolveIssueRange(
+  mapper: ReturnType<typeof createPositionMapper>,
+  issue: ZodIssue,
+): Diagnostic["range"] {
+  const params =
+    issue.code === "custom"
+      ? ((issue as { params?: unknown }).params as
+          | { badKey?: unknown }
+          | undefined)
+      : undefined;
+  const isUnrecognizedKey =
+    params !== undefined && typeof params.badKey === "string";
+  if (isUnrecognizedKey) {
+    const keyRange = mapper.resolveKey(issue.path);
+    if (keyRange) return keyRange;
+    // Fall through to the value/walk-up resolver when resolveKey can't
+    // pin a key range.
+  }
+  return resolveOrWalkUp(mapper, issue.path);
 }
 
 /**

--- a/apps/vscode/src/lib/validateTreatmentDiff.ts
+++ b/apps/vscode/src/lib/validateTreatmentDiff.ts
@@ -1,0 +1,229 @@
+import {
+  runValidationDiff,
+  collectPreHydrationIssues,
+  parseTreatmentYaml as parseStagebookYaml,
+  type PreHydrationIssue,
+} from "stagebook";
+import type { ZodIssue } from "zod";
+import { loadAndMergeImports } from "./loadAndMergeImports";
+import { createPositionMapper, extractYamlErrors } from "./yamlPositionMap";
+import type { Diagnostic } from "./types";
+
+/**
+ * Editor-side wrapper around the diff orchestrator. Loads imports
+ * asynchronously, runs the orchestrator, runs the pre-hydration
+ * semantic checks, and maps every issue's path to a source position
+ * via the existing YAML AST mapper.
+ *
+ * Diagnostic display strategy (v1):
+ *
+ *   - YAML parse / duplicate-key warnings    → existing behavior
+ *   - Imports failed to load                  → error at line 1
+ *   - Pre-hydration semantic issues           → error at source path
+ *   - Hydration error (after lex/imports OK)  → error at top of file
+ *   - matched (real bugs in both passes)      → error at source path
+ *   - unreachableReferences                   → error at source path
+ *                                               (walks up the path until
+ *                                                resolvable in source)
+ *   - sourceOnly (artifact OR template-def    → warning at source path
+ *                 bug not surviving expansion)
+ *   - hydratedOnly                            → not surfaced in source
+ *                                               file; the expanded
+ *                                               preview shows them
+ *
+ * `loadImport` is the editor's bridge to vscode.workspace.fs. Tests
+ * pass a Map-backed mock.
+ *
+ * See #321 for the broader pipeline.
+ */
+
+export interface ValidateTreatmentDiffResult {
+  diagnostics: Diagnostic[];
+  /** The parsed-with-mapper JS object. null when YAML parse failed.
+   *  Used by the file-existence checker. */
+  parsedObj: unknown;
+}
+
+export async function validateTreatmentWithDiff({
+  source,
+  loadImport,
+}: {
+  source: string;
+  loadImport: (importPath: string) => Promise<string>;
+}): Promise<ValidateTreatmentDiffResult> {
+  const diagnostics: Diagnostic[] = [];
+
+  // YAML syntax + duplicate-key warnings (existing behavior, preserved
+  // so we don't regress on noise-level diagnostics the orchestrator
+  // doesn't cover).
+  for (const err of extractYamlErrors(source)) {
+    diagnostics.push({
+      message: err.message,
+      severity: err.message.match(/unique|duplicate/i) ? "warning" : "error",
+      range: {
+        startLine: err.line,
+        startCol: err.col,
+        endLine: err.line,
+        endCol: err.col + 1,
+      },
+    });
+  }
+
+  // Build the source-side AST mapper once. Used for every issue
+  // routed to a source position.
+  const mapper = createPositionMapper(source);
+  const parsedObj = mapper.toJSON();
+
+  // Load imports asynchronously.
+  const loadResult = await loadAndMergeImports({ source, loadImport });
+  if (!loadResult.ok) {
+    // Couldn't even load imports. Surface as a top-of-file error;
+    // skip the rest of the pipeline (it'd just produce noise).
+    diagnostics.push({
+      message: loadResult.message,
+      severity: "error",
+      range: { startLine: 0, startCol: 0, endLine: 0, endCol: 1 },
+    });
+    return { diagnostics, parsedObj };
+  }
+
+  // Compute the just-imported templates (slice past the root portion
+  // of the merged list). `resolveImports` writes root templates first
+  // then imports, so this gives us the orchestrator's expected
+  // `importedTemplates` parameter shape.
+  const rootParse = safeParseStagebookYaml(source);
+  const rootTemplatesCount =
+    rootParse !== null && Array.isArray(rootParse.parsed?.templates)
+      ? rootParse.parsed.templates.length
+      : 0;
+  const importedTemplates = loadResult.templates.slice(rootTemplatesCount);
+
+  // Pre-hydration semantic checks (template-name resolution, circular
+  // invocations). Catches a class of errors the orchestrator's
+  // hydration step would otherwise throw on generically.
+  const preHydration = collectPreHydrationIssues({
+    root: (loadResult.merged ?? {}) as Record<string, unknown>,
+    importedTemplates,
+  });
+  for (const issue of preHydration) {
+    diagnostics.push({
+      message: issue.message,
+      severity: "error",
+      range: resolveOrWalkUp(mapper, issue.path),
+    });
+  }
+
+  // Run the diff orchestrator.
+  const diff = runValidationDiff({ source, importedTemplates });
+
+  if (diff.hydrationError) {
+    // Hydration failed. Top-of-file error; skip the diff buckets
+    // (they're empty anyway when hydration fails).
+    diagnostics.push({
+      message: diff.hydrationError,
+      severity: "error",
+      range: { startLine: 0, startCol: 0, endLine: 0, endCol: 1 },
+    });
+    return { diagnostics, parsedObj };
+  }
+
+  // matched: real bugs in both passes. Source-positioned by virtue of
+  // being a source-pass issue.
+  for (const issue of diff.matched) {
+    diagnostics.push({
+      message: appendPathIfMissing(issue),
+      severity: "error",
+      range: resolveOrWalkUp(mapper, issue.path),
+    });
+  }
+
+  // unreachableReferences: paths are into the hydrated form. Walk up
+  // until we find a source-resolvable position. For fully-templated
+  // treatments that means landing on the template invocation node.
+  for (const issue of diff.unreachableReferences) {
+    diagnostics.push({
+      message: appendPathIfMissing(issue),
+      severity: "error",
+      range: resolveOrWalkUp(mapper, issue.path),
+    });
+  }
+
+  // sourceOnly: mixed bucket. Could be a templating artifact OR a
+  // real bug in a template definition / authoring oddity that didn't
+  // survive expansion. Surface as warning so the user has visibility
+  // without us overclaiming "this is definitely a bug." The
+  // expanded-preview document still shows the full hydrated-pass
+  // diagnostics for users who want to drill in.
+  for (const issue of diff.sourceOnly) {
+    diagnostics.push({
+      message: appendPathIfMissing(issue),
+      severity: "warning",
+      range: resolveOrWalkUp(mapper, issue.path),
+    });
+  }
+
+  return { diagnostics, parsedObj };
+}
+
+/**
+ * Resolve a path to a source range; if the exact path doesn't
+ * resolve (e.g., a hydrated path that points inside a template-
+ * expanded subtree the source doesn't contain), walk up one segment
+ * at a time and retry. As a last resort, return a top-of-file range.
+ */
+function resolveOrWalkUp(
+  mapper: ReturnType<typeof createPositionMapper>,
+  path: (string | number)[],
+): Diagnostic["range"] {
+  let p = path;
+  let range = mapper.resolve(p);
+  while (!range && p.length > 0) {
+    p = p.slice(0, -1);
+    range = mapper.resolve(p);
+  }
+  return range ?? { startLine: 0, startCol: 0, endLine: 0, endCol: 1 };
+}
+
+/**
+ * Append the field path to a Zod issue's message so the user has
+ * locational context even when the diagnostic position is approximate
+ * (e.g., walk-up landed on the enclosing treatment for a hydrated
+ * path). Mirrors the existing `validateTreatmentSource` behavior.
+ */
+function appendPathIfMissing(issue: ZodIssue | PreHydrationIssue): string {
+  const pathStr = formatPath(issue.path);
+  if (!pathStr || issue.message.toLowerCase().includes(pathStr.toLowerCase())) {
+    return issue.message;
+  }
+  return `${issue.message} (${pathStr})`;
+}
+
+function formatPath(path: (string | number)[]): string {
+  if (path.length === 0) return "";
+  let out = "";
+  for (const segment of path) {
+    if (typeof segment === "number") {
+      out += `[${segment}]`;
+    } else {
+      out += out ? `.${segment}` : segment;
+    }
+  }
+  return out;
+}
+
+/**
+ * Best-effort parse of the root source for the purpose of counting
+ * root-level templates. Returns null on parse failure (in which case
+ * the caller treats root.templates as empty).
+ */
+function safeParseStagebookYaml(
+  source: string,
+): { parsed: { templates?: unknown } } | null {
+  try {
+    return parseStagebookYaml(source) as {
+      parsed: { templates?: unknown };
+    };
+  } catch {
+    return null;
+  }
+}

--- a/packages/stagebook/src/schemas/runValidationDiff.ts
+++ b/packages/stagebook/src/schemas/runValidationDiff.ts
@@ -1,5 +1,5 @@
 import type { ZodIssue } from "zod";
-import { parse as parseYaml } from "yaml";
+import { load as loadYaml } from "js-yaml";
 import { fillTemplates } from "../templates/fillTemplates.js";
 import { safeParseTreatmentFile } from "./safeParseTreatmentFile.js";
 import { findUnreachableReferences } from "./findUnreachableReferences.js";
@@ -160,7 +160,10 @@ export function runValidationDiff({
 
   let parsed: unknown;
   try {
-    parsed = parseYaml(source);
+    // `js-yaml` (browser-safe, no `process` deps) — matches the rest
+    // of stagebook. The `yaml` package would pull in process-touching
+    // code that breaks the VS Code webview bundle.
+    parsed = loadYaml(source);
   } catch (e) {
     return {
       ...empty,


### PR DESCRIPTION
## Summary

Wires the full #321 validation pipeline into the editor's `validateTreatmentFile`. **First user-visible behavior change** in this series — earlier PRs added library helpers; this is what actually shows up in the squiggles.

## What the editor now does

`validateTreatmentFile` is async and runs this pipeline on each debounced edit:

1. **YAML parse + duplicate-key warnings** (existing behavior, preserved)
2. **Load imports** via `vscode.workspace.fs` (was sync before)
3. **Pre-hydration semantic checks** ([#324](https://github.com/deliberation-lab/stagebook/pull/324)) — template-name resolution + circular invocation detection
4. **Diff orchestrator** ([#327](https://github.com/deliberation-lab/stagebook/pull/327)) — runs schema twice, classifies issues as `matched` / `sourceOnly` / `hydratedOnly`
5. **Strict per-treatment reachable-keys check** ([#328](https://github.com/deliberation-lab/stagebook/pull/328)) — surfaces cross-treatment leaks and other unreachable-reference cases
6. **File-existence checks** (existing async behavior, preserved)

## Diagnostic display strategy

| Pipeline output | Editor display |
|---|---|
| `matched` (real bug in both passes) | red squiggle at source position |
| `unreachableReferences` (cross-treatment / uninvoked-template / etc.) | red squiggle at source position (walk-up if hydrated path doesn't resolve in source) |
| Pre-hydration semantic + hydration errors + YAML parse errors | red squiggle at source position |
| `sourceOnly` (mixed — artifact OR template-def bug not surviving expansion) | **yellow squiggle** at source position |
| `hydratedOnly` | not surfaced in source file; expanded preview already shows them |

The `sourceOnly` bucket gets warning-level treatment per the honest framing established in #327 — it genuinely can't be distinguished between artifacts and real bugs without provenance. Users see them but the validator doesn't overclaim.

## Path mapping

Source-pass issues (`matched`) land at their actual source paths via the existing AST mapper. `unreachableReferences` carry hydrated paths (e.g., paths inside a template-expanded treatment that don't exist in the unfilled source); we walk up the path one segment at a time until it resolves, landing at the closest source ancestor — typically the template invocation node for templated treatments. Last resort: top-of-file.

## Bundle fix

Also fixed a packaging bug in `runValidationDiff` — it imported `parse` from the `yaml` package, which uses `process` and isn't browser-safe. The VS Code webview broke with *"Dynamic require of 'process' is not supported"* (caught during smoke testing). Stagebook standardizes on `js-yaml` (browser-safe); switched to `js-yaml`'s `load`. Webview bundle returns to its previous size (728kb).

## Test plan

- [x] 7 new tests in `validateTreatmentDiff.test.ts` covering happy path, cross-treatment leaks, sourceOnly → warning routing, import-failure top-of-file errors, circular-template flagging, YAML parse error preservation
- [x] All 208 vscode + 87 viewer + 975 stagebook tests pass
- [x] Workspace lint + format clean
- [x] **Manual smoke test on pilot_3** ✓ — preview works; webview renders; no false-positive squiggles on the cleaned-up file
- [x] Extension reinstalled locally and verified

## Relationship to #321

Step 5 of the pipeline. Building on:
- [#324](https://github.com/deliberation-lab/stagebook/pull/324) — pre-hydration semantic (template-name resolution, circular invocations)
- [#327](https://github.com/deliberation-lab/stagebook/pull/327) — diff orchestrator + Zod-issue normalization
- [#328](https://github.com/deliberation-lab/stagebook/pull/328) — strict per-treatment unreachable-reference check
- [#329](https://github.com/deliberation-lab/stagebook/pull/329) — regression test for the intro-producer bug

Next: Phase 6 (static sweep against treatment files to catch any residual edge cases) and Phase 7 (docs + CHANGELOG + minor version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)