### PR TITLE
Slider: `- N:` renders explicit empty label (#325)

### DIFF
--- a/packages/stagebook/src/schemas/promptFile.test.ts
+++ b/packages/stagebook/src/schemas/promptFile.test.ts
@@ -430,7 +430,10 @@ Rate.
     }
   });
 
-  test("slider line with `<n>:` (empty label) defaults label to the number", () => {
+  test("slider line with `<n>:` (colon, empty after) renders an empty label (#325)", () => {
+    // Previously this fell back to the stringified number. The colon now
+    // signals "labeled position, empty label string" — useful for putting
+    // a tick at a snap point without rendering numeric text underneath.
     const markdown = `---
 type: slider
 min: 0
@@ -444,7 +447,79 @@ Rate.
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.sliderPoints).toEqual([5]);
+      expect(result.data.responseItems).toEqual([""]);
+    }
+  });
+
+  test("slider line with `<n>: ` (colon + whitespace) also renders empty (#325)", () => {
+    const markdown = `---
+type: slider
+min: 0
+max: 10
+interval: 1
+---
+Rate.
+---
+- 5:   `;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.responseItems).toEqual([""]);
+    }
+  });
+
+  test("slider bare `- N` (no colon) still falls back to the number (#325)", () => {
+    // Regression guard for the backward-compat half of the change: the
+    // fallback only applies when there's no colon at all.
+    const markdown = `---
+type: slider
+min: 0
+max: 10
+interval: 1
+---
+Rate.
+---
+- 5`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(true);
+    if (result.success) {
       expect(result.data.responseItems).toEqual(["5"]);
+    }
+  });
+
+  test("slider with ticks-everywhere-but-labels-only-at-anchors (TIPI pattern, #325)", () => {
+    // The motivating use case for #325: a 7-point Likert slider with
+    // ticks at every snap point but text only at the endpoints and
+    // midpoint. Previously required choosing between "all numeric
+    // labels" (cluttered) or "anchors only" (no intermediate ticks).
+    const markdown = `---
+type: slider
+min: 1
+max: 7
+interval: 1
+---
+How strongly do you agree?
+---
+- 1: Strongly disagree
+- 2:
+- 3:
+- 4: Neutral
+- 5:
+- 6:
+- 7: Strongly agree`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.sliderPoints).toEqual([1, 2, 3, 4, 5, 6, 7]);
+      expect(result.data.responseItems).toEqual([
+        "Strongly disagree",
+        "",
+        "",
+        "Neutral",
+        "",
+        "",
+        "Strongly agree",
+      ]);
     }
   });
 

--- a/packages/stagebook/src/schemas/promptFile.test.ts
+++ b/packages/stagebook/src/schemas/promptFile.test.ts
@@ -487,6 +487,28 @@ Rate.
     }
   });
 
+  test("multipleChoice numeric `- N:` keeps the legacy fallback (#325 scoping)", () => {
+    // The empty-label-after-colon change is scoped to sliders. For
+    // multipleChoice numeric mode, an empty label would produce an
+    // unlabeled radio (bad UX, no accessible name), so we keep the
+    // legacy fallback to the stringified number.
+    const markdown = `---
+name: scale
+type: multipleChoice
+---
+Rate it
+---
+- 1:
+- 2:
+- 3:`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.responsePoints).toEqual([1, 2, 3]);
+      expect(result.data.responseItems).toEqual(["1", "2", "3"]);
+    }
+  });
+
   test("slider with ticks-everywhere-but-labels-only-at-anchors (TIPI pattern, #325)", () => {
     // The motivating use case for #325: a 7-point Likert slider with
     // ticks at every snap point but text only at the endpoints and

--- a/packages/stagebook/src/schemas/promptFile.ts
+++ b/packages/stagebook/src/schemas/promptFile.ts
@@ -155,9 +155,12 @@ export type MetadataRefineType = MetadataType;
 /**
  * Parse a numeric response line. Used by sliders (always numeric) and by
  * multipleChoice prompts in numeric mode (#282). One of:
- *   - `- 50` — bare number (label defaults to the number's string form)
+ *   - `- 50` — bare number (no colon → label defaults to the number's
+ *     string form)
  *   - `- 50: Somewhat familiar` — number + label
- *   - `- 50:` — number + empty label (label defaults to the number)
+ *   - `- 50:` — number + explicit empty label. Useful for sliders where
+ *     a researcher wants a tick at this snap point but no label text
+ *     underneath it (#325).
  * The first colon separates point from label, so labels can themselves
  * contain colons.
  */
@@ -177,12 +180,17 @@ function parseNumericResponseLine(
   let pointStr: string;
   let label: string | null;
   if (colonIdx < 0) {
+    // No colon — fall through to the pointStr fallback below.
     pointStr = trimmed;
     label = null;
   } else {
+    // Colon present — preserve the post-colon text verbatim (after trim).
+    // An empty string here is a deliberate "tick with no label", not a
+    // missing label; the `??` fallback below keeps empty strings intact
+    // because `"" ?? x` is `""` (only null/undefined trigger the
+    // fallback).
     pointStr = trimmed.slice(0, colonIdx).trim();
-    const afterColon = trimmed.slice(colonIdx + 1).trim();
-    label = afterColon.length > 0 ? afterColon : null;
+    label = trimmed.slice(colonIdx + 1).trim();
   }
   if (pointStr.length === 0) {
     return {

--- a/packages/stagebook/src/schemas/promptFile.ts
+++ b/packages/stagebook/src/schemas/promptFile.ts
@@ -158,14 +158,17 @@ export type MetadataRefineType = MetadataType;
  *   - `- 50` — bare number (no colon → label defaults to the number's
  *     string form)
  *   - `- 50: Somewhat familiar` — number + label
- *   - `- 50:` — number + explicit empty label. Useful for sliders where
- *     a researcher wants a tick at this snap point but no label text
- *     underneath it (#325).
+ *   - `- 50:` — number + explicit empty label. Only honored when
+ *     `allowEmptyLabel` is true (sliders, #325). For multipleChoice
+ *     numeric mode we fall back to the number string instead, because
+ *     an unlabeled radio is bad UX (empty visible text + empty
+ *     accessible name).
  * The first colon separates point from label, so labels can themselves
  * contain colons.
  */
 function parseNumericResponseLine(
   raw: string,
+  options: { allowEmptyLabel?: boolean } = {},
 ): { ok: true; point: number; label: string } | { ok: false; message: string } {
   // Caller has already stripped the `- ` prefix and `\n`.
   const trimmed = raw.trim();
@@ -184,13 +187,19 @@ function parseNumericResponseLine(
     pointStr = trimmed;
     label = null;
   } else {
-    // Colon present — preserve the post-colon text verbatim (after trim).
-    // An empty string here is a deliberate "tick with no label", not a
-    // missing label; the `??` fallback below keeps empty strings intact
-    // because `"" ?? x` is `""` (only null/undefined trigger the
-    // fallback).
     pointStr = trimmed.slice(0, colonIdx).trim();
-    label = trimmed.slice(colonIdx + 1).trim();
+    const afterColon = trimmed.slice(colonIdx + 1).trim();
+    if (options.allowEmptyLabel) {
+      // Slider case (#325): preserve `""` so a researcher can put a tick
+      // at this snap point with no label text. `"" ?? x` is `""`, so the
+      // empty string survives the fallback below.
+      label = afterColon;
+    } else {
+      // multipleChoice numeric mode (#282): collapse empty-after-colon
+      // back to null so the fallback produces the stringified number.
+      // Legacy behavior preserved — unlabeled radios are bad UX.
+      label = afterColon.length > 0 ? afterColon : null;
+    }
   }
   if (pointStr.length === 0) {
     return {
@@ -418,7 +427,11 @@ export const promptFileSchema: z.ZodType<
       for (const line of responseLines) {
         if (!(line.startsWith("- ") || line === "-")) continue;
         const stripped = line === "-" ? "" : line.substring(2);
-        const parsed = parseNumericResponseLine(stripped);
+        // Slider: `- N:` is a deliberate empty label (tick with no
+        // visible text). multipleChoice keeps the legacy fallback (#325).
+        const parsed = parseNumericResponseLine(stripped, {
+          allowEmptyLabel: true,
+        });
         if (!parsed.ok) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,


### PR DESCRIPTION
Closes #325.

## Summary

Previously, both \`- N\` (bare) and \`- N:\` (colon followed by empty) fell back to \`label = \"N\"\`. There was no way to express \"I want a tick at this snap point with no label text\" — forcing researchers to either label every tick (cluttered) or list only the anchors (losing intermediate snap-point indicators).

The fix treats the colon as the signal:

| Body line     | Label                        |
| ------------- | ---------------------------- |
| \`- N\`         | \`\"N\"\` (unchanged — fallback) |
| \`- N:\`        | \`\"\"\` (new — explicit empty)  |
| \`- N: \` (ws)  | \`\"\"\` (new — trimmed)         |
| \`- N: Foo\`    | \`\"Foo\"\` (unchanged)          |

Implementation: scope the fallback to the colon-absent case. The \`label ?? pointStr\` return naturally preserves the empty string when the colon is present (only \`null\`/\`undefined\` trigger \`??\`).

The renderer needs no changes — \`labels[idx] === \"\"\` already renders an empty \`<div>\` that takes no visible space.

## The motivating use case

A standard 7-point Likert-on-slider:

\`\`\`yaml
- 1: Strongly disagree
- 2:
- 3:
- 4: Neutral
- 5:
- 6:
- 7: Strongly agree
\`\`\`

Renders ticks at all 7 snap positions, with text only at the endpoints and midpoint.

## Backward compatibility

\`- N:\` previously produced \`label = \"N\"\`. Any existing prompt file relying on that fallback now renders an empty label instead. In practice authors write either bare \`- N\` or \`- N: <text>\`; the zero-text-after-colon form is unusual.

The existing test \"slider line with \`<n>:\` (empty label) defaults label to the number\" was updated to reflect the new contract; new tests cover the whitespace-trimming case, the no-colon-fallback regression guard, and the full TIPI-shaped pattern from the issue.

## Test plan

- [x] Build, lint, vitest (1287 tests) all pass
- [x] Pre-push hook passed
- [x] 3 new tests added in \`promptFile.test.ts\`: colon-with-empty, colon-with-whitespace, TIPI-shaped pattern
- [ ] Manual: load a TIPI-shaped slider prompt in the viewer, confirm 7 ticks with labels only at 1/4/7

🤖 Generated with [Claude Code](https://claude.com/claude-code)