### PR TITLE
Tighten CI job timeouts based on observed durations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 2
     outputs:
       stagebook: ${{ steps.filter.outputs.stagebook }}
       viewer: ${{ steps.filter.outputs.viewer }}
@@ -61,7 +61,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.lint == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -77,7 +77,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.stagebook == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 4
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -92,7 +92,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.viewer == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -108,7 +108,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.vscode == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -124,9 +124,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.ct == 'true'
     runs-on: ubuntu-latest
-    # Playwright install + tests typically run in ~5-6 min on a clean
-    # cache, so 15 leaves headroom without letting a hang waste 6 hours.
-    timeout-minutes: 15
+    # Playwright runs are noisy — p50 ~2min but cold-cache runs have
+    # been observed up to ~7.5min. 10 leaves ~30% headroom over the
+    # worst observed; tighter trips false alarms on cold runners.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -140,7 +141,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 3
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-node@v5
@@ -155,7 +156,7 @@ jobs:
     if: always()
     needs: [changes, lint, test-stagebook, test-viewer, test-vscode, test-ct, build]
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 2
     steps:
       - name: Check for failures
         run: |


### PR DESCRIPTION
Follow-up to #340. The conservative 10-15min limits left a lot of slack; tightening them helps the runner-minutes budget by killing hangs sooner.

## Methodology

Sampled per-job durations across the last 10 successful CI runs:

| Job | p50 | max | old | new |
|-----|-----|-----|-----|-----|
| Detect changes | 6s | 7s | 5m | **2m** |
| CI Gate | 3s | 6s | 5m | **2m** |
| Build | 30s | 68s | 10m | **3m** |
| Lint & Format | 34s | 64s | 10m | **3m** |
| Unit Tests (stagebook) | 27s | **112s** | 10m | **4m** |
| Unit Tests (viewer) | 28s | 70s | 10m | **3m** |
| Unit Tests (vscode) | 29s | 79s | 10m | **3m** |
| Component Tests | 124s | **454s** | 15m | **10m** |

Most jobs have ~2.5-3× headroom over the worst observed run. CT is the exception — its 7.5min max (likely cold cache) limits how tight we can safely go without false alarms. 10min leaves ~30% headroom there.

## Savings

A multi-job hang previously could burn ~75min before any timeout kicked in. With these values it tops out at ~28min — and a single unit-test hang now caps at 3min instead of 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)