### PR TITLE
UI polish: RadioGroup (#368)

### DIFF
--- a/packages/stagebook/src/components/form/RadioGroup.ct.tsx
+++ b/packages/stagebook/src/components/form/RadioGroup.ct.tsx
@@ -137,28 +137,134 @@ test.describe("RadioGroup", () => {
     expect(aBorder).toBe(cBorder);
   });
 
-  test("focus ring appears inline on focus and disappears on blur", async ({
+  test("focus ring appears on keyboard focus via :focus-visible", async ({
+    mount,
+    page,
+  }) => {
+    // Focus ring is keyboard-only — `:focus-visible` rather than
+    // `:focus` so a mouse click doesn't leave a lingering ring on the
+    // just-clicked option. The ring is delivered via the component's
+    // own `<style>` block (pseudo-classes can't be expressed inline),
+    // so we assert on computed `boxShadow` rather than inline style.
+    const component = await mount(
+      <RadioGroup options={options} onChange={() => {}} />,
+    );
+
+    // Tab into the page — first Tab lands on the first focusable
+    // element inside the mount root, which is the first radio.
+    await page.keyboard.press("Tab");
+    const focused = component.locator('input[value="a"]');
+    await expect(focused).toBeFocused();
+    const shadowOnKeyboardFocus = await focused.evaluate(
+      (el) => window.getComputedStyle(el).boxShadow,
+    );
+    // Should contain a non-`none` box-shadow (the focus ring).
+    expect(shadowOnKeyboardFocus).not.toBe("none");
+  });
+
+  test("mouse click does not leave a focus ring on the clicked radio (:focus-visible)", async ({
+    mount,
+  }) => {
+    // Companion to the keyboard-focus test: mouse clicks should not
+    // trigger `:focus-visible`, so the focus ring stays hidden even
+    // though the input is the active element.
+    const component = await mount(
+      <RadioGroup options={options} onChange={() => {}} />,
+    );
+    const inputA = component.locator('input[value="a"]');
+    await inputA.click();
+
+    const shadow = await inputA.evaluate(
+      (el) => window.getComputedStyle(el).boxShadow,
+    );
+    expect(shadow).toBe("none");
+  });
+
+  test("option row gets a hover background fill (#350 whole-row hover)", async ({
     mount,
   }) => {
     const component = await mount(
       <RadioGroup options={options} onChange={() => {}} />,
     );
-    const input = component.locator('input[value="a"]');
+    const row = component.locator('[data-testid="option"]').first();
 
-    // Nothing before focus
-    expect(
-      await input.evaluate((el) => (el as HTMLElement).style.boxShadow),
-    ).toBe("");
+    const before = await row.evaluate(
+      (el) => window.getComputedStyle(el).backgroundColor,
+    );
+    await row.hover();
+    // `expect.poll` retries until the polled value satisfies the
+    // matcher (or the timeout hits). Needed because the hover state
+    // is gated on a 120ms `background-color` transition; reading
+    // getComputedStyle synchronously after `hover()` can catch the
+    // transition mid-flight or before it starts depending on warm-up.
+    await expect
+      .poll(
+        () => row.evaluate((el) => window.getComputedStyle(el).backgroundColor),
+        { timeout: 1500 },
+      )
+      .not.toBe(before);
+  });
 
-    await input.focus();
-    expect(
-      await input.evaluate((el) => (el as HTMLElement).style.boxShadow),
-    ).toContain("--stagebook-focus-ring");
+  test("long option labels wrap without losing hover-fill coverage", async ({
+    mount,
+  }) => {
+    // Guard against a regression where someone sets a fixed
+    // `height: 2.25rem` on the row instead of `minHeight`. With
+    // minHeight the row grows to fit a wrapping label; with a fixed
+    // height the label would visually overflow and the hover-fill
+    // background wouldn't cover the wrapped lines.
+    const longOptions = [
+      {
+        key: "a",
+        value:
+          "A deliberately long option label that should wrap across multiple lines when constrained to a narrow column so we can verify the row grows to fit",
+      },
+      { key: "b", value: "Short" },
+    ];
+    const component = await mount(
+      <div style={{ width: "240px" }}>
+        <RadioGroup options={longOptions} onChange={() => {}} />
+      </div>,
+    );
+    const longRow = component.locator('[data-testid="option"]').first();
+    const box = await longRow.boundingBox();
+    expect(box).not.toBeNull();
+    // A single 36px row can't fit ~26 words at 240px wide; expect at
+    // least two lines worth (≥ ~50px).
+    expect(box!.height).toBeGreaterThan(50);
+  });
 
-    await input.blur();
-    expect(
-      await input.evaluate((el) => (el as HTMLElement).style.boxShadow),
-    ).toBe("");
+  test("options container has role=radiogroup and is labelled by the legend", async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <RadioGroup
+        options={options}
+        onChange={() => {}}
+        label="Pick your favorite"
+      />,
+    );
+    const group = component.locator('[role="radiogroup"]');
+    await expect(group).toBeVisible();
+    // The aria-labelledby points at the legend label
+    const labelledById = await group.getAttribute("aria-labelledby");
+    expect(labelledById).not.toBeNull();
+    const legend = component.locator(`#${labelledById!}`);
+    await expect(legend).toHaveText("Pick your favorite");
+  });
+
+  test("row meets touch-target sizing (≥36px tall)", async ({ mount }) => {
+    // 36px (2.25rem) — balances HIG's 44px recommendation against
+    // vertical density on long Likert-style scales.
+    const component = await mount(
+      <RadioGroup options={options} onChange={() => {}} />,
+    );
+    const rowBox = await component
+      .locator('[data-testid="option"]')
+      .first()
+      .boundingBox();
+    expect(rowBox).not.toBeNull();
+    expect(rowBox!.height).toBeGreaterThanOrEqual(36);
   });
 
   test("inline styles survive an aggressive host CSS reset (issue #213)", async ({

--- a/packages/stagebook/src/components/form/RadioGroup.tsx
+++ b/packages/stagebook/src/components/form/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useId } from "react";
 
 export interface RadioOption {
   key: string;
@@ -17,23 +17,30 @@ export interface RadioGroupProps {
   "data-testid"?: string;
 }
 
-// Radio input styling is applied inline so <input type="radio"> elements
-// render consistently on any host — including Tailwind-preflight hosts
-// where `appearance: none` strips the native OS chrome and leaves an
-// empty circle that ignores --stagebook-primary. See issue #213.
+// Radio input + row styling. Defensive structural rules live inline so
+// they survive aggressive host CSS resets (Tailwind preflight, etc. —
+// see issue #213). Pseudo-class behaviors (`:hover`, `:focus-visible`)
+// live in a class-scoped `<style>` block — pseudo-classes can't be
+// expressed in inline styles, and these rules don't need to survive
+// host overrides at the same level the structural rules do.
+//
+// `:focus-visible` (not `:focus`) so the focus ring appears only when
+// the participant is navigating by keyboard — clicking with a mouse
+// no longer leaves a lingering ring around the just-clicked option.
 
 const radioBaseStyle: React.CSSProperties = {
   appearance: "none",
   WebkitAppearance: "none",
   width: "1rem",
   height: "1rem",
+  flexShrink: 0,
   // Border longhands rather than the `border` shorthand. The checked
-  // and focus state styles below override `borderColor` (longhand);
-  // mixing shorthand with a longhand override breaks React's inline-
-  // style diff — when the longhand drops out of the next render, React
-  // clears the individual longhand properties and the shorthand's
-  // expansion is lost, leaving the browser's appearance:none default
-  // (black border). See the radio-color-bleed bug for the repro.
+  // state below overrides `borderColor` (longhand); mixing shorthand
+  // with a longhand override breaks React's inline-style diff — when
+  // the longhand drops out of the next render, React clears the
+  // individual longhand properties and the shorthand's expansion is
+  // lost, leaving the browser's appearance:none default (black
+  // border). See #367 for the repro.
   borderWidth: "1px",
   borderStyle: "solid",
   borderColor: "var(--stagebook-border, #d1d5db)",
@@ -58,9 +65,27 @@ const radioCheckedStyle: React.CSSProperties = {
   backgroundImage: RADIO_DOT_SVG,
 };
 
-const radioFocusStyle: React.CSSProperties = {
-  outline: "none",
-  boxShadow: "0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25))",
+const radioRowStyle: React.CSSProperties = {
+  fontWeight: 400,
+  fontSize: "0.875rem",
+  color: "var(--stagebook-text-muted, #6b7280)",
+  cursor: "pointer",
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+  // Touch-target sizing — HIG / Material both recommend ~44px for
+  // pointer-coarse targets; 2.25rem (36px) balances target size
+  // against vertical density on long Likert-style scales. Hosts that
+  // want a different target size (e.g., mobile-first deployments
+  // wanting full 44px) override via `--stagebook-row-min-height`.
+  // Padding bakes into the hover-fill area so the visual affordance
+  // covers the full clickable region.
+  minHeight: "var(--stagebook-row-min-height, 2.25rem)",
+  padding: "0.25rem 0.5rem",
+  borderRadius: "0.375rem",
+  // Smooth the hover-fill transition; respects prefers-reduced-motion
+  // via the media query in the style block below.
+  transition: "background-color 120ms ease-out",
 };
 
 export function RadioGroup({
@@ -69,18 +94,51 @@ export function RadioGroup({
   onChange,
   label = "",
   layout = "vertical",
-  id = "radioGroup",
+  id,
   "data-testid": dataTestId,
 }: RadioGroupProps) {
-  // Only one radio can hold keyboard focus at a time, so a single
-  // focused-key on the group suffices. Avoids per-input child components.
-  const [focusedKey, setFocusedKey] = useState<string | null>(null);
+  // Stable per-instance id for the radiogroup + label association.
+  // `useId` guarantees uniqueness even when multiple RadioGroups
+  // render on the same page without explicit `id` props — so the
+  // `name=` HTML attribute (which scopes the native radio group)
+  // doesn't accidentally merge two groups into one.
+  const reactId = useId();
+  // `useId` returns an opaque string the React docs explicitly call
+  // "not a valid HTML id/class on its own" — today it contains `:`
+  // (e.g. `:r0:`), and future React versions may introduce other
+  // CSS-unsafe characters. Strip anything outside the class-name-safe
+  // set rather than just `:` so the regex doesn't drift if React's
+  // format changes underneath us.
+  const safeId = reactId.replace(/[^a-zA-Z0-9_-]/g, "");
+  const rowClass = `stagebook-radio-row-${safeId}`;
+  const inputClass = `stagebook-radio-input-${safeId}`;
+  const groupId = id ?? `radioGroup-${reactId}`;
+  const labelId = `${groupId}-label`;
+  // `data-testid` keeps the literal default ("radioGroup") for
+  // back-compat with existing tests; only the HTML `id`/`name` need
+  // to be DOM-unique.
+  const testId = dataTestId ?? "radioGroup";
 
   return (
-    <div data-testid={dataTestId ?? id} style={{ marginTop: "1rem" }}>
+    <div data-testid={testId} style={{ marginTop: "1rem" }}>
+      <style>{`
+        .${rowClass}:hover {
+          background-color: var(--stagebook-hover-bg, #f3f4f6);
+        }
+        .${inputClass}:focus-visible {
+          outline: none;
+          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .${rowClass} {
+            transition: none;
+          }
+        }
+      `}</style>
       {label && (
         <label
-          htmlFor={id}
+          id={labelId}
+          htmlFor={groupId}
           style={{
             display: "block",
             fontSize: "1rem",
@@ -93,10 +151,12 @@ export function RadioGroup({
         </label>
       )}
       <div
+        role="radiogroup"
+        aria-labelledby={label ? labelId : undefined}
         style={{
           marginLeft: "1.25rem",
           display: layout === "horizontal" ? "flex" : "grid",
-          gap: layout === "horizontal" ? "1rem" : "0.375rem",
+          gap: layout === "horizontal" ? "1rem" : "0.125rem",
           flexWrap: layout === "horizontal" ? "wrap" : undefined,
         }}
       >
@@ -104,36 +164,26 @@ export function RadioGroup({
           const checked = value === key;
           return (
             <label
-              key={`${id}_${key}`}
+              key={`${groupId}_${key}`}
               data-testid="option"
-              style={{
-                fontWeight: 400,
-                fontSize: "0.875rem",
-                color: "var(--stagebook-text-muted, #6b7280)",
-                cursor: "pointer",
-                display: "flex",
-                alignItems: "center",
-                gap: "0.5rem",
-              }}
+              className={rowClass}
+              style={radioRowStyle}
             >
               <input
                 type="radio"
-                // Shared `name` so the browser treats these as one radio
-                // group (arrow-key navigation between options + AT
-                // grouping semantics). Scoped to `id` so multiple
-                // RadioGroup instances on the same page don't collide.
-                name={id}
+                className={inputClass}
+                // Shared `name` so the browser treats these as one
+                // radio group (arrow-key navigation between options +
+                // AT grouping semantics). Scoped to `groupId` so
+                // multiple RadioGroup instances on the same page
+                // don't collide.
+                name={groupId}
                 value={key}
                 checked={checked}
                 onChange={onChange}
-                onFocus={() => setFocusedKey(key)}
-                onBlur={() =>
-                  setFocusedKey((prev) => (prev === key ? null : prev))
-                }
                 style={{
                   ...radioBaseStyle,
                   ...(checked ? radioCheckedStyle : {}),
-                  ...(focusedKey === key ? radioFocusStyle : {}),
                 }}
               />
               {optionValue}

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -80,6 +80,19 @@
   --stagebook-bg: #ffffff;
   --stagebook-bg-muted: #f9fafb;
   --stagebook-bg-track: #e5e7eb;
+  /* Hover-state background fill for interactive rows (radio /
+   * checkbox option labels, sortable items, etc.). Sits between
+   * --stagebook-bg-muted (page-level subdued surface) and the
+   * primary-tinted focus ring so the hover affordance reads as
+   * "this row is interactive" without competing with selection
+   * indicators. */
+  --stagebook-hover-bg: #f3f4f6;
+  /* Minimum height for interactive rows (radio / checkbox option
+   * labels). Default 2.25rem (36px) balances HIG's 44px touch-target
+   * recommendation against vertical density on long Likert-style
+   * scales. Mobile-first deployments can override to "2.75rem" to
+   * hit 44px without forking. */
+  --stagebook-row-min-height: 2.25rem;
 
   /* Form control surface (input, textarea, select, checkbox, radio). Kept
    * distinct from --stagebook-bg so hosts can tint form controls separately


### PR DESCRIPTION
First PR in the #350 UI polish sweep — closes #368.

Starting with RadioGroup because [#367](https://github.com/deliberation-lab/stagebook/pull/367) just bit us there. While we were in the file, applied the per-component checklist from #350.

## Items addressed (from #350's checklist)

| Item | Status |
|------|:------:|
| Whole-row hover affordance | ✅ |
| Focus visibility via `:focus-visible` (not always-on) | ✅ |
| ARIA `role=radiogroup` + `aria-labelledby` | ✅ |
| Touch-target sizing (≥ 36px, overridable to 44px) | ✅ |
| Reduced-motion behavior on the hover transition | ✅ |
| Keyboard nav | ✓ already worked via shared `name` |
| Disabled state | Deferred — no consumer uses it; cleaner as its own PR |

## What changed

**[RadioGroup.tsx](packages/stagebook/src/components/form/RadioGroup.tsx)**
- Replaced React-state-tracked `focusedKey` with a scoped `<style>` block applying `:focus-visible`. Mouse clicks no longer leave a lingering ring; keyboard nav still does.
- New `:hover` rule on the option row paints `--stagebook-hover-bg`, with `padding` + `border-radius` so the fill area covers the full clickable region.
- Option row min-height bumped to `var(--stagebook-row-min-height, 2.25rem)` for a 36px touch target.
- Options container now carries `role="radiogroup"` and `aria-labelledby={labelId}` when a `label` prop is provided.
- `useId()`-backed `name`/`id` so multiple RadioGroups on the same page don't merge into one native radio group. The opaque ID is sanitized via `[^a-zA-Z0-9_-]` (not just stripping `:`) so future React versions don't break the CSS selectors.
- `data-testid` default stays the literal `"radioGroup"` for back-compat with existing Prompt tests.

**[styles.css](packages/stagebook/src/styles.css)**
- New `--stagebook-hover-bg: #f3f4f6` (Tailwind gray-100). Will be reused in CheckboxGroup (#369) and ListSorter (#374).
- New `--stagebook-row-min-height: 2.25rem`. Mobile-first hosts can set `2.75rem` (44px) without forking.

**[RadioGroup.ct.tsx](packages/stagebook/src/components/form/RadioGroup.ct.tsx)** — 5 new tests, all 18 pass:
- focus ring appears on keyboard focus via `:focus-visible`
- mouse click does NOT leave a focus ring on the clicked radio
- option row gets a hover background fill
- long option labels wrap without losing hover-fill coverage
- options container has `role=radiogroup` and `aria-labelledby`
- row meets touch-target sizing ≥ 36px

## Constraint compliance

Per CLAUDE.md — referenced shadcn/Radix patterns (whole-row hover, `:focus-visible`, ARIA roles, touch-target sizing) but **didn't import them**. Stagebook keeps full ownership so experiment reproducibility holds across versions. Defensive structural styles stay inline (so they survive aggressive host CSS resets per #213); only pseudo-class behavior moves to the scoped `<style>` block.

## Reviewer feedback applied (from a pre-PR subagent review, verdict SHIP WITH NITS)

- Defensive `useId` sanitization rather than just stripping `:`
- Lifted className computation to a `safeId` const
- Dropped a redundant baseline assertion in the hover test
- Added the wrapped-label hover-coverage test
- Exposed touch-target sizing as `--stagebook-row-min-height`

## Deferred follow-ups (out of scope here)

- Disabled state — no current consumer; better as its own focused PR
- AT name for an unlabelled RadioGroup — the right fix is at the Prompt level, since question text is rendered as markdown above the radiogroup rather than via the `label` prop
- Spread `--stagebook-hover-bg` to CheckboxGroup (#369) and ListSorter (#374)

🤖 Generated with [Claude Code](https://claude.com/claude-code)