### PR TITLE
Bump stagebook to 0.10.0 + document strict-validation integration

### DIFF
--- a/apps/vscode/src/lib/examples.test.ts
+++ b/apps/vscode/src/lib/examples.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { validateTreatmentWithDiff } from "./validateTreatmentDiff";
+
+/**
+ * Regression test: every bundled example treatment file must pass the
+ * full editor pipeline with zero error-level diagnostics. Mirrors
+ * `apps/viewer/src/examples.test.ts` (which checks the schema
+ * directly) but exercises the diff orchestrator, the pre-hydration
+ * semantic checks, the unreachable-references check, and the source-
+ * position mapping — the entire path the in-editor validator runs on
+ * every keystroke.
+ *
+ * Closes the gap the schema-only test left: a regression that affects
+ * only the new pipeline (e.g., an incorrect rule in
+ * `findUnreachableReferences`, or a normalization bug in the diff
+ * matcher) wouldn't have failed the existing tests. This one will.
+ *
+ * Warnings are not asserted-against — the `sourceOnly` bucket
+ * legitimately produces warnings in some examples (templating
+ * artifacts the diff can't conclusively classify as bugs).
+ */
+
+const examplesRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../../examples",
+);
+
+const EXAMPLES = [
+  "annotated-walkthrough/walkthrough.stagebook.yaml",
+  "imports-walkthrough/imports-walkthrough.stagebook.yaml",
+  "prisoners-dilemma/prisoners-dilemma.stagebook.yaml",
+  "survey-experiment/survey-experiment.stagebook.yaml",
+  "ultimatum-game/ultimatum-game.stagebook.yaml",
+];
+
+describe.each(EXAMPLES)("editor pipeline: %s", (relPath) => {
+  it("produces zero error-level diagnostics", async () => {
+    const fullPath = resolve(examplesRoot, relPath);
+    const source = readFileSync(fullPath, "utf8");
+    const rootDir = dirname(fullPath);
+
+    const result = await validateTreatmentWithDiff({
+      source,
+      loadImport: async (importPath) =>
+        readFileSync(resolve(rootDir, importPath), "utf8"),
+    });
+
+    const errors = result.diagnostics.filter((d) => d.severity === "error");
+    if (errors.length > 0) {
+      const summary = errors
+        .map((d) => `  L${d.range?.startLine ?? "?"}: ${d.message}`)
+        .join("\n");
+      throw new Error(
+        `Expected zero errors from the editor pipeline, got ${errors.length}:\n${summary}`,
+      );
+    }
+  });
+});

--- a/docs/engineer/integration-guide.md
+++ b/docs/engineer/integration-guide.md
@@ -61,6 +61,49 @@ if (!result.success) {
 }
 ```
 
+### Strict validation (recommended for editor / pre-deploy)
+
+The schema's reference checker has a permissive fallthrough that silently passes a reference to a key produced *anywhere* in the file — including in another treatment or an uninvoked template. Per #321, that fallthrough is preserved on the schema for backward compatibility, but stricter consumers (editor tooling, pre-deploy checks) should layer on the following helpers that catch the bugs the fallthrough masks:
+
+```typescript
+import {
+  treatmentFileSchema,
+  fillTemplates,
+  collectPreHydrationIssues, // template-name resolution + circular invocations
+  findUnreachableReferences,  // cross-treatment leaks (runs on hydrated form)
+  runValidationDiff,          // optional: full diff orchestrator (see below)
+} from "stagebook";
+
+// Pre-hydration semantic — catches "Template 'foo' is not defined"
+// and "Templates form an invocation cycle" before hydration would
+// throw a generic error.
+const preHydration = collectPreHydrationIssues({
+  root: raw,
+  importedTemplates,
+});
+
+// Hydrate (as before)
+const { result: expanded } = fillTemplates({
+  obj: raw,
+  templates: [...(raw.templates ?? []), ...importedTemplates],
+  allowUnresolved: true,
+});
+
+// Schema validation
+const schemaResult = treatmentFileSchema.safeParse(expanded);
+
+// Strict per-treatment reachable-keys check — catches references that
+// resolve to a key produced in another treatment, an uninvoked
+// template, or otherwise unreachable from the consuming treatment.
+// These are silent passes in the schema by design; the strict check
+// surfaces them.
+const unreachable = findUnreachableReferences(expanded, {
+  templates: [...(raw.templates ?? []), ...importedTemplates],
+});
+```
+
+The VS Code extension runs this exact pipeline plus a [diff orchestrator](https://github.com/deliberation-lab/stagebook/issues/321) that distinguishes "real bug in both source and hydrated form" from "templating artifact that disappears after expansion." Runtime hosts can use the same pieces (orchestrator output buckets) for fine-grained diagnostic routing, but the simpler "schema + pre-hydration + unreachable" sequence above is usually enough for build-time and pre-deploy checks.
+
 ## Validating Prompt Files
 
 ```typescript

--- a/docs/engineer/integration-guide.md
+++ b/docs/engineer/integration-guide.md
@@ -69,40 +69,89 @@ The schema's reference checker has a permissive fallthrough that silently passes
 import {
   treatmentFileSchema,
   fillTemplates,
+  parseTreatmentYaml,
+  resolveImportPath,
+  resolveImports,
   collectPreHydrationIssues, // template-name resolution + circular invocations
-  findUnreachableReferences,  // cross-treatment leaks (runs on hydrated form)
-  runValidationDiff,          // optional: full diff orchestrator (see below)
+  findUnreachableReferences, // cross-treatment leaks (runs on hydrated form)
+  type ParsedFile,
 } from "stagebook";
+import { load as loadYaml } from "js-yaml";
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
 
-// Pre-hydration semantic — catches "Template 'foo' is not defined"
-// and "Templates form an invocation cycle" before hydration would
-// throw a generic error.
+const yamlPath = "study.stagebook.yaml";
+const raw = loadYaml(readFileSync(yamlPath, "utf-8")) as ParsedFile;
+
+// 1. Resolve `imports:` — load each imported file and merge its
+//    `templates:` into one flat list. `importedTemplates` is the
+//    post-merge list of just the *imported* template definitions.
+const rootDir = dirname(yamlPath);
+const loaded = new Map<string, ParsedFile>();
+const queue = (raw.imports ?? []).map((p) =>
+  resolveImportPath("root.stagebook.yaml", p),
+);
+while (queue.length > 0) {
+  const importPath = queue.shift()!;
+  if (loaded.has(importPath)) continue;
+  const importedRaw = readFileSync(resolve(rootDir, importPath), "utf-8");
+  const { parsed, imports } = parseTreatmentYaml(importedRaw);
+  loaded.set(importPath, parsed as ParsedFile);
+  for (const next of imports) {
+    queue.push(resolveImportPath(importPath, next));
+  }
+}
+const mergedTemplates = resolveImports({ main: raw, files: loaded });
+const rootCount = (raw.templates ?? []).length;
+const importedTemplates = mergedTemplates.slice(rootCount);
+
+// 2. Pre-hydration semantic — catches "Template 'foo' is not defined"
+//    and "Templates form an invocation cycle" before hydration would
+//    throw a generic error.
 const preHydration = collectPreHydrationIssues({
   root: raw,
   importedTemplates,
 });
 
-// Hydrate (as before)
+// 3. Hydrate.
 const { result: expanded } = fillTemplates({
   obj: raw,
-  templates: [...(raw.templates ?? []), ...importedTemplates],
+  templates: mergedTemplates,
   allowUnresolved: true,
 });
 
-// Schema validation
+// 4. Schema validation (existing behavior).
 const schemaResult = treatmentFileSchema.safeParse(expanded);
 
-// Strict per-treatment reachable-keys check — catches references that
-// resolve to a key produced in another treatment, an uninvoked
-// template, or otherwise unreachable from the consuming treatment.
-// These are silent passes in the schema by design; the strict check
-// surfaces them.
+// 5. Strict per-treatment reachable-keys check — catches references
+//    that resolve to a key produced in another treatment, an uninvoked
+//    template, or otherwise unreachable from the consuming treatment.
+//    These are silent passes in the schema by design; the strict
+//    check surfaces them.
 const unreachable = findUnreachableReferences(expanded, {
-  templates: [...(raw.templates ?? []), ...importedTemplates],
+  templates: mergedTemplates,
 });
 ```
 
-The VS Code extension runs this exact pipeline plus a [diff orchestrator](https://github.com/deliberation-lab/stagebook/issues/321) that distinguishes "real bug in both source and hydrated form" from "templating artifact that disappears after expansion." Runtime hosts can use the same pieces (orchestrator output buckets) for fine-grained diagnostic routing, but the simpler "schema + pre-hydration + unreachable" sequence above is usually enough for build-time and pre-deploy checks.
+If your file doesn't use `imports:`, the resolve step is a no-op (`importedTemplates = []` and `mergedTemplates = raw.templates ?? []`). The example above runs end-to-end for either case.
+
+The VS Code extension runs this exact pipeline plus a [diff orchestrator](https://github.com/deliberation-lab/stagebook/issues/321) that distinguishes "real bug in both source and hydrated form" from "templating artifact that disappears after expansion." If your tooling needs the same fine-grained diagnostic routing (e.g., to display templating artifacts as warnings instead of errors), use `runValidationDiff` from `stagebook`:
+
+```typescript
+import { runValidationDiff } from "stagebook";
+
+const sourceText = readFileSync(yamlPath, "utf-8");
+const diff = runValidationDiff({
+  source: sourceText,
+  importedTemplates, // computed above
+});
+// diff.matched          — real bugs in both passes
+// diff.sourceOnly       — likely templating artifacts (display as warning)
+// diff.hydratedOnly     — revealed by expansion (display in expanded view)
+// diff.unreachableReferences — strict reachable-keys check, same as above
+```
+
+For build-time and pre-deploy checks the simpler "schema + pre-hydration + unreachable" sequence is usually enough — the diff orchestrator pays for two schema runs to enable the artifact/real-bug distinction, which only matters when you're surfacing diagnostics live to an author.
 
 ## Validating Prompt Files
 

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.9.7",
+  "version": "0.10.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

Releases the #321 pipeline rewrite. Minor bump (still v0 — no external consumers per [#321 runtime/release notes](https://github.com/deliberation-lab/stagebook/issues/321)).

## What ships in 0.10.0

The series of PRs that built the new validator pipeline:

- [#322](https://github.com/deliberation-lab/stagebook/pull/322) — preview / expand commands surface specific errors (no more "could not parse" silence)
- [#323](https://github.com/deliberation-lab/stagebook/pull/323) — position-based storage-key fallback for unnamed audio/mediaPlayer/survey
- [#324](https://github.com/deliberation-lab/stagebook/pull/324) — `collectPreHydrationIssues` (template-name resolution + circular invocations)
- [#327](https://github.com/deliberation-lab/stagebook/pull/327) — `runValidationDiff` + `normalizeIssueKey` (diff orchestrator)
- [#328](https://github.com/deliberation-lab/stagebook/pull/328) — `findUnreachableReferences` (strict per-treatment reachable-keys check)
- [#329](https://github.com/deliberation-lab/stagebook/pull/329) — regression test for the intro-producer bug
- [#330](https://github.com/deliberation-lab/stagebook/pull/330) — wired the orchestrator into the editor's `validateTreatmentFile`

## New public API

- `collectPreHydrationIssues({ root, importedTemplates })` → `PreHydrationIssue[]` — catches unknown template names and circular invocations before hydration.
- `runValidationDiff({ source, importedTemplates })` → `ValidationDiffResult` — runs the schema twice, partitions issues into `matched` / `sourceOnly` / `hydratedOnly` / `unreachableReferences` buckets.
- `findUnreachableReferences(hydratedTreatmentFile, { templates })` → `ZodIssue[]` — strict per-treatment reachable-keys check (catches cross-treatment leaks the schema's fallthrough silently permits).
- `normalizeIssueKey(issue)` → `string` — exposes the diff matcher's canonical form.

## Schema behavior: unchanged

`treatmentFileSchema` and `safeParseTreatmentFile` produce the same diagnostics they always did. The `globalProducedKeys` fallthrough in the reference checker is intentionally preserved — the new strict check is opt-in via `findUnreachableReferences`. This avoids breaking runtime hosts that currently rely on the schema's permissive behavior for templated references that resolve through expansion.

## Editor behavior: new diagnostics surface

The VS Code extension (via #330) now runs the full pipeline on every edit. New diagnostic classes users will see:

- Cross-treatment reference leaks (red squiggle)
- Circular template invocations (red squiggle)
- Unknown template names (red squiggle, before hydration would throw)
- Templating artifacts that don't survive expansion (yellow squiggle — mixed bucket per the [honest framing](https://github.com/deliberation-lab/stagebook/pull/327))

## Test plan

- [x] All 211 vscode + 87 viewer + 975 stagebook tests pass
- [x] Workspace lint + format clean
- [x] Phase 6 static sweep across 26 real treatment files: pilot_3 + bundled examples all clean (no regressions); backchannel-manipulation files surface pre-existing #298 migration debt (real bugs)
- [x] Pipeline timing well under 300ms debounce (median 3.7ms, p90 56.6ms, max 279ms on pilot_3 with all imports loaded)

## Docs

[docs/engineer/integration-guide.md](docs/engineer/integration-guide.md) gets a new "Strict validation" subsection showing how to layer the new helpers on top of `safeParseTreatmentFile` for pre-deploy / build-time checks. No other doc updates — researcher docs are unchanged (the YAML syntax didn't change, only what the validator catches).

## Post-merge

Tag `v0.10.0` and let the release workflow publish to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)