### PR TITLE
Richer typing telemetry on TextArea (#335)

### DIFF
--- a/packages/stagebook/src/components/elements/Prompt.tsx
+++ b/packages/stagebook/src/components/elements/Prompt.tsx
@@ -69,7 +69,13 @@ export function Prompt({
   // its corresponding numeric value (#282 — without this, a shuffled
   // numeric multipleChoice records the wrong number for the chosen label).
   const [shuffleOrder, setShuffleOrder] = useState<number[]>([]);
+  // `debugMessages` is also mirrored to a ref (`debugMessagesRef`) so that
+  // saveData() reads the latest list at save-time, not at the time the
+  // debounced save was scheduled. Without this, telemetry emitted on blur
+  // (after onChange has already scheduled a save) would not appear in the
+  // saved record.
   const [debugMessages, setDebugMessages] = useState<DebugMessage[]>([]);
+  const debugMessagesRef = useRef<DebugMessage[]>([]);
   const debounceTextRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const debounceInteractiveRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
@@ -146,6 +152,11 @@ export function Prompt({
     (newValue: unknown, recordData: typeof record, label?: string) => {
       const updatedRecord = {
         ...recordData,
+        // Always read debugMessages from the ref at save-time. The
+        // `recordData` closure may have been captured before a TypingStats
+        // or PasteAttempt was appended (e.g. blur emits stats after the
+        // value-change debounce was already scheduled).
+        debugMessages: debugMessagesRef.current,
         value: newValue,
         // For multipleChoice prompts (#282), record both the chosen value
         // and its display label. In numeric mode `value` is the number and
@@ -295,9 +306,10 @@ export function Prompt({
         <TextArea
           defaultText={responses.join("\n")}
           onChange={(val) => debouncedSaveText(val, record)}
-          onDebugMessage={(message) =>
-            setDebugMessages((prev) => [...prev, message])
-          }
+          onDebugMessage={(message) => {
+            debugMessagesRef.current = [...debugMessagesRef.current, message];
+            setDebugMessages(debugMessagesRef.current);
+          }}
           value={value as string | undefined}
           rows={rows}
           showCharacterCount={!!(minLength || maxLength)}

--- a/packages/stagebook/src/components/form/TextArea.tsx
+++ b/packages/stagebook/src/components/form/TextArea.tsx
@@ -1,10 +1,22 @@
 import React, { useEffect, useState, useRef, useId } from "react";
+import { computeIntervalQuantiles } from "./typingQuantiles.js";
 
 export interface TypingStats {
   type: "typingStats";
   totalKeystrokes: number;
+  backspaceCount: number;
+  arrowKeyCount: number;
+  mouseClickCount: number;
+  focusCount: number;
+  blurCount: number;
   avgInterval: number;
   stdDev: number;
+  // 21 values at the 0%, 5%, 10%, ..., 95%, 100% quantiles of inter-keystroke
+  // intervals (ms). null when fewer than 2 keystrokes have been recorded.
+  intervalQuantiles: number[] | null;
+  firstKeystrokeDelayMs: number | null;
+  totalTypingTimeMs: number | null;
+  focusedDurationMs: number;
 }
 
 export interface PasteAttempt {
@@ -28,6 +40,19 @@ export interface TextAreaProps {
   id?: string;
 }
 
+const CURSOR_KEYS = new Set([
+  "ArrowLeft",
+  "ArrowRight",
+  "ArrowUp",
+  "ArrowDown",
+  "Home",
+  "End",
+  "PageUp",
+  "PageDown",
+]);
+
+const EDITING_KEYS = new Set(["Backspace", "Delete"]);
+
 export function TextArea({
   defaultText,
   onChange,
@@ -44,7 +69,27 @@ export function TextArea({
   const textAreaId = id || generatedId;
   const [localValue, setLocalValue] = useState(value || "");
   const debounceTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Inter-keystroke timing comes from character-producing and editing keys
+  // (Backspace/Delete). Cursor-only keys (arrows, Home/End) are excluded so
+  // that pure navigation doesn't dilute the typing rhythm signal.
   const keystrokeTimestamps = useRef<number[]>([]);
+
+  const backspaceCount = useRef(0);
+  const arrowKeyCount = useRef(0);
+  const mouseClickCount = useRef(0);
+  const focusCount = useRef(0);
+  const blurCount = useRef(0);
+
+  // Time of the very first focus event on this textarea — used to compute
+  // firstKeystrokeDelayMs (time the participant stared at the field before
+  // typing anything). Set once, never reset.
+  const firstFocusAt = useRef<number | null>(null);
+  // Start of the current focused interval; null when not focused. Combined
+  // with focusedDurationMs to accumulate total focused time across blurs.
+  const currentFocusStartedAt = useRef<number | null>(null);
+  const focusedDurationMs = useRef(0);
+
   const isDebouncing = useRef(false);
 
   // Sync with external value only when not actively debouncing
@@ -90,23 +135,65 @@ export function TextArea({
     debouncedSubmit(newValue);
   };
 
-  const computeTypingStats = (): TypingStats | null => {
+  const computeTypingStats = (): TypingStats => {
     const timestamps = keystrokeTimestamps.current;
-    if (timestamps.length < 2) return null;
 
-    const intervals = timestamps.slice(1).map((t, i) => t - timestamps[i]);
-    const avgInterval = intervals.reduce((a, b) => a + b, 0) / intervals.length;
-    const stdDev = Math.sqrt(
-      intervals.map((x) => (x - avgInterval) ** 2).reduce((a, b) => a + b, 0) /
-        intervals.length,
-    );
+    // Accumulated focus duration plus any in-progress focus interval.
+    const now = Date.now();
+    const liveFocusDelta =
+      currentFocusStartedAt.current !== null
+        ? now - currentFocusStartedAt.current
+        : 0;
+    const totalFocusedMs = focusedDurationMs.current + liveFocusDelta;
+
+    let avgInterval = 0;
+    let stdDev = 0;
+    let intervalQuantiles: number[] | null = null;
+    if (timestamps.length >= 2) {
+      const intervals = timestamps.slice(1).map((t, i) => t - timestamps[i]);
+      avgInterval = intervals.reduce((a, b) => a + b, 0) / intervals.length;
+      stdDev = Math.sqrt(
+        intervals
+          .map((x) => (x - avgInterval) ** 2)
+          .reduce((a, b) => a + b, 0) / intervals.length,
+      );
+      intervalQuantiles = computeIntervalQuantiles(intervals);
+    }
+
+    const firstKeystrokeDelayMs =
+      timestamps.length > 0 && firstFocusAt.current !== null
+        ? timestamps[0] - firstFocusAt.current
+        : null;
+
+    const totalTypingTimeMs =
+      timestamps.length >= 2
+        ? timestamps[timestamps.length - 1] - timestamps[0]
+        : null;
 
     return {
       type: "typingStats",
       totalKeystrokes: timestamps.length,
+      backspaceCount: backspaceCount.current,
+      arrowKeyCount: arrowKeyCount.current,
+      mouseClickCount: mouseClickCount.current,
+      focusCount: focusCount.current,
+      blurCount: blurCount.current,
       avgInterval,
       stdDev,
+      intervalQuantiles,
+      firstKeystrokeDelayMs,
+      totalTypingTimeMs,
+      focusedDurationMs: totalFocusedMs,
     };
+  };
+
+  const handleFocus = () => {
+    const now = Date.now();
+    focusCount.current += 1;
+    if (firstFocusAt.current === null) {
+      firstFocusAt.current = now;
+    }
+    currentFocusStartedAt.current = now;
   };
 
   const handleBlur = () => {
@@ -115,14 +202,38 @@ export function TextArea({
       isDebouncing.current = false;
     }
     submitChange(localValue);
-    const typingStats = computeTypingStats();
-    if (typingStats && onDebugMessage) {
-      onDebugMessage(typingStats);
+
+    blurCount.current += 1;
+    if (currentFocusStartedAt.current !== null) {
+      focusedDurationMs.current += Date.now() - currentFocusStartedAt.current;
+      currentFocusStartedAt.current = null;
+    }
+
+    if (onDebugMessage) {
+      onDebugMessage(computeTypingStats());
     }
   };
 
-  const handleKeyDown = () => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (CURSOR_KEYS.has(e.key)) {
+      arrowKeyCount.current += 1;
+      return;
+    }
+    if (EDITING_KEYS.has(e.key)) {
+      backspaceCount.current += 1;
+      keystrokeTimestamps.current.push(Date.now());
+      return;
+    }
+    // Ignore modifier-only events (no character produced); they shouldn't
+    // count as keystrokes for rhythm purposes.
+    if (e.key.length !== 1 && e.key !== "Enter" && e.key !== "Tab") {
+      return;
+    }
     keystrokeTimestamps.current.push(Date.now());
+  };
+
+  const handleClick = () => {
+    mouseClickCount.current += 1;
   };
 
   const renderCharacterCount = () => {
@@ -188,7 +299,9 @@ export function TextArea({
         placeholder={defaultText}
         value={localValue}
         onChange={handleChange}
+        onFocus={handleFocus}
         onBlur={handleBlur}
+        onClick={handleClick}
         onPaste={handlePaste}
         onKeyDown={handleKeyDown}
         style={{

--- a/packages/stagebook/src/components/form/TextArea.tsx
+++ b/packages/stagebook/src/components/form/TextArea.tsx
@@ -4,7 +4,9 @@ import { computeIntervalQuantiles } from "./typingQuantiles.js";
 export interface TypingStats {
   type: "typingStats";
   totalKeystrokes: number;
-  backspaceCount: number;
+  // Backspace + Delete — both are participant edits to previously-typed text
+  // and contribute identically to keystroke timing.
+  editingKeyCount: number;
   arrowKeyCount: number;
   mouseClickCount: number;
   focusCount: number;
@@ -12,7 +14,10 @@ export interface TypingStats {
   avgInterval: number;
   stdDev: number;
   // 21 values at the 0%, 5%, 10%, ..., 95%, 100% quantiles of inter-keystroke
-  // intervals (ms). null when fewer than 2 keystrokes have been recorded.
+  // intervals (ms). null when fewer than 2 keystrokes (and thus zero
+  // intervals) have been recorded. With ≥2 keystrokes the vector is always
+  // 21 values long; a degenerate single-interval distribution emits 21
+  // identical values.
   intervalQuantiles: number[] | null;
   firstKeystrokeDelayMs: number | null;
   totalTypingTimeMs: number | null;
@@ -75,7 +80,7 @@ export function TextArea({
   // that pure navigation doesn't dilute the typing rhythm signal.
   const keystrokeTimestamps = useRef<number[]>([]);
 
-  const backspaceCount = useRef(0);
+  const editingKeyCount = useRef(0);
   const arrowKeyCount = useRef(0);
   const mouseClickCount = useRef(0);
   const focusCount = useRef(0);
@@ -157,6 +162,9 @@ export function TextArea({
           .map((x) => (x - avgInterval) ** 2)
           .reduce((a, b) => a + b, 0) / intervals.length,
       );
+      // intervals is non-empty here (timestamps.length >= 2), so the helper
+      // returns a 21-value vector. A single-interval distribution emits 21
+      // identical values rather than an empty array.
       intervalQuantiles = computeIntervalQuantiles(intervals);
     }
 
@@ -173,7 +181,7 @@ export function TextArea({
     return {
       type: "typingStats",
       totalKeystrokes: timestamps.length,
-      backspaceCount: backspaceCount.current,
+      editingKeyCount: editingKeyCount.current,
       arrowKeyCount: arrowKeyCount.current,
       mouseClickCount: mouseClickCount.current,
       focusCount: focusCount.current,
@@ -220,7 +228,7 @@ export function TextArea({
       return;
     }
     if (EDITING_KEYS.has(e.key)) {
-      backspaceCount.current += 1;
+      editingKeyCount.current += 1;
       keystrokeTimestamps.current.push(Date.now());
       return;
     }

--- a/packages/stagebook/src/components/form/typingQuantiles.test.ts
+++ b/packages/stagebook/src/components/form/typingQuantiles.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { computeIntervalQuantiles, quantile } from "./typingQuantiles.js";
+
+describe("quantile", () => {
+  it("returns 0 for empty input", () => {
+    expect(quantile([], 0.5)).toBe(0);
+  });
+
+  it("returns the sole value for a single-element array regardless of q", () => {
+    expect(quantile([42], 0)).toBe(42);
+    expect(quantile([42], 0.5)).toBe(42);
+    expect(quantile([42], 1)).toBe(42);
+  });
+
+  it("returns min at q=0 and max at q=1", () => {
+    const xs = [10, 20, 30, 40, 50];
+    expect(quantile(xs, 0)).toBe(10);
+    expect(quantile(xs, 1)).toBe(50);
+  });
+
+  it("linearly interpolates between adjacent samples", () => {
+    // pos = 0.25 * (4) = 1.0 -> value at index 1 = 20
+    const xs = [10, 20, 30, 40, 50];
+    expect(quantile(xs, 0.25)).toBe(20);
+    // pos = 0.5 * 4 = 2.0 -> value at index 2 = 30
+    expect(quantile(xs, 0.5)).toBe(30);
+    // pos = 0.125 * 4 = 0.5 -> midpoint of 10 and 20 = 15
+    expect(quantile(xs, 0.125)).toBe(15);
+  });
+});
+
+describe("computeIntervalQuantiles", () => {
+  it("returns empty array for inputs with fewer than 2 samples", () => {
+    expect(computeIntervalQuantiles([])).toEqual([]);
+    expect(computeIntervalQuantiles([100])).toEqual([]);
+  });
+
+  it("returns 21 values for valid input", () => {
+    const intervals = Array.from({ length: 100 }, (_, i) => i + 1);
+    const result = computeIntervalQuantiles(intervals);
+    expect(result).toHaveLength(21);
+  });
+
+  it("returns monotonically non-decreasing values (sorted distribution)", () => {
+    // Intentionally shuffled input
+    const intervals = [50, 10, 30, 90, 70, 20, 80, 40, 60, 100];
+    const result = computeIntervalQuantiles(intervals);
+    for (let i = 1; i < result.length; i++) {
+      expect(result[i]).toBeGreaterThanOrEqual(result[i - 1]);
+    }
+  });
+
+  it("places the median (q=0.5, index 10) at the central value", () => {
+    const intervals = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+    const result = computeIntervalQuantiles(intervals);
+    // 11 samples sorted: pos = 0.5 * 10 = 5 -> value at index 5 = 6
+    expect(result[10]).toBe(6);
+  });
+
+  it("places the min at index 0 and the max at index 20", () => {
+    const intervals = [50, 10, 30, 90, 70, 20, 80, 40, 60, 100];
+    const result = computeIntervalQuantiles(intervals);
+    expect(result[0]).toBe(10);
+    expect(result[20]).toBe(100);
+  });
+});

--- a/packages/stagebook/src/components/form/typingQuantiles.test.ts
+++ b/packages/stagebook/src/components/form/typingQuantiles.test.ts
@@ -30,9 +30,17 @@ describe("quantile", () => {
 });
 
 describe("computeIntervalQuantiles", () => {
-  it("returns empty array for inputs with fewer than 2 samples", () => {
+  it("returns empty array for empty input", () => {
     expect(computeIntervalQuantiles([])).toEqual([]);
-    expect(computeIntervalQuantiles([100])).toEqual([]);
+  });
+
+  it("returns 21 identical values for a single-sample (1-interval) input", () => {
+    // With 2 keystrokes there's exactly 1 interval. All quantiles of a
+    // degenerate distribution equal that one sample — emitting a 21-value
+    // vector keeps the schema fixed-length downstream.
+    const result = computeIntervalQuantiles([42]);
+    expect(result).toHaveLength(21);
+    expect(result.every((v) => v === 42)).toBe(true);
   });
 
   it("returns 21 values for valid input", () => {

--- a/packages/stagebook/src/components/form/typingQuantiles.ts
+++ b/packages/stagebook/src/components/form/typingQuantiles.ts
@@ -1,0 +1,24 @@
+// Linear interpolation between sorted samples at the requested quantile in
+// [0, 1]. Empty arrays return 0; callers gate on length first.
+export function quantile(sorted: number[], q: number): number {
+  if (sorted.length === 0) return 0;
+  if (sorted.length === 1) return sorted[0];
+  const pos = q * (sorted.length - 1);
+  const lo = Math.floor(pos);
+  const hi = Math.ceil(pos);
+  if (lo === hi) return sorted[lo];
+  return sorted[lo] + (sorted[hi] - sorted[lo]) * (pos - lo);
+}
+
+// 21 quantiles at 0%, 5%, 10%, ..., 95%, 100% of the input distribution.
+// Returns an empty array for inputs with fewer than 2 samples; callers
+// should gate on length and emit `null` in that case.
+export function computeIntervalQuantiles(intervals: number[]): number[] {
+  if (intervals.length < 2) return [];
+  const sorted = [...intervals].sort((a, b) => a - b);
+  const result: number[] = [];
+  for (let i = 0; i <= 20; i++) {
+    result.push(quantile(sorted, i / 20));
+  }
+  return result;
+}

--- a/packages/stagebook/src/components/form/typingQuantiles.ts
+++ b/packages/stagebook/src/components/form/typingQuantiles.ts
@@ -11,10 +11,12 @@ export function quantile(sorted: number[], q: number): number {
 }
 
 // 21 quantiles at 0%, 5%, 10%, ..., 95%, 100% of the input distribution.
-// Returns an empty array for inputs with fewer than 2 samples; callers
-// should gate on length and emit `null` in that case.
+// Returns 21 values for any non-empty input — a single-sample distribution
+// is degenerate but well-defined (all quantiles equal that sample). Returns
+// an empty array only for empty input; callers gate on emptiness and emit
+// `null` in that case.
 export function computeIntervalQuantiles(intervals: number[]): number[] {
-  if (intervals.length < 2) return [];
+  if (intervals.length === 0) return [];
   const sorted = [...intervals].sort((a, b) => a - b);
   const result: number[] = [];
   for (let i = 0; i <= 20; i++) {


### PR DESCRIPTION
## Summary

Closes #335 partially — paste is already blocked unconditionally in `TextArea`, which addresses the issue's core request. This PR is the complementary telemetry expansion that gives downstream analysis stronger signals for detecting non-typed content (LLM paraphrase, dictation, etc.).

New `TypingStats` fields, all cumulative across focus cycles:

- `intervalQuantiles` — 21 values at 0%, 5%, 10%, …, 95%, 100% of inter-keystroke intervals (ms). Richer signal than mean+stddev for the same storage cost; surfaces bimodal/heavy-tailed typing patterns that mean+stddev hide.
- `firstKeystrokeDelayMs` — time from first focus to first keystroke. Long delays may indicate the participant was reading/composing elsewhere before typing.
- `totalTypingTimeMs` — first-to-last keystroke span.
- `focusedDurationMs` — accumulated focused duration across focus cycles. Includes any in-progress focus interval at emission time.
- `backspaceCount`, `arrowKeyCount`, `mouseClickCount`, `focusCount`, `blurCount` — discrete interaction counters.

Existing `totalKeystrokes`, `avgInterval`, `stdDev` retained — they're useful for backward-compat consumers and as a quick summary.

### Behavior notes

- Cursor-only keys (Arrow*, Home/End, PageUp/Down) increment `arrowKeyCount` but **do not** push a keystroke timestamp — pure navigation shouldn't dilute the typing-rhythm signal.
- Backspace/Delete count as both a `backspaceCount` event and a keystroke timestamp (they're real editing actions that participate in rhythm).
- Modifier-only events (Shift, Ctrl, etc.) are ignored entirely.
- `intervalQuantiles` is `null` when fewer than 2 keystrokes have been recorded; `firstKeystrokeDelayMs` and `totalTypingTimeMs` are `null` when undefined.
- `TypingStats` is now emitted on every blur (previously only when ≥2 keystrokes). With the new counter-based fields, a focus-blur cycle without typing still carries meaningful information (e.g. `focusedDurationMs`).

### What this PR does NOT do

The original issue proposed an opt-in `allowPaste` flag in prompt metadata. Paste is already unconditionally blocked in `TextArea` (and has been for some time) — paste events fire `e.preventDefault()` and emit a `PasteAttempt` debug message. The `allowPaste` flag is therefore not added here. If a future use case needs paste to be allowed, that flag can be re-introduced as a separate PR.

## Test plan

- [x] `npm run lint -w stagebook` — clean
- [x] `npm run build -w stagebook` — succeeds, no type errors in published surface
- [x] `npx vitest run` — 990 tests pass (981 prior + 9 new for `computeIntervalQuantiles` / `quantile`)
- [x] Pre-push hook (full workspace lint + tests) passed
- [ ] Manual: type in a `TextArea` in the viewer/extension preview, blur, inspect the emitted `debugMessages` on the saved record; verify `intervalQuantiles` length 21, monotonically non-decreasing; verify `firstKeystrokeDelayMs`, `focusCount`, etc. populate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)