### PR TITLE
Bump stagebook to 0.10.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13396,7 +13396,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.9.7",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Patch release rolling up the UI fixes and DX work that merged since 0.10.0.

## What's included since 0.10.0

| PR | Issue | Summary |
| -- | ----- | ------- |
| #336 | #335 | Richer typing telemetry on TextArea — added \`intervalQuantiles\`, \`firstKeystrokeDelayMs\`, \`focusedDurationMs\`, plus discrete interaction counters. Additive to \`TypingStats\`; existing fields preserved. |
| #337 | #326 | Slider thumb fixes — round (not oblong), reaches the bar edges, aligns with ticks at non-center values. Custom thumb over invisible native input. |
| #338 | #333 | TextArea char-counter UX at upper bound — at-max is no longer falsely red; overflow keystrokes get a brief red pulse; \"chars\" → \"characters\" everywhere. |
| #339 | #325 | Slider \`- N:\` renders explicit empty label — enables the TIPI / Likert pattern of ticks at every snap point but text labels only at the endpoints. |
| #342 | #315 | Explicit exit-phase coverage for \`StageConditionGate\`. CT test only. |
| #343 | #295 | Videocall skeleton layout — refactored to match deliberation-empirica's media-query approach so the skeleton fills the discussion column in wide mode and stacks cleanly in narrow mode. |
| #340 | — | Add \`timeout-minutes\` to all CI jobs. |
| #341 | — | Tighten CI job timeouts based on observed durations. |

## Breaking changes

None. No changes to the schema or the existing component API surface; \`TypingStats\` additions are additive.

## Test plan

- [x] \`npm run build -w stagebook\` — clean
- [x] \`npm run lint -w stagebook\` — clean
- [x] \`npx vitest run --root packages/stagebook\` — 995 tests pass
- [ ] CI green
- [ ] After merge: publish v0.10.1 GitHub release + tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)