### PR TITLE
Note PR-close keyword convention in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Never skip the red step. Tests document intent.
 - PRs must pass CI before merge
 - Key decisions are recorded in `docs/decisions/` as ADRs (link back to the issue for full context)
 - Check `docs/decisions/` for architectural context before proposing changes to core systems
+- When a PR closes multiple issues, repeat the keyword for each one — `Fixes #331, fixes #359, fixes #360`. The comma-list form `Fixes #331, #359, #360` only auto-closes the first issue; the rest stay open silently.
 
 ## Conventions
 


### PR DESCRIPTION
GitHub's auto-close only attaches the `Fixes/Closes` keyword to the first issue in a comma-separated list. PR #361 used `Fixes #331, #359, #360` and only #331 was auto-closed — #359 and #360 had to be closed manually after the release.

Adds a one-line convention note in CLAUDE.md so future PRs use the per-issue keyword form (`Fixes #331, fixes #359, fixes #360`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)