### PR TITLE
Wire cross-file imports into viewer URL loader (#312)

### DIFF
--- a/apps/viewer/src/lib/loader.test.ts
+++ b/apps/viewer/src/lib/loader.test.ts
@@ -30,6 +30,32 @@ function mockFetch(body: string, ok = true) {
   });
 }
 
+/**
+ * Build a fetch mock that routes by URL substring. Each entry is
+ * `[match, body, ok?]`; the first match wins. `ok` defaults to true.
+ * URLs not matched return 404.
+ */
+function routedFetch(
+  routes: ReadonlyArray<readonly [string, string, boolean?]>,
+) {
+  return vi.fn().mockImplementation((url: string) => {
+    for (const [match, body, ok = true] of routes) {
+      if (url.includes(match)) {
+        return Promise.resolve({
+          ok,
+          status: ok ? 200 : 404,
+          text: () => Promise.resolve(body),
+        });
+      }
+    }
+    return Promise.resolve({
+      ok: false,
+      status: 404,
+      text: () => Promise.resolve("Not Found"),
+    });
+  });
+}
+
 describe("loadTreatmentFromUrl", () => {
   it("fetches, parses, and expands a treatment file", async () => {
     const fetch = mockFetch(MINIMAL_YAML);
@@ -68,5 +94,164 @@ describe("loadTreatmentFromUrl", () => {
         fetch,
       ),
     ).rejects.toThrow();
+  });
+
+  // -- #312: cross-file imports via URL --
+
+  it("resolves `imports:` from the same repo and merges templates (#312)", async () => {
+    const rootYaml = `
+imports:
+  - ./modules/consent.stagebook.yaml
+
+introSequences:
+  - name: intro1
+    introSteps:
+      - template: shared_consent_step
+
+treatments:
+  - name: treatment1
+    playerCount: 2
+    gameStages:
+      - name: stage1
+        duration: 10
+        elements:
+          - type: submitButton
+            buttonText: Continue
+`;
+    const moduleYaml = `
+templates:
+  - name: shared_consent_step
+    contentType: introExitStep
+    content:
+      name: consent
+      elements:
+        - type: submitButton
+          buttonText: I agree
+`;
+
+    const fetch = routedFetch([
+      ["treatment.yaml", rootYaml],
+      ["modules/consent.stagebook.yaml", moduleYaml],
+    ]);
+
+    const result = await loadTreatmentFromUrl(
+      "https://github.com/org/repo/blob/main/treatment.yaml",
+      fetch,
+    );
+
+    // Imports should have been fetched from the same repo + branch
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "https://raw.githubusercontent.com/org/repo/main/modules/consent.stagebook.yaml",
+      ),
+    );
+
+    // The template invocation resolved during expansion
+    expect(result.treatmentFile.introSequences?.[0].introSteps[0].name).toBe(
+      "consent",
+    );
+  });
+
+  it("throws a clear error when an imported file 404s (#312)", async () => {
+    const rootYaml = `
+imports:
+  - ./modules/missing.stagebook.yaml
+
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: s
+        duration: 10
+        elements:
+          - type: submitButton
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+`;
+    const fetch = routedFetch([
+      ["treatment.yaml", rootYaml],
+      // modules/missing.stagebook.yaml not routed → 404
+    ]);
+
+    await expect(
+      loadTreatmentFromUrl(
+        "https://github.com/org/repo/blob/main/treatment.yaml",
+        fetch,
+      ),
+    ).rejects.toThrow(
+      /Failed to fetch imported file 'modules\/missing\.stagebook\.yaml'.*HTTP 404.*same repo/s,
+    );
+  });
+
+  it("supports transitive imports (A imports B imports C) (#312)", async () => {
+    const rootYaml = `
+imports:
+  - ./surveys/tipi.stagebook.yaml
+
+introSequences:
+  - name: i
+    introSteps:
+      - template: tipi_step
+
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+    const tipiYaml = `
+imports:
+  - ./shared.stagebook.yaml
+
+templates:
+  - name: tipi_step
+    contentType: introExitStep
+    content:
+      name: tipi
+      elements:
+        - template: shared_button
+`;
+    const sharedYaml = `
+templates:
+  - name: shared_button
+    contentType: element
+    content:
+      type: submitButton
+      buttonText: Continue
+`;
+
+    const fetch = routedFetch([
+      ["treatment.yaml", rootYaml],
+      ["surveys/tipi.stagebook.yaml", tipiYaml],
+      ["surveys/shared.stagebook.yaml", sharedYaml],
+    ]);
+
+    const result = await loadTreatmentFromUrl(
+      "https://github.com/org/repo/blob/main/treatment.yaml",
+      fetch,
+    );
+
+    // Transitive import (shared.stagebook.yaml) was fetched relative to
+    // its parent file (surveys/tipi.stagebook.yaml), not relative to the
+    // entry-point root. So the URL is `surveys/shared.stagebook.yaml`.
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "https://raw.githubusercontent.com/org/repo/main/surveys/shared.stagebook.yaml",
+      ),
+    );
+
+    // The nested template was resolved through both layers
+    const introStep = result.treatmentFile.introSequences?.[0].introSteps[0];
+    expect(introStep?.elements?.[0]).toMatchObject({
+      type: "submitButton",
+      buttonText: "Continue",
+    });
   });
 });

--- a/apps/viewer/src/lib/loader.ts
+++ b/apps/viewer/src/lib/loader.ts
@@ -1,6 +1,8 @@
 import { parseGitHubUrl } from "./github";
-import { parseTreatmentYaml, expandTreatmentFile } from "./treatment";
-import type { TreatmentFileType } from "stagebook";
+import { expandTreatmentFile } from "./expandTreatmentFile";
+import { loadAndMergeTreatmentFile } from "./loadAndMergeTreatmentFile";
+import { TreatmentValidationError } from "./treatment";
+import { safeParseTreatmentFile, type TreatmentFileType } from "stagebook";
 
 export interface LoadResult {
   treatmentFile: TreatmentFileType;
@@ -13,7 +15,8 @@ type FetchFn = (
 ) => Promise<{ ok: boolean; status: number; text: () => Promise<string> }>;
 
 /**
- * Load a treatment file from a GitHub URL.
+ * Load a treatment file from a GitHub URL, resolving any `imports:`
+ * against the same repo and branch as the entry-point file (#312).
  * Accepts an injectable fetch function for testing.
  */
 export async function loadTreatmentFromUrl(
@@ -31,9 +34,43 @@ export async function loadTreatmentFromUrl(
     );
   }
 
-  const yaml = await response.text();
-  const parsed = parseTreatmentYaml(yaml);
-  const { result, unresolvedFields } = expandTreatmentFile(parsed);
+  const rootYaml = await response.text();
+
+  // Fetch each `imports:` from the same repo + branch as the entry-point
+  // file. `canonicalPath` is POSIX-normalized (e.g. `modules/foo.stagebook.yaml`),
+  // and `rawBaseUrl` already has a trailing slash, so concatenation produces
+  // a valid raw.githubusercontent.com URL.
+  const loadImport = async (canonicalPath: string): Promise<string> => {
+    const importUrl = `${rawBaseUrl}${canonicalPath}?t=${Date.now()}`;
+    const importResponse = await fetchFn(importUrl);
+    if (!importResponse.ok) {
+      throw new Error(
+        `Failed to fetch imported file '${canonicalPath}' (HTTP ${importResponse.status}) — ` +
+          `make sure the file exists in the same repo as the entry-point file. ` +
+          `Tried: ${rawBaseUrl}${canonicalPath}`,
+      );
+    }
+    return importResponse.text();
+  };
+
+  // `loadAndMergeTreatmentFile` parses the root YAML, recursively fetches
+  // every imported file via `loadImport`, and returns the merged object
+  // with `imports:` stripped and `templates:` replaced by the merged set.
+  // It does not validate against `treatmentFileSchema` — we do that here
+  // so validation errors come through the same `TreatmentValidationError`
+  // path as the local-YAML flow.
+  const merged = await loadAndMergeTreatmentFile(rootYaml, loadImport);
+  const parsed = safeParseTreatmentFile(merged);
+  if (!parsed.success) {
+    throw new TreatmentValidationError(
+      parsed.error.issues.map((issue) => ({
+        path: issue.path.join(".") || "(root)",
+        message: issue.message,
+      })),
+    );
+  }
+
+  const { result, unresolvedFields } = expandTreatmentFile(parsed.data);
 
   return { treatmentFile: result, unresolvedFields, rawBaseUrl };
 }


### PR DESCRIPTION
Closes #312.

## What was wrong

The standalone viewer's URL flow (\`loadTreatmentFromUrl\`) parsed the root file once and skipped the \`imports:\` resolution entirely. A treatment file that uses \`imports:\` would:

- Pass the GitHub URL → fetch the entry-point file
- Pass the schema (the \`imports:\` field is permitted)
- Fail at the first template invocation with a \"template not found\" error

The fix is small because the async \`loadAndMergeTreatmentFile\` helper already existed from #314 — this PR just wires it into the URL flow.

## Changes

[apps/viewer/src/lib/loader.ts](apps/viewer/src/lib/loader.ts):

- Pass the fetched root YAML through \`loadAndMergeTreatmentFile\` with a \`loadImport\` callback that fetches each imported file from the same repo + branch as the entry-point (\`rawBaseUrl + canonicalPath\`).
- Imports are cache-busted the same way the entry-point file is (\`?t=Date.now()\`).
- Validate the merged object via \`safeParseTreatmentFile\` and rethrow validation failures through \`TreatmentValidationError\` so they surface identically to the local-YAML flow.
- 404s on imported files produce a clear \`Failed to fetch imported file '...' (HTTP 404) — make sure the file exists in the same repo as the entry-point file. Tried: ...\` rather than a confusing downstream template-resolution error.

## Test plan

Three new tests in [loader.test.ts](apps/viewer/src/lib/loader.test.ts) covering the URL-flow import paths:

- **Sibling import resolves and the template renders** — verifies the imported file is fetched from \`rawBaseUrl + canonicalPath\` and that the template invocation succeeds during expansion.
- **404 on imported file** — verifies the clear error message above.
- **Transitive imports (A imports B imports C)** — verifies B's import resolves relative to B's directory, not the entry-point's. Exercises \`resolveImportPath\` semantics through the loop.

The existing happy-path / fetch-failure / invalid-YAML tests are unchanged — the new flow goes through \`loadAndMergeTreatmentFile.parse\` which throws on bad YAML the same way the previous path did.

- [x] \`npx vitest run --root apps/viewer\` — 90 tests pass (6 in loader.test.ts, including 3 new)
- [x] \`npm run lint\` — clean
- [x] \`npm run build -w stagebook\` — clean

## Out of scope

Same as the issue: cross-repo imports (would need different \`rawBaseUrl\` per import) and smart caching of imported files (browser HTTP cache is sufficient). #313 (VS Code expand-templates virtual document) is a sibling issue and not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)