### PR TITLE
StateInspector: walk boolean-tree conditions when extracting references

### DIFF
--- a/apps/viewer/src/lib/references.test.ts
+++ b/apps/viewer/src/lib/references.test.ts
@@ -67,4 +67,132 @@ describe("extractStageReferences", () => {
     const refs = extractStageReferences(elements);
     expect(refs).toEqual([]);
   });
+
+  // -- Boolean-tree conditions (post-#235) --
+
+  it("extracts references from `all:` operator nodes", () => {
+    const elements = [
+      {
+        type: "prompt" as const,
+        name: "p",
+        file: "p.prompt.md",
+        conditions: [
+          {
+            all: [
+              {
+                reference: "0.prompt.continue_with_partner",
+                comparator: "equals",
+                value: "Yes",
+              },
+              {
+                reference: "1.prompt.continue_with_partner",
+                comparator: "equals",
+                value: "Yes",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const refs = extractStageReferences(elements);
+    expect(refs).toEqual([
+      "0.prompt.continue_with_partner",
+      "1.prompt.continue_with_partner",
+    ]);
+  });
+
+  it("extracts references from `any:` operator nodes", () => {
+    const elements = [
+      {
+        type: "prompt" as const,
+        name: "p",
+        file: "p.prompt.md",
+        conditions: [
+          {
+            any: [
+              {
+                reference: "0.prompt.x",
+                comparator: "doesNotEqual",
+                value: "Yes",
+              },
+              { reference: "1.prompt.x", comparator: "doesNotExist" },
+            ],
+          },
+        ],
+      },
+    ];
+    const refs = extractStageReferences(elements);
+    expect(refs).toEqual(["0.prompt.x", "1.prompt.x"]);
+  });
+
+  it("extracts references from `none:` operator nodes", () => {
+    const elements = [
+      {
+        type: "prompt" as const,
+        name: "p",
+        file: "p.prompt.md",
+        conditions: [
+          {
+            none: [{ reference: "shared.survey.tipi", comparator: "exists" }],
+          },
+        ],
+      },
+    ];
+    const refs = extractStageReferences(elements);
+    expect(refs).toEqual(["shared.survey.tipi"]);
+  });
+
+  it("extracts references from nested operator trees", () => {
+    const elements = [
+      {
+        type: "prompt" as const,
+        name: "p",
+        file: "p.prompt.md",
+        conditions: [
+          {
+            all: [
+              { reference: "0.prompt.a", comparator: "equals", value: "y" },
+              {
+                any: [
+                  { reference: "1.prompt.b", comparator: "exists" },
+                  {
+                    none: [
+                      { reference: "shared.prompt.c", comparator: "exists" },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const refs = extractStageReferences(elements);
+    expect(refs).toEqual(["0.prompt.a", "1.prompt.b", "shared.prompt.c"]);
+  });
+
+  it("deduplicates across operator children and sibling leaves", () => {
+    const elements = [
+      {
+        type: "prompt" as const,
+        name: "p",
+        file: "p.prompt.md",
+        conditions: [
+          { reference: "self.prompt.q1", comparator: "equals", value: "y" },
+          {
+            all: [
+              {
+                reference: "self.prompt.q1",
+                comparator: "doesNotEqual",
+                value: "n",
+              },
+              { reference: "0.prompt.q2", comparator: "exists" },
+            ],
+          },
+        ],
+      },
+    ];
+    const refs = extractStageReferences(elements);
+    expect(refs).toEqual(["self.prompt.q1", "0.prompt.q2"]);
+  });
 });

--- a/apps/viewer/src/lib/references.ts
+++ b/apps/viewer/src/lib/references.ts
@@ -1,6 +1,13 @@
 /**
  * Scan a stage's elements and extract DSL references that affect rendering.
  * These are the values the state inspector should display for the current stage.
+ *
+ * Walks both leaf-shaped conditions (`{reference, comparator, value?}`) AND
+ * the boolean-tree operators introduced by #235 (`{all:[...]}`,
+ * `{any:[...]}`, `{none:[...]}`). Without the recursion, a stage whose
+ * conditions are wrapped in `all:`/`any:`/`none:` produces an empty
+ * reference list and the inspector misleadingly says "No external
+ * references on this stage."
  */
 export function extractStageReferences(
   elements: Record<string, unknown>[],
@@ -8,17 +15,10 @@ export function extractStageReferences(
   const refs = new Set<string>();
 
   for (const element of elements) {
-    // Condition references
+    // Condition references (leaf or boolean-tree)
     if (Array.isArray(element.conditions)) {
       for (const condition of element.conditions) {
-        if (
-          condition &&
-          typeof condition === "object" &&
-          "reference" in condition &&
-          typeof condition.reference === "string"
-        ) {
-          refs.add(condition.reference);
-        }
+        collectFromConditionNode(condition, refs);
       }
     }
 
@@ -29,4 +29,35 @@ export function extractStageReferences(
   }
 
   return [...refs];
+}
+
+/**
+ * Recursively walk a condition node, adding any string references found at
+ * leaf nodes. Operator nodes (`all`/`any`/`none`) hold an array of child
+ * nodes that may themselves be operators or leaves.
+ */
+function collectFromConditionNode(node: unknown, refs: Set<string>): void {
+  if (!node || typeof node !== "object") return;
+
+  // Leaf: `{ reference, comparator, value? }`
+  if (
+    "reference" in node &&
+    typeof (node as { reference: unknown }).reference === "string"
+  ) {
+    refs.add((node as { reference: string }).reference);
+    return;
+  }
+
+  // Operator: `{ all: [...] }`, `{ any: [...] }`, `{ none: [...] }`.
+  // Schema enforces exactly one of these keys per node, but we walk
+  // every operator we recognize so the inspector handles malformed
+  // multi-key nodes gracefully.
+  for (const op of ["all", "any", "none"] as const) {
+    const children = (node as Record<string, unknown>)[op];
+    if (Array.isArray(children)) {
+      for (const child of children) {
+        collectFromConditionNode(child, refs);
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Bug

\`extractStageReferences\` only handled the leaf-shaped condition form (\`{reference, comparator, value?}\`). After #235 introduced boolean-tree operators (\`{all: [...]}\`, \`{any: [...]}\`, \`{none: [...]}\`), any stage whose conditions wrap their leaves in an operator produced an empty reference list — and the inspector misleadingly said \"No external references on this stage.\"

Concrete repro from a real treatment:

\`\`\`yaml
- name: pre_second_discussion
  elements:
    - type: prompt
      file: game/pre_second_discussion.prompt.md
      conditions:
        - all:
            - reference: 0.prompt.continue_with_partner
              comparator: equals
              value: \"Yes\"
            - reference: 1.prompt.continue_with_partner
              comparator: equals
              value: \"Yes\"
\`\`\`

Walker saw \`{all: [...]}\`, no \`.reference\` on it, skipped entirely. Two genuine cross-position references invisible to the inspector — exactly the references the user wanted to inspect to verify they were resolving against the right positions.

## Fix

New recursive \`collectFromConditionNode\` that handles both shapes:
- **Leaf**: has \`.reference\` (string) → add to set, stop.
- **Operator**: has \`all\` / \`any\` / \`none\` keyed array → recurse into each child.

Walks every operator key it recognizes so malformed multi-key nodes degrade gracefully rather than dropping the whole subtree.

## Tests

5 new tests in [\`references.test.ts\`](apps/viewer/src/lib/references.test.ts) covering:
- \`all:\` operator nodes (the headline repro)
- \`any:\` operator nodes
- \`none:\` operator nodes
- nested trees (\`all\` containing \`any\` containing \`none\`)
- dedup across operator children + sibling leaves

The 4 existing tests for the leaf-only path are untouched.

92 viewer tests pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)