### PR TITLE
Sanitize auto-derived prompt/audio names (#331, #359, #360)

### DIFF
--- a/apps/vscode/src/lib/validatePrompt.test.ts
+++ b/apps/vscode/src/lib/validatePrompt.test.ts
@@ -5,7 +5,7 @@ describe("validatePromptSource", () => {
   describe("valid prompt files", () => {
     it("returns no diagnostics for a valid multipleChoice prompt", () => {
       const src = `---
-name: test/prompt.prompt.md
+name: test_prompt
 type: multipleChoice
 ---
 What is your favorite color?
@@ -19,7 +19,7 @@ What is your favorite color?
 
     it("returns no diagnostics for a valid noResponse prompt (#243 — two-section file)", () => {
       const src = `---
-name: test/info.prompt.md
+name: test_info
 type: noResponse
 ---
 Please read the following instructions carefully.
@@ -30,7 +30,7 @@ Please read the following instructions carefully.
 
     it("returns no diagnostics for a valid openResponse prompt", () => {
       const src = `---
-name: test/open.prompt.md
+name: test_open
 type: openResponse
 ---
 Please describe your experience.
@@ -52,7 +52,7 @@ Please describe your experience.
 
     it("reports error for only two delimiters on a multipleChoice prompt (third section required)", () => {
       const src = `---
-name: test.prompt.md
+name: test
 type: multipleChoice
 ---
 Body text but no third section`;
@@ -72,7 +72,7 @@ Body text but no third section`;
   describe("metadata errors", () => {
     it("reports error for missing type field", () => {
       const src = `---
-name: test/prompt.prompt.md
+name: test_prompt
 ---
 Body text`;
       const result = validatePromptSource(src);
@@ -82,7 +82,7 @@ Body text`;
 
     it("reports error for invalid type value", () => {
       const src = `---
-name: test/prompt.prompt.md
+name: test_prompt
 type: invalidType
 ---
 Body text`;
@@ -93,7 +93,7 @@ Body text`;
 
     it("reports error for rows on non-openResponse type (strict-keys per #243)", () => {
       const src = `---
-name: test/prompt.prompt.md
+name: test_prompt
 type: multipleChoice
 rows: 3
 ---
@@ -113,7 +113,7 @@ Pick one
   describe("response errors", () => {
     it("reports error for invalid response line format", () => {
       const src = `---
-name: test/prompt.prompt.md
+name: test_prompt
 type: multipleChoice
 ---
 Pick one
@@ -132,7 +132,7 @@ Blue`;
   describe("error position mapping", () => {
     it("maps metadata errors to the metadata section", () => {
       const src = `---
-name: test/prompt.prompt.md
+name: test_prompt
 type: invalidType
 ---
 Body text`;
@@ -146,7 +146,7 @@ Body text`;
 
     it("maps response errors to the response section", () => {
       const src = `---
-name: test/prompt.prompt.md
+name: test_prompt
 type: multipleChoice
 ---
 Pick one
@@ -168,7 +168,7 @@ bad line`;
       // section delimiter between body and responses), but the explicit
       // warning steers authors to *** / ___ instead.
       const src = `---
-name: test/prompt.prompt.md
+name: test_prompt
 type: multipleChoice
 ---
 Pick one
@@ -189,7 +189,7 @@ then a horizontal rule
   describe("slider type", () => {
     it("returns no diagnostics for a valid slider prompt (#243 — labels in body, `- <n>: <label>`)", () => {
       const src = `---
-name: test/slider.prompt.md
+name: test_slider
 type: slider
 min: 0
 max: 100
@@ -205,7 +205,7 @@ Rate your agreement.
 
     it("reports errors when slider is missing required fields (#243 — strict required)", () => {
       const src = `---
-name: test/slider.prompt.md
+name: test_slider
 type: slider
 ---
 Rate something.
@@ -223,7 +223,7 @@ Rate something.
   describe("listSorter type", () => {
     it("returns no diagnostics for a valid listSorter prompt (#243 — `-` marker required)", () => {
       const src = `---
-name: test/sort.prompt.md
+name: test_sort
 type: listSorter
 ---
 Rank these items.
@@ -239,7 +239,7 @@ Rank these items.
   describe("metadata YAML parse failure", () => {
     it("reports error for malformed YAML in metadata", () => {
       const src = `---
-name: test/prompt.prompt.md
+name: test_prompt
 type: [unclosed bracket
 ---
 Body text`;
@@ -256,7 +256,7 @@ Body text`;
   describe("CRLF line endings", () => {
     it("handles CRLF line endings correctly", () => {
       const src =
-        "---\r\nname: test/prompt.prompt.md\r\ntype: multipleChoice\r\n---\r\nPick one\r\n---\r\n- A\r\n- B";
+        "---\r\nname: test_prompt\r\ntype: multipleChoice\r\n---\r\nPick one\r\n---\r\n- A\r\n- B";
       const result = validatePromptSource(src);
       expect(result.diagnostics).toEqual([]);
     });
@@ -265,7 +265,7 @@ Body text`;
   describe("metadata field position mapping", () => {
     it("maps metadata field error to the specific YAML key line", () => {
       const src = `---
-name: test/prompt.prompt.md
+name: test_prompt
 type: multipleChoice
 rows: 3
 ---

--- a/examples/annotated-walkthrough/prompts/post_changed.prompt.md
+++ b/examples/annotated-walkthrough/prompts/post_changed.prompt.md
@@ -1,6 +1,6 @@
 ---
 type: multipleChoice
-name: Did your view change?
+name: Did your view change
 select: single
 layout: horizontal
 ---

--- a/examples/annotated-walkthrough/prompts/topic_four_day_week.prompt.md
+++ b/examples/annotated-walkthrough/prompts/topic_four_day_week.prompt.md
@@ -1,6 +1,6 @@
 ---
 type: openResponse
-name: Four-day week — initial position
+name: Four-day week - initial position
 rows: 5
 minLength: 60
 maxLength: 600

--- a/examples/annotated-walkthrough/prompts/topic_remote_work.prompt.md
+++ b/examples/annotated-walkthrough/prompts/topic_remote_work.prompt.md
@@ -1,6 +1,6 @@
 ---
 type: openResponse
-name: Remote work — initial position
+name: Remote work - initial position
 rows: 5
 minLength: 60
 maxLength: 600

--- a/examples/prisoners-dilemma/prompts/outcome_both_cooperated.prompt.md
+++ b/examples/prisoners-dilemma/prompts/outcome_both_cooperated.prompt.md
@@ -1,6 +1,6 @@
 ---
 type: noResponse
-name: Outcome — both cooperated
+name: Outcome - both cooperated
 ---
 
 ## Mutual cooperation

--- a/examples/prisoners-dilemma/prompts/outcome_both_defected.prompt.md
+++ b/examples/prisoners-dilemma/prompts/outcome_both_defected.prompt.md
@@ -1,6 +1,6 @@
 ---
 type: noResponse
-name: Outcome — both defected
+name: Outcome - both defected
 ---
 
 ## Mutual defection

--- a/examples/prisoners-dilemma/prompts/outcome_you_cooperated_they_defected.prompt.md
+++ b/examples/prisoners-dilemma/prompts/outcome_you_cooperated_they_defected.prompt.md
@@ -1,6 +1,6 @@
 ---
 type: noResponse
-name: Outcome — you cooperated, partner defected
+name: Outcome - you cooperated partner defected
 ---
 
 ## You were exploited

--- a/examples/prisoners-dilemma/prompts/outcome_you_defected_they_cooperated.prompt.md
+++ b/examples/prisoners-dilemma/prompts/outcome_you_defected_they_cooperated.prompt.md
@@ -1,6 +1,6 @@
 ---
 type: noResponse
-name: Outcome — you defected, partner cooperated
+name: Outcome - you defected partner cooperated
 ---
 
 ## You exploited your partner

--- a/examples/survey-experiment/prompts/article_control.prompt.md
+++ b/examples/survey-experiment/prompts/article_control.prompt.md
@@ -1,6 +1,6 @@
 ---
 type: noResponse
-name: Article — control
+name: Article - control
 ---
 
 # Mechanical clocks: a short history

--- a/examples/survey-experiment/prompts/article_treatment.prompt.md
+++ b/examples/survey-experiment/prompts/article_treatment.prompt.md
@@ -1,6 +1,6 @@
 ---
 type: noResponse
-name: Article — treatment
+name: Article - treatment
 ---
 
 # Why some districts are pushing high school start times later

--- a/examples/ultimatum-game/prompts/outcome_accepted.prompt.md
+++ b/examples/ultimatum-game/prompts/outcome_accepted.prompt.md
@@ -1,6 +1,6 @@
 ---
 type: noResponse
-name: Outcome — offer accepted
+name: Outcome - offer accepted
 ---
 
 ## Deal

--- a/examples/ultimatum-game/prompts/outcome_rejected.prompt.md
+++ b/examples/ultimatum-game/prompts/outcome_rejected.prompt.md
@@ -1,6 +1,6 @@
 ---
 type: noResponse
-name: Outcome — offer rejected
+name: Outcome - offer rejected
 ---
 
 ## No deal

--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -316,7 +316,15 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
           // Position-based fallback when `name:` is omitted — same
           // intent as the audio case above: distinct storage keys
           // for the same media used in different stages.
-          name={String(element.name ?? `${progressLabel}_${rawURL}`)}
+          //
+          // `rawURL` is either a file path (slugged by
+          // `deriveStorageKeyName`) or a full HTTP(S) URL (which also
+          // contains `://` and slashes — same regex problem). Either
+          // way the helper produces a reference-name-valid identifier
+          // (#359).
+          name={
+            element.name ?? deriveStorageKeyName(`${progressLabel}_${rawURL}`)
+          }
           url={resolvedURL}
           save={wrappedSave}
           getElapsedTime={getElapsedTime}
@@ -402,8 +410,13 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
       const surveyName = element.surveyName ?? "";
       // Position-based fallback when `name:` is omitted — same
       // intent as audio/mediaPlayer: distinct storage keys for the
-      // same survey used in different stages.
-      const surveyKey = element.name ?? `${progressLabel}_${surveyName}`;
+      // same survey used in different stages. `surveyName` is schema-
+      // validated upstream, so a synthesized `${progressLabel}_${surveyName}`
+      // is already regex-clean in practice; wrapping with
+      // `deriveStorageKeyName` is defensive — same contract for all
+      // four auto-derivation sites (#359).
+      const surveyKey =
+        element.name ?? deriveStorageKeyName(`${progressLabel}_${surveyName}`);
       return (
         renderSurvey?.({
           surveyName,

--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -19,6 +19,7 @@ import { Timeline } from "./elements/Timeline.js";
 import { Prompt } from "./elements/Prompt.js";
 import { Qualtrics } from "./elements/Qualtrics.js";
 import { Loading } from "./form/Loading.js";
+import { deriveStorageKeyName } from "../utils/deriveStorageKeyName.js";
 
 // Resolve element URL params using the StagebookProvider's resolve.
 // Plain function — no hooks — so it's safe to call conditionally (e.g. in
@@ -154,7 +155,15 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
           // distinct storage keys instead of silently overwriting
           // each other. Researchers who do want a stable name
           // across stages set `name:` explicitly.
-          name={element.name ?? `${progressLabel}_${element.file ?? ""}`}
+          //
+          // `deriveStorageKeyName` slugs the file path into the
+          // reference-name regex so a path like
+          // `intro/clips/welcome.mp3` doesn't produce a storage key
+          // that fails reference parsing (#359).
+          name={
+            element.name ??
+            deriveStorageKeyName(`${progressLabel}_${element.file ?? ""}`)
+          }
         />
       );
 
@@ -224,8 +233,19 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
         );
       }
       const { metadata, body, responseItems, responsePoints } = parsed.data;
+      // Auto-derivation when `element.name` is absent. Tier 2 is the
+      // frontmatter `metadata.name` (validated against `nameSchema` at
+      // parse time, so it's already regex-clean and ≤64 chars). Tier 3
+      // is the raw file path, which may contain `/` and `.` and may
+      // exceed the 64-char authoring cap. `deriveStorageKeyName` slugs
+      // the joined string into the reference-name regex and truncates
+      // with a stable hash suffix if the result exceeds the 256-char
+      // lookup cap (#331, #359, #360).
       const promptName =
-        element.name ?? `${progressLabel}_${metadata.name ?? element.file}`;
+        element.name ??
+        deriveStorageKeyName(
+          `${progressLabel}_${metadata.name ?? element.file}`,
+        );
 
       // Read current value from state. Position comes from the
       // reference itself per #298 — `shared.prompt.X` for shared

--- a/packages/stagebook/src/components/testing/MockStageRenderer.tsx
+++ b/packages/stagebook/src/components/testing/MockStageRenderer.tsx
@@ -12,6 +12,7 @@ import {
 } from "../StagebookProvider.js";
 import { Stage, type StageConfig } from "../Stage.js";
 import { getReferenceKeyAndPath } from "../../utils/reference.js";
+import { sanitizeName } from "../../utils/deriveStorageKeyName.js";
 
 export interface MockStageRendererProps {
   stage: StageConfig;
@@ -91,7 +92,10 @@ export function MockStageRenderer({
     getTextContent: (path: string) =>
       Promise.resolve(
         // After #243 noResponse files are two-section (no trailing `---`).
-        `---\nname: ${path}\ntype: noResponse\n---\nMock content for ${path}\n`,
+        // After #360 the frontmatter `name:` is validated against
+        // `nameSchema`, so synthesized names must be sanitized — raw
+        // paths contain `/` and `.` which the regex rejects.
+        `---\nname: ${sanitizeName(path)}\ntype: noResponse\n---\nMock content for ${path}\n`,
       ),
     progressLabel: `game_0_${stage.name}`,
     playerId: "test-player-1",

--- a/packages/stagebook/src/schemas/primitives.ts
+++ b/packages/stagebook/src/schemas/primitives.ts
@@ -1,23 +1,42 @@
 /**
  * Tiny schema primitives shared between `reference.ts` and `treatment.ts`.
  * Lives in its own file so `reference.ts` (imported by the cross-stage
- * walker) can pull `nameSchema` without dragging in `treatment.ts`'s
+ * walker) can pull these schemas without dragging in `treatment.ts`'s
  * import-cycle with the walker.
  */
 
 import { z } from "zod";
 
-// Names should have properties:
-// max length: 64 characters
-// min length: 1 character
-// allowed characters: a-z, A-Z, 0-9, -, _, and space
+// Allowed identifier characters: a-z, A-Z, 0-9, -, _, and space.
 // Plus optional `${field}` template placeholders.
+const NAME_REGEX = /^(?:[a-zA-Z0-9 _-]|\$\{[a-zA-Z0-9_]+\})+$/;
+const NAME_REGEX_MESSAGE =
+  "Name must be alphanumeric, cannot have special characters, with optional template fields in the format ${fieldname}";
+
+/**
+ * Authoring constraint: applied where a human writes an identifier
+ * (treatment YAML `element.name`, prompt-file frontmatter `name:`).
+ * 64-char cap keeps hand-authored names short and readable.
+ */
 export const nameSchema = z
   .string()
   .min(1, "Name is required")
   .max(64)
-  .regex(/^(?:[a-zA-Z0-9 _-]|\$\{[a-zA-Z0-9_]+\})+$/, {
-    message:
-      "Name must be alphanumeric, cannot have special characters, with optional template fields in the format ${fieldname}",
-  });
+  .regex(NAME_REGEX, { message: NAME_REGEX_MESSAGE });
 export type NameType = z.infer<typeof nameSchema>;
+
+/**
+ * Lookup constraint: applied where the runtime parses a reference
+ * string and matches it against storage keys. Auto-derived names join
+ * separately-validated components (e.g. `<progressLabel>_<file slug>`)
+ * so the joined identifier can exceed the 64-char authoring cap even
+ * when every component is well-formed. 256 is a hard sanity ceiling
+ * that catches genuine bugs (unbounded key construction) without
+ * rejecting reasonable auto-derived names. The character regex is
+ * identical — no looser at the lookup boundary.
+ */
+export const referenceNameSchema = z
+  .string()
+  .min(1, "Name is required")
+  .max(256)
+  .regex(NAME_REGEX, { message: NAME_REGEX_MESSAGE });

--- a/packages/stagebook/src/schemas/promptFile.test.ts
+++ b/packages/stagebook/src/schemas/promptFile.test.ts
@@ -960,4 +960,46 @@ How warm?
       expect(result.data.responseItems).toEqual(["Cold", "Mid", "Hot"]);
     }
   });
+
+  // ----------- metadata.name validation (#360) ------------
+
+  test("frontmatter name with a slash is rejected at parse time", () => {
+    const markdown = `---
+name: foo/bar
+type: noResponse
+---
+Body.`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      // The error from `nameSchema`'s regex
+      const msg = result.error.issues.map((i) => i.message).join(" | ");
+      expect(msg).toMatch(/alphanumeric|special characters/i);
+    }
+  });
+
+  test("frontmatter name over 64 chars is rejected at parse time", () => {
+    const longName = "a".repeat(65);
+    const markdown = `---
+name: ${longName}
+type: noResponse
+---
+Body.`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(false);
+  });
+
+  test("frontmatter name at the 64-char limit is accepted", () => {
+    const okName = "a".repeat(64);
+    const markdown = `---
+name: ${okName}
+type: noResponse
+---
+Body.`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.metadata.name).toBe(okName);
+    }
+  });
 });

--- a/packages/stagebook/src/schemas/promptFile.ts
+++ b/packages/stagebook/src/schemas/promptFile.ts
@@ -1,5 +1,6 @@
 import { z, ZodIssue } from "zod";
 import { load as loadYaml } from "js-yaml";
+import { nameSchema } from "./primitives.js";
 
 // ---------------------------------------------------------------------------
 // Prompt file format (#243)
@@ -28,7 +29,13 @@ import { load as loadYaml } from "js-yaml";
 const baseMetadataFields = {
   // `name` is kept (Principle 9 — name is the universal identifier
   // across all study portions, addressable or not). Optional.
-  name: z.string().optional(),
+  //
+  // Validated against `nameSchema` (64-char cap, alphanumeric + space +
+  // `_`/`-` + `${field}` templates) so a frontmatter `name: foo/bar`
+  // or `name: <65 chars>` is rejected at parse time with a clear
+  // message — instead of silently producing an invalid synthesized
+  // storage key later in the render path (#360).
+  name: nameSchema.optional(),
   notes: z.string().optional(),
 };
 

--- a/packages/stagebook/src/schemas/reference.ts
+++ b/packages/stagebook/src/schemas/reference.ts
@@ -28,7 +28,7 @@
  */
 
 import { z } from "zod";
-import { nameSchema } from "./primitives.js";
+import { referenceNameSchema } from "./primitives.js";
 
 export const namedSourceEnum = z.enum([
   "prompt",
@@ -82,11 +82,20 @@ export const positionSelectorSchema = z.union([
 ]);
 export type PositionSelectorType = z.infer<typeof positionSelectorSchema>;
 
+// `name` uses the relaxed `referenceNameSchema` (256-char cap) rather
+// than the 64-char authoring `nameSchema`. This schema validates both
+// runtime auto-derived references (`<progressLabel>_<file slug>`, which
+// can exceed 64 chars even when each component is well-formed) and
+// user-authored references in YAML. User-authored names that don't
+// match any produced storage key still fail the forward-ref check in
+// `validateReferences.ts`, so the 64-char authoring discipline is
+// enforced at the source-of-truth (`element.name`, `metadata.name`)
+// rather than at every reference site.
 export const namedReferenceSchema = z
   .object({
     position: positionSelectorSchema,
     source: namedSourceEnum,
-    name: nameSchema,
+    name: referenceNameSchema,
     path: referencePathSchema.optional(),
   })
   .strict();

--- a/packages/stagebook/src/utils/deriveStorageKeyName.test.ts
+++ b/packages/stagebook/src/utils/deriveStorageKeyName.test.ts
@@ -1,0 +1,127 @@
+import { describe, test, expect } from "vitest";
+import { sanitizeName, deriveStorageKeyName } from "./deriveStorageKeyName.js";
+import { referenceNameSchema, nameSchema } from "../schemas/primitives.js";
+import { parseDottedReference } from "../schemas/reference.js";
+
+describe("sanitizeName", () => {
+  test("strips .prompt.md trailing extension", () => {
+    expect(sanitizeName("foo.prompt.md")).toBe("foo");
+  });
+
+  test("replaces slashes with underscores", () => {
+    expect(sanitizeName("game/topics/abortion")).toBe("game_topics_abortion");
+  });
+
+  test("replaces interior dots with underscores", () => {
+    expect(sanitizeName("game.topics.abortion")).toBe("game_topics_abortion");
+  });
+
+  test("strips .prompt.md before sanitizing slashes", () => {
+    expect(sanitizeName("game/topics/abortion.prompt.md")).toBe(
+      "game_topics_abortion",
+    );
+  });
+
+  test("replaces other disallowed chars with underscores", () => {
+    expect(sanitizeName("foo!@#bar")).toBe("foo___bar");
+  });
+
+  test("preserves allowed characters (alphanumeric, space, _, -)", () => {
+    expect(sanitizeName("foo bar_baz-qux")).toBe("foo bar_baz-qux");
+  });
+});
+
+describe("deriveStorageKeyName", () => {
+  test("real production example #1: returns plain sanitized form when ≤256 chars", () => {
+    // From the issue #359 examples:
+    const input = "game_0_attitude_attributes_topics/abortion.prompt.md";
+    const result = deriveStorageKeyName(input);
+    expect(result).toBe("game_0_attitude_attributes_topics_abortion");
+    expect(referenceNameSchema.safeParse(result).success).toBe(true);
+  });
+
+  test("real production example #2: 75-char path passes the lookup cap without hashing", () => {
+    // From the issue #359 examples — this was reported as exceeding the
+    // previous 64-char cap. Under the relaxed 256-char lookup cap it
+    // fits without hashing.
+    const input =
+      "game_0_attitude_attributes_game/attitude_attribute_instructions_A.prompt.md";
+    const result = deriveStorageKeyName(input);
+    expect(result.length).toBeLessThanOrEqual(256);
+    expect(referenceNameSchema.safeParse(result).success).toBe(true);
+    // Hashing should NOT have fired for this length — the result is the
+    // straight sanitization.
+    expect(result).toBe(
+      "game_0_attitude_attributes_game_attitude_attribute_instructions_A",
+    );
+  });
+
+  test("inputs over 256 chars get truncated with an 8-char hash suffix", () => {
+    const input = "a/".repeat(200); // 400 chars, alternating a and /
+    const result = deriveStorageKeyName(input);
+    expect(result.length).toBeLessThanOrEqual(256);
+    // Last 9 chars: underscore + 8 hex chars
+    expect(result.slice(-9)).toMatch(/^_[0-9a-f]{8}$/);
+  });
+
+  test("hash is deterministic — same input produces same output", () => {
+    const long = "x".repeat(300);
+    expect(deriveStorageKeyName(long)).toBe(deriveStorageKeyName(long));
+  });
+
+  test("two long inputs sharing a long common prefix produce distinct outputs", () => {
+    const prefix = "shared_".repeat(40); // 280 chars of common prefix
+    const a = prefix + "_alpha";
+    const b = prefix + "_beta";
+    const ra = deriveStorageKeyName(a);
+    const rb = deriveStorageKeyName(b);
+    expect(ra).not.toBe(rb);
+    // Both still pass the lookup schema
+    expect(referenceNameSchema.safeParse(ra).success).toBe(true);
+    expect(referenceNameSchema.safeParse(rb).success).toBe(true);
+  });
+
+  test("output always satisfies referenceNameSchema", () => {
+    const cases = [
+      "simple",
+      "game/topics/abortion.prompt.md",
+      "with spaces and-dashes",
+      "x".repeat(500),
+      "weird!@#$chars/in/path",
+    ];
+    for (const input of cases) {
+      const result = deriveStorageKeyName(input);
+      const parsed = referenceNameSchema.safeParse(result);
+      expect(
+        parsed.success,
+        `failed for input ${JSON.stringify(input)}: ${result}`,
+      ).toBe(true);
+    }
+  });
+
+  test("authoring nameSchema rejects what the lookup schema accepts (≥65 chars)", () => {
+    // Confirms the split: authoring stays strict, lookup is permissive.
+    const long = "a".repeat(100);
+    expect(referenceNameSchema.safeParse(long).success).toBe(true);
+    expect(nameSchema.safeParse(long).success).toBe(false);
+  });
+
+  test("end-to-end: synthesized reference parses without error (#331, #359)", () => {
+    // Mirrors the synthesis flow in Element.tsx — given a progress
+    // label and a bad file path, the synthesized reference must round-trip
+    // through `parseDottedReference` without error.
+    const progressLabel = "game_16";
+    const filePath = "game/pre_A_shared.prompt.md";
+    const promptName = deriveStorageKeyName(`${progressLabel}_${filePath}`);
+    const refStr = `self.prompt.${promptName}`;
+    const parsed = parseDottedReference(refStr);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.value).toMatchObject({
+        position: "self",
+        source: "prompt",
+        name: promptName,
+      });
+    }
+  });
+});

--- a/packages/stagebook/src/utils/deriveStorageKeyName.ts
+++ b/packages/stagebook/src/utils/deriveStorageKeyName.ts
@@ -1,0 +1,79 @@
+/**
+ * Sanitize and length-cap a synthesized identifier so it always satisfies
+ * the reference-name regex (`[a-zA-Z0-9 _-]`) and the 256-char lookup
+ * cap (`referenceNameSchema`).
+ *
+ * Used at the auto-derivation sites in `Element.tsx` where a prompt or
+ * audio element has no explicit `name:` — the runtime falls back to a
+ * synthesized identifier built from the progress label and either
+ * `metadata.name` (prompt frontmatter) or `element.file` (raw path).
+ * Raw file paths contain `/` and `.`, both of which the regex rejects;
+ * long folder-nested paths can exceed 64 chars and (rarely) 256.
+ *
+ * Background: #331, #359, #360.
+ */
+
+const REFERENCE_NAME_MAX = 256;
+const PROMPT_FILE_EXT = /\.prompt\.md$/;
+const SLUG_REPLACE = /[./]/g;
+const NON_NAME_CHAR = /[^a-zA-Z0-9 _-]/g;
+
+/**
+ * Slug a raw string into the reference-name character set without any
+ * length handling. Strips a trailing `.prompt.md` (the most common
+ * extension at synthesis sites), then replaces `.` and `/` with `_`,
+ * then replaces any other disallowed char with `_`.
+ *
+ * Two file paths that differ only in a `.` vs `/` separator collapse to
+ * the same slug — that's fine for the auto-derivation use case because
+ * the caller pairs the slug with the stage's `progressLabel`, which
+ * disambiguates by stage.
+ */
+export function sanitizeName(raw: string): string {
+  return raw
+    .replace(PROMPT_FILE_EXT, "")
+    .replace(SLUG_REPLACE, "_")
+    .replace(NON_NAME_CHAR, "_");
+}
+
+/**
+ * Sanitize a raw string and ensure the result fits within the 256-char
+ * reference-name cap. When the sanitized form is short enough, it's
+ * returned as-is — readable, traces back to the source.
+ *
+ * When it exceeds the cap, truncate the readable portion and append an
+ * underscore plus an 8-char stable hash of the full sanitized string.
+ * The hash is FNV-1a (non-crypto, fast, deterministic across browser
+ * and node, no deps) — sufficient for "two long paths that differ
+ * anywhere produce different keys" without crypto-grade guarantees.
+ * Two paths sharing a 200-char prefix and differing only in their last
+ * segment still produce distinct outputs.
+ *
+ * The truncation budget is `256 - 1 (underscore) - 8 (hash) = 247`.
+ */
+export function deriveStorageKeyName(raw: string): string {
+  const sanitized = sanitizeName(raw);
+  if (sanitized.length <= REFERENCE_NAME_MAX) return sanitized;
+  const hash = fnv1aHash8(sanitized);
+  return sanitized.slice(0, REFERENCE_NAME_MAX - 1 - 8) + "_" + hash;
+}
+
+/**
+ * FNV-1a 32-bit hash, returned as an 8-char zero-padded lowercase hex
+ * string. Used as a collision-resistant suffix when truncating long
+ * synthesized names. Not cryptographic; the goal is "two distinct
+ * inputs almost always produce distinct outputs" for the runtime
+ * identifier-collision-avoidance use case.
+ *
+ * Implementation: standard 32-bit FNV-1a. `Math.imul` keeps the
+ * 32-bit multiplication in V8's int32 fast path; `>>> 0` after each
+ * step coerces back to unsigned 32-bit.
+ */
+function fnv1aHash8(input: string): string {
+  let hash = 0x811c9dc5; // FNV offset basis (32-bit)
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0; // FNV prime, mod 2^32
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}

--- a/packages/stagebook/src/utils/index.ts
+++ b/packages/stagebook/src/utils/index.ts
@@ -15,3 +15,4 @@ export {
   getReferencedAssets,
   type ReferencedAsset,
 } from "./referencedAssets.js";
+export { sanitizeName, deriveStorageKeyName } from "./deriveStorageKeyName.js";


### PR DESCRIPTION
Fixes #331, #359, #360.

## Problem

When a `prompt` or `audio` element has no `name:` set, the runtime synthesized an identifier from the progress label + frontmatter name or raw file path:

```ts
const promptName = element.name ?? `${progressLabel}_${metadata.name ?? element.file}`;
```

Three tiers, only one validated:

| Tier | Source | Validation |
|------|--------|------------|
| 1 | `element.name` (treatment YAML) | ✅ `nameSchema` via `elementSchema` |
| 2 | `metadata.name` (prompt frontmatter) | ❌ `z.string().optional()` |
| 3 | `element.file` (raw path) | ❌ unsanitized |

Result: synthesized names like `game_16_game/pre_A_shared.prompt.md` violated `nameSchema`'s regex, spamming `Invalid reference: …` to console on every render, and storing data under keys that broke downstream tokenizers. Long paths exceeded the 64-char cap.

## Solution

Three coupled changes close the contract that every output of the chain is a valid identifier.

### 1. Schema split

`nameSchema` keeps the 64-char authoring cap; new `referenceNameSchema` relaxes to 256 chars (same regex). Authoring stays strict at the source-of-truth — runtime parser accepts the longer auto-derived names that compose separately-validated components. User-authored references with non-existent names still fail the forward-ref check in `validateReferences.ts`.

### 2. `metadata.name` validation (#360)

Prompt frontmatter `name:` now validates against `nameSchema` at parse time. A `name: foo/bar` produces a clear parse error in the existing `Error parsing prompt …` branch instead of silently producing an invalid synthesized key downstream.

### 3. `deriveStorageKeyName` helper (#331, #359)

Slugs the joined synthesis string into the reference-name regex:
- Strip `.prompt.md`
- Replace `.` and `/` with `_`
- Replace any other disallowed char with `_`

Truncates with an 8-char FNV-1a hash suffix if the sanitized form exceeds 256 chars. Used at both prompt and audio synthesis sites in `Element.tsx`. Output always satisfies `referenceNameSchema`.

## Verification (acceptance criteria)

- ✅ Unit test pinning the algorithm — `("game_0_attitude_attributes", "topics/abortion.prompt.md")` → satisfies `referenceNameSchema.safeParse()`
- ✅ Unit test pinning the long-name path — input where sanitized > 256 chars → ≤ 256 chars + stable 8-char hash suffix
- ✅ Unit test pinning collision-resistance — two paths sharing a 280-char prefix → distinct outputs
- ✅ Unit test pinning frontmatter validation — `name: foo/bar` and 65-char names rejected at parse time
- ✅ End-to-end test — synthesized reference round-trips through `parseDottedReference` without error
- ✅ Full repo test suite passes (stagebook 1029, viewer 100, vscode 216)

## Fixture updates

The new validation caught real issues in fixtures:
- Several example prompt files used em-dashes (`—`) and `?` in `name:` — sanitized to plain identifiers
- `MockStageRenderer` mock synthesized `name: ${path}` (containing `/` and `.`) — now sanitizes via the new helper
- A handful of VS Code extension tests used raw paths as `name:` values — sanitized

## Out of scope

`collectProducedKeys` in `validateReferences.ts` still doesn't mirror the auto-derivation, so forward-ref validation against unnamed prompts remains incomplete. Tracking separately — referencing an unnamed prompt should still be a sign the author should give it an explicit `name:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)