### PR TITLE
Discussion-page: symmetric padding-top + bound height (0.10.3)

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/stagebook/src/components/Stage.tsx
+++ b/packages/stagebook/src/components/Stage.tsx
@@ -279,8 +279,20 @@ export function Stage({
             .stagebook-discussion-page {
               flex-direction: row;
               align-items: stretch;
+              padding-top: 1rem;
               padding-left: 1.5rem;
               padding-right: 1.5rem;
+              /* \`height: 100%\` (alongside the existing min-height floor)
+                 makes the wrapper fill a definite-height host container
+                 instead of growing past it. Without this, an elements
+                 column whose content exceeds viewport height pushes the
+                 wrapper taller rather than triggering the column's
+                 own \`overflow-y: auto\` — defeating the "fixed video
+                 column, scrolling right column" layout. In hosts whose
+                 parent is content-sized (no definite height), height:
+                 100% resolves to auto and the min-height floor still
+                 applies, so this change is backward-compatible. */
+              height: 100%;
               min-height: calc(100vh - 4rem);
             }
             .stagebook-discussion-column {


### PR DESCRIPTION
Follow-up to #355. The padding-top + height:100% commit was pushed to the merged branch a few minutes after it was squash-merged, so it got orphaned. Cherry-picked here on top of current main.

## What changes

Two adjustments to `.stagebook-discussion-page` at md+:

1. **Add `padding-top: 1rem`** to match `padding-bottom: 1rem`. The wrapper had asymmetric padding (0 top, 1rem bottom, 1.5rem L/R) inherited from the original deliberation-empirica reference. With the layout otherwise fixed, the missing top breathing room is now visually noticeable.

2. **Add `height: 100%`** alongside the existing `min-height` floor. With only the min-height floor, an elements-column whose content exceeds the viewport pushed the wrapper taller than the host's bounded area, defeating the column's own `overflow-y: auto`. The "fixed video column, scrolling right column" layout requires a ceiling, not just a floor. In hosts whose parent is content-sized (no definite height), `height: 100%` resolves to auto and the min-height floor still applies — backward-compatible.

## Test plan

- [x] 1012/1012 stagebook unit tests pass
- [x] Visually verified in deliberation-lab via npm link: video column now stays fixed when right-column content overflows; symmetric top/bottom padding around the video tiles

## Refs

- #355 — the previous PR these commits were originally on
- deliberation-lab discussion layout regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)