### PR TITLE
Replace flex-wrap with media-query switch in Stage discussion layout (#295 followup)

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/stagebook/src/components/Stage.tsx
+++ b/packages/stagebook/src/components/Stage.tsx
@@ -227,65 +227,20 @@ export function Stage({
       | undefined;
 
     const discussionPage = (
-      <div
-        className="stagebook-discussion-page"
-        style={{
-          display: "flex",
-          flexWrap: "wrap",
-          height: "100%",
-          width: "100%",
-          flexDirection: "row",
-          alignItems: "stretch",
-          // `alignContent: flex-start` (#295): in single-line (wide) mode
-          // this has no effect — `alignItems: stretch` still stretches
-          // both columns to the line height. In wrapped (narrow) mode
-          // it stops the default `stretch` behavior, which would
-          // otherwise inflate each wrapped line to fill the parent's
-          // `minHeight: "calc(100vh - 4rem)"` — the cause of the
-          // over-tall skeleton (≈50vh) and the obscured
-          // elements-column content reported in #295.
-          alignContent: "flex-start",
-          gap: "1rem",
-          paddingBottom: "1rem",
-          paddingLeft: "1.5rem",
-          paddingRight: "1.5rem",
-          minHeight: "calc(100vh - 4rem)",
-          // Container query context — the per-column min-height below
-          // depends on the *parent's* inline size, not the viewport's,
-          // so embedded preview panes (VS Code, narrow viewer chrome,
-          // etc.) get the right wrap detection regardless of what
-          // `100vh` resolves to.
-          containerType: "inline-size",
-        }}
-      >
+      <div className="stagebook-discussion-page">
         {/* Discussion column */}
-        <div
-          data-testid="discussion"
-          className="stagebook-discussion-column"
-          style={{
-            position: "relative",
-            flex: 1,
-            minWidth: "24rem",
-            minHeight: "16rem",
-          }}
-        >
+        <div data-testid="discussion" className="stagebook-discussion-column">
           {renderDiscussion(stage.discussion)}
         </div>
 
-        {/* Elements column — scrollable independently in `internal` mode.
-            flex: "1 1 20rem" lets it share space in row mode (40vw preferred)
-            but stretch to full width when the container wraps to column. */}
+        {/* Elements / content column. In host-scroll mode the host owns
+            the scroll container; in internal-scroll mode this column
+            scrolls itself, governed by the `data-internal-scroll` attr. */}
         <div
           ref={isHostScroll ? null : discussionContentRef}
           data-testid="stageContent"
-          style={{
-            flex: "1 1 20rem",
-            maxWidth: "48rem",
-            alignSelf: "stretch",
-            ...(isHostScroll
-              ? {}
-              : { overflowY: "auto", scrollBehavior: "smooth" }),
-          }}
+          className="stagebook-discussion-content"
+          data-internal-scroll={isHostScroll ? undefined : "true"}
         >
           {elementsColumn}
           {!isHostScroll && (
@@ -293,17 +248,57 @@ export function Stage({
           )}
         </div>
         <style>{`
-          /* When the discussion page is wide enough that the two columns
-             sit side by side (no wrap), force the discussion column to be
-             at least viewport-height so the skeleton/VideoCall fills the
-             column visually (#295). Threshold matches the wrap point —
-             24rem + 1rem gap + 20rem = 45rem of inline size. In wrap
-             mode this query doesn't apply, so the column collapses to
-             its content + 16rem minimum, which is what we want for
-             stacked layouts. */
-          @container (min-width: 45rem) {
-            .stagebook-discussion-column {
+          /* Mirrors deliberation-empirica's Stage layout (#295). On
+             narrow viewports the two columns stack; at the md breakpoint
+             they switch to a side-by-side row with the parent forced to
+             viewport-min-height so \`align-items: stretch\` reliably
+             extends both columns to fill the visible area. We avoid
+             \`flex-wrap\` here because the wrap path made the layout
+             depend on a brittle interaction between line-height,
+             align-content, and the discussion column's intrinsic
+             height — the empirica reference (which works) uses a
+             clean media-query switch. */
+          .stagebook-discussion-page {
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+            gap: 1rem;
+            padding-bottom: 1rem;
+          }
+          .stagebook-discussion-column {
+            position: relative;
+            width: 100%;
+            min-height: 16rem;
+          }
+          .stagebook-discussion-content {
+            width: 100%;
+            padding-left: 1rem;
+            padding-right: 1rem;
+          }
+          @media (min-width: 48rem) {
+            .stagebook-discussion-page {
+              flex-direction: row;
+              align-items: stretch;
+              padding-left: 1.5rem;
+              padding-right: 1.5rem;
               min-height: calc(100vh - 4rem);
+            }
+            .stagebook-discussion-column {
+              flex: 1;
+              min-width: 24rem;
+            }
+            .stagebook-discussion-content {
+              flex: 0 1 auto;
+              width: 40vw;
+              min-width: 20rem;
+              max-width: 48rem;
+              align-self: stretch;
+              padding-left: 0;
+              padding-right: 0;
+            }
+            .stagebook-discussion-content[data-internal-scroll="true"] {
+              overflow-y: auto;
+              scroll-behavior: smooth;
             }
           }
         `}</style>

--- a/packages/stagebook/src/components/Stage.tsx
+++ b/packages/stagebook/src/components/Stage.tsx
@@ -228,6 +228,7 @@ export function Stage({
 
     const discussionPage = (
       <div
+        className="stagebook-discussion-page"
         style={{
           display: "flex",
           flexWrap: "wrap",
@@ -249,11 +250,18 @@ export function Stage({
           paddingLeft: "1.5rem",
           paddingRight: "1.5rem",
           minHeight: "calc(100vh - 4rem)",
+          // Container query context — the per-column min-height below
+          // depends on the *parent's* inline size, not the viewport's,
+          // so embedded preview panes (VS Code, narrow viewer chrome,
+          // etc.) get the right wrap detection regardless of what
+          // `100vh` resolves to.
+          containerType: "inline-size",
         }}
       >
         {/* Discussion column */}
         <div
           data-testid="discussion"
+          className="stagebook-discussion-column"
           style={{
             position: "relative",
             flex: 1,
@@ -284,6 +292,21 @@ export function Stage({
             <ScrollIndicator visible={showDiscussionScrollIndicator} />
           )}
         </div>
+        <style>{`
+          /* When the discussion page is wide enough that the two columns
+             sit side by side (no wrap), force the discussion column to be
+             at least viewport-height so the skeleton/VideoCall fills the
+             column visually (#295). Threshold matches the wrap point —
+             24rem + 1rem gap + 20rem = 45rem of inline size. In wrap
+             mode this query doesn't apply, so the column collapses to
+             its content + 16rem minimum, which is what we want for
+             stacked layouts. */
+          @container (min-width: 45rem) {
+            .stagebook-discussion-column {
+              min-height: calc(100vh - 4rem);
+            }
+          }
+        `}</style>
       </div>
     );
 


### PR DESCRIPTION
## Summary

Follow-up to #343, which fixed the narrow-mode skeleton overflow but kept the `flex-wrap: wrap` + `align-content: flex-start` + `container-query` approach for wide mode. That approach turns out to be unreliable in real-world layout chains: in deliberation-lab the discussion column collapses to its `min-height: 16rem` intrinsic size instead of stretching to viewport height, producing tiny ~191×107px video tiles in the wide layout.

Root cause: `flex-wrap: wrap` in a single-line container makes the cross-axis sizing depend on a brittle interaction between `align-content`, the discussion column's intrinsic height, and the parent's min-height. The empirica reference (which works in production) avoids this entirely by using a clean `@media (min-width: 48rem)` switch between `flex-direction: column` (stacked) and `flex-direction: row` (side-by-side with `align-items: stretch` + `min-height: calc(100vh - 4rem)`).

## What changes

- Drop `flex-wrap: wrap`, `align-content: flex-start`, `container-type: inline-size` from the discussion-page wrapper
- Replace with a `@media (min-width: 48rem)` switch that mirrors the original deliberation-empirica Stage:
  - Below 48rem: `flex-direction: column`, columns stack, no parent min-height
  - 48rem+: `flex-direction: row`, `align-items: stretch`, `min-height: calc(100vh - 4rem)`, elements column `width: 40vw; min-width: 20rem; max-width: 48rem`
- Inline conditional bits (`isHostScroll` overflow toggle) move onto a `data-internal-scroll` attribute selector

## Why these two commits (cherry-picked from `fix/295-videocall-skeleton-layout`)

These were originally drafted on the same branch as #343 but not included in that PR. They were sitting unmerged on `fix/295-videocall-skeleton-layout`. Cherry-picked onto current main here for a clean diff.

## Test plan

- [x] 995/995 unit tests pass
- [x] Lint clean
- [ ] Visually verify in stagebook viewer at 2400/1343/700px viewports (already done in the original branch per `e14066a` commit message)
- [ ] Verify the deliberation-lab regression resolves after stagebook bump

## Refs

- #295 — original issue
- #343 — merged half of the fix (narrow-mode skeleton overflow)
- deliberation-lab discussion layout regression — the wide-mode half this PR fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)