### PR TITLE
Fix slider thumb shape, edge-reach, and tick alignment (#326)

### DIFF
--- a/packages/stagebook/src/components/form/Slider.ct.tsx
+++ b/packages/stagebook/src/components/form/Slider.ct.tsx
@@ -101,3 +101,83 @@ test("changing range input updates value", async ({ mount }) => {
     "75",
   );
 });
+
+// -- Thumb shape and alignment (#326) --
+
+test("thumb is a square (round via border-radius) — not an oblong", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <Slider min={0} max={100} interval={1} value={50} />,
+  );
+  const thumb = component.locator('[data-testid="slider-thumb"]');
+  await expect(thumb).toHaveCount(1);
+  // width === height for a true circle when border-radius is 50%
+  const box = await thumb.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.width).toBe(box!.height);
+  // And it's the expected 20×20
+  expect(box!.width).toBe(20);
+});
+
+test("thumb is centered on the track at value=min", async ({ mount }) => {
+  // At min, the thumb's horizontal center should be at the leftmost tick's
+  // horizontal center — i.e., at 0% of the track, not 10px in.
+  const component = await mount(
+    <Slider min={1} max={7} interval={1} labelPts={[1, 7]} value={1} />,
+  );
+  const track = component.locator('[data-testid="slider-track"]');
+  const thumb = component.locator('[data-testid="slider-thumb"]');
+  const trackBox = await track.boundingBox();
+  const thumbBox = await thumb.boundingBox();
+  expect(trackBox).not.toBeNull();
+  expect(thumbBox).not.toBeNull();
+  const thumbCenterX = thumbBox!.x + thumbBox!.width / 2;
+  // Thumb center should be at the track's left edge (within 1px tolerance
+  // for sub-pixel rendering).
+  expect(Math.abs(thumbCenterX - trackBox!.x)).toBeLessThanOrEqual(1);
+});
+
+test("thumb is centered on the track at value=max", async ({ mount }) => {
+  const component = await mount(
+    <Slider min={1} max={7} interval={1} labelPts={[1, 7]} value={7} />,
+  );
+  const track = component.locator('[data-testid="slider-track"]');
+  const thumb = component.locator('[data-testid="slider-thumb"]');
+  const trackBox = await track.boundingBox();
+  const thumbBox = await thumb.boundingBox();
+  expect(trackBox).not.toBeNull();
+  expect(thumbBox).not.toBeNull();
+  const thumbCenterX = thumbBox!.x + thumbBox!.width / 2;
+  const trackRight = trackBox!.x + trackBox!.width;
+  expect(Math.abs(thumbCenterX - trackRight)).toBeLessThanOrEqual(1);
+});
+
+test("thumb aligns with the tick at non-center values (value=5 on 1..7)", async ({
+  mount,
+}) => {
+  // The bug: at value=5 on a 1..7 scale, the thumb was ~3px left of the
+  // tick at 5 because the native range thumb's half-thumb-width offset
+  // doesn't match the tick coordinate system.
+  const component = await mount(
+    <Slider
+      min={1}
+      max={7}
+      interval={1}
+      labelPts={[1, 2, 3, 4, 5, 6, 7]}
+      value={5}
+    />,
+  );
+  const thumb = component.locator('[data-testid="slider-thumb"]');
+  // Ticks render in order before the thumb, so direct child index 4 is
+  // the 5th tick (the one at value=5).
+  const track = component.locator('[data-testid="slider-track"]');
+  const tickAt5 = track.locator("> div").nth(4);
+  const tickBox = await tickAt5.boundingBox();
+  const thumbBox = await thumb.boundingBox();
+  expect(tickBox).not.toBeNull();
+  expect(thumbBox).not.toBeNull();
+  const thumbCenterX = thumbBox!.x + thumbBox!.width / 2;
+  const tickCenterX = tickBox!.x + tickBox!.width / 2;
+  expect(Math.abs(thumbCenterX - tickCenterX)).toBeLessThanOrEqual(1);
+});

--- a/packages/stagebook/src/components/form/Slider.tsx
+++ b/packages/stagebook/src/components/form/Slider.tsx
@@ -20,6 +20,7 @@ export function Slider({
   onChange,
 }: SliderProps) {
   const [localValue, setLocalValue] = useState<number | undefined>(value);
+  const [isFocused, setIsFocused] = useState(false);
 
   useEffect(() => {
     setLocalValue(value);
@@ -93,6 +94,34 @@ export function Slider({
               }}
             />
           ))}
+
+          {/* Custom thumb — only rendered after first interaction. Sits in
+              the same coordinate space as the ticks (positioned via the
+              same getPosition() that places the ticks), which fixes the
+              half-thumb-width offset that native range inputs reserve and
+              that previously caused thumb/tick misalignment at non-center
+              values (#326). pointer-events: none routes clicks/drags
+              through to the invisible native input behind it. */}
+          {hasValue && (
+            <div
+              data-testid="slider-thumb"
+              style={{
+                position: "absolute",
+                left: `${getPosition(localValue)}%`,
+                top: "50%",
+                transform: "translate(-50%, -50%)",
+                width: 20,
+                height: 20,
+                borderRadius: "50%",
+                background: "var(--stagebook-primary, #3b82f6)",
+                border: "2px solid white",
+                boxShadow: isFocused
+                  ? "0 0 0 3px rgba(59, 130, 246, 0.3), 0 2px 4px rgba(0,0,0,0.2)"
+                  : "0 2px 4px rgba(0,0,0,0.2)",
+                pointerEvents: "none",
+              }}
+            />
+          )}
         </div>
 
         {/* Instruction when no value set — avoids anchoring */}
@@ -113,7 +142,12 @@ export function Slider({
           </div>
         )}
 
-        {/* Range input — only rendered after first interaction */}
+        {/* Range input — only rendered after first interaction. Visually
+            invisible (opacity: 0) but still handles keyboard and pointer
+            interaction. The native thumb is forced to 0×0 so the browser
+            doesn't reserve the half-thumb-width padding that previously
+            broke tick alignment; the visible thumb is drawn separately
+            above. */}
         {hasValue && (
           <input
             type="range"
@@ -122,6 +156,8 @@ export function Slider({
             step={interval}
             value={localValue}
             onChange={handleChange}
+            onFocus={() => setIsFocused(true)}
+            onBlur={() => setIsFocused(false)}
             style={{
               position: "absolute",
               top: "8px",
@@ -132,6 +168,9 @@ export function Slider({
               cursor: "pointer",
               WebkitAppearance: "none",
               MozAppearance: "none",
+              opacity: 0,
+              margin: 0,
+              padding: 0,
             }}
             aria-label="Slider"
             aria-valuemin={min}
@@ -178,23 +217,16 @@ export function Slider({
         input[type="range"]::-webkit-slider-thumb {
           -webkit-appearance: none;
           appearance: none;
-          width: 20px;
-          height: 24px;
-          background: var(--stagebook-primary, #3b82f6);
-          border-radius: 50%;
-          cursor: pointer;
-          border: 2px solid white;
-          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-          margin-top: -8px;
+          width: 0;
+          height: 0;
+          background: transparent;
+          border: none;
         }
         input[type="range"]::-moz-range-thumb {
-          width: 20px;
-          height: 24px;
-          background: var(--stagebook-primary, #3b82f6);
-          border-radius: 50%;
-          cursor: pointer;
-          border: 2px solid white;
-          box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+          width: 0;
+          height: 0;
+          background: transparent;
+          border: none;
         }
         input[type="range"]::-webkit-slider-runnable-track {
           width: 100%;
@@ -208,12 +240,6 @@ export function Slider({
         }
         input[type="range"]:focus {
           outline: none;
-        }
-        input[type="range"]:focus::-webkit-slider-thumb {
-          box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
-        }
-        input[type="range"]:focus::-moz-range-thumb {
-          box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
         }
       `}</style>
     </div>

--- a/packages/stagebook/src/components/form/Slider.tsx
+++ b/packages/stagebook/src/components/form/Slider.tsx
@@ -110,13 +110,20 @@ export function Slider({
                 left: `${getPosition(localValue)}%`,
                 top: "50%",
                 transform: "translate(-50%, -50%)",
+                // box-sizing: border-box keeps the visible thumb at 20×20
+                // including the 2px white border, so the bounding box (and
+                // the tick-alignment math in tests) matches the declared
+                // size. Default content-box would render at 24×24.
+                boxSizing: "border-box",
                 width: 20,
                 height: 20,
                 borderRadius: "50%",
                 background: "var(--stagebook-primary, #3b82f6)",
                 border: "2px solid white",
+                // Match the focus-ring token used by RadioGroup/CheckboxGroup/
+                // Select so hosts can retheme focus visuals consistently.
                 boxShadow: isFocused
-                  ? "0 0 0 3px rgba(59, 130, 246, 0.3), 0 2px 4px rgba(0,0,0,0.2)"
+                  ? "0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25)), 0 2px 4px rgba(0,0,0,0.2)"
                   : "0 2px 4px rgba(0,0,0,0.2)",
                 pointerEvents: "none",
               }}


### PR DESCRIPTION
Closes #326.

## Summary

Three related visual bugs, one root cause and one fix.

**Bugs:**
1. Thumb was 20×24 with `border-radius: 50%` → vertical oblong, not a circle.
2. Thumb couldn't reach the bar edges — native `<input type=\"range\">` reserves half-thumb-width of internal padding on each side.
3. At non-center values, the thumb was offset toward the bar's center relative to the tick it was sitting on. The misalignment was exactly `thumb-width/2 × (1 - 2 × normalized-position)` — zero at center, ±10px at the extremes.

Bugs 2 and 3 share a root cause: the ticks use a 0%..100% coordinate system over the track, but the native thumb uses a `[half-thumb-width, width - half-thumb-width]` coordinate system. They don't align.

**Fix:** render a custom thumb as an absolutely-positioned `<div>` at `getPosition(value)%` — the same coordinate system as the ticks. The native `<input type=\"range\">` stays underneath at `opacity: 0` for keyboard and pointer accessibility, with its `::-*-slider-thumb` forced to `0×0` so the browser doesn't reserve the padding that previously caused misalignment. Focus state on the input drives a focus ring on the custom thumb.

This is the same pattern Radix UI and MUI use, and for the same reason.

## Behavior notes

- Custom thumb is `data-testid=\"slider-thumb\"` for testing.
- The unanchored-no-thumb behavior is unchanged: no thumb rendered until first interaction.
- Keyboard (arrows, Home/End) still works because the underlying native input is still focusable.
- Click-on-track-to-anchor still works because the existing `handleClick` on the track handles unanchored state before the input renders.

## Test plan

- [x] `npm run build -w stagebook` — succeeds
- [x] `npm run lint -w stagebook` — clean
- [x] `npx vitest run` — 1284 tests pass
- [x] Pre-push hook (full workspace lint + tests) passed
- [ ] CI: Playwright CT tests — new tests added for round-thumb shape, edge-reach at min/max, and tick alignment at value=5 on a 1..7 scale (the exact case described in the issue)
- [ ] Manual: load a TIPI-style slider in the viewer, drag the thumb to each tick, verify visual alignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)