### PR TITLE
UI polish: CheckboxGroup (#369)

### DIFF
--- a/packages/stagebook/src/components/form/CheckboxGroup.ct.tsx
+++ b/packages/stagebook/src/components/form/CheckboxGroup.ct.tsx
@@ -103,27 +103,152 @@ test.describe("CheckboxGroup", () => {
     expect(backgroundImage).toContain("data:image/svg+xml");
   });
 
-  test("focus ring appears inline on focus and disappears on blur", async ({
+  test("previously-checked box reverts to gray border after deselection (no color bleed)", async ({
+    mount,
+  }) => {
+    // Mirrors the RadioGroup regression test (#367) — the
+    // shorthand-vs-longhand border bug applies identically to
+    // CheckboxGroup. Toggling a checkbox off must not leave its
+    // border stuck at the previous fill color.
+    const component = await mount(
+      <MockCheckboxGroup options={options} initialValue={["x"]} />,
+    );
+
+    // Sanity: X starts checked, Y is untouched
+    await expect(component.locator('input[value="x"]')).toBeChecked();
+    await expect(component.locator('input[value="y"]')).not.toBeChecked();
+
+    // Click X to uncheck it
+    await component.getByText("Choice X").click();
+    await expect(component.locator('input[value="x"]')).not.toBeChecked();
+
+    // X (just unchecked) and Y (never clicked) should have the same
+    // gray border. Pre-fix this would have left X with rgb(0, 0, 0).
+    const xBorder = await component
+      .locator('input[value="x"]')
+      .evaluate((el) => window.getComputedStyle(el).borderColor);
+    const yBorder = await component
+      .locator('input[value="y"]')
+      .evaluate((el) => window.getComputedStyle(el).borderColor);
+    expect(xBorder).toBe(yBorder);
+  });
+
+  test("focus ring appears on keyboard focus via :focus-visible", async ({
+    mount,
+    page,
+  }) => {
+    // Focus ring is keyboard-only — `:focus-visible` rather than
+    // `:focus` so a mouse click doesn't leave a lingering ring on
+    // the just-clicked option. The ring is delivered via the
+    // component's `<style>` block, so we assert on computed
+    // `boxShadow` rather than inline style.
+    const component = await mount(
+      <CheckboxGroup options={options} value={[]} onChange={() => {}} />,
+    );
+
+    await page.keyboard.press("Tab");
+    const focused = component.locator('input[value="x"]');
+    await expect(focused).toBeFocused();
+    const shadow = await focused.evaluate(
+      (el) => window.getComputedStyle(el).boxShadow,
+    );
+    expect(shadow).not.toBe("none");
+  });
+
+  test("mouse click does not leave a focus ring on the clicked checkbox (:focus-visible)", async ({
     mount,
   }) => {
     const component = await mount(
       <CheckboxGroup options={options} value={[]} onChange={() => {}} />,
     );
     const input = component.locator('input[value="x"]');
+    await input.click();
 
-    expect(
-      await input.evaluate((el) => (el as HTMLElement).style.boxShadow),
-    ).toBe("");
+    const shadow = await input.evaluate(
+      (el) => window.getComputedStyle(el).boxShadow,
+    );
+    expect(shadow).toBe("none");
+  });
 
-    await input.focus();
-    expect(
-      await input.evaluate((el) => (el as HTMLElement).style.boxShadow),
-    ).toContain("--stagebook-focus-ring");
+  test("option row gets a hover background fill (#350 whole-row hover)", async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <CheckboxGroup options={options} value={[]} onChange={() => {}} />,
+    );
+    const row = component.locator('[data-testid="option"]').first();
 
-    await input.blur();
-    expect(
-      await input.evaluate((el) => (el as HTMLElement).style.boxShadow),
-    ).toBe("");
+    const before = await row.evaluate(
+      (el) => window.getComputedStyle(el).backgroundColor,
+    );
+    await row.hover();
+    // Poll to allow for the 120ms background-color transition.
+    await expect
+      .poll(
+        () => row.evaluate((el) => window.getComputedStyle(el).backgroundColor),
+        { timeout: 1500 },
+      )
+      .not.toBe(before);
+  });
+
+  test("long option labels wrap without losing hover-fill coverage", async ({
+    mount,
+  }) => {
+    // Guard against a regression where someone sets `height` instead
+    // of `minHeight` — a fixed height would clip a wrapping label and
+    // the hover-fill would not cover the wrapped lines.
+    const longOptions = [
+      {
+        key: "x",
+        value:
+          "A deliberately long option label that should wrap across multiple lines when constrained to a narrow column so we can verify the row grows to fit",
+      },
+      { key: "y", value: "Short" },
+    ];
+    const component = await mount(
+      <div style={{ width: "240px" }}>
+        <CheckboxGroup options={longOptions} value={[]} onChange={() => {}} />
+      </div>,
+    );
+    const longRow = component.locator('[data-testid="option"]').first();
+    const box = await longRow.boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.height).toBeGreaterThan(50);
+  });
+
+  test("options container has role=group and is labelled by the legend", async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <CheckboxGroup
+        options={options}
+        value={[]}
+        onChange={() => {}}
+        label="Pick all that apply"
+      />,
+    );
+    // `role="group"` is the right ARIA role for a collection of
+    // related checkboxes — there's no `role="checkboxgroup"`. The
+    // `aria-labelledby` points at the legend label so AT announces
+    // the group name when entering.
+    const group = component.locator('[role="group"]');
+    await expect(group).toBeVisible();
+    const labelledById = await group.getAttribute("aria-labelledby");
+    expect(labelledById).not.toBeNull();
+    const legend = component.locator(`#${labelledById!}`);
+    await expect(legend).toHaveText("Pick all that apply");
+  });
+
+  test("row meets touch-target sizing (≥36px tall)", async ({ mount }) => {
+    const component = await mount(
+      <CheckboxGroup options={options} value={[]} onChange={() => {}} />,
+    );
+    const rowBox = await component
+      .locator('[data-testid="option"]')
+      .first()
+      .boundingBox();
+    expect(rowBox).not.toBeNull();
+    expect(rowBox!.height).toBeGreaterThanOrEqual(36);
   });
 
   test("inline styles survive an aggressive host CSS reset (issue #213)", async ({

--- a/packages/stagebook/src/components/form/CheckboxGroup.tsx
+++ b/packages/stagebook/src/components/form/CheckboxGroup.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useId } from "react";
 
 export interface CheckboxOption {
   key: string;
@@ -17,17 +17,33 @@ export interface CheckboxGroupProps {
   "data-testid"?: string;
 }
 
-// Checkbox input styling is applied inline so <input type="checkbox">
-// elements render consistently on any host — including Tailwind-preflight
-// hosts where `appearance: none` strips the native OS chrome and leaves
-// an empty box that ignores --stagebook-primary. See issue #213.
+// Checkbox input + row styling. Same pattern as RadioGroup (#368) —
+// defensive structural rules live inline so they survive aggressive
+// host CSS resets (Tailwind preflight, etc. — see issue #213).
+// Pseudo-class behaviors (`:hover`, `:focus-visible`) live in a
+// class-scoped `<style>` block since pseudo-classes can't be
+// expressed in inline styles.
+//
+// `:focus-visible` (not `:focus`) so the focus ring appears only when
+// the participant is navigating by keyboard — clicking with a mouse
+// no longer leaves a lingering ring around the just-clicked option.
 
 const checkboxBaseStyle: React.CSSProperties = {
   appearance: "none",
   WebkitAppearance: "none",
   width: "1rem",
   height: "1rem",
-  border: "1px solid var(--stagebook-border, #d1d5db)",
+  flexShrink: 0,
+  // Border longhands rather than the `border` shorthand. The checked
+  // state below overrides `borderColor` (longhand); mixing shorthand
+  // with a longhand override breaks React's inline-style diff — when
+  // the longhand drops out of the next render, React clears the
+  // individual longhand properties and the shorthand's expansion is
+  // lost, leaving the browser's appearance:none default (black
+  // border). Same root cause as #367 for RadioGroup.
+  borderWidth: "1px",
+  borderStyle: "solid",
+  borderColor: "var(--stagebook-border, #d1d5db)",
   borderRadius: "0.125rem",
   backgroundColor: "var(--stagebook-surface, #fff)",
   backgroundSize: "100% 100%",
@@ -49,9 +65,23 @@ const checkboxCheckedStyle: React.CSSProperties = {
   backgroundImage: CHECKBOX_CHECK_SVG,
 };
 
-const checkboxFocusStyle: React.CSSProperties = {
-  outline: "none",
-  boxShadow: "0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25))",
+const checkboxRowStyle: React.CSSProperties = {
+  fontWeight: 400,
+  fontSize: "0.875rem",
+  color: "var(--stagebook-text-muted, #6b7280)",
+  cursor: "pointer",
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+  // Touch-target sizing — see RadioGroup for the rationale. Defaults
+  // to 36px via `--stagebook-row-min-height`; hosts targeting
+  // mobile-first can override to 2.75rem to hit HIG's 44px.
+  minHeight: "var(--stagebook-row-min-height, 2.25rem)",
+  padding: "0.25rem 0.5rem",
+  borderRadius: "0.375rem",
+  // Smooth hover-fill transition; respects prefers-reduced-motion
+  // via the media query in the style block below.
+  transition: "background-color 120ms ease-out",
 };
 
 export function CheckboxGroup({
@@ -60,12 +90,24 @@ export function CheckboxGroup({
   onChange,
   label = "",
   layout = "vertical",
-  id = "checkboxGroup",
+  id,
   "data-testid": dataTestId,
 }: CheckboxGroupProps) {
-  // Only one input can hold keyboard focus at a time, so a single
-  // focused-key on the group suffices. Avoids per-input child components.
-  const [focusedKey, setFocusedKey] = useState<string | null>(null);
+  // Stable per-instance id for the group + label association.
+  const reactId = useId();
+  // `useId` returns an opaque string the React docs explicitly call
+  // "not a valid HTML id/class on its own". Strip anything outside
+  // the class-name-safe set rather than just `:` so the regex doesn't
+  // drift if React's format changes underneath us.
+  const safeId = reactId.replace(/[^a-zA-Z0-9_-]/g, "");
+  const rowClass = `stagebook-checkbox-row-${safeId}`;
+  const inputClass = `stagebook-checkbox-input-${safeId}`;
+  const groupId = id ?? `checkboxGroup-${reactId}`;
+  const labelId = `${groupId}-label`;
+  // `data-testid` keeps the literal default ("checkboxGroup") for
+  // back-compat with existing tests; only the HTML `id` needs to be
+  // DOM-unique.
+  const testId = dataTestId ?? "checkboxGroup";
 
   const handleToggle = (key: string) => {
     const selectedSet = new Set(value);
@@ -78,10 +120,25 @@ export function CheckboxGroup({
   };
 
   return (
-    <div data-testid={dataTestId ?? id} style={{ marginTop: "1rem" }}>
+    <div data-testid={testId} style={{ marginTop: "1rem" }}>
+      <style>{`
+        .${rowClass}:hover {
+          background-color: var(--stagebook-hover-bg, #f3f4f6);
+        }
+        .${inputClass}:focus-visible {
+          outline: none;
+          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .${rowClass} {
+            transition: none;
+          }
+        }
+      `}</style>
       {label && (
         <label
-          htmlFor={id}
+          id={labelId}
+          htmlFor={groupId}
           style={{
             display: "block",
             fontSize: "1rem",
@@ -94,10 +151,17 @@ export function CheckboxGroup({
         </label>
       )}
       <div
+        // ARIA — `role="group"` (not "checkboxgroup", which isn't a
+        // real ARIA role) so a screen reader announces the
+        // collection of checkboxes as a labelled group rather than
+        // as loose siblings. Native `<input type="checkbox">` already
+        // conveys `aria-checked` via its `:checked` state.
+        role="group"
+        aria-labelledby={label ? labelId : undefined}
         style={{
           marginLeft: "1.25rem",
           display: layout === "horizontal" ? "flex" : "grid",
-          gap: layout === "horizontal" ? "1rem" : "0.375rem",
+          gap: layout === "horizontal" ? "1rem" : "0.125rem",
           flexWrap: layout === "horizontal" ? "wrap" : undefined,
         }}
       >
@@ -105,33 +169,22 @@ export function CheckboxGroup({
           const checked = value.includes(key);
           return (
             <label
-              key={`${id}_${key}`}
+              key={`${groupId}_${key}`}
               data-testid="option"
-              style={{
-                fontWeight: 400,
-                fontSize: "0.875rem",
-                color: "var(--stagebook-text-muted, #6b7280)",
-                cursor: "pointer",
-                display: "flex",
-                alignItems: "center",
-                gap: "0.5rem",
-              }}
+              className={rowClass}
+              style={checkboxRowStyle}
             >
               <input
                 type="checkbox"
+                className={inputClass}
                 name={key}
                 value={key}
-                id={`${id}_${key}`}
+                id={`${groupId}_${key}`}
                 checked={checked}
                 onChange={() => handleToggle(key)}
-                onFocus={() => setFocusedKey(key)}
-                onBlur={() =>
-                  setFocusedKey((prev) => (prev === key ? null : prev))
-                }
                 style={{
                   ...checkboxBaseStyle,
                   ...(checked ? checkboxCheckedStyle : {}),
-                  ...(focusedKey === key ? checkboxFocusStyle : {}),
                 }}
               />
               {optionValue}


### PR DESCRIPTION
Second PR in the #350 UI polish sweep — closes #369.

CheckboxGroup is RadioGroup's twin. Same shape, same gaps. Same playbook as #375, with the same tokens (`--stagebook-hover-bg`, `--stagebook-row-min-height`) flowing through.

## Items addressed

| Item | Status |
|------|:------:|
| Latent #367-style border-color bleed | ✅ |
| Whole-row hover affordance | ✅ |
| `:focus-visible` (focus ring keyboard-only) | ✅ |
| ARIA `role="group"` + `aria-labelledby` | ✅ |
| Touch-target sizing (≥ 36px) | ✅ |
| Reduced-motion on hover transition | ✅ |
| Per-instance unique HTML ids | ✅ |

The #367-style bug applies identically — CheckboxGroup used `border` shorthand with a `borderColor` longhand override, so toggling a checked box off left a black border instead of reverting to gray. Regression test included.

## What changed

**[CheckboxGroup.tsx](packages/stagebook/src/components/form/CheckboxGroup.tsx)**
- Border longhands (instead of shorthand) so React's inline-style diff is well-behaved.
- Scoped `<style>` block with `:hover` row fill, `:focus-visible` ring, reduced-motion fallback.
- `role="group"` + `aria-labelledby` (no `role="checkboxgroup"` exists per WAI-ARIA — Radix and MUI both use `role="group"` here).
- `useId()`-backed default `id` so multiple groups on the page don't collide.
- `data-testid` default stays the literal `"checkboxGroup"` for back-compat with Prompt tests.

**[CheckboxGroup.ct.tsx](packages/stagebook/src/components/form/CheckboxGroup.ct.tsx)** — 7 new tests, 17 total pass:
- previously-checked box reverts to gray border after deselection
- focus ring appears on keyboard focus via `:focus-visible`
- mouse click does NOT leave a focus ring on the clicked checkbox
- option row gets a hover background fill
- long option labels wrap without losing hover-fill coverage
- options container has `role=group` and `aria-labelledby`
- row meets touch-target sizing ≥ 36px

No changes to `styles.css` — both tokens (`--stagebook-hover-bg`, `--stagebook-row-min-height`) were added in #375 specifically for cross-component reuse.

## Reviewer feedback (pre-PR subagent review)

Verdict: **SHIP IT**. All findings were nits/questions about symmetry, confirmed correct:
- `role="group"` is the right ARIA choice (no `role="checkboxgroup"` exists)
- No double-fire from label-vs-input click (native browser behavior dedupes)
- Indeterminate state / "select all" deliberately out of scope (no consumer)

One pre-existing nit surfaced: the legend label's `htmlFor={groupId}` is dead (points at an id that doesn't exist on the `role=group` div). Same in RadioGroup. AT picks up the association via `aria-labelledby` regardless, so no functional impact. Worth cleaning up across both in a follow-up.

## Release plan

Per discussion in #375: batching this with #375 (RadioGroup) into a single release once it merges. They're a tightly-coupled pair and the release notes read better together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)