### PR TITLE
UI polish: Button (#373)

### DIFF
--- a/packages/stagebook/src/components/form/Button.ct.tsx
+++ b/packages/stagebook/src/components/form/Button.ct.tsx
@@ -1,6 +1,12 @@
 import { test, expect } from "@playwright/experimental-ct-react";
 import { Button } from "./Button";
 
+// Note: the Button renders a fragment (style + button), so
+// `component` refers to Playwright CT's mount wrapper, not the
+// <button> itself. Query `component.getByRole("button")` or
+// `component.locator("button")` to target the button element
+// when asserting interaction or computed style.
+
 test("renders with children text", async ({ mount }) => {
   const component = await mount(<Button>Click me</Button>);
   await expect(component).toContainText("Click me");
@@ -17,26 +23,194 @@ test("calls onClick when clicked", async ({ mount }) => {
       Submit
     </Button>,
   );
-  await component.click();
+  await component.getByRole("button").click();
   expect(clicked).toBe(true);
 });
 
 test("renders as disabled", async ({ mount }) => {
   const component = await mount(<Button disabled>Disabled</Button>);
-  await expect(component).toBeDisabled();
+  await expect(component.getByRole("button")).toBeDisabled();
 });
 
 test("applies secondary style when primary is false", async ({ mount }) => {
   const component = await mount(<Button primary={false}>Secondary</Button>);
   // Secondary button has white-ish background, not the primary blue
-  await expect(component).toHaveCSS("background-color", "rgb(255, 255, 255)");
+  await expect(component.getByRole("button")).toHaveCSS(
+    "background-color",
+    "rgb(255, 255, 255)",
+  );
 });
 
 test("applies primary style by default", async ({ mount }) => {
   const component = await mount(<Button>Primary</Button>);
   // Primary button should not have white background
-  const bg = await component.evaluate(
-    (el) => getComputedStyle(el).backgroundColor,
-  );
+  const bg = await component
+    .getByRole("button")
+    .evaluate((el) => getComputedStyle(el).backgroundColor);
   expect(bg).not.toBe("rgb(255, 255, 255)");
+});
+
+// ----------- UI polish (#373) -----------
+
+test("primary button darkens on hover", async ({ mount }) => {
+  const component = await mount(<Button>Submit</Button>);
+  const button = component.getByRole("button");
+  const before = await button.evaluate(
+    (el) => window.getComputedStyle(el).backgroundColor,
+  );
+  await button.hover();
+  // Poll for the 120ms background-color transition.
+  await expect
+    .poll(
+      () =>
+        button.evaluate((el) => window.getComputedStyle(el).backgroundColor),
+      { timeout: 1500 },
+    )
+    .not.toBe(before);
+});
+
+test("secondary button tints on hover", async ({ mount }) => {
+  const component = await mount(<Button primary={false}>Cancel</Button>);
+  const button = component.getByRole("button");
+  const before = await button.evaluate(
+    (el) => window.getComputedStyle(el).backgroundColor,
+  );
+  await button.hover();
+  await expect
+    .poll(
+      () =>
+        button.evaluate((el) => window.getComputedStyle(el).backgroundColor),
+      { timeout: 1500 },
+    )
+    .not.toBe(before);
+});
+
+test("focus ring appears on keyboard focus via :focus-visible", async ({
+  mount,
+  page,
+}) => {
+  // Focus ring is keyboard-only — `:focus-visible` rather than
+  // `:focus` so a mouse click on the button doesn't leave a
+  // lingering ring around it after release.
+  const component = await mount(<Button>Submit</Button>);
+  const button = component.getByRole("button");
+  const baseline = await button.evaluate(
+    (el) => window.getComputedStyle(el).boxShadow,
+  );
+
+  await page.keyboard.press("Tab");
+  await expect(button).toBeFocused();
+  await expect
+    .poll(
+      () => button.evaluate((el) => window.getComputedStyle(el).boxShadow),
+      { timeout: 1500 },
+    )
+    .not.toBe(baseline);
+});
+
+test("secondary variant also shows the focus ring on keyboard focus", async ({
+  mount,
+  page,
+}) => {
+  // The white-bg secondary button is the harder case for ring
+  // contrast — a thin translucent-blue ring against white can read
+  // as faint or invisible if any style overrides it. Lock it in
+  // separately from the primary test.
+  const component = await mount(<Button primary={false}>Cancel</Button>);
+  const button = component.getByRole("button");
+  const baseline = await button.evaluate(
+    (el) => window.getComputedStyle(el).boxShadow,
+  );
+
+  await page.keyboard.press("Tab");
+  await expect(button).toBeFocused();
+  await expect
+    .poll(
+      () => button.evaluate((el) => window.getComputedStyle(el).boxShadow),
+      { timeout: 1500 },
+    )
+    .not.toBe(baseline);
+});
+
+test("disabled button has pointer-events: none (no hover state fires)", async ({
+  mount,
+}) => {
+  // Even though the `disabled` attr already prevents click events,
+  // `pointer-events: none` additionally guards against any hover
+  // CSS firing — without it a hover over a disabled button would
+  // briefly darken before the click is ignored, contradicting
+  // the "disabled" semantic.
+  const component = await mount(<Button disabled>Disabled</Button>);
+  const button = component.getByRole("button");
+  const pointerEvents = await button.evaluate(
+    (el) => window.getComputedStyle(el).pointerEvents,
+  );
+  expect(pointerEvents).toBe("none");
+});
+
+test("disabled button has reduced opacity", async ({ mount }) => {
+  const component = await mount(<Button disabled>Disabled</Button>);
+  const button = component.getByRole("button");
+  const opacity = await button.evaluate((el) =>
+    parseFloat(window.getComputedStyle(el).opacity),
+  );
+  // Should be 0.5 (the documented disabled treatment) — at least
+  // visibly faded.
+  expect(opacity).toBeLessThan(1);
+  expect(opacity).toBeGreaterThan(0);
+});
+
+test("disabled button does NOT darken on hover (pointer-events: none)", async ({
+  mount,
+}) => {
+  // The strongest test of the `pointer-events: none` rule. Without
+  // it, hovering a disabled button would briefly fire the hover
+  // CSS — visually contradicting the "disabled" semantic ("looks
+  // interactive, isn't"). With it, the hover state can't fire.
+  const component = await mount(<Button disabled>Disabled</Button>);
+  const button = component.getByRole("button");
+  const before = await button.evaluate(
+    (el) => window.getComputedStyle(el).backgroundColor,
+  );
+  // Force the hover with a CSS state — Playwright's .hover() can't
+  // hover a pointer-events: none element. We test that even when
+  // we artificially apply :hover-equivalent state, nothing changes.
+  await button.hover({ force: true }).catch(() => {});
+  await new Promise((r) => setTimeout(r, 300));
+  const after = await button.evaluate(
+    (el) => window.getComputedStyle(el).backgroundColor,
+  );
+  expect(after).toBe(before);
+});
+
+test("primary button :active state is darker than hover (tactile feedback)", async ({
+  mount,
+  page,
+}) => {
+  // Symmetric with the hover tests. Mouse down on the button
+  // triggers the :active pseudo-class — the bg should darken
+  // further than the hover state did, so the click registers
+  // visually.
+  const component = await mount(<Button>Submit</Button>);
+  const button = component.getByRole("button");
+  const base = await button.evaluate(
+    (el) => window.getComputedStyle(el).backgroundColor,
+  );
+
+  // Press the mouse down on the button without releasing — this
+  // puts the button in the :active state without triggering the
+  // onClick.
+  const box = await button.boundingBox();
+  if (!box) throw new Error("button has no bounding box");
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  // Poll for the 120ms transition to settle on the active color.
+  await expect
+    .poll(
+      () =>
+        button.evaluate((el) => window.getComputedStyle(el).backgroundColor),
+      { timeout: 1500 },
+    )
+    .not.toBe(base);
+  await page.mouse.up();
 });

--- a/packages/stagebook/src/components/form/Button.tsx
+++ b/packages/stagebook/src/components/form/Button.tsx
@@ -13,6 +13,32 @@ export interface ButtonProps {
   "data-testid"?: string;
 }
 
+// Structural / dimensional styles live inline so the button survives
+// aggressive host CSS resets (#213). State-dependent properties
+// (background-color, box-shadow, border-color) live in the
+// class-scoped <style> block instead — keeping them inline would
+// have made the hover / focus-visible / active rules lose
+// specificity and never apply (same trap I hit on Slider / TextArea).
+//
+// The Button ships as SubmitButton on every stage, so it's the most
+// visible component in the form-input family.
+
+const baseInlineStyle: React.CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  padding: "0.5rem 1rem",
+  // Border longhands rather than the `border` shorthand — same #367
+  // fix pattern as the sibling form components.
+  borderWidth: "1px",
+  borderStyle: "solid",
+  fontSize: "0.875rem",
+  fontWeight: 500,
+  borderRadius: "0.375rem",
+  // The reduced-motion media query in the <style> block disables
+  // these transitions.
+  transition: "background-color 120ms ease-out, box-shadow 120ms ease-out",
+};
+
 export function Button({
   children,
   onClick = null,
@@ -27,45 +53,95 @@ export function Button({
 }: ButtonProps) {
   const generatedId = useId();
   const buttonId = id || `button${generatedId}`;
+  // useId returns an opaque string. Preventive sanitization for
+  // future React versions — today's output (`:r0:` style) only has
+  // colons outside the allowlist, but the regex covers anything
+  // else that might land in there.
+  const safeId = generatedId.replace(/[^a-zA-Z0-9_-]/g, "");
+  const buttonClass = `stagebook-button-${safeId}`;
 
-  const baseStyle: React.CSSProperties = {
-    display: "inline-flex",
-    alignItems: "center",
-    padding: "0.5rem 1rem",
-    border: "1px solid",
-    fontSize: "0.875rem",
-    fontWeight: 500,
-    borderRadius: "0.375rem",
-    cursor: disabled ? "not-allowed" : "pointer",
-    opacity: disabled ? 0.5 : 1,
-  };
-
-  const colorStyle: React.CSSProperties = primary
+  const stateStyle: React.CSSProperties = disabled
     ? {
-        color: "#fff",
-        backgroundColor: "var(--stagebook-primary, #3b82f6)",
-        borderColor: "transparent",
-        boxShadow: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
+        cursor: "not-allowed",
+        opacity: 0.5,
+        // Belt-and-suspenders: the `disabled` attr on the <button>
+        // already prevents click events, but `pointer-events: none`
+        // additionally guards against hover-state CSS firing on a
+        // disabled button (which would visually contradict the
+        // "disabled" semantic).
+        pointerEvents: "none",
       }
     : {
-        color: "var(--stagebook-text-secondary, #374151)",
-        backgroundColor: "#fff",
-        borderColor: "var(--stagebook-border, #d1d5db)",
-        boxShadow: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
+        cursor: "pointer",
       };
 
+  const variant = primary ? "primary" : "secondary";
+
   return (
-    <button
-      type={type}
-      onClick={onClick ?? undefined}
-      className={className}
-      autoFocus={autoFocus}
-      style={{ ...baseStyle, ...colorStyle, ...style }}
-      id={buttonId}
-      data-testid={dataTestId}
-      disabled={disabled}
-    >
-      {children}
-    </button>
+    <>
+      <style>{`
+        /* Base + variant fills. Live in CSS (not inline) so the
+           hover / active / focus-visible rules below can override
+           background-color and box-shadow. */
+        .${buttonClass} {
+          color: #fff;
+          background-color: var(--stagebook-primary, #3b82f6);
+          border-color: transparent;
+          box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+        }
+        .${buttonClass}[data-variant="secondary"] {
+          color: var(--stagebook-text-secondary, #374151);
+          background-color: #fff;
+          border-color: var(--stagebook-border, #d1d5db);
+        }
+        /* Hover — subtly darkens the fill. Primary shifts to the
+           one-step-darker brand color (--stagebook-primary-hover,
+           already a token for theming consistency). Secondary tints
+           with --stagebook-hover-bg, the same token Radio /
+           Checkbox rows use for their hover. */
+        .${buttonClass}[data-variant="primary"]:hover {
+          background-color: var(--stagebook-primary-hover, #2563eb);
+        }
+        .${buttonClass}[data-variant="secondary"]:hover {
+          background-color: var(--stagebook-hover-bg, #f3f4f6);
+        }
+        /* Active / pressed — a touch darker than hover. Provides
+           tactile feedback during the click; without it the button
+           feels unresponsive on slow clicks. */
+        .${buttonClass}[data-variant="primary"]:active {
+          background-color: var(--stagebook-primary-active, #1d4ed8);
+        }
+        .${buttonClass}[data-variant="secondary"]:active {
+          background-color: var(--stagebook-bg-track, #e5e7eb);
+        }
+        /* :focus-visible so the focus ring appears only on keyboard
+           navigation, not after a mouse click. Stacks on top of the
+           base elevation shadow. */
+        .${buttonClass}:focus-visible {
+          outline: none;
+          box-shadow:
+            0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25)),
+            0 1px 2px 0 rgba(0, 0, 0, 0.05);
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .${buttonClass} {
+            transition: none;
+          }
+        }
+      `}</style>
+      <button
+        type={type}
+        onClick={onClick ?? undefined}
+        className={`${buttonClass} ${className}`.trim()}
+        data-variant={variant}
+        autoFocus={autoFocus}
+        style={{ ...baseInlineStyle, ...stateStyle, ...style }}
+        id={buttonId}
+        data-testid={dataTestId}
+        disabled={disabled}
+      >
+        {children}
+      </button>
+    </>
   );
 }

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -54,6 +54,11 @@
   /* Primary action color (buttons, slider thumb, focus rings) */
   --stagebook-primary: #3b82f6;
   --stagebook-primary-hover: #2563eb;
+  /* One step darker than --stagebook-primary-hover for the
+   * `:active` (pressed) state on primary buttons. The
+   * hover→active progression telegraphs "the click registered"
+   * during slow clicks. */
+  --stagebook-primary-active: #1d4ed8;
 
   /* Status colors */
   --stagebook-success: #16a34a;


### PR DESCRIPTION
Sixth PR in the #350 UI polish sweep — closes #373.

Button ships as `SubmitButton` on every stage, so it's the most visible form component. Pre-PR it had **no `:hover`**, **no `:focus-visible`**, **no `:active`**, and relied on the browser's default focus outline.

## Items addressed

| Item | Status |
|------|:------:|
| Hover affordance (primary darken + secondary tint) | ✅ |
| `:focus-visible` focus ring | ✅ |
| `:active` darken (tactile feedback) | ✅ |
| Disabled state hardened with `pointer-events: none` | ✅ |
| Latent #367-style border bleed | ✅ |
| Reduced-motion fallback | ✅ |
| Per-instance unique class names | ✅ |

## What changed

**[Button.tsx](packages/stagebook/src/components/form/Button.tsx)**
- Renders a fragment of `<style>` + `<button>`. State-dependent properties (`background-color`, `box-shadow`) moved from inline to CSS so the hover/focus/active rules aren't blocked by inline-style specificity. Structural styles (padding, font, border longhands) stay inline so the button still survives aggressive host CSS resets per #213.
- Primary hover → `--stagebook-primary-hover` (existing token, blue-600).
- Primary active → new `--stagebook-primary-active` token (blue-700) — one step past hover.
- Secondary hover → `--stagebook-hover-bg` (shared with Radio/Checkbox row hovers).
- Disabled: existing `opacity 0.5` + `cursor: not-allowed` + new `pointer-events: none`. Without the latter, hover CSS would fire on a disabled button — visually contradicting the semantic.

**[styles.css](packages/stagebook/src/styles.css)**
- New `--stagebook-primary-active: #1d4ed8` (Tailwind blue-700).

**[Button.ct.tsx](packages/stagebook/src/components/form/Button.ct.tsx)** — 8 new tests, 5 existing tests updated.

The DOM restructure (fragment) broke 3 of 5 existing tests because they assumed `component === <button>`. Updated to `component.getByRole("button")` — more robust than depending on Playwright CT's mount-wrapper shape.

## Reviewer feedback (pre-PR subagent review)

Verdict: **SHIP WITH NITS**. Both nits addressed:
- Added a `:active` test symmetric with the hover tests
- Added a "disabled button does NOT darken on hover" test — the strongest test of `pointer-events: none`'s purpose

## Tier 1 status

After this lands, #350 tier 1 is at **6/7 form inputs done**. Only ListSorter (#374) remains. Then one batched release for the whole tier (Select / TextArea / Slider / Button / ListSorter + the component-gallery example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)