### PR TITLE
Bump stagebook to 0.10.4

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Patch release picking up the auto-derived-name sanitization fix from #361 (closes #331, #359, #360).

## What's in

- **#361** — Sanitize auto-derived prompt/audio/mediaPlayer/survey names. When an element has no `name:`, the runtime synthesized an identifier from `${progressLabel}_${file}` which produced strings like `game_16_game/pre_A_shared.prompt.md` — violating `nameSchema`'s regex and triggering `Invalid reference: …` console errors on every render. Storage keys also became fragile for downstream tokenizers.

Three coupled changes close the contract that every output of the auto-derivation chain is a valid identifier:

1. **Schema split** — `nameSchema` (64-char authoring cap) stays strict where humans write names (treatment YAML, prompt frontmatter). New `referenceNameSchema` (256-char lookup cap) at the reference parser accepts longer auto-derived names that compose separately-validated components.
2. **`metadata.name` validation** at prompt-file parse time — a `name: foo/bar` in frontmatter now produces a clear parse error instead of silently producing an invalid synthesized key.
3. **`deriveStorageKeyName` helper** — slugs the joined string (strip `.prompt.md`, replace `.`/`/` with `_`, anything else with `_`) and truncates with an 8-char FNV-1a hash suffix when sanitized output exceeds 256 chars. Used at all four auto-derivation sites in `Element.tsx`.

## Compatibility

- No API changes.
- No breaking changes to schema or component surface.
- Existing prompt files with valid `name:` values are unaffected.
- Existing prompt files with `name:` containing chars outside `[a-zA-Z0-9 _-]` (em-dash, slash, etc.) now produce a clear parse error rather than the previous silent-then-noisy failure. Several example fixtures were sanitized in #361 as part of this surfacing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)