### PR TITLE
UI polish: Markdown (#350 tier 2)

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -626,7 +626,7 @@ function getWebviewContent(
       --stagebook-link: #2563eb;
       --stagebook-code-bg: rgba(0, 0, 0, 0.06);
       --stagebook-code-font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-      --stagebook-blockquote-border: #d1d5db;
+      --stagebook-blockquote-border: #9ca3af;
       --stagebook-blockquote-bg: #f9fafb;
     }
     body {

--- a/examples/component-gallery/prompts/markdown_demo.prompt.md
+++ b/examples/component-gallery/prompts/markdown_demo.prompt.md
@@ -5,8 +5,18 @@ name: markdown_demo
 
 ## Headings, paragraphs, emphasis
 
-Paragraphs flow normally. **Bold**, *italic*, and `inline code` all
-work. So do [external links](https://github.com/deliberation-lab/stagebook).
+Paragraphs flow normally. **Bold**, *italic*, ~~strikethrough~~, and
+`inline code` all work. So do
+[external links](https://github.com/deliberation-lab/stagebook).
+
+### Heading hierarchy
+
+The full set (h1-h6). Researchers usually stop at h3, but the deeper
+levels are available for long-form instruction text.
+
+#### h4 — section
+##### h5 — sub-section
+###### h6 — minor heading
 
 ### Lists
 
@@ -19,6 +29,12 @@ work. So do [external links](https://github.com/deliberation-lab/stagebook).
 2. Ordered second
 3. Ordered third
 
+Task-list checkboxes work too:
+
+- [x] Saved consent
+- [x] Verified microphone
+- [ ] Completed practice round
+
 ### Code blocks
 
 ```yaml
@@ -30,10 +46,29 @@ gameStages:
       - type: submitButton
 ```
 
+### Tables
+
+GFM tables get borders, a header background, zebra striping, and
+horizontal scroll on narrow viewports.
+
+| Element type      | Renders                       | Records a response?           |
+|-------------------|-------------------------------|-------------------------------|
+| `prompt`          | A markdown prompt body        | Yes (per type)                |
+| `submitButton`    | "Next" affordance             | Submit timestamp, when named  |
+| `separator`       | Horizontal rule between rows  | No                            |
+| `audio`           | Audio playback widget         | No                            |
+| `display`         | Echoes a prior response       | No                            |
+
 ### Block quote
 
-> Block quotes render with a left rule. Useful for participant-facing
-> notes or pull quotes inside instructions.
+> Block quotes render with a left rule and muted text so the quote
+> visually steps back from body content. Useful for participant-
+> facing notes or pull quotes inside instructions.
+
+### Images
+
+![A 1×1 transparent placeholder showing that images render at max
+width 100%.](data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=)
 
 ### Horizontal rule (use `***` or `___`)
 

--- a/packages/stagebook/src/components/elements/Display.tsx
+++ b/packages/stagebook/src/components/elements/Display.tsx
@@ -25,15 +25,21 @@ export interface DisplayProps {
 // Intentional duplication with Markdown.tsx's blockquote entry — both
 // render <blockquote> and should look identical so a markdown blockquote
 // and a Display element are visually consistent. See issue #33.
+// Polish (#350 sweep): dropped the redundant inner maxWidth (parent
+// already caps at 36rem), tightened padding to read taller-than-wide
+// like a quote rather than a box, muted text color so the quoted
+// participant data visually steps back from prompt body text, bumped
+// the default border to gray-400 in styles.css so the rail actually
+// reads against the page.
 const blockquoteStyle: React.CSSProperties = {
-  maxWidth: "36rem",
   wordBreak: "break-word",
-  padding: "1rem",
+  padding: "0.75rem 1rem",
   margin: "1rem 0",
   borderLeftWidth: "0.25rem",
   borderLeftStyle: "solid",
-  borderLeftColor: "var(--stagebook-blockquote-border, #d1d5db)",
+  borderLeftColor: "var(--stagebook-blockquote-border, #9ca3af)",
   background: "var(--stagebook-blockquote-bg, #f9fafb)",
+  color: "var(--stagebook-text-muted, #6b7280)",
 };
 
 export function Display({ reference, values }: DisplayProps) {

--- a/packages/stagebook/src/components/form/Markdown.ct.tsx
+++ b/packages/stagebook/src/components/form/Markdown.ct.tsx
@@ -456,12 +456,15 @@ test("fenced code block renders with background, monospace font, and horizontal 
   expect(styles.overflowX).toBe("auto");
 });
 
-test("fenced code block does not double-wrap background on the inner code", async ({
+test("fenced code block: inner <code> background is explicitly transparent (defeats host code-styling resets)", async ({
   mount,
 }) => {
   // The <pre> carries the chip styling; the inner <code class="language-*">
-  // must NOT also apply its own background/padding, or the block looks
-  // like a nested box.
+  // must explicitly clear background + padding so host CSS that paints
+  // behind every <code> (e.g. VS Code's webview applies
+  // `code { background-color: var(--vscode-textPreformat-background) }`)
+  // doesn't render a per-line tint behind the text inside our chip.
+  // Asserts inline-style values, which beat any host CSS rule.
   const component = await mount(<Markdown text={"```js\nconst x = 1;\n```"} />);
   const innerCodeInline = await component
     .locator("pre > code")
@@ -469,8 +472,34 @@ test("fenced code block does not double-wrap background on the inner code", asyn
       background: (el as HTMLElement).style.background,
       padding: (el as HTMLElement).style.padding,
     }));
-  expect(innerCodeInline.background).toBe("");
-  expect(innerCodeInline.padding).toBe("");
+  expect(innerCodeInline.background).toBe("transparent");
+  expect(innerCodeInline.padding).toBe("0px");
+});
+
+test("fenced code block survives a host CSS rule that paints behind <code> (#350 polish regression)", async ({
+  mount,
+}) => {
+  // Regression for the VS Code webview bug where the inner <code>
+  // showed a per-line tint behind the text. The hostile host CSS
+  // simulated here paints bright red behind every <code> element
+  // (matching what VS Code's webview does at lower intensity via
+  // `--vscode-textPreformat-background`). Without our inline
+  // transparent override, the inner code in a fenced block would
+  // render red, making the outer chip look striped. Not using
+  // `!important` because the actual host CSS that motivated this
+  // (VS Code's webview defaults) is a plain non-!important rule.
+  const component = await mount(
+    <div>
+      <style>{`code { background-color: rgb(255, 0, 0); padding: 4px; }`}</style>
+      <Markdown text={"```js\nconst x = 1;\n```"} />
+    </div>,
+  );
+  const innerCodeBg = await component
+    .locator("pre > code")
+    .evaluate((el) => getComputedStyle(el).backgroundColor);
+  // Inline `background: transparent` beats the class selector (inline >
+  // author class without !important). Expect transparent.
+  expect(innerCodeBg).not.toBe("rgb(255, 0, 0)");
 });
 
 test("inline code renders as a styled chip with background and padding", async ({
@@ -517,4 +546,249 @@ test("GFM task-list checkbox has inline base + check SVG when checked", async ({
   expect(uncheckedStyle.appearance).toBe("none");
   expect(uncheckedStyle.backgroundColor).toContain("--stagebook-surface");
   expect(uncheckedStyle.backgroundImage).toBe("");
+});
+
+// ----------- UI polish (#350 sweep) -----------
+
+test("link darkens on hover via --stagebook-link-hover", async ({ mount }) => {
+  // Polish: links previously had no hover state. The scoped <style>
+  // block now darkens the link color on hover. We can't observe
+  // :hover via inline style; we read computed color before vs after
+  // .hover().
+  const component = await mount(
+    <Markdown text="[click](https://example.com)" />,
+  );
+  const link = component.locator("a");
+  const before = await link.evaluate((el) => getComputedStyle(el).color);
+  await link.hover();
+  await expect
+    .poll(() => link.evaluate((el) => getComputedStyle(el).color), {
+      timeout: 1500,
+    })
+    .not.toBe(before);
+});
+
+test("link gets focus ring on keyboard focus (:focus-visible)", async ({
+  mount,
+  page,
+}) => {
+  // Polish: links had no focus indicator (WCAG 2.4.7). Tabbing to a
+  // link now shows an outline from the scoped <style> block.
+  const component = await mount(
+    <Markdown text="[click](https://example.com)" />,
+  );
+  const link = component.locator("a");
+  const baseline = await link.evaluate(
+    (el) => getComputedStyle(el).outlineWidth,
+  );
+  await page.keyboard.press("Tab");
+  await expect(link).toBeFocused();
+  await expect
+    .poll(() => link.evaluate((el) => getComputedStyle(el).outlineWidth), {
+      timeout: 1500,
+    })
+    .not.toBe(baseline);
+});
+
+test("external link (target=_blank) gets rel=noopener noreferrer", async ({
+  mount,
+}) => {
+  // Polish: links opening in new tabs leak the opener window object
+  // unless rel="noopener noreferrer" is set. The handler now appends
+  // these automatically when target="_blank" is present. Researchers
+  // can write target=_blank via raw HTML or via rehype configuration.
+  //
+  // react-markdown by default doesn't emit target=_blank; we use a
+  // raw <a target="_blank"> via rehype-raw to test the handler.
+  // Since rehype-raw isn't wired in by default, we test the contract
+  // by passing the attribute via the handler directly — the unit
+  // assertion is that IF target=_blank is set, rel includes noopener
+  // and noreferrer.
+  const component = await mount(<Markdown text="[ext](https://example.com)" />);
+  // Confirm baseline: a default markdown link has no target.
+  const target = await component
+    .locator("a")
+    .evaluate((el) => (el as HTMLAnchorElement).target);
+  expect(target).toBe("");
+});
+
+test("pre is in the tab order (tabIndex=0) so keyboard users can scroll", async ({
+  mount,
+}) => {
+  // Polish: <pre> has overflowX: auto but previously no tabIndex,
+  // so keyboard users couldn't scroll long lines (WCAG 2.1.1).
+  // tabIndex={0} puts it in the document tab order.
+  const component = await mount(<Markdown text={"```js\nconst x = 1;\n```"} />);
+  const pre = component.locator("pre");
+  const tabIndex = await pre.evaluate((el) => (el as HTMLElement).tabIndex);
+  expect(tabIndex).toBe(0);
+});
+
+test("pre shows focus ring on keyboard focus", async ({ mount, page }) => {
+  const component = await mount(<Markdown text={"```js\nconst x = 1;\n```"} />);
+  const pre = component.locator("pre");
+  const baseline = await pre.evaluate(
+    (el) => getComputedStyle(el).outlineWidth,
+  );
+  await page.keyboard.press("Tab");
+  await expect(pre).toBeFocused();
+  await expect
+    .poll(() => pre.evaluate((el) => getComputedStyle(el).outlineWidth), {
+      timeout: 1500,
+    })
+    .not.toBe(baseline);
+});
+
+test("h5 and h6 render with their configured sizes", async ({ mount }) => {
+  // Polish: h5/h6 previously had no handlers and collapsed to body
+  // text size on hosts that strip the UA stylesheet. They now read
+  // from --stagebook-prompt-h5-size / -h6-size with sensible
+  // defaults.
+  const component = await mount(<Markdown text={"##### Five\n\n###### Six"} />);
+  const h5 = await component
+    .locator("h5")
+    .evaluate((el) => parseFloat(getComputedStyle(el).fontSize));
+  const h6 = await component
+    .locator("h6")
+    .evaluate((el) => parseFloat(getComputedStyle(el).fontSize));
+  // Default h5 is 1rem = 16px, h6 is 0.875rem = 14px.
+  expect(h5).toBeGreaterThanOrEqual(15);
+  expect(h6).toBeGreaterThanOrEqual(13);
+  // h5 should be at least as large as h6 (hierarchy preserved).
+  expect(h5).toBeGreaterThanOrEqual(h6);
+});
+
+test("table is wrapped in a horizontal-scroll container on narrow viewports", async ({
+  mount,
+}) => {
+  // Polish: wide GFM tables used to overflow the prompt container on
+  // narrow viewports. The table is now wrapped in <div overflowX: auto>
+  // so the table can scroll independently while the prompt stays in
+  // bounds.
+  const component = await mount(
+    <Markdown text={"| A | B | C |\n|---|---|---|\n| 1 | 2 | 3 |"} />,
+  );
+  // The <table>'s immediate parent should be a div with overflowX: auto.
+  const parentOverflowX = await component.locator("table").evaluate((el) => {
+    const parent = el.parentElement;
+    return parent ? getComputedStyle(parent).overflowX : null;
+  });
+  expect(parentOverflowX).toBe("auto");
+});
+
+test("table rows have zebra striping (even rows get a tint)", async ({
+  mount,
+}) => {
+  // Polish: tables previously had no zebra striping. Body rows now
+  // alternate background via tr:nth-child(even) in the scoped style
+  // block, matching the GitHub / Notion consensus.
+  const component = await mount(
+    <Markdown
+      text={"| A | B |\n|---|---|\n| 1 | a |\n| 2 | b |\n| 3 | c |\n| 4 | d |"}
+    />,
+  );
+  // First body row (nth-child(1) = odd) → no tint.
+  // Second body row (nth-child(2) = even) → tint.
+  const evenTd = await component
+    .locator("tbody tr:nth-child(2) td")
+    .first()
+    .evaluate((el) => getComputedStyle(el).backgroundColor);
+  const oddTd = await component
+    .locator("tbody tr:nth-child(1) td")
+    .first()
+    .evaluate((el) => getComputedStyle(el).backgroundColor);
+  expect(evenTd).not.toBe(oddTd);
+});
+
+test("table rows darken on hover", async ({ mount }) => {
+  const component = await mount(
+    <Markdown text={"| A | B |\n|---|---|\n| 1 | 2 |"} />,
+  );
+  const td = component.locator("tbody td").first();
+  const before = await td.evaluate(
+    (el) => getComputedStyle(el).backgroundColor,
+  );
+  await component.locator("tbody tr").first().hover();
+  await expect
+    .poll(() => td.evaluate((el) => getComputedStyle(el).backgroundColor), {
+      timeout: 1500,
+    })
+    .not.toBe(before);
+});
+
+test("blockquote uses muted text color (not body text)", async ({ mount }) => {
+  // Polish: blockquote text is now muted so the quote visually steps
+  // back from body text. Previously it inherited body color, making
+  // the quote treatment depend on the (faint) bg + border alone.
+  // Render a paragraph BEFORE the blockquote so the body comparison
+  // doesn't accidentally pick up the <p> wrapped inside the quote.
+  const component = await mount(
+    <Markdown text={"A body paragraph.\n\n> A quoted line."} />,
+  );
+  const blockquoteColor = await component
+    .locator("blockquote")
+    .evaluate((el) => getComputedStyle(el).color);
+  // The first <p> in the document is the body paragraph, not the
+  // one nested in the blockquote. Scope explicitly anyway to be
+  // explicit about intent.
+  const bodyColor = await component
+    .locator(":scope > div > p")
+    .first()
+    .evaluate((el) => getComputedStyle(el).color);
+  // The default mute is #6b7280, body is #1f2937. Whatever the
+  // exact computed values, they should differ.
+  expect(blockquoteColor).not.toBe(bodyColor);
+});
+
+test("list markers are muted (not body text color)", async ({ mount }) => {
+  // Polish: list markers now read as structure, not weight-competing
+  // with body text. Asserted via ::marker color in the scoped style.
+  // ::marker isn't fully directly inspectable via getComputedStyle on
+  // the <li>, so we read the pseudo-element via getComputedStyle.
+  const component = await mount(
+    <Markdown text="- alpha\n- bravo\n- charlie" />,
+  );
+  const markerColor = await component
+    .locator("li")
+    .first()
+    .evaluate((el) => getComputedStyle(el, "::marker").color);
+  // Default --stagebook-text-muted is #6b7280 = rgb(107, 114, 128).
+  // We don't pin the exact rgb (browsers may compute differently);
+  // just assert it's not the body color (#1f2937 = rgb(31, 41, 55)).
+  expect(markerColor).not.toBe("rgb(31, 41, 55)");
+});
+
+test("images get loading=lazy + decoding=async", async ({ mount }) => {
+  // Polish: images in long-form prompts now defer offscreen loads,
+  // freeing bandwidth for above-the-fold content.
+  const component = await mount(
+    <Markdown text="![alt text](https://example.com/i.png)" />,
+  );
+  const img = component.locator("img");
+  const loading = await img.evaluate((el) => (el as HTMLImageElement).loading);
+  const decoding = await img.evaluate(
+    (el) => (el as HTMLImageElement).decoding,
+  );
+  expect(loading).toBe("lazy");
+  expect(decoding).toBe("async");
+});
+
+test("two Markdown instances on the same page have unique per-instance classes", async ({
+  mount,
+}) => {
+  // Polish: the previous `id="markdown"` was a duplicate-id bug on
+  // any page rendering multiple Markdown blocks (e.g. a stage with
+  // multiple Prompts). Now each instance has a useId()-backed class.
+  const component = await mount(
+    <div>
+      <Markdown text="alpha" />
+      <Markdown text="bravo" />
+    </div>,
+  );
+  // Find both root divs (the className-bearing wrapper).
+  const classes = await component
+    .locator('[class^="stagebook-markdown-"]')
+    .evaluateAll((els) => els.map((el) => el.className));
+  expect(classes).toHaveLength(2);
+  expect(classes[0]).not.toBe(classes[1]);
 });

--- a/packages/stagebook/src/components/form/Markdown.ct.tsx
+++ b/packages/stagebook/src/components/form/Markdown.ct.tsx
@@ -263,8 +263,9 @@ test("nested ol uses flat decimal numbering at every level", async ({
   // lists as 1., 1.1, 1.1.1. The new inline approach can't express
   // counter-based nested numbering (no ::before in inline styles), so
   // every level uses decimal "1., 2., 3.". If a researcher needs
-  // counter-style nesting they can override --stagebook-prompt-* via a
-  // host stylesheet that targets `#markdown ol > li::before`.
+  // counter-style nesting they can override --stagebook-prompt-* via
+  // a host stylesheet that targets `.stagebook-markdown-* ol > li::before`
+  // (each Markdown instance now carries a useId-generated class).
   const component = await mount(
     <Markdown text={"1. outer\n   1. inner\n   2. inner two"} />,
   );
@@ -590,26 +591,23 @@ test("link gets focus ring on keyboard focus (:focus-visible)", async ({
     .not.toBe(baseline);
 });
 
-test("external link (target=_blank) gets rel=noopener noreferrer", async ({
+test("default markdown link has no target attribute (no rel rewrite triggers)", async ({
   mount,
 }) => {
-  // Polish: links opening in new tabs leak the opener window object
-  // unless rel="noopener noreferrer" is set. The handler now appends
-  // these automatically when target="_blank" is present. Researchers
-  // can write target=_blank via raw HTML or via rehype configuration.
-  //
-  // react-markdown by default doesn't emit target=_blank; we use a
-  // raw <a target="_blank"> via rehype-raw to test the handler.
-  // Since rehype-raw isn't wired in by default, we test the contract
-  // by passing the attribute via the handler directly — the unit
-  // assertion is that IF target=_blank is set, rel includes noopener
-  // and noreferrer.
+  // Confirms the *baseline* of the rel-rewrite contract: a vanilla
+  // markdown link never gets target=_blank from react-markdown, so
+  // it shouldn't get a synthetic rel either. The actual rel-rewrite
+  // logic (computeSafeRel) is unit-tested in Markdown.test.ts — it
+  // can't be driven from markdown source without wiring rehype-raw.
   const component = await mount(<Markdown text="[ext](https://example.com)" />);
-  // Confirm baseline: a default markdown link has no target.
   const target = await component
     .locator("a")
     .evaluate((el) => (el as HTMLAnchorElement).target);
+  const rel = await component
+    .locator("a")
+    .evaluate((el) => (el as HTMLAnchorElement).rel);
   expect(target).toBe("");
+  expect(rel).toBe("");
 });
 
 test("pre is in the tab order (tabIndex=0) so keyboard users can scroll", async ({

--- a/packages/stagebook/src/components/form/Markdown.test.ts
+++ b/packages/stagebook/src/components/form/Markdown.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import { computeSafeRel } from "./Markdown.js";
+
+// External-link `rel` contract: markdown links that open in a new
+// tab (target="_blank") must receive `rel="noopener noreferrer"`
+// so the new tab can't reach back to `window.opener` (tab-nabbing)
+// and the destination doesn't receive a Referer header. The handler
+// is invoked from inside react-markdown's `components.a`, where the
+// only way to introduce `target="_blank"` without raw HTML is via
+// rehype-raw — too much plumbing for one contract assertion. The
+// helper is exported so the contract is unit-testable on its own.
+
+describe("computeSafeRel", () => {
+  test("no target → rel passes through unchanged (no rewrite)", () => {
+    expect(computeSafeRel(undefined, undefined)).toBeUndefined();
+    expect(computeSafeRel(undefined, "author")).toBe("author");
+  });
+
+  test("target=_self → rel passes through unchanged", () => {
+    expect(computeSafeRel("_self", "author")).toBe("author");
+  });
+
+  test("target=_blank + no source rel → adds 'noopener noreferrer'", () => {
+    expect(computeSafeRel("_blank", undefined)).toBe("noopener noreferrer");
+  });
+
+  test("target=_blank + existing rel → appends noopener noreferrer to the source", () => {
+    // Researcher-provided `rel="author"` is preserved.
+    expect(computeSafeRel("_blank", "author")).toBe(
+      "author noopener noreferrer",
+    );
+  });
+
+  test("target=_blank with already-present noopener → still safe (no harm in duplicate tokens)", () => {
+    // Browsers tokenize `rel`, so duplicate `noopener` is a no-op.
+    // The helper doesn't dedupe — duplicates aren't a bug, just
+    // verbose. This test locks in the simple-concat behavior.
+    const out = computeSafeRel("_blank", "noopener");
+    expect(out).toContain("noopener");
+    expect(out).toContain("noreferrer");
+  });
+});

--- a/packages/stagebook/src/components/form/Markdown.tsx
+++ b/packages/stagebook/src/components/form/Markdown.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useId } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
@@ -27,6 +27,13 @@ export interface MarkdownProps {
 // the host's reset does. This is the same logic that makes Stagebook own
 // button shapes, slider thumbs, and the media player controls — visual
 // behavior is part of the contract, not a property of the host.
+//
+// State-dependent behavior (`:hover`, `:focus-visible`, `:visited`,
+// `::marker`, `tr:nth-child`) is NOT expressible inline. A small
+// `<style>` block scoped to a per-instance class (via `useId()`) adds
+// just those pseudo-class rules — the host can't override them unless
+// they also know the generated class name. Same pattern as Button /
+// Slider / ListSorter.
 //
 // These styles are tunable, but not every value is exposed as a CSS
 // custom property. Key typography and color values are variable-backed
@@ -79,6 +86,20 @@ const h4Style: React.CSSProperties = {
   marginBlock: "0.5em 0.25em",
 };
 
+const h5Style: React.CSSProperties = {
+  ...headingBase,
+  fontSize: "var(--stagebook-prompt-h5-size, 1rem)",
+  fontWeight: "var(--stagebook-prompt-h5-weight, 600)",
+  marginBlock: "0.5em 0.25em",
+};
+
+const h6Style: React.CSSProperties = {
+  ...headingBase,
+  fontSize: "var(--stagebook-prompt-h6-size, 0.875rem)",
+  fontWeight: "var(--stagebook-prompt-h6-weight, 600)",
+  marginBlock: "0.5em 0.25em",
+};
+
 const pStyle: React.CSSProperties = {
   marginBlock: "0.5em",
 };
@@ -109,6 +130,17 @@ const emStyle: React.CSSProperties = {
   fontStyle: "italic",
 };
 
+// Neutralize host code-styling resets on the inner <code> of a
+// fenced block. The outer <pre> already has the chip background;
+// without these overrides, host CSS like VS Code's
+// `code { background-color: var(--vscode-textPreformat-background); }`
+// paints a per-line tint behind the text inside our chip. Background
+// transparent + padding 0 defeats that without affecting the chip.
+const fencedInnerCodeStyle: React.CSSProperties = {
+  background: "transparent",
+  padding: 0,
+};
+
 // Inline code only — `like this`. Fenced code blocks (```...```) get
 // className="language-*" from react-markdown; the <pre> wrapper receives
 // the block-level chip styling (see preStyle), so the inner <code> is
@@ -129,6 +161,11 @@ const inlineCodeStyle: React.CSSProperties = {
 // horizontal scroll). The inner <code> keeps only the font so the block
 // doesn't render as a nested box. Tailwind preflight and similar resets
 // strip the UA <pre> monospace font, so we reassert it here. See #215.
+//
+// `tabIndex={0}` is supplied at the render site (not here) so the block
+// joins the tab order whenever its content overflows horizontally —
+// without it, keyboard users can't scroll long lines (WCAG 2.1.1).
+// `:focus-visible` ring is in the scoped <style> block.
 const preStyle: React.CSSProperties = {
   background: "var(--stagebook-code-bg, rgba(0,0,0,0.06))",
   padding: "0.75rem 1rem",
@@ -153,22 +190,33 @@ const hrStyle: React.CSSProperties = {
   marginBlock: "1em",
 };
 
+// Only `text-decoration: underline` stays inline — the base color
+// AND the `:hover` / `:focus-visible` / `:visited` overrides all
+// live in the scoped <style> block. Putting the base color inline
+// would block the hover/visited rules on specificity (inline beats
+// any class selector, including pseudo-classes). Same trap as
+// Slider / Button / TextArea — structural inline, state in CSS.
 const aStyle: React.CSSProperties = {
-  color: "var(--stagebook-link, #2563eb)",
   textDecoration: "underline",
 };
 
 // Shared with Display.tsx (intentional inline duplication, see issue #33).
 // Both render <blockquote> and should look identical.
+//
+// Polish (#350 sweep): dropped the redundant inner maxWidth (parent
+// already caps at 36rem), tightened padding to read taller-than-wide
+// like a quote rather than a box, muted text color so the quote
+// visually steps back from body text, bumped the default border to
+// gray-400 in styles.css so the rail actually reads against the page.
 const blockquoteStyle: React.CSSProperties = {
-  maxWidth: "36rem",
   wordBreak: "break-word",
-  padding: "1rem",
+  padding: "0.75rem 1rem",
   margin: "1rem 0",
   borderLeftWidth: "0.25rem",
   borderLeftStyle: "solid",
-  borderLeftColor: "var(--stagebook-blockquote-border, #d1d5db)",
+  borderLeftColor: "var(--stagebook-blockquote-border, #9ca3af)",
   background: "var(--stagebook-blockquote-bg, #f9fafb)",
+  color: "var(--stagebook-text-muted, #6b7280)",
 };
 
 const imgStyle: React.CSSProperties = {
@@ -180,11 +228,20 @@ const imgStyle: React.CSSProperties = {
 // padding even on hosts that don't import styles.css. thead / tbody / tr
 // have no handlers here — browser defaults are acceptable once the table
 // itself has border-collapse and the cells have borders + padding.
+//
+// On narrow viewports the table now lives inside a horizontal-scroll
+// wrapper (see tableWrapperStyle) so wide tables don't overflow the
+// prompt container. Zebra striping and row hover are in the scoped
+// <style> block (need `:nth-child` / `:hover`).
+const tableWrapperStyle: React.CSSProperties = {
+  overflowX: "auto",
+  maxWidth: "var(--stagebook-prompt-max-width, 36rem)",
+  marginBlock: "1rem",
+};
+
 const tableStyle: React.CSSProperties = {
   borderCollapse: "collapse",
-  margin: "1rem 0",
   width: "100%",
-  maxWidth: "var(--stagebook-prompt-max-width, 36rem)",
 };
 
 const tableCellBase: React.CSSProperties = {
@@ -261,99 +318,233 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
     );
   }
 
+  // Per-instance class for pseudo-class rules. The previous
+  // `id="markdown"` was a duplicate-id bug on any page rendering
+  // multiple Markdown blocks (e.g. a stage with multiple Prompts).
+  // useId() returns an opaque string; sanitize for use as a CSS
+  // identifier (same regex as Button / Slider / ListSorter).
+  const reactId = useId();
+  const safeId = reactId.replace(/[^a-zA-Z0-9_-]/g, "");
+  const rootClass = `stagebook-markdown-${safeId}`;
+
   return (
-    <div
-      id="markdown"
-      style={{
-        maxWidth: "var(--stagebook-prompt-max-width, 36rem)",
-        fontSize: "var(--stagebook-prompt-text-size, 1rem)",
-        lineHeight: "var(--stagebook-prompt-line-height, 1.5)",
-        color: "var(--stagebook-text, #1f2937)",
-      }}
-    >
-      <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
-        components={{
-          h1: ({ node: _node, ...props }) => <h1 style={h1Style} {...props} />,
-          h2: ({ node: _node, ...props }) => <h2 style={h2Style} {...props} />,
-          h3: ({ node: _node, ...props }) => <h3 style={h3Style} {...props} />,
-          h4: ({ node: _node, ...props }) => <h4 style={h4Style} {...props} />,
-          p: ({ node: _node, ...props }) => <p style={pStyle} {...props} />,
-          ul: ({ node: _node, ...props }) => <ul style={ulStyle} {...props} />,
-          ol: ({ node: _node, ...props }) => <ol style={olStyle} {...props} />,
-          li: ({ node: _node, ...props }) => <li style={liStyle} {...props} />,
-          strong: ({ node: _node, ...props }) => (
-            <strong style={strongStyle} {...props} />
-          ),
-          em: ({ node: _node, ...props }) => <em style={emStyle} {...props} />,
-          code: ({ node: _node, className, ...props }) => {
-            // react-markdown v10 dropped the `inline` prop. Fenced code
-            // blocks get className="language-*"; inline code has no
-            // className. The inline variant gets the chip styling
-            // (background, padding, radius); the fenced variant's
-            // block-level chip is supplied by the surrounding <pre>
-            // (preStyle) so we don't double-wrap the background/padding
-            // here. See #215.
-            const isFenced =
-              typeof className === "string" &&
-              className.startsWith("language-");
-            return isFenced ? (
-              <code className={className} {...props} />
-            ) : (
-              <code style={inlineCodeStyle} {...props} />
-            );
-          },
-          pre: ({ node: _node, ...props }) => (
-            <pre style={preStyle} {...props} />
-          ),
-          hr: ({ node: _node, ...props }) => <hr style={hrStyle} {...props} />,
-          a: ({ node: _node, ...props }) => <a style={aStyle} {...props} />,
-          blockquote: ({ node: _node, ...props }) => (
-            <blockquote style={blockquoteStyle} {...props} />
-          ),
-          // Inline max-width keeps markdown-embedded images inside the
-          // prompt container on any host, regardless of what reset the
-          // host chose. host-typography provides the same rule for the
-          // host's own bare-tag pages; this override ensures stagebook's
-          // own rendered content is self-constraining even when the host
-          // hasn't opted in. See issue #211.
-          img: ({ node: _node, ...props }) => (
-            <img style={imgStyle} {...props} alt={props.alt ?? ""} />
-          ),
-          // GFM tables (issue #214). Only table / th / td need handlers —
-          // thead / tbody / tr use browser defaults.
-          table: ({ node: _node, ...props }) => (
-            <table style={tableStyle} {...props} />
-          ),
-          th: ({ node: _node, ...props }) => <th style={thStyle} {...props} />,
-          td: ({ node: _node, ...props }) => <td style={tdStyle} {...props} />,
-          // GFM task-list checkboxes (#213). The task-list input is
-          // rendered as a disabled <input type="checkbox">, so no focus
-          // ring is needed — but the base + checked visuals still need
-          // inline styling to survive hosts without styles.css. Other
-          // `<input>` types emitted from raw HTML (if any ever passed
-          // through rehype-raw) aren't styled here; the contract is
-          // specifically about the GFM task-list case.
-          input: ({ node: _node, type, checked, ...props }) => {
-            if (type !== "checkbox") {
-              return <input type={type} checked={checked} {...props} />;
-            }
-            return (
-              <input
-                type="checkbox"
-                checked={checked}
-                {...props}
-                style={{
-                  ...taskListCheckboxBaseStyle,
-                  ...(checked ? taskListCheckboxCheckedStyle : {}),
-                }}
-              />
-            );
-          },
+    <>
+      <style>{`
+        /* Base link color (in CSS, not inline) so the hover /
+           visited rules below can override it. Underline lives
+           inline so the link still reads as a link even if our
+           <style> tag is stripped by something exotic. */
+        .${rootClass} a {
+          color: var(--stagebook-link, #2563eb);
+        }
+        /* Links — hover / focus-visible / visited. */
+        .${rootClass} a:hover {
+          color: var(--stagebook-link-hover, #1d4ed8);
+        }
+        .${rootClass} a:visited {
+          color: var(--stagebook-link-visited, #7c3aed);
+        }
+        .${rootClass} a:focus-visible {
+          outline: 2px solid var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+          outline-offset: 2px;
+          border-radius: 0.125rem;
+        }
+        /* Code blocks — keyboard scroll. The <pre> carries
+           tabIndex={0} so keyboard users can horizontally scroll
+           long lines (WCAG 2.1.1); the focus-visible ring tells
+           them it's selected. */
+        .${rootClass} pre:focus-visible {
+          outline: 2px solid var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+          outline-offset: 2px;
+        }
+        /* List markers — muted so the bullet/number reads as
+           structure, not weight-competing with body text. */
+        .${rootClass} li::marker {
+          color: var(--stagebook-text-muted, #6b7280);
+        }
+        /* Tables — zebra striping (every other body row) +
+           row hover. Cells already have borders + padding from
+           the inline thStyle / tdStyle. */
+        .${rootClass} tbody tr:nth-child(even) td {
+          background-color: var(--stagebook-bg-muted, #f9fafb);
+        }
+        .${rootClass} tbody tr:hover td {
+          background-color: var(--stagebook-hover-bg, #f3f4f6);
+        }
+        /* Reduced motion: there are no transitions here today,
+           but if a future polish round adds one (link color
+           transition, hover fade) this gate is in place. */
+        @media (prefers-reduced-motion: reduce) {
+          .${rootClass} * {
+            transition: none !important;
+          }
+        }
+      `}</style>
+      <div
+        className={rootClass}
+        style={{
+          maxWidth: "var(--stagebook-prompt-max-width, 36rem)",
+          fontSize: "var(--stagebook-prompt-text-size, 1rem)",
+          lineHeight: "var(--stagebook-prompt-line-height, 1.5)",
+          color: "var(--stagebook-text, #1f2937)",
         }}
       >
-        {displayText}
-      </ReactMarkdown>
-    </div>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          components={{
+            h1: ({ node: _node, ...props }) => (
+              <h1 style={h1Style} {...props} />
+            ),
+            h2: ({ node: _node, ...props }) => (
+              <h2 style={h2Style} {...props} />
+            ),
+            h3: ({ node: _node, ...props }) => (
+              <h3 style={h3Style} {...props} />
+            ),
+            h4: ({ node: _node, ...props }) => (
+              <h4 style={h4Style} {...props} />
+            ),
+            h5: ({ node: _node, ...props }) => (
+              <h5 style={h5Style} {...props} />
+            ),
+            h6: ({ node: _node, ...props }) => (
+              <h6 style={h6Style} {...props} />
+            ),
+            p: ({ node: _node, ...props }) => <p style={pStyle} {...props} />,
+            ul: ({ node: _node, ...props }) => (
+              <ul style={ulStyle} {...props} />
+            ),
+            ol: ({ node: _node, ...props }) => (
+              <ol style={olStyle} {...props} />
+            ),
+            li: ({ node: _node, ...props }) => (
+              <li style={liStyle} {...props} />
+            ),
+            strong: ({ node: _node, ...props }) => (
+              <strong style={strongStyle} {...props} />
+            ),
+            em: ({ node: _node, ...props }) => (
+              <em style={emStyle} {...props} />
+            ),
+            code: ({ node: _node, className, ...props }) => {
+              // react-markdown v10 dropped the `inline` prop. Fenced code
+              // blocks get className="language-*"; inline code has no
+              // className. The inline variant gets the chip styling
+              // (background, padding, radius); the fenced variant's
+              // block-level chip is supplied by the surrounding <pre>
+              // (preStyle), so we explicitly neutralize the inner
+              // <code>'s background + padding. Host CSS sometimes
+              // paints behind ALL <code> elements (VS Code's webview
+              // does this via --vscode-textPreformat-background), so
+              // an empty style would let that host rule render a
+              // line-by-line chip behind the text inside the <pre>'s
+              // outer chip. Setting background: transparent + padding: 0
+              // defeats any host code-styling reset for the fenced case.
+              // See #215.
+              const isFenced =
+                typeof className === "string" &&
+                className.startsWith("language-");
+              return isFenced ? (
+                <code
+                  className={className}
+                  style={fencedInnerCodeStyle}
+                  {...props}
+                />
+              ) : (
+                <code style={inlineCodeStyle} {...props} />
+              );
+            },
+            // `tabIndex={0}` puts the <pre> in the tab order so a
+            // keyboard user can horizontally scroll long lines via
+            // arrow keys. The :focus-visible ring (in the scoped
+            // <style>) confirms selection.
+            pre: ({ node: _node, ...props }) => (
+              <pre style={preStyle} tabIndex={0} {...props} />
+            ),
+            hr: ({ node: _node, ...props }) => (
+              <hr style={hrStyle} {...props} />
+            ),
+            // External links (anything with an explicit target=_blank
+            // from the host or rehype-raw) get `rel="noopener
+            // noreferrer"` for security parity with shadcn / GitHub.
+            // No visual external-link arrow is added — adding chrome
+            // to researcher-authored text would change what
+            // participants see relative to the prompt source. If
+            // researchers want an indicator they can write one.
+            a: ({ node: _node, target, rel, ...props }) => {
+              const safeRel =
+                target === "_blank"
+                  ? rel
+                    ? `${rel} noopener noreferrer`
+                    : "noopener noreferrer"
+                  : rel;
+              return (
+                <a style={aStyle} target={target} rel={safeRel} {...props} />
+              );
+            },
+            blockquote: ({ node: _node, ...props }) => (
+              <blockquote style={blockquoteStyle} {...props} />
+            ),
+            // `loading="lazy"` defers offscreen image loads, freeing
+            // bandwidth for above-the-fold content in long prompts.
+            // `decoding="async"` lets the browser decode off the main
+            // thread. Both are no-ops on unsupported browsers.
+            // Inline max-width keeps markdown-embedded images inside
+            // the prompt container on any host, regardless of what
+            // reset the host chose. See issue #211.
+            img: ({ node: _node, ...props }) => (
+              <img
+                style={imgStyle}
+                loading="lazy"
+                decoding="async"
+                {...props}
+                alt={props.alt ?? ""}
+              />
+            ),
+            // GFM tables (issue #214). The table itself lives inside a
+            // horizontal-scroll wrapper so wide tables on narrow
+            // viewports don't overflow the prompt container. Zebra
+            // striping + row hover come from the scoped <style> block
+            // (need :nth-child / :hover, not inline-expressible).
+            table: ({ node: _node, ...props }) => (
+              <div style={tableWrapperStyle}>
+                <table style={tableStyle} {...props} />
+              </div>
+            ),
+            th: ({ node: _node, ...props }) => (
+              <th style={thStyle} {...props} />
+            ),
+            td: ({ node: _node, ...props }) => (
+              <td style={tdStyle} {...props} />
+            ),
+            // GFM task-list checkboxes (#213). The task-list input is
+            // rendered as a disabled <input type="checkbox">, so no focus
+            // ring is needed — but the base + checked visuals still need
+            // inline styling to survive hosts without styles.css. Other
+            // `<input>` types emitted from raw HTML (if any ever passed
+            // through rehype-raw) aren't styled here; the contract is
+            // specifically about the GFM task-list case.
+            input: ({ node: _node, type, checked, ...props }) => {
+              if (type !== "checkbox") {
+                return <input type={type} checked={checked} {...props} />;
+              }
+              return (
+                <input
+                  type="checkbox"
+                  checked={checked}
+                  {...props}
+                  style={{
+                    ...taskListCheckboxBaseStyle,
+                    ...(checked ? taskListCheckboxCheckedStyle : {}),
+                  }}
+                />
+              );
+            },
+          }}
+        >
+          {displayText}
+        </ReactMarkdown>
+      </div>
+    </>
   );
 }

--- a/packages/stagebook/src/components/form/Markdown.tsx
+++ b/packages/stagebook/src/components/form/Markdown.tsx
@@ -162,10 +162,13 @@ const inlineCodeStyle: React.CSSProperties = {
 // doesn't render as a nested box. Tailwind preflight and similar resets
 // strip the UA <pre> monospace font, so we reassert it here. See #215.
 //
-// `tabIndex={0}` is supplied at the render site (not here) so the block
-// joins the tab order whenever its content overflows horizontally —
-// without it, keyboard users can't scroll long lines (WCAG 2.1.1).
-// `:focus-visible` ring is in the scoped <style> block.
+// `tabIndex={0}` is supplied unconditionally at the render site (not
+// here) so every fenced block joins the tab order. We don't measure
+// overflow at render time, so the simplest path is to make every
+// block focusable; for non-overflowing blocks the tab stop is
+// harmless (no scroll happens). Without this, keyboard users can't
+// horizontally scroll long lines (WCAG 2.1.1). The `:focus-visible`
+// ring is in the scoped <style> block.
 const preStyle: React.CSSProperties = {
   background: "var(--stagebook-code-bg, rgba(0,0,0,0.06))",
   padding: "0.75rem 1rem",
@@ -189,6 +192,25 @@ const hrStyle: React.CSSProperties = {
   borderTopColor: "var(--stagebook-border, #d1d5db)",
   marginBlock: "1em",
 };
+
+/**
+ * Compute the `rel` attribute for a markdown-rendered `<a>`. When the
+ * link opens in a new tab (`target="_blank"`), append `noopener` and
+ * `noreferrer` to whatever the source rel already contains so the new
+ * tab can't reach back to `window.opener` (tab-nabbing) and the
+ * destination doesn't receive a Referer header. Same security parity
+ * shadcn / GitHub markdown extensions enforce.
+ *
+ * Exported so the contract is unit-testable without wiring rehype-raw
+ * just to introduce a `target="_blank"` into the rendered DOM.
+ */
+export function computeSafeRel(
+  target: string | undefined,
+  rel: string | undefined,
+): string | undefined {
+  if (target !== "_blank") return rel;
+  return rel ? `${rel} noopener noreferrer` : "noopener noreferrer";
+}
 
 // Only `text-decoration: underline` stays inline — the base color
 // AND the `:hover` / `:focus-visible` / `:visited` overrides all
@@ -471,17 +493,14 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
             // to researcher-authored text would change what
             // participants see relative to the prompt source. If
             // researchers want an indicator they can write one.
-            a: ({ node: _node, target, rel, ...props }) => {
-              const safeRel =
-                target === "_blank"
-                  ? rel
-                    ? `${rel} noopener noreferrer`
-                    : "noopener noreferrer"
-                  : rel;
-              return (
-                <a style={aStyle} target={target} rel={safeRel} {...props} />
-              );
-            },
+            a: ({ node: _node, target, rel, ...props }) => (
+              <a
+                style={aStyle}
+                target={target}
+                rel={computeSafeRel(target, rel)}
+                {...props}
+              />
+            ),
             blockquote: ({ node: _node, ...props }) => (
               <blockquote style={blockquoteStyle} {...props} />
             ),

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -136,11 +136,24 @@
   --stagebook-prompt-h2-size: 1.5rem;
   --stagebook-prompt-h3-size: 1.25rem;
   --stagebook-prompt-h4-size: 1.125rem;
+  --stagebook-prompt-h5-size: 1rem;
+  --stagebook-prompt-h6-size: 0.875rem;
   --stagebook-prompt-h1-weight: 700;
   --stagebook-prompt-h2-weight: 600;
   --stagebook-prompt-h3-weight: 600;
   --stagebook-prompt-h4-weight: 600;
+  --stagebook-prompt-h5-weight: 600;
+  --stagebook-prompt-h6-weight: 600;
   --stagebook-link: #2563eb;
+  /* One step darker than --stagebook-link for the `:hover` state on
+   * markdown links. The hover → base progression telegraphs "I'm
+   * hovering this" without inventing a new hue. */
+  --stagebook-link-hover: #1d4ed8;
+  /* Purple for `:visited`, the established convention since 1993.
+   * Researcher prompts sometimes link back to consent / instructions
+   * pages — distinguishing visited tells participants they've already
+   * been there. */
+  --stagebook-link-visited: #7c3aed;
   --stagebook-code-bg: rgba(0, 0, 0, 0.06);
   --stagebook-code-font:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
@@ -149,8 +162,12 @@
   --stagebook-table-text: #4a5568;
   --stagebook-table-header-text: #1a202c;
 
-  /* Blockquote (used by Display element and markdown blockquotes) */
-  --stagebook-blockquote-border: #d1d5db;
+  /* Blockquote (used by Display element and markdown blockquotes).
+   * Border bumped from #d1d5db (gray-300) → #9ca3af (gray-400) so the
+   * quote rail actually reads against the page background — at #d1d5db
+   * the rail and the body text contrast was indistinguishable from
+   * "softly highlighted box" rather than "quote." */
+  --stagebook-blockquote-border: #9ca3af;
   --stagebook-blockquote-bg: #f9fafb;
 }
 


### PR DESCRIPTION
First component in tier 2 of the #350 polish sweep. Markdown renders every prompt body in every study, so the gains compound across all deployments.

## Visible changes

- **Links** — `:hover` (`--stagebook-link-hover` #1d4ed8), `:focus-visible` ring, `:visited` (`--stagebook-link-visited` #7c3aed). No focus indicator before this was a WCAG 2.4.7 fail. External links (`target=_blank`) get `rel="noopener noreferrer"` automatically. No external-link arrow glyph: adding chrome to researcher-authored text would visually rewrite what participants see.

- **`<pre>` keyboard-scrollable** — `tabIndex={0}` + focus-visible ring. Previously keyboard users couldn't horizontally scroll long code lines (WCAG 2.1.1).

- **h5 + h6 handlers** — previously absent; deeper headings collapsed to body-text size on hosts that strip the UA stylesheet. Added handlers + `--stagebook-prompt-h5-size` (1rem) / `-h6-size` (0.875rem) / matching weight variables.

- **Tables**: mobile overflow + zebra + row hover. Tables now live inside an `overflowX: auto` wrapper so wide tables on narrow viewports scroll independently. Body rows alternate background via `tr:nth-child(even)`; rows tint on hover. Matches GitHub / Notion consensus.

- **Blockquote refresh** — dropped redundant inner `maxWidth` (parent already caps at 36rem), tightened padding (taller-than-wide reads as quote vs. box), added muted `color` so quoted text visually steps back from body, bumped default border `#d1d5db` → `#9ca3af` so the rail actually reads against the page. Mirrored to [Display.tsx](packages/stagebook/src/components/elements/Display.tsx) (the inline duplication is intentional per #33). No italic — researcher quotes should render verbatim.

- **List markers muted** via `::marker` so bullet/number reads as structure, not weight-competing with body content.

- **Images** — `loading="lazy"` + `decoding="async"` so offscreen images in long prompts free bandwidth for above-the-fold content.

## Two latent bugs fixed along the way

- **Duplicate `id="markdown"`** — every Markdown instance shared the same id (invalid HTML on multi-Prompt stages). Switched to `useId()`-backed per-instance class. Same pattern as Button / Slider / ListSorter.

- **Fenced `<code>` showed per-line tint inside the chip in VS Code's webview.** The outer `<pre>` had our inline chip background, but the inner `<code>` had no inline style — so VS Code's default `code { background-color: var(--vscode-textPreformat-background) }` painted behind every text glyph. Inner code now carries `background: transparent` + `padding: 0` so it defeats host code styling. New regression test simulates the hostile rule.

## Architectural decision: scoped `<style>` per instance

State-dependent behavior (`:hover` / `:focus-visible` / `:visited` / `::marker` / `:nth-child`) isn't inline-expressible. One `<style>` block per instance, scoped to the `useId()`-derived class, carries those rules. Inline styles still own structural/dimensional properties; the scoped block only adds pseudo-class behavior. Hosts can't override the structural contract but Stagebook gains state behavior the inline-only philosophy couldn't express. Same pattern as Button / Slider / ListSorter / Markdown's siblings in tier 1.

## CSS variables added (to `styles.css` `:root`)

- `--stagebook-link-hover` (#1d4ed8)
- `--stagebook-link-visited` (#7c3aed)
- `--stagebook-prompt-h5-size` (1rem) / `-h6-size` (0.875rem)
- `--stagebook-prompt-h5-weight` / `-h6-weight` (both 600)
- Default bumped: `--stagebook-blockquote-border` #d1d5db → #9ca3af

Reuses existing `--stagebook-hover-bg` (table row hover), `--stagebook-text-muted` (list markers + blockquote text), `--stagebook-focus-ring` (link + pre focus rings), `--stagebook-bg-muted` (zebra stripe).

## Gallery demo expanded

Previous demo exercised h1-h3, lists, fenced code, blockquote, hr. Added: full h1-h6 hierarchy, GFM strikethrough, GFM task-list checkboxes, a 5-row GFM table, an inline image (data-URI placeholder). Also corrected the demo table copy — `submitButton` records a submit timestamp when named, so it's not in the same "no signal" bucket as `separator` / `audio` / `display`.

## Tests

47 Markdown CT pass (33 existing + 14 new):
- link hover / focus-visible
- external link rel attribute contract
- pre tabIndex + focus-visible
- h5 + h6 sized correctly
- table wrapped in overflow container
- table zebra striping
- table row hover
- blockquote muted color
- list marker color
- images lazy + decoding async
- two Markdown instances get unique classes (no duplicate id)
- fenced code inner-code inline background = transparent
- fenced code survives a hostile host code-styling rule

Full unit (1030) + CT (515) suites also pass.

## Test plan

- [x] `npm run build -w stagebook`
- [x] `npm run test:ct -w stagebook -- --grep "Markdown"` (47/47 pass)
- [x] `npm test` (1030/1030 unit pass)
- [x] `npm run test:ct -w stagebook` (515/515 CT pass)
- [x] Visual smoke in the VS Code extension preview, gallery's expanded markdown stage
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)