### PR TITLE
StateInspector: honor the reference's named position (#349)

### DIFF
--- a/apps/viewer/src/components/StateInspector.test.ts
+++ b/apps/viewer/src/components/StateInspector.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { resolveReferencePosition } from "./StateInspector";
+
+/**
+ * Focused unit test for the position-resolution helper that closes
+ * #349. The bug was: the inspector used the *current participant's*
+ * position for every store lookup/edit, so references that named a
+ * different position (`0.prompt.X` while viewing as participant 1)
+ * read and wrote the wrong position's bucket.
+ *
+ * The helper translates a reference's position prefix to the
+ * `PositionKey` (or "all"-aggregator marker) the store should use.
+ */
+describe("resolveReferencePosition (#349)", () => {
+  it("maps `self.X` to the current participant's position", () => {
+    expect(resolveReferencePosition("self.prompt.q1", 0)).toEqual({
+      kind: "single",
+      position: 0,
+    });
+    expect(resolveReferencePosition("self.prompt.q1", 1)).toEqual({
+      kind: "single",
+      position: 1,
+    });
+  });
+
+  it("maps `shared.X` to the shared bucket regardless of current position", () => {
+    expect(resolveReferencePosition("shared.survey.tipi", 0)).toEqual({
+      kind: "single",
+      position: "shared",
+    });
+    expect(resolveReferencePosition("shared.survey.tipi", 1)).toEqual({
+      kind: "single",
+      position: "shared",
+    });
+  });
+
+  it("maps numeric position prefixes to that exact position (#349 core)", () => {
+    // The headline bug: `0.prompt.X` viewed while current participant
+    // is position 1 must still read position 0's bucket.
+    expect(
+      resolveReferencePosition("0.prompt.continue_with_partner", 1),
+    ).toEqual({ kind: "single", position: 0 });
+    expect(
+      resolveReferencePosition("1.prompt.continue_with_partner", 0),
+    ).toEqual({ kind: "single", position: 1 });
+    expect(resolveReferencePosition("2.prompt.foo", 0)).toEqual({
+      kind: "single",
+      position: 2,
+    });
+  });
+
+  it("maps `all.X` to the aggregator marker (read across all positions)", () => {
+    expect(resolveReferencePosition("all.prompt.q1", 0)).toEqual({
+      kind: "all",
+    });
+    expect(resolveReferencePosition("all.prompt.q1", 5)).toEqual({
+      kind: "all",
+    });
+  });
+
+  it("returns null for an invalid reference (caller renders disabled placeholder)", () => {
+    expect(resolveReferencePosition("not-a-reference", 0)).toBeNull();
+    expect(resolveReferencePosition("urlParams.foo", 0)).toBeNull();
+    expect(resolveReferencePosition("", 0)).toBeNull();
+  });
+});

--- a/apps/viewer/src/components/StateInspector.tsx
+++ b/apps/viewer/src/components/StateInspector.tsx
@@ -1,9 +1,48 @@
 import { useState } from "react";
-import { getReferenceKeyAndPath, getNestedValueByPath } from "stagebook";
+import {
+  getReferenceKeyAndPath,
+  getNestedValueByPath,
+  parseDottedReference,
+} from "stagebook";
 import { Markdown } from "stagebook/components";
-import { ViewerStateStore } from "../lib/store";
+import { ViewerStateStore, type PositionKey } from "../lib/store";
 import { extractStageReferences } from "../lib/references";
 import type { ViewerStep } from "../lib/steps";
+
+/**
+ * Resolve a reference string's position prefix to a store-level
+ * `PositionKey` (or `undefined` for "all"-style aggregator reads that
+ * span every player position).
+ *
+ * Pre-#298 references had no position prefix and the inspector
+ * implicitly used the current participant's position for every
+ * lookup/edit. After #298 the position is part of the reference
+ * itself (`0.prompt.X`, `shared.survey.X`, `self.entryUrl.params.X`),
+ * so the inspector must honor the reference's *named* position — not
+ * the current participant — when reading or writing that reference's
+ * stored value. Without this, `0.prompt.X` viewed/edited while the
+ * current participant is position 1 would (a) display position 1's
+ * value instead of position 0's, and (b) write inspector edits into
+ * position 1's bucket instead of position 0's. (#349.)
+ *
+ * Returns `null` for invalid references (caller renders a disabled
+ * "(invalid reference)" placeholder).
+ */
+export function resolveReferencePosition(
+  reference: string,
+  currentPosition: number,
+): { kind: "single"; position: PositionKey } | { kind: "all" } | null {
+  const parsed = parseDottedReference(reference);
+  if (!parsed.ok) return null;
+  const refPos = parsed.value.position;
+  if (refPos === "self") return { kind: "single", position: currentPosition };
+  if (refPos === "shared") return { kind: "single", position: "shared" };
+  if (refPos === "all") return { kind: "all" };
+  if (typeof refPos === "number") return { kind: "single", position: refPos };
+  // Fallback for any future position-token shape we haven't taught
+  // the inspector about yet.
+  return { kind: "single", position: currentPosition };
+}
 
 // Mirrors the read-side guard in stagebook/utils/reference.ts. The viewer
 // writes through these paths, so traversing into prototype slots would let
@@ -264,7 +303,33 @@ function ReferenceEditor({
     );
   }
 
-  const rawValues = store.lookup(referenceKey, position);
+  // Honor the reference's named position when reading + writing (#349).
+  // `self` → current participant; `shared` → "shared"; numeric → that
+  // slot index; `all` → read across every position (display only — no
+  // single-cell edit target).
+  const refPos = resolveReferencePosition(reference, position);
+  if (refPos === null) {
+    return (
+      <div style={refGroupStyle}>
+        <label style={refLabelStyle}>{reference}</label>
+        <input
+          type="text"
+          value=""
+          disabled
+          placeholder="(invalid reference)"
+          style={{ ...refInputStyle, opacity: 0.5 }}
+        />
+      </div>
+    );
+  }
+
+  // For "all" refs, lookup with no position arg — store.lookup returns
+  // every player position's value for the key. For single-position refs,
+  // lookup with the resolved key.
+  const rawValues =
+    refPos.kind === "all"
+      ? store.lookup(referenceKey)
+      : store.lookup(referenceKey, refPos.position);
   const values = rawValues
     .map((v) => getNestedValueByPath(v, path))
     .filter((v) => v !== undefined);
@@ -276,21 +341,32 @@ function ReferenceEditor({
   // would require JSON parsing per keystroke (#169 explicitly punted on
   // that); for compound writes use "Show all state" or the ✕ clear.
   const isCompound = firstValue !== null && typeof firstValue === "object";
+  // For "all" references showing N values, render as a JSON array (read
+  // only) so the inspector surfaces every position's contribution.
+  const isAggregateRead = refPos.kind === "all" && values.length > 1;
   const currentValue = !isSet
     ? ""
-    : isCompound
-      ? JSON.stringify(firstValue, null, 2)
-      : String(firstValue);
+    : isAggregateRead
+      ? JSON.stringify(values, null, 2)
+      : isCompound
+        ? JSON.stringify(firstValue, null, 2)
+        : String(firstValue);
+
+  // Edits are scoped to a single position. `all`-style references don't
+  // have an unambiguous write target, so they're read-only here.
+  const editPosition: PositionKey | null =
+    refPos.kind === "single" ? refPos.position : null;
 
   const handleChange = (newValue: string) => {
+    if (editPosition === null) return;
     if (path.length === 0) {
       // No nested path — store the value directly
-      store.set(position, referenceKey, newValue, stageIndex);
+      store.set(editPosition, referenceKey, newValue, stageIndex);
     } else {
       // Nested path (e.g., prompt → path=["value"]) — preserve existing
       // object structure and write the value at the correct path. Use
       // Object.hasOwn to avoid traversing inherited properties.
-      const existing = store.get(position, referenceKey)?.value;
+      const existing = store.get(editPosition, referenceKey)?.value;
       const obj =
         existing && typeof existing === "object" && !Array.isArray(existing)
           ? { ...(existing as Record<string, unknown>) }
@@ -305,15 +381,16 @@ function ReferenceEditor({
         cursor = cursor[seg] as Record<string, unknown>;
       }
       cursor[path[path.length - 1]] = newValue;
-      store.set(position, referenceKey, obj, stageIndex);
+      store.set(editPosition, referenceKey, obj, stageIndex);
     }
   };
 
   const handleClear = () => {
+    if (editPosition === null) return;
     if (path.length === 0) {
-      store.delete(position, referenceKey);
+      store.delete(editPosition, referenceKey);
     } else {
-      const existing = store.get(position, referenceKey)?.value;
+      const existing = store.get(editPosition, referenceKey)?.value;
       if (
         !existing ||
         typeof existing !== "object" ||
@@ -321,13 +398,13 @@ function ReferenceEditor({
       ) {
         // Nothing to prune at this path — drop the whole entry so `exists`
         // fails.
-        store.delete(position, referenceKey);
+        store.delete(editPosition, referenceKey);
       } else {
         const root = deletePath(existing as Record<string, unknown>, path);
         if (root === undefined) {
-          store.delete(position, referenceKey);
+          store.delete(editPosition, referenceKey);
         } else {
-          store.set(position, referenceKey, root, stageIndex);
+          store.set(editPosition, referenceKey, root, stageIndex);
         }
       }
     }
@@ -337,16 +414,25 @@ function ReferenceEditor({
     onAfterClear?.();
   };
 
+  // `all`-style references span every player position — there's no
+  // single cell to edit or clear, so the inspector renders them
+  // read-only with an explanatory title.
+  const isReadOnly = editPosition === null || isAggregateRead;
+  const readOnlyTitle =
+    editPosition === null
+      ? "Aggregate reference (`all`) — read-only across positions"
+      : "Compound value — edit via 'Show all state' or clear with ×";
+
   return (
     <div style={refGroupStyle}>
       <label style={refLabelStyle}>{reference}</label>
       <div style={refInputRowStyle}>
-        {isCompound ? (
+        {isCompound || isReadOnly ? (
           <textarea
             value={currentValue}
             readOnly
-            rows={Math.min(currentValue.split("\n").length, 10)}
-            title="Compound value — edit via 'Show all state' or clear with ×"
+            rows={Math.min(Math.max(currentValue.split("\n").length, 1), 10)}
+            title={readOnlyTitle}
             style={refTextareaStyle}
           />
         ) : (
@@ -361,14 +447,20 @@ function ReferenceEditor({
         <button
           type="button"
           onClick={handleClear}
-          disabled={!isSet}
+          disabled={!isSet || editPosition === null}
           aria-label={`Clear ${reference}`}
           title={
-            isSet
-              ? "Remove this value entirely (so exists checks fail)"
-              : "Not set"
+            editPosition === null
+              ? "Aggregate reference — clear individual positions in 'Show all state'"
+              : isSet
+                ? "Remove this value entirely (so exists checks fail)"
+                : "Not set"
           }
-          style={isSet ? refClearButtonStyle : refClearButtonDisabledStyle}
+          style={
+            isSet && editPosition !== null
+              ? refClearButtonStyle
+              : refClearButtonDisabledStyle
+          }
         >
           ×
         </button>


### PR DESCRIPTION
Closes #349.

## What was wrong

The viewer/preview state inspector used the *current participant's* position for every store read and write, regardless of what position the reference itself named. Pre-#298 this was correct (references had no position prefix; \"self\" was implicit). After #298 the position is part of the reference (\`0.prompt.X\`, \`shared.survey.X\`, \`self.entryUrl.params.X\`), and this part of the inspector was never updated.

User-visible symptoms in the VSCode preview / standalone viewer:

1. A reference like \`0.prompt.continue_with_partner\` viewed while the current participant is position 1 displayed *position 1's* value, not position 0's.
2. Switching positions made values appear to \"leak\" — what the user typed for position 0 (saved correctly to position 0's bucket by the form) was hidden behind the inspector's wrong-position read, and inspector edits to a numeric-position reference silently went to the *current participant's* bucket instead of the named one.
3. The user's followup observation: stages with cross-position references showed the current player's value in the left-hand inspector even when the reference clearly named another player's position. Same bug.

## Fix

Extract a small \`resolveReferencePosition(reference, currentPosition)\` helper that parses the reference's position prefix and maps it to a \`PositionKey\`:

| Prefix | Resolved |
| ------ | -------- |
| \`self\` | current participant's position |
| \`shared\` | \`\"shared\"\` bucket |
| \`0\` / \`1\` / … | that exact slot index |
| \`all\` | aggregator marker (read across every position) |
| invalid | null → render disabled \"(invalid reference)\" |

Use the resolved position for every \`store.lookup\` / \`store.get\` / \`store.set\` / \`store.delete\` call in \`ReferenceEditor\`. For \`all\`-style references — which span multiple positions and have no unambiguous write target — render the input read-only with an explanatory title and disable the clear button (point users at \"Show all state\" for per-position edits).

The component-level edits are mechanical substitutions (replace \`position\` with \`editPosition\` derived from the helper). Storage layer and reference parser are unchanged.

## Tests

Five-test focused suite around \`resolveReferencePosition\` covering every prefix shape plus the invalid-reference fallback. The component-level changes are mechanical, so the helper test plus the existing 87-test viewer suite cover the behavior.

- \`npx vitest run --root apps/viewer\` — 92 tests pass (5 new)
- \`npm run lint\` — clean
- \`npm run build -w stagebook\` — clean

## Out of scope

The performance \"unresponsive extension host\" log mentioned at the bottom of #349. The fix removes the infinite-feedback path that the OP suspected (cross-position store reads after every save), so it'll likely also resolve the perf issue, but that's a follow-up confirmation rather than something I want to claim here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)