### PR TITLE
Fix TextArea char-counter UX at upper bound (#333)

### DIFF
--- a/packages/stagebook/src/components/elements/Prompt.ct.tsx
+++ b/packages/stagebook/src/components/elements/Prompt.ct.tsx
@@ -217,7 +217,7 @@ test.describe("Open Response", () => {
       />,
     );
     await expect(component.locator("textarea")).toBeVisible();
-    await expect(component).toContainText("(5 / 50-200 chars)");
+    await expect(component).toContainText("(5 / 50-200 characters)");
   });
 
   test("counter is gray when under minimum", async ({ mount }) => {
@@ -251,12 +251,14 @@ test.describe("Open Response", () => {
     await expect(counter).toHaveCSS("color", "rgb(22, 163, 74)");
   });
 
-  test("counter is red at maximum", async ({ mount }) => {
+  test("counter is green at maximum (#333 — upper bound is valid, not error)", async ({
+    mount,
+  }) => {
     const maxValue = "A".repeat(200);
     const component = await mount(
       <Prompt
         {...openResponseWithLimits}
-        name="testRed"
+        name="testAtMax"
         value={maxValue}
         progressLabel="game_0_test"
         save={() => {}}
@@ -264,7 +266,7 @@ test.describe("Open Response", () => {
       />,
     );
     const counter = component.locator('[data-testid="char-counter"]');
-    await expect(counter).toHaveCSS("color", "rgb(220, 38, 38)");
+    await expect(counter).toHaveCSS("color", "rgb(22, 163, 74)");
   });
 
   test("shared mode hides textarea (notepad slot)", async ({ mount }) => {

--- a/packages/stagebook/src/components/form/TextArea.ct.tsx
+++ b/packages/stagebook/src/components/form/TextArea.ct.tsx
@@ -55,18 +55,24 @@ test("max only: shows count in gray when under", async ({ mount }) => {
   const component = await mount(
     <MockTextArea value="Hello" showCharacterCount maxLength={200} />,
   );
-  await expect(component).toContainText("(5 / 200 chars max)");
+  await expect(component).toContainText("(5 / 200 characters max)");
   const counter = component.locator('[data-testid="char-counter"]');
   await expect(counter).toHaveCSS("color", "rgb(107, 114, 128)");
 });
 
-test("max only: shows red at max", async ({ mount }) => {
+test("max only: at max is steady gray, not error red (#333)", async ({
+  mount,
+}) => {
+  // Sitting at maxLength is "you're at the upper limit", not an error.
+  // The red signal was the pre-#333 behavior — now it's reserved for the
+  // transient pulse animation on a rejected overflow keystroke.
   const component = await mount(
     <MockTextArea value="12345" showCharacterCount maxLength={5} />,
   );
-  await expect(component).toContainText("(5 / 5 chars max)");
+  await expect(component).toContainText("(5 / 5 characters max)");
   const counter = component.locator('[data-testid="char-counter"]');
-  await expect(counter).toHaveCSS("color", "rgb(220, 38, 38)");
+  await expect(counter).toHaveCSS("color", "rgb(107, 114, 128)");
+  await expect(counter).toHaveAttribute("data-state", "default");
 });
 
 // -- Character counter: min and max --
@@ -80,7 +86,7 @@ test("min+max: gray when under minimum", async ({ mount }) => {
       maxLength={50}
     />,
   );
-  await expect(component).toContainText("(2 / 10-50 chars)");
+  await expect(component).toContainText("(2 / 10-50 characters)");
   const counter = component.locator('[data-testid="char-counter"]');
   await expect(counter).toHaveCSS("color", "rgb(107, 114, 128)");
 });
@@ -94,12 +100,14 @@ test("min+max: green when in range", async ({ mount }) => {
       maxLength={50}
     />,
   );
-  await expect(component).toContainText("(13 / 10-50 chars)");
+  await expect(component).toContainText("(13 / 10-50 characters)");
   const counter = component.locator('[data-testid="char-counter"]');
   await expect(counter).toHaveCSS("color", "rgb(22, 163, 74)");
 });
 
-test("min+max: red at maximum", async ({ mount }) => {
+test("min+max: at maximum is valid green (#333)", async ({ mount }) => {
+  // Previously this was red — but the valid range is [minLength, maxLength]
+  // inclusive. Hitting exactly maxLength is the upper bound of valid.
   const component = await mount(
     <MockTextArea
       value="1234567890"
@@ -108,9 +116,55 @@ test("min+max: red at maximum", async ({ mount }) => {
       maxLength={10}
     />,
   );
-  await expect(component).toContainText("(10 / 5-10 chars)");
+  await expect(component).toContainText("(10 / 5-10 characters)");
   const counter = component.locator('[data-testid="char-counter"]');
-  await expect(counter).toHaveCSS("color", "rgb(220, 38, 38)");
+  await expect(counter).toHaveCSS("color", "rgb(22, 163, 74)");
+  await expect(counter).toHaveAttribute("data-state", "valid");
+});
+
+test("min+max: exact-length input (e.g. birth year 4/4-4) is valid (#333)", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockTextArea
+      value="1990"
+      showCharacterCount
+      minLength={4}
+      maxLength={4}
+    />,
+  );
+  await expect(component).toContainText("(4 / 4-4 characters)");
+  const counter = component.locator('[data-testid="char-counter"]');
+  await expect(counter).toHaveCSS("color", "rgb(22, 163, 74)");
+  await expect(counter).toHaveAttribute("data-state", "valid");
+});
+
+// -- Overflow pulse (#333) --
+
+test("typing past maxLength triggers a transient overflow pulse", async ({
+  mount,
+}) => {
+  // Pre-fill to exactly maxLength, then attempt to type one more
+  // character. The textarea's value should stay at maxLength (rejected)
+  // and the counter should flip to data-state="overflow" briefly.
+  const component = await mount(
+    <MockTextArea value="12345" showCharacterCount maxLength={5} />,
+  );
+  const textarea = component.locator("textarea");
+  const counter = component.locator('[data-testid="char-counter"]');
+  // Steady state at max is valid/default — not overflow.
+  await expect(counter).toHaveAttribute("data-state", "default");
+  // Attempt to type a 6th character. The change handler rejects it, sets
+  // the overflow flag, and schedules a 300ms clear.
+  await textarea.focus();
+  await textarea.press("x");
+  // Value is unchanged (still 5 chars), state flipped to "overflow".
+  await expect(textarea).toHaveValue("12345");
+  await expect(counter).toHaveAttribute("data-state", "overflow");
+  // After ~300ms the flag clears.
+  await expect(counter).toHaveAttribute("data-state", "default", {
+    timeout: 1000,
+  });
 });
 
 // -- No min/max --

--- a/packages/stagebook/src/components/form/TextArea.tsx
+++ b/packages/stagebook/src/components/form/TextArea.tsx
@@ -43,7 +43,18 @@ export function TextArea({
   const generatedId = useId();
   const textAreaId = id || generatedId;
   const [localValue, setLocalValue] = useState(value || "");
+  // Transient flag set when a keystroke is rejected for exceeding maxLength;
+  // drives the brief red pulse animation on the character counter. The
+  // steady-state color stays valid-green when length === maxLength (#333).
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  // Bumped on each rejected overflow keystroke. Used as the React `key`
+  // on the counter element so that rapid repeat overflows reliably restart
+  // the pulse animation — without this, a second overflow within 300ms
+  // would not retrigger the keyframe (the animation prop string is
+  // unchanged, so the browser doesn't restart).
+  const [overflowPulseId, setOverflowPulseId] = useState(0);
   const debounceTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const overflowTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const keystrokeTimestamps = useRef<number[]>([]);
   const isDebouncing = useRef(false);
 
@@ -85,7 +96,18 @@ export function TextArea({
 
   const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value;
-    if (maxLength && newValue.length > maxLength) return;
+    if (maxLength && newValue.length > maxLength) {
+      // Keystroke would overflow — reject it and pulse the counter red
+      // briefly. Distinguishes "you tried to overflow" (transient, this
+      // animation) from "you're at the limit" (steady valid state).
+      if (overflowTimeout.current) clearTimeout(overflowTimeout.current);
+      setIsOverflowing(true);
+      setOverflowPulseId((p) => p + 1);
+      overflowTimeout.current = setTimeout(() => {
+        setIsOverflowing(false);
+      }, 300);
+      return;
+    }
     setLocalValue(newValue);
     debouncedSubmit(newValue);
   };
@@ -134,13 +156,13 @@ export function TextArea({
     const currentLength = localValue.length;
 
     if (minLength && maxLength) {
-      countText = `(${currentLength} / ${minLength}-${maxLength} chars)`;
-      if (currentLength >= minLength && currentLength < maxLength) {
+      countText = `(${currentLength} / ${minLength}-${maxLength} characters)`;
+      // The valid range is [minLength, maxLength] inclusive on both ends.
+      // Hitting maxLength is "you're at the upper limit" — a fact, not an
+      // error. Attempts to type past it pulse red via isOverflowing (#333).
+      if (currentLength >= minLength && currentLength <= maxLength) {
         countColor = "var(--stagebook-success, #16a34a)";
         countState = "valid";
-      } else if (currentLength === maxLength) {
-        countColor = "var(--stagebook-warning, #dc2626)";
-        countState = "error";
       }
     } else if (minLength) {
       countText = `(${currentLength} / ${minLength}+ characters required)`;
@@ -149,19 +171,24 @@ export function TextArea({
         countState = "valid";
       }
     } else if (maxLength) {
-      countText = `(${currentLength} / ${maxLength} chars max)`;
-      if (currentLength === maxLength) {
-        countColor = "var(--stagebook-warning, #dc2626)";
-        countState = "error";
-      }
+      countText = `(${currentLength} / ${maxLength} characters max)`;
     } else {
       countText = `(${currentLength} characters)`;
     }
 
+    // Pulse animation takes priority over the steady-state color — when the
+    // participant tries to type past maxLength, the counter flashes red for
+    // 300ms regardless of the underlying valid state.
+    const animationStyle = isOverflowing
+      ? { animation: "stagebook-char-counter-pulse 300ms ease-out" }
+      : {};
+    const overflowState = isOverflowing ? "overflow" : countState;
+
     return (
       <div
+        key={isOverflowing ? `pulse-${overflowPulseId}` : "steady"}
         data-testid="char-counter"
-        data-state={countState}
+        data-state={overflowState}
         style={{
           textAlign: "right",
           fontSize: "0.75rem",
@@ -170,6 +197,7 @@ export function TextArea({
           color: countColor,
           boxSizing: "border-box",
           width: "100%",
+          ...animationStyle,
         }}
       >
         {countText}
@@ -206,6 +234,12 @@ export function TextArea({
         }}
       />
       {renderCharacterCount()}
+      <style>{`
+        @keyframes stagebook-char-counter-pulse {
+          0% { color: var(--stagebook-warning, #dc2626); }
+          100% { color: inherit; }
+        }
+      `}</style>
     </div>
   );
 }

--- a/packages/stagebook/src/components/form/TextArea.tsx
+++ b/packages/stagebook/src/components/form/TextArea.tsx
@@ -65,6 +65,15 @@ export function TextArea({
     }
   }, [value]);
 
+  // Clear the overflow timeout on unmount — without this, a stage/page
+  // change within the 300ms window would fire setIsOverflowing(false) on
+  // an unmounted component (silent in React 18+ but still a leak).
+  useEffect(() => {
+    return () => {
+      if (overflowTimeout.current) clearTimeout(overflowTimeout.current);
+    };
+  }, []);
+
   const submitChange = (val: string) => {
     if (onChange && typeof onChange === "function") {
       onChange(val);
@@ -235,9 +244,23 @@ export function TextArea({
       />
       {renderCharacterCount()}
       <style>{`
+        /* Animate a box-shadow glow instead of the text color, so the
+           steady-state countColor (gray/green) is preserved throughout
+           the pulse — animating color back to "inherit" produced a brief
+           flash to the parent color before snapping back to countColor at
+           animation end. The warning color is referenced via the same
+           --stagebook-warning token used by host theming, so a themed
+           orange (etc.) propagates through the pulse. */
         @keyframes stagebook-char-counter-pulse {
-          0% { color: var(--stagebook-warning, #dc2626); }
-          100% { color: inherit; }
+          0% {
+            box-shadow: 0 0 0 0 var(--stagebook-warning, #dc2626);
+          }
+          30% {
+            box-shadow: 0 0 0 4px var(--stagebook-warning, #dc2626);
+          }
+          100% {
+            box-shadow: 0 0 0 0 var(--stagebook-warning, #dc2626);
+          }
         }
       `}</style>
     </div>

--- a/packages/stagebook/src/components/form/ThemeOverride.ct.tsx
+++ b/packages/stagebook/src/components/form/ThemeOverride.ct.tsx
@@ -88,9 +88,14 @@ test.describe("CSS Variable Theme Override", () => {
     await expect(counter).toHaveCSS("color", "rgb(234, 88, 12)");
   });
 
-  test("TextArea counter uses overridden warning color (red → orange)", async ({
+  test("TextArea counter uses overridden warning color during overflow pulse (#333)", async ({
     mount,
   }) => {
+    // The warning color is no longer the steady state at maxLength —
+    // post-#333 that's the valid/default state. The warning color now
+    // appears only during the transient overflow-pulse box-shadow glow.
+    // We exercise the override by triggering an overflow keystroke and
+    // sampling the box-shadow color while data-state="overflow".
     const component = await mount(
       <ThemedTextArea
         value="12345"
@@ -99,9 +104,20 @@ test.describe("CSS Variable Theme Override", () => {
         themeOverrides={orangeTheme}
       />,
     );
+    const textarea = component.locator("textarea");
     const counter = component.locator('[data-testid="char-counter"]');
-    // #f97316 = rgb(249, 115, 22)
-    await expect(counter).toHaveCSS("color", "rgb(249, 115, 22)");
+    await textarea.focus();
+    await textarea.press("x");
+    await expect(counter).toHaveAttribute("data-state", "overflow");
+    // The pulse animates `box-shadow`; the keyframe's 0% frame uses the
+    // themed --stagebook-warning variable. Sample box-shadow and confirm
+    // the orange-override RGB is present.
+    const shadow = await counter.evaluate(
+      (el) => getComputedStyle(el).boxShadow,
+    );
+    // #f97316 = rgb(249, 115, 22); RGBA in box-shadow may render with
+    // alpha channel. We assert any RGB() containing the override hue.
+    expect(shadow).toMatch(/249,?\s*115,?\s*22/);
   });
 
   test("side-by-side: blue default vs orange override", async ({ mount }) => {


### PR DESCRIPTION
Closes #333.

## Summary

Three related problems with the character count badge at the upper bound:

1. **\`currentLength === maxLength\` painted red and marked \`data-state=\"error\"\`** — that's the upper bound of the valid range, not an error. Most surprising case: a 4-digit birth year (\`minLength: 4, maxLength: 4\`) goes red the moment the participant types a valid year.
2. **\"You tried to overflow\" was bundled into the same persistent red state as \"you're at the limit\"** — conflating two distinct conditions.
3. **\"chars\" was used in two branches while min-only used \"characters\"** — inconsistent label wording.

## Fixes

### a. Steady-state color

\`[minLength, maxLength]\` is inclusive on both ends. At exactly maxLength:
- with min+max: **valid/green** (was red)
- with maxLength-only: **default/gray** (was red)

### b. Transient overflow pulse

When a keystroke would push past maxLength, the counter pulses red for 300ms via a CSS keyframe. \`data-state=\"overflow\"\` during the pulse; reverts to steady state after.

Rapid retriggers within 300ms reliably restart the pulse — a React \`key\` bumped on each overflow re-mounts the counter element so the animation runs fresh. Without this, a second overflow within 300ms wouldn't restart the animation (the \`animation\` style string is identical, so the browser doesn't re-trigger).

### c. \"chars\" → \"characters\"

All three counter formats now read \"characters\":
- \`(N / M+ characters required)\` (unchanged)
- \`(N / A-B characters)\` (was \"chars\")
- \`(N / M characters max)\` (was \"chars\")

## Test plan

- [x] Build, lint, vitest (1284 tests) all pass
- [x] Pre-push hook passed
- [x] Updated existing CT tests for new wording + colors
- [x] Added two new CT tests:
  - \`min+max: exact-length input (e.g. birth year 4/4-4) is valid\` — the issue's headline case
  - \`typing past maxLength triggers a transient overflow pulse\` — verifies the new pulse behavior
- [ ] Manual: load a TextArea with minLength=4, maxLength=4, type 1990, confirm green not red; type a 5th char, confirm 300ms red pulse then back to green

🤖 Generated with [Claude Code](https://claude.com/claude-code)