### PR TITLE
Add timeout-minutes to all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       stagebook: ${{ steps.filter.outputs.stagebook }}
       viewer: ${{ steps.filter.outputs.viewer }}
@@ -60,6 +61,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.lint == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -75,6 +77,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.stagebook == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -89,6 +92,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.viewer == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -104,6 +108,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.vscode == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -119,6 +124,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.ct == 'true'
     runs-on: ubuntu-latest
+    # Playwright install + tests typically run in ~5-6 min on a clean
+    # cache, so 15 leaves headroom without letting a hang waste 6 hours.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -132,6 +140,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -146,6 +155,7 @@ jobs:
     if: always()
     needs: [changes, lint, test-stagebook, test-viewer, test-vscode, test-ct, build]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Check for failures
         run: |


### PR DESCRIPTION
GitHub's default per-job timeout is 360 minutes (6 hours). The \`Unit Tests (vscode)\` job on #339 hit a 45-minute hang before the runner lost communication with the server — a genuine wedge in the job, but without a tighter limit we'd burn runner-minutes before any backpressure kicks in.

## Per-job timeouts

Chosen to leave ~2-3× headroom over typical duration:

| Job                          | Typical | Limit |
| ---------------------------- | ------- | ----- |
| Detect changes               | 5s      | 5m    |
| CI Gate                      | 3s      | 5m    |
| Lint & Format                | 35s     | 10m   |
| Build                        | 30s     | 10m   |
| Unit Tests (stagebook)       | 25s     | 10m   |
| Unit Tests (viewer)          | 30s     | 10m   |
| Unit Tests (vscode)          | 1m      | 10m   |
| Component Tests (Playwright) | 5m30s   | 15m   |

## Not addressed here

The root cause of the vscode-job hang is unknown. The previous run on the same branch passed in 3m16s, and a logic-level change to a shared schema helper (the #339 Copilot-fix commit) preceded the hang. That's worth its own investigation, but a timeout is the right floor regardless — a wedge in any job shouldn't be able to consume 45 minutes of runner time before being killed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)