### PR TITLE
UI polish: TextArea (#371)

### DIFF
--- a/packages/stagebook/src/components/form/TextArea.ct.tsx
+++ b/packages/stagebook/src/components/form/TextArea.ct.tsx
@@ -183,3 +183,152 @@ test("no counter when showCharacterCount is false", async ({ mount }) => {
   await expect(component).not.toContainText("characters");
   await expect(component).not.toContainText("chars");
 });
+
+// -- UI polish (#371) --
+
+test("focus ring appears on keyboard focus via :focus-visible", async ({
+  mount,
+  page,
+}) => {
+  // Browsers apply `:focus-visible` to text inputs even on mouse
+  // click (text fields are always keyboard-active per WHATWG), so we
+  // can use Tab here for clarity but mouse click would also work.
+  // The ring is delivered via the component's class-scoped `<style>`
+  // block, so we assert on computed `boxShadow` rather than inline.
+  const component = await mount(<TextArea />);
+  const textarea = component.locator("textarea");
+
+  // Baseline: elevation shadow only.
+  const baseline = await textarea.evaluate(
+    (el) => window.getComputedStyle(el).boxShadow,
+  );
+
+  await page.keyboard.press("Tab");
+  await expect(textarea).toBeFocused();
+  // Poll for the 120ms box-shadow transition. The focused shadow
+  // includes the focus-ring var, distinguishing it from the baseline.
+  await expect
+    .poll(
+      () => textarea.evaluate((el) => window.getComputedStyle(el).boxShadow),
+      { timeout: 1500 },
+    )
+    .not.toBe(baseline);
+});
+
+test("focus ring goes away on blur", async ({ mount, page }) => {
+  const component = await mount(<TextArea />);
+  const textarea = component.locator("textarea");
+
+  const baseline = await textarea.evaluate(
+    (el) => window.getComputedStyle(el).boxShadow,
+  );
+
+  await page.keyboard.press("Tab");
+  await expect(textarea).toBeFocused();
+  // Confirm the ring is showing (different from baseline).
+  await expect
+    .poll(
+      () => textarea.evaluate((el) => window.getComputedStyle(el).boxShadow),
+      { timeout: 1500 },
+    )
+    .not.toBe(baseline);
+
+  await textarea.evaluate((el) => (el as HTMLElement).blur());
+  // After blur, the box-shadow should return to the baseline (the
+  // elevation shadow alone).
+  await expect
+    .poll(
+      () => textarea.evaluate((el) => window.getComputedStyle(el).boxShadow),
+      { timeout: 1500 },
+    )
+    .toBe(baseline);
+});
+
+test("focus ring also appears on mouse click (text inputs are always keyboard-active for :focus-visible)", async ({
+  mount,
+}) => {
+  // Symmetric to the keyboard-Tab test. Unlike Radio/Checkbox (where
+  // mouse click should NOT show the ring), text inputs get
+  // `:focus-visible` after mouse click in Chromium / Firefox /
+  // Safari 15.4+ because they're always keyboard-active. Guards
+  // against an accidental switch to `:focus-within` or React-state
+  // tracking that would regress this.
+  const component = await mount(<TextArea />);
+  const textarea = component.locator("textarea");
+
+  const baseline = await textarea.evaluate(
+    (el) => window.getComputedStyle(el).boxShadow,
+  );
+
+  await textarea.click();
+  await expect(textarea).toBeFocused();
+  await expect
+    .poll(
+      () => textarea.evaluate((el) => window.getComputedStyle(el).boxShadow),
+      { timeout: 1500 },
+    )
+    .not.toBe(baseline);
+});
+
+test("prefers-reduced-motion: pulse animation is replaced with a static red glow", async ({
+  mount,
+  page,
+}) => {
+  // Reduced-motion users still need the "you tried to type past max"
+  // signal — they just shouldn't see the pulsing animation. The
+  // CSS swap is: `animation: none` + static `box-shadow` so the
+  // counter shows a non-animated red ring for the 300ms window.
+  await page.emulateMedia({ reducedMotion: "reduce" });
+
+  const component = await mount(
+    <MockTextArea value="abcdefgh" showCharacterCount maxLength={10} />,
+  );
+  const textarea = component.locator("textarea");
+
+  // Type two characters to hit max (10), then a third to trigger
+  // overflow.
+  await textarea.focus();
+  await textarea.pressSequentially("ij");
+  await textarea.press("k");
+
+  const counter = component.locator('[data-testid="char-counter"]');
+  // Animation should be 'none' under reduced-motion (the pulse was
+  // 'stagebook-char-counter-pulse 300ms ease-out' otherwise).
+  const animationName = await counter.evaluate(
+    (el) => window.getComputedStyle(el).animationName,
+  );
+  expect(animationName).toBe("none");
+  // And the static red glow stands in for the pulse.
+  const boxShadow = await counter.evaluate(
+    (el) => window.getComputedStyle(el).boxShadow,
+  );
+  expect(boxShadow).not.toBe("none");
+});
+
+test("focused-then-blurred textarea doesn't leave a stuck border color (no #367-style bleed)", async ({
+  mount,
+}) => {
+  // Regression guard for the shorthand-vs-longhand border bug — same
+  // pattern as the Radio/Checkbox/Select cases. Even though TextArea
+  // doesn't currently override `borderColor` on focus, switching to
+  // border longhands keeps future state-color additions safe.
+  const component = await mount(
+    <div>
+      <TextArea id="touched" />
+      <TextArea id="untouched" />
+    </div>,
+  );
+  const touched = component.locator('textarea[id="touched"]');
+  const untouched = component.locator('textarea[id="untouched"]');
+
+  await touched.focus();
+  await touched.blur();
+
+  const touchedBorder = await touched.evaluate(
+    (el) => window.getComputedStyle(el).borderColor,
+  );
+  const untouchedBorder = await untouched.evaluate(
+    (el) => window.getComputedStyle(el).borderColor,
+  );
+  expect(touchedBorder).toBe(untouchedBorder);
+});

--- a/packages/stagebook/src/components/form/TextArea.tsx
+++ b/packages/stagebook/src/components/form/TextArea.tsx
@@ -72,6 +72,11 @@ export function TextArea({
 }: TextAreaProps) {
   const generatedId = useId();
   const textAreaId = id || generatedId;
+  // `useId` returns an opaque string the React docs call "not a valid
+  // HTML id/class on its own". Strip anything outside the class-name-
+  // safe set so the regex doesn't drift if React's format changes.
+  const safeId = generatedId.replace(/[^a-zA-Z0-9_-]/g, "");
+  const textareaClass = `stagebook-textarea-${safeId}`;
   const [localValue, setLocalValue] = useState(value || "");
   // Transient flag set when a keystroke is rejected for exceeding maxLength;
   // drives the brief red pulse animation on the character counter. The
@@ -122,6 +127,23 @@ export function TextArea({
     return () => {
       if (overflowTimeout.current) clearTimeout(overflowTimeout.current);
     };
+  }, []);
+
+  // Listen to `prefers-reduced-motion` so the overflow signal can swap
+  // its animated pulse for a static red glow. The inline `animation`
+  // style applied while overflowing wins specificity over any CSS
+  // media query, so we need to switch in JS rather than purely in CSS.
+  // SSR-safe: matches `false` server-side; hydrates to the real value
+  // on the first useEffect tick.
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReducedMotion(mq.matches);
+    const onChange = (e: MediaQueryListEvent) =>
+      setPrefersReducedMotion(e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
   }, []);
 
   const submitChange = (val: string) => {
@@ -306,10 +328,16 @@ export function TextArea({
 
     // Pulse animation takes priority over the steady-state color — when the
     // participant tries to type past maxLength, the counter flashes red for
-    // 300ms regardless of the underlying valid state.
-    const animationStyle = isOverflowing
-      ? { animation: "stagebook-char-counter-pulse 300ms ease-out" }
-      : {};
+    // 300ms regardless of the underlying valid state. For participants who
+    // prefer reduced motion we drop the pulse animation but keep the signal
+    // visible as a static red glow for the same 300ms window — the React
+    // `key` on the wrapper div still re-mounts the element so the glow
+    // reliably re-appears on every overflow attempt.
+    const animationStyle = !isOverflowing
+      ? {}
+      : prefersReducedMotion
+        ? { boxShadow: "0 0 0 4px var(--stagebook-warning, #dc2626)" }
+        : { animation: "stagebook-char-counter-pulse 300ms ease-out" };
     const overflowState = isOverflowing ? "overflow" : countState;
 
     return (
@@ -339,6 +367,7 @@ export function TextArea({
     >
       <textarea
         id={textAreaId}
+        className={textareaClass}
         autoComplete="off"
         rows={rows}
         placeholder={defaultText}
@@ -354,17 +383,47 @@ export function TextArea({
           width: "100%",
           boxSizing: "border-box",
           padding: "0.5rem 0.75rem",
-          border: "1px solid var(--stagebook-border, #d1d5db)",
+          // Border longhands rather than the `border` shorthand —
+          // matches the pattern adopted in #367 (RadioGroup) and the
+          // sibling form components. Lets future state-based color
+          // overrides on `borderColor` (e.g. an error state) play
+          // nicely with React's inline-style diff.
+          borderWidth: "1px",
+          borderStyle: "solid",
+          borderColor: "var(--stagebook-border, #d1d5db)",
           borderRadius: "0.375rem",
-          boxShadow: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
           fontSize: "0.875rem",
           lineHeight: "1.25rem",
           color: "var(--stagebook-text, #1f2937)",
           resize: "vertical",
+          // Note on `box-shadow`: kept in the class-scoped <style>
+          // block (not inline) so the `:focus-visible` rule can
+          // stack the focus ring on top of the elevation shadow.
+          // Inline `boxShadow` would win specificity over the class
+          // selector, blocking the focus ring.
+          transition: "box-shadow 120ms ease-out",
         }}
       />
       {renderCharacterCount()}
       <style>{`
+        /* Base subtle elevation, kept in CSS so the :focus-visible
+           rule below can layer the focus ring on top without
+           losing to an inline-style boxShadow on specificity. */
+        .${textareaClass} {
+          box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+        }
+        /* Focus ring on the textarea — uses :focus-visible (not
+           :focus). Browsers apply :focus-visible to text inputs even
+           on mouse click because text fields are always
+           keyboard-active. The ring matches the pattern used by the
+           sibling form components (Radio / Checkbox / Select). The
+           trailing 1px shadow preserves the textarea subtle elevation
+           under the ring. */
+        .${textareaClass}:focus-visible {
+          outline: none;
+          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25)), 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+        }
+
         /* Animate a box-shadow glow instead of the text color, so the
            steady-state countColor (gray/green) is preserved throughout
            the pulse — animating color back to "inherit" produced a brief
@@ -381,6 +440,18 @@ export function TextArea({
           }
           100% {
             box-shadow: 0 0 0 0 var(--stagebook-warning, #dc2626);
+          }
+        }
+
+        /* Respect prefers-reduced-motion for the focus-ring
+           transition. (The char-counter overflow signal is handled
+           in JS via the prefersReducedMotion state — the inline
+           animation style applied while overflowing wins specificity
+           over any class-scoped CSS rule, so JS is the cleaner
+           path.) */
+        @media (prefers-reduced-motion: reduce) {
+          .${textareaClass} {
+            transition: none;
           }
         }
       `}</style>


### PR DESCRIPTION
Fourth PR in the #350 UI polish sweep — closes #371.

TextArea is the `openResponse` free-text input with **typing telemetry baked in** (keystroke timing, paste detection, focus duration). That telemetry is part of stagebook's measurement-instrument identity and stays **untouched** per CLAUDE.md.

## Items addressed

| Item | Status | Notes |
|------|:------:|-------|
| **Focus ring** | ✅ | Zero focus indicator before. Real a11y gap. |
| **Reduced-motion fallback for char-counter pulse** | ✅ | Named in #371. Static red glow replaces the animated pulse when `prefers-reduced-motion: reduce`. |
| Latent #367-style border bleed | ✅ | Proactive fix. |
| Char counter polish | ✓ | Already done in #338. |
| Keyboard nav | ✓ | Native textarea. |
| Typing telemetry | ✓ | Untouched. |

## Why reduced-motion needed JS, not just CSS

The char-counter pulse is applied via an **inline** `style={{ animation: ... }}` when `isOverflowing` is true. Inline styles win specificity over class-scoped CSS rules, so a `@media (prefers-reduced-motion: reduce) { ... animation: none }` rule in the component's `<style>` block never takes effect.

The fix listens to `window.matchMedia('(prefers-reduced-motion: reduce)')` in a `useEffect`, stores the result in state (`prefersReducedMotion`), and substitutes a static red `box-shadow` for the animated `animation` property when both `isOverflowing` AND `prefersReducedMotion` are true. SSR-safe (defaults to `false`, hydrates on first effect). Reacts to preference changes mid-session via the media query's `change` event.

## Elevation shadow tradeoff

The original code had `boxShadow: "0 1px 2px 0 rgba(0, 0, 0, 0.05)"` inline — a subtle elevation. To let the `:focus-visible` rule stack a focus ring on top, both shadows moved to the class-scoped `<style>` block. The decorative elevation no longer survives an aggressive host CSS reset that targets `textarea { box-shadow: none }` — but the #213 defensive-inline-styles posture was about preserving *structural* behavior (appearance, border, color), not decorations. Reviewer agreed.

## Reviewer feedback (pre-PR subagent review)

Verdict: **SHIP WITH NITS**. The reviewer caught a real bug: I claimed the counter goes red via inline color change for reduced-motion users, but `countColor` has no red path. Without the animation, reduced-motion participants would have got **zero** visual feedback on rejected overflow keystrokes. Fixed by substituting a static red glow (`box-shadow`) for the animation, keeping the 300ms signal window. Also added two requested tests:
- Mouse-click symmetry (TextArea ring DOES appear on click, unlike Radio/Checkbox)
- `prefers-reduced-motion`: pulse animation replaced with static glow

## Tests

22 → 23 TextArea tests pass. New:
- focus ring appears on keyboard focus via `:focus-visible`
- focus ring goes away on blur
- focus ring also appears on mouse click (text-input symmetry guard)
- `prefers-reduced-motion`: pulse animation is replaced with a static red glow
- focused-then-blurred no border bleed (regression guard for #367-style)

## Caveat for future component-polish PRs

JSX `<style>{` ... `}</style>` is a JS expression containing a template literal. Backticks inside that template literal — even inside CSS comments like `:focus-visible` — terminate the literal early. Bit me twice this PR. Easy to spot from the build error, but worth knowing in advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)