### PR TITLE
Radio border reverts to gray after deselection

### DIFF
--- a/packages/stagebook/src/components/form/RadioGroup.ct.tsx
+++ b/packages/stagebook/src/components/form/RadioGroup.ct.tsx
@@ -102,6 +102,41 @@ test.describe("RadioGroup", () => {
     expect(backgroundImage).toContain("data:image/svg+xml");
   });
 
+  test("previously-checked radio reverts to gray border after deselection (no color bleed)", async ({
+    mount,
+  }) => {
+    // Regression: when one radio was selected and then another was
+    // clicked, the previously-selected radio's border stayed black
+    // (browser default for appearance:none inputs) instead of
+    // reverting to the gray default. Root cause: mixing the `border`
+    // shorthand in base style with a `borderColor` longhand override
+    // in the checked style — React's inline-style diff cleared the
+    // longhand on deselect, blowing away the shorthand's expansion.
+    // Fix: use border longhands consistently in base style.
+    const component = await mount(
+      <MockRadioGroup options={options} initialValue="a" />,
+    );
+
+    // Sanity: A starts checked
+    await expect(component.locator('input[value="a"]')).toBeChecked();
+
+    // Click B to deselect A
+    await component.getByText("Option B").click();
+    await expect(component.locator('input[value="b"]')).toBeChecked();
+    await expect(component.locator('input[value="a"]')).not.toBeChecked();
+
+    // The previously-checked A and never-clicked C should have the
+    // same gray border. Pre-fix: A had rgb(0, 0, 0), C had rgb(209,
+    // 213, 219).
+    const aBorder = await component
+      .locator('input[value="a"]')
+      .evaluate((el) => window.getComputedStyle(el).borderColor);
+    const cBorder = await component
+      .locator('input[value="c"]')
+      .evaluate((el) => window.getComputedStyle(el).borderColor);
+    expect(aBorder).toBe(cBorder);
+  });
+
   test("focus ring appears inline on focus and disappears on blur", async ({
     mount,
   }) => {

--- a/packages/stagebook/src/components/form/RadioGroup.tsx
+++ b/packages/stagebook/src/components/form/RadioGroup.tsx
@@ -27,7 +27,16 @@ const radioBaseStyle: React.CSSProperties = {
   WebkitAppearance: "none",
   width: "1rem",
   height: "1rem",
-  border: "1px solid var(--stagebook-border, #d1d5db)",
+  // Border longhands rather than the `border` shorthand. The checked
+  // and focus state styles below override `borderColor` (longhand);
+  // mixing shorthand with a longhand override breaks React's inline-
+  // style diff — when the longhand drops out of the next render, React
+  // clears the individual longhand properties and the shorthand's
+  // expansion is lost, leaving the browser's appearance:none default
+  // (black border). See the radio-color-bleed bug for the repro.
+  borderWidth: "1px",
+  borderStyle: "solid",
+  borderColor: "var(--stagebook-border, #d1d5db)",
   borderRadius: "9999px",
   backgroundColor: "var(--stagebook-surface, #fff)",
   backgroundSize: "100% 100%",


### PR DESCRIPTION
## Bug

When a participant clicked one radio option and then another, the previously-selected radio's border stayed BLACK rather than reverting to the default gray. Looked like a stray focus ring lingering on the old option.

## Data integrity check

Verified live in the viewer: the second click IS saved correctly. After clicking option \`a\` then option \`b\`:

| Radio | checked | border-color |
|-------|---------|---------------|
| a (was clicked) | `false` ✓ | `rgb(0, 0, 0)` ← bug |
| b (current) | `true` ✓ | `rgb(59, 130, 246)` ← primary, correct |
| c (untouched) | `false` ✓ | `rgb(209, 213, 219)` ← gray, correct |

So only the visual was wrong, not the data.

## Root cause

[RadioGroup.tsx](packages/stagebook/src/components/form/RadioGroup.tsx) mixed CSS shorthand and longhand in its inline style objects:

```ts
const radioBaseStyle = { border: "1px solid var(--stagebook-border, #d1d5db)" };  // shorthand
const radioCheckedStyle = { borderColor: "var(--stagebook-primary, #3b82f6)" };   // longhand
```

When a radio went checked → unchecked, React's inline-style diff cleared the longhand `borderColor` back to empty — and in doing so blew away the shorthand `border`'s expansion too. The element fell back to the browser's `appearance: none` default, which Chrome resolves to `rgb(0, 0, 0)`.

Confirmed by inspecting the inline style attribute mid-transition:

```
border-top-style: ; border-top-width: ; border-right-style: ; ...   ← all empty
```

## Fix

Use border longhands consistently in the base style. React's diff never has to reconcile shorthand vs longhand, so the deselect path is reliable:

```ts
borderWidth: "1px",
borderStyle: "solid",
borderColor: "var(--stagebook-border, #d1d5db)",
```

## Test

Regression test in [RadioGroup.ct.tsx](packages/stagebook/src/components/form/RadioGroup.ct.tsx) asserts the previously-checked radio and an untouched radio have the same computed `border-color` after the user clicks a different option. Verified the test fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)