### PR TITLE
Bump stagebook to 0.10.8

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Patch release picking up the Markdown polish work — first component in tier 2 of the #350 polish sweep. Every prompt body in every study renders through Markdown, so the gains compound across all deployments.

## What's in

- **#390** (closes #350 tier 2 first item) — Markdown polish. Links now have `:hover`, `:focus-visible`, and `:visited` (no focus indicator before was a WCAG 2.4.7 fail). `<pre>` is keyboard-scrollable via `tabIndex={0}` + focus ring (WCAG 2.1.1). Tables wrap in `overflowX: auto` containers for mobile, plus zebra striping and row hover. h5 and h6 finally have handlers (deeper headings used to collapse to body text on hosts that strip the UA stylesheet). Blockquote refresh: dropped redundant inner maxWidth, tightened padding, muted text color, bumped default border #d1d5db → #9ca3af so the rail actually reads. List markers muted via `::marker`. Images get `loading="lazy"` + `decoding="async"`. Display element's blockquote mirrored to match Markdown's (intentional duplication per #33). Fixed a duplicate-id bug (every Markdown instance shared `id="markdown"`) by switching to a useId-backed class. Also defeated a VS Code webview host-CSS issue where the default `code { background-color: var(--vscode-textPreformat-background) }` painted a per-line tint behind the text inside our fenced-code chip.

- **#366** — CI: cache Playwright browser binaries to skip the ~33s install step on cached runs. Developer-facing, no consumer impact.

## New CSS variables (additive)

- `--stagebook-link-hover` (#1d4ed8) — pressed/hover link color.
- `--stagebook-link-visited` (#7c3aed) — visited-link convention.
- `--stagebook-prompt-h5-size` (1rem) / `-h6-size` (0.875rem).
- `--stagebook-prompt-h5-weight` / `-h6-weight` (both 600).

## New exports (additive)

- `computeSafeRel(target, rel)` from `stagebook/components` — helper that appends `noopener noreferrer` to the rel attribute when target is `_blank`. Used internally by the Markdown component; exported for unit-testable contract.

## Default changed (still additive)

- `--stagebook-blockquote-border` default #d1d5db → #9ca3af. The previous gray-300 rail was nearly invisible against the page background; gray-400 actually reads as "quote." Hosts that pinned the variable continue to see their override; only the fallback default changed.

## Compatibility

- No API removals, no schema changes, no behavior changes for existing prompt content.
- Visual changes are net additions (hover/focus/visited link affordances, table responsiveness, h5/h6 rendering) — researcher-authored content renders the same except where it previously invisibly relied on missing default styling (h5/h6, mobile-wide tables).

🤖 Generated with [Claude Code](https://claude.com/claude-code)