### PR TITLE
Bump stagebook to 0.10.5

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Patch release picking up the React key-uniqueness fix from #363.

## What's in

- **#363** — Scope React keys by element type. The `key=` in `ElementsColumn`'s element map was just `element.name`, so two elements with the same `name:` but different `type:` collided. React warned at render time:

  > Encountered two children with the same key, `presurvey_vaccination`.

  Authors legitimately pair a `prompt` and a `submitButton` under the same `name` — storage keys are namespaced by type server-side (`prompt_<name>` vs `submitButton_<name>`). The React key now mirrors that scoping (`${element.type}_${element.name}`), with a fallback to the index for unnamed elements.

## Compatibility

- No API changes.
- No schema or behavior changes for hosts.
- Pure rendering fix — internal React key only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)