### PR TITLE
Scope React keys by element type

### DIFF
--- a/packages/stagebook/src/components/Stage.keys.test.tsx
+++ b/packages/stagebook/src/components/Stage.keys.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  type StagebookContext,
+  StagebookProvider,
+} from "./StagebookProvider.js";
+import { Stage } from "./Stage.js";
+
+// Stage rendering in CT is built in production mode where React
+// silences dev warnings. To catch React's "two children with the
+// same key" warning we render under jsdom (vitest) with a
+// console.error spy. The warning is dev-mode-only, but vitest +
+// react-dom both run in dev mode by default.
+
+function createMockContext(): StagebookContext {
+  return {
+    get: vi.fn(() => []),
+    save: vi.fn(),
+    getElapsedTime: vi.fn(() => 0),
+    submit: vi.fn(),
+    getAssetURL: vi.fn((path: string) => `https://cdn.test/${path}`),
+    getTextContent: vi.fn(() => Promise.resolve("mock content")),
+    progressLabel: "game_0_stage1",
+    playerId: "player1",
+    position: 0,
+    playerCount: 1,
+    isSubmitted: false,
+  };
+}
+
+describe("Stage — React key uniqueness", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  test("two elements with the same `name` but different `type` do not emit a duplicate-key warning", () => {
+    // Real-world repro: pilot_3's topicPrompt template pairs a
+    // `prompt` and a `submitButton` under the same `name:
+    // presurvey_${topicName}`. Server-side these get distinct
+    // storage keys (`prompt_<name>` vs `submitButton_<name>`).
+    // The React `key=` in `ElementsColumn`'s map must scope by
+    // type or these collide on the client.
+    const container = document.createElement("div");
+    let root: Root;
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <StagebookProvider value={createMockContext()}>
+          <Stage
+            stage={{
+              name: "SameNameDifferentType",
+              duration: 60,
+              elements: [
+                {
+                  type: "prompt",
+                  name: "presurvey_vaccination",
+                  file: "x.md",
+                },
+                { type: "submitButton", name: "presurvey_vaccination" },
+              ],
+            }}
+            onSubmit={() => {}}
+          />
+        </StagebookProvider>,
+      );
+    });
+
+    const duplicateKeyCalls = consoleErrorSpy.mock.calls.filter((args) =>
+      String(args[0]).includes("Encountered two children with the same key"),
+    );
+    expect(duplicateKeyCalls).toEqual([]);
+
+    act(() => root.unmount());
+  });
+});

--- a/packages/stagebook/src/components/Stage.tsx
+++ b/packages/stagebook/src/components/Stage.tsx
@@ -155,7 +155,14 @@ function ElementsColumn({
     <>
       {elements.map((element, i) => (
         <WrappedElement
-          key={element.name ?? `element-${i}`}
+          // Key scopes by type so two elements with the same `name:`
+          // but different `type:` don't collide. Authors legitimately
+          // pair a `prompt` and a `submitButton` under the same `name`
+          // (the storage keys are `prompt_<name>` vs
+          // `submitButton_<name>` server-side — distinct). The React
+          // key needs to mirror that scoping or it warns about
+          // duplicate keys at render time.
+          key={`${element.type}_${element.name ?? `at-${i}`}`}
           element={element}
           siblings={elements}
           onSubmit={onSubmit}


### PR DESCRIPTION
The `key=` in `ElementsColumn`'s element map was just `element.name`, so two elements with the same `name:` but different `type:` collided. React warned at render time:

> Warning: Encountered two children with the same key, \`presurvey_vaccination\`. Keys should be unique so that components maintain their identity across updates.

## Why this happened

Authors legitimately pair a `prompt` and a `submitButton` under the same `name` — the storage keys are namespaced by element type server-side (`prompt_<name>` vs `submitButton_<name>`), so they don't collide on the data side. The React key just needs to mirror that scoping.

Live repro from [dialogue-levers/pilot_3](https://github.com/dialogue-levers/dialogue-levers/blob/main/stagebook/pilot_3/pilot_3.stagebook.yaml):

```yaml
elements:
  - type: prompt
    name: presurvey_${topicName}
    file: intro/topicPrompt/topic_opinion.prompt.md
  - type: submitButton
    name: presurvey_${topicName}
    conditions:
      - reference: self.prompt.presurvey_${topicName}
        comparator: exists
```

## Fix

[Stage.tsx](packages/stagebook/src/components/Stage.tsx) — change the key from `element.name ?? \`element-${i}\`` to `\`${element.type}_${element.name ?? \`at-${i}\`}\``. Mirrors the storage-key scoping; falls back to the index for unnamed elements.

## Test

Regression test in [Stage.keys.test.tsx](packages/stagebook/src/components/Stage.keys.test.tsx) runs under vitest+jsdom rather than Playwright CT — Playwright CT runs React in production mode, which silences the duplicate-key warning entirely. The vitest test spies on `console.error` and asserts no duplicate-key warning fires for the pilot_3 repro shape. Verified the test catches the bug (fails without the fix, passes with).

## Impact

Just a key change — no behavior change for hosts. Storage keys, references, and rendering are all unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)