### PR TITLE
Bump stagebook to 0.10.6

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Form-options polish release — pairs RadioGroup and CheckboxGroup through the UI polish checklist from #350.

## What's in

- **#367** — Radio border-color bleed fix. Selecting one radio then another left the previously-selected option's border stuck at black instead of reverting to gray, due to React's inline-style diff blowing up a `border` shorthand when the `borderColor` longhand override dropped. Data was always saved correctly; only the visual was wrong.

- **#375** (closes #368) — RadioGroup UI polish. Whole-row hover affordance, `:focus-visible` (focus ring keyboard-only), `role="radiogroup"` + `aria-labelledby`, touch-target rows ≥ 36px, reduced-motion fallback, `useId()`-backed unique ids.

- **#376** (closes #369) — CheckboxGroup UI polish. Same playbook as #375; same #367-style border bug existed here too and was fixed. Reuses the `--stagebook-hover-bg` and `--stagebook-row-min-height` tokens introduced in #375.

## New CSS variables (additive, opt-in)

- `--stagebook-hover-bg` (default `#f3f4f6`) — interactive-row hover fill.
- `--stagebook-row-min-height` (default `2.25rem` = 36px) — touch-target row size; hosts targeting mobile-first can override to `2.75rem` (44px).

## Compatibility

- No API changes.
- No schema or behavior changes for hosts.
- Visual defaults unchanged from 0.10.5 except for the new hover/focus/touch affordances — which are net additions, not replacements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)