### PR TITLE
Fix videocall skeleton layout in wide and narrow modes (#295)

### DIFF
--- a/apps/viewer/src/components/SkeletonPlaceholder.tsx
+++ b/apps/viewer/src/components/SkeletonPlaceholder.tsx
@@ -170,7 +170,12 @@ const discussionContainerStyle: React.CSSProperties = {
   display: "flex",
   flexDirection: "column",
   alignItems: "center",
-  justifyContent: "center",
+  // `flex-start` rather than `center` (#295): the real VideoCall renders
+  // video tiles starting from the top of its container, so anchoring the
+  // skeleton's informational content to the top matches the live
+  // experience better. Centering left the "Video Call" label floating in
+  // the middle of a mostly-empty dashed box at full height.
+  justifyContent: "flex-start",
   gap: "0.75rem",
   padding: "2rem",
   border: "2px dashed #93c5fd",

--- a/packages/stagebook/src/components/Stage.tsx
+++ b/packages/stagebook/src/components/Stage.tsx
@@ -235,6 +235,15 @@ export function Stage({
           width: "100%",
           flexDirection: "row",
           alignItems: "stretch",
+          // `alignContent: flex-start` (#295): in single-line (wide) mode
+          // this has no effect — `alignItems: stretch` still stretches
+          // both columns to the line height. In wrapped (narrow) mode
+          // it stops the default `stretch` behavior, which would
+          // otherwise inflate each wrapped line to fill the parent's
+          // `minHeight: 100vh - 4rem` — the cause of the over-tall
+          // skeleton (≈50vh) and the obscured elements-column content
+          // reported in #295.
+          alignContent: "flex-start",
           gap: "1rem",
           paddingBottom: "1rem",
           paddingLeft: "1.5rem",

--- a/packages/stagebook/src/components/Stage.tsx
+++ b/packages/stagebook/src/components/Stage.tsx
@@ -240,9 +240,9 @@ export function Stage({
           // both columns to the line height. In wrapped (narrow) mode
           // it stops the default `stretch` behavior, which would
           // otherwise inflate each wrapped line to fill the parent's
-          // `minHeight: 100vh - 4rem` — the cause of the over-tall
-          // skeleton (≈50vh) and the obscured elements-column content
-          // reported in #295.
+          // `minHeight: "calc(100vh - 4rem)"` — the cause of the
+          // over-tall skeleton (≈50vh) and the obscured
+          // elements-column content reported in #295.
           alignContent: "flex-start",
           gap: "1rem",
           paddingBottom: "1rem",


### PR DESCRIPTION
Closes #295.

## Two root causes

### 1. Wide mode — centered content in a tall column

The skeleton's container used \`justifyContent: center\`, which floats the \"Video Call\" label and config bullets in the middle of a mostly-empty dashed box when the column is stretched to viewport height. The real \`VideoCall\` in deliberation-empirica renders video tiles from the top, so the centered placeholder reads as visually wrong.

**Fix:** \`apps/viewer/src/components/SkeletonPlaceholder.tsx\` → \`justifyContent: flex-start\` for the discussion variant. The informational content now anchors to the top; the remaining dashed region reads as \"video tiles would render here\".

### 2. Narrow mode — wrapped lines inflated to ~50vh each

The discussion-page wrapper in \`Stage.tsx\` has \`flex-wrap: wrap\`, \`align-items: stretch\`, and \`min-height: calc(100vh - 4rem)\`. When columns wrap to two lines, the default \`align-content: stretch\` inflates each line to fill the parent's minimum height — each line becomes ~50vh. Two side effects:

- The skeleton became ~50vh tall (much larger than necessary).
- The elements column was over-stretched. Combined with \`overflow-y: auto\`, content above the natural-fit scroll region got clipped — the \"obscured content\" the issue reports.

**Fix:** \`packages/stagebook/src/components/Stage.tsx\` → add \`align-content: flex-start\` to the discussion-page wrapper. Wrapped lines now size to their natural content height; the elements column displays at its natural height with no clipping.

In single-line (non-wrap) mode, \`align-content\` has no effect, so existing wide-layout behavior is unchanged beyond the skeleton's internal alignment.

## Test plan

- [x] Visual verification at 2400×1099 (mimics the VS Code preview's full-width single-line mode): skeleton content anchors to top, column fills behind it
- [x] Visual verification at 900×1100 (wrap mode): skeleton is naturally sized at \`minHeight: 16rem\`, elements column displays without clipping
- [x] \`npm run build -w stagebook\` — clean
- [x] \`npm run lint\` — clean
- [x] \`npx vitest run\` — 995 tests pass
- [x] \`npm run test:ct -w stagebook -- --grep \"discussion\"\` — 3 discussion CT tests pass
- [ ] Manual: load \`dialogue-levers/pilot_3\` storytelling_1 in the VS Code preview and confirm wide + narrow layouts no longer have empty centered content / obscured elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)