### PR TITLE
Explicit exit-phase coverage for StageConditionGate (#315)

### DIFF
--- a/packages/stagebook/src/components/conditions/StageConditionGate.ct.tsx
+++ b/packages/stagebook/src/components/conditions/StageConditionGate.ct.tsx
@@ -163,9 +163,14 @@ test.describe("StageConditionGate (#183)", () => {
     const gate = page.locator('[data-testid="stage-condition-gate"]');
     await expect(gate).toBeVisible();
     await expect(gate).toHaveAttribute("data-state", "advancing");
+    // `not.toBeAttached()` rather than `not.toBeVisible()` — when the
+    // gate advances, StageConditionGate returns only the gate <div>
+    // without children, so stageContent should not be in the DOM at
+    // all. The stronger assertion catches a regression that mounted
+    // children but hid them via CSS (visibility/display tricks).
     await expect(
       page.locator('[data-testid="stageContent"]'),
-    ).not.toBeVisible();
+    ).not.toBeAttached();
   });
 
   test("no gate overhead when stage has no conditions", async ({

--- a/packages/stagebook/src/components/conditions/StageConditionGate.ct.tsx
+++ b/packages/stagebook/src/components/conditions/StageConditionGate.ct.tsx
@@ -125,6 +125,49 @@ test.describe("StageConditionGate (#183)", () => {
     ).not.toBeVisible();
   });
 
+  test("exit-phase stage with a false condition skips cleanly (#315)", async ({
+    mount,
+    page,
+  }) => {
+    // The Stage component is phase-agnostic — game, intro, and exit
+    // stages all share the same StageConditionGate path because the
+    // viewer's flattenSteps collapses all three phases into a uniform
+    // step shape. This test makes that guarantee explicit using the
+    // dialogue-levers `second_discussion_followup` pattern from #315:
+    // an exit-sequence stage gated on whether the participant opted
+    // into the second discussion in a prior game stage. When the
+    // referenced prompt answer is absent (e.g. partner attrited, or
+    // the gating stage itself was skipped — the transitive-skip case),
+    // the gate skips the exit step end-to-end.
+    await mount(
+      <MockStageRenderer
+        stage={{
+          // No `duration:` — matches how the viewer flattens exit steps
+          // (only gameStages carry a duration). Keeping the field absent
+          // exercises the schema path the host hits for exit phases.
+          name: "second_discussion_followup",
+          conditions: [
+            {
+              reference: "0.prompt.continue_with_partner",
+              comparator: "equals",
+              value: "Yes",
+            },
+          ],
+          elements,
+        }}
+        // No stateValues — `0.prompt.continue_with_partner` is absent,
+        // which is what the runtime sees when the prior gating stage
+        // was itself skipped (transitive skip).
+      />,
+    );
+    const gate = page.locator('[data-testid="stage-condition-gate"]');
+    await expect(gate).toBeVisible();
+    await expect(gate).toHaveAttribute("data-state", "advancing");
+    await expect(
+      page.locator('[data-testid="stageContent"]'),
+    ).not.toBeVisible();
+  });
+
   test("no gate overhead when stage has no conditions", async ({
     mount,
     page,


### PR DESCRIPTION
Closes #315.

## Summary

The skip-at-load mechanism was already covered for game stages and (by inference from \`Stage\`'s phase-agnostic design + the viewer's \`flattenSteps\`) for intro and exit phases. This adds an explicit CT test that mirrors the dialogue-levers \`second_discussion_followup\` pattern from the issue: an exit-sequence stage gated on a prior game-phase prompt, asserting the gate skips end-to-end when the referenced data is absent.

That single test simultaneously demonstrates **scenario 1 (clean skip)** and **scenario 4 (transitive skip)** from #315 in an exit-phase context — when the gating stage was itself skipped, its outputs are never written, which is structurally identical to \"data is absent\".

## What was already verified

| # | Scenario | Already covered |
| - | -------- | --------------- |
| 1 | Clean skip when condition is false | [StageConditionGate.ct.tsx:39](packages/stagebook/src/components/conditions/StageConditionGate.ct.tsx#L39) |
| 2 | Undefined reference → falsy | [StageConditionGate.ct.tsx:71](packages/stagebook/src/components/conditions/StageConditionGate.ct.tsx#L71), [evaluateConditions.test.ts:226](packages/stagebook/src/utils/evaluateConditions.test.ts#L226-L243) |
| 3 | Boolean tree (\`all\`/\`any\`/\`none\`) gating | [evaluateConditions.test.ts:390-691](packages/stagebook/src/utils/evaluateConditions.test.ts#L390-L691) |
| 4 | Transitive skip | Covered by the absent-data path (same primitive) |

## What this PR adds

One CT test (\`exit-phase stage with a false condition skips cleanly\`) that:
- Uses a stage config without \`duration:\` — matches how \`flattenSteps\` shapes exit steps.
- References \`0.prompt.continue_with_partner\` — a game-phase value pattern, mirroring the real dialogue-levers fixture.
- Passes no \`stateValues\` — simulating either partner attrition OR the prior gating stage having been itself skipped.
- Asserts the gate is visible with \`data-state=\"advancing\"\` and \`stageContent\` is not rendered.

## Test plan

- [x] \`npm run lint -w stagebook\` — clean
- [x] \`npm run test:ct -w stagebook -- --grep \"StageConditionGate\"\` — all 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)