### PR TITLE
Bump stagebook to 0.10.7

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.10.6",
+  "version": "0.10.7",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Patch release completing the form-input UI polish sweep from #350. Tier-1 form components (Select, TextArea, Slider, Button, ListSorter) now share the same hover / `:focus-visible` / touch-target / reduced-motion / border-longhand treatment as the radio/checkbox work shipped in v0.10.6.

## What's in

- **#378** (closes #370) — Select polish. Hover affordance, keyboard-only focus ring, touch-target sizing, reduced-motion fallback, border longhands.

- **#381** (closes #371) — TextArea polish. Same checklist; also fixed the #367-style `border` shorthand bug where React's inline-style diff dropped the longhand override and let the border color bleed through.

- **#383** (closes #372) — Slider polish. 36px click target, snap-point ticks with graceful degradation when steps don't divide the range, value badge on interaction, click-to-jump enabled, hover affordance on the track. Largest polish change in the wave.

- **#384** (closes #373) — Button polish. New `--stagebook-primary-active` token (one step darker than `--stagebook-primary-hover`) for the `:active` pressed state; `disabled` buttons now carry `pointer-events: none` so hover CSS can't fire and contradict the disabled semantic.

- **#387** (closes #374) — ListSorter polish. Drag-handle glyph swapped from `⇅` to the bigger `⠿` (Braille drag handle, the modern web convention from shadcn / Notion / GitHub). Optimistic local state on drop so the new order is visible immediately rather than snapping back to props for the duration of any server roundtrip. Position-number labels now hold matching transparent borders so they no longer drift out of alignment with their rows on longer lists.

- **#379** — `examples/component-gallery/` study. Walks through every standalone form component in a single previewable study, paired with notes for what each is meant to measure. Doubles as the visual smoke-test surface for this polish wave.

## New CSS variables (additive)

- `--stagebook-primary-active` (default `#1d4ed8`) — pressed-state fill for primary buttons.

## Compatibility

- No API changes. Drop-in patch from 0.10.6.
- No schema or behavior changes for hosts.
- Visual defaults unchanged except for the new affordances added by each component's polish PR — net additions, not replacements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)