### PR TITLE
UI polish: Separator (#350 tier 2)

### DIFF
--- a/packages/stagebook/src/components/form/Separator.ct.tsx
+++ b/packages/stagebook/src/components/form/Separator.ct.tsx
@@ -1,19 +1,99 @@
 import { test, expect } from "@playwright/experimental-ct-react";
 import { Separator } from "./Separator";
 
+// The Separator renders a single <hr> as its root element, so the
+// Playwright `mount` locator IS the <hr> — assert against `component`
+// directly rather than locator("hr") (which would search for a nested
+// hr inside the hr, which doesn't exist).
+
 test("renders regular separator by default", async ({ mount }) => {
   const component = await mount(<Separator />);
-  const hr = component.locator("hr");
-  await expect(hr).toBeVisible();
-  await expect(hr).toHaveCSS("height", "3px");
+  await expect(component).toBeVisible();
+  await expect(component).toHaveCSS("height", "3px");
 });
 
 test("renders thin separator", async ({ mount }) => {
   const component = await mount(<Separator style="thin" />);
-  await expect(component.locator("hr")).toHaveCSS("height", "1px");
+  await expect(component).toHaveCSS("height", "1px");
 });
 
 test("renders thick separator", async ({ mount }) => {
   const component = await mount(<Separator style="thick" />);
-  await expect(component.locator("hr")).toHaveCSS("height", "5px");
+  await expect(component).toHaveCSS("height", "5px");
+});
+
+// ----------- UI polish (#350 tier 2) -----------
+
+test("legacy empty-string style resolves to regular (back-compat)", async ({
+  mount,
+}) => {
+  // The prompt-file schema historically accepted `style: ""` to mean
+  // "unspecified" and that resolved to regular. The refactor switched
+  // from three ternaries to a single lookup; this locks in the same
+  // back-compat behavior.
+  const component = await mount(<Separator style="" />);
+  await expect(component).toHaveCSS("height", "3px");
+});
+
+test("renders <hr> directly (no wrapper div)", async ({ mount }) => {
+  // Polish: the previous implementation wrapped <hr> in a structurally
+  // pointless <div>. <hr> is already block-level, so the wrapper added
+  // a DOM node for no rendering reason. Asserts the mounted root IS
+  // an <hr>; guards against accidental reintroduction of a wrapper.
+  const component = await mount(<Separator />);
+  const tagName = await component.evaluate((el) => el.tagName);
+  expect(tagName).toBe("HR");
+});
+
+test("uses border longhands, not the border shorthand (#367 defense)", async ({
+  mount,
+}) => {
+  // React's inline-style diff has been observed to clear `border` (a
+  // shorthand) without re-emitting the longhand expansion when
+  // switching between styles — surfaces as a stray default border
+  // stripe overlapping the colored bar. The fix is to use the
+  // longhand `borderStyle: "none"` (not the shorthand `border:
+  // "none"`). Reads the inline style attribute to confirm we ship
+  // longhands.
+  const component = await mount(<Separator />);
+  const inlineStyle = await component.evaluate(
+    (el) => el.getAttribute("style") ?? "",
+  );
+  // We want `border-style: none` (the longhand) and NO bare `border`
+  // shorthand. Regex excludes `border-style`, `border-color`, etc.
+  expect(inlineStyle).toMatch(/border-style:\s*none/);
+  expect(inlineStyle).not.toMatch(/(?:^|;)\s*border\s*:/);
+});
+
+test("inline styles survive an aggressive host CSS reset", async ({
+  mount,
+}) => {
+  // Mirror of the table inline-style test (#214) and the <hr> test
+  // in Markdown.ct.tsx. A Tailwind-style preflight ships:
+  //   hr { border-top-width: 1px; color: inherit; background: transparent; }
+  // The Separator's inline `backgroundColor` and `height` must beat
+  // those resets so the rule stays visible regardless of host.
+  const resetCSS = `
+    hr {
+      border-top-width: 1px;
+      background-color: transparent;
+      height: 0;
+    }
+  `;
+  const component = await mount(
+    <div>
+      <style dangerouslySetInnerHTML={{ __html: resetCSS }} />
+      <Separator style="thick" />
+    </div>,
+  );
+  const hr = component.locator("hr");
+  // height stays at 5px (the thick variant), not 0
+  const height = await hr.evaluate((el) =>
+    parseFloat(getComputedStyle(el).height),
+  );
+  expect(height).toBeGreaterThanOrEqual(5);
+  // background-color stays the muted token, not transparent
+  const bg = await hr.evaluate((el) => getComputedStyle(el).backgroundColor);
+  expect(bg).not.toBe("rgba(0, 0, 0, 0)");
+  expect(bg).not.toBe("transparent");
 });

--- a/packages/stagebook/src/components/form/Separator.tsx
+++ b/packages/stagebook/src/components/form/Separator.tsx
@@ -4,36 +4,53 @@ export interface SeparatorProps {
   style?: "" | "thin" | "regular" | "thick";
 }
 
+// Border longhands (not the `border` shorthand) — React's inline-style
+// diff routinely clears the longhand without re-emitting the shorthand
+// expansion, which would surface here as a stray default 1-3px border
+// stripe overlapping the colored bar. Same #367-pattern defense as the
+// sibling form components. `borderStyle: "none"` covers all four sides.
+//
+// `backgroundColor` + explicit `height` is what draws the visible rule;
+// using these (not `border-top`) lets the rule render correctly even
+// on hosts that ship `hr { border: 0 }` in their reset (Tailwind
+// preflight). The inline `backgroundColor` wins on specificity over a
+// host's `hr { background-color: transparent }`. See issue #215 for
+// the related `<hr>` rendering work in Markdown.
 const baseStyle: React.CSSProperties = {
   margin: "1rem 0",
   width: "100%",
-  border: "none",
+  borderStyle: "none",
 };
 
-const thinStyle: React.CSSProperties = {
-  ...baseStyle,
-  height: "1px",
-  backgroundColor: "var(--stagebook-text-faint, #9ca3af)",
-};
-
-const regularStyle: React.CSSProperties = {
-  ...baseStyle,
-  height: "3px",
-  backgroundColor: "var(--stagebook-text-faint, #9ca3af)",
-};
-
-const thickStyle: React.CSSProperties = {
-  ...baseStyle,
-  height: "5px",
-  backgroundColor: "var(--stagebook-text-muted, #6b7280)",
+// Three sizes, three colors. Thin and regular share the gray-400
+// `--stagebook-text-faint` token; thick steps up to the heavier
+// `--stagebook-text-muted` to read as a strong separator. Researchers
+// pick the style via the prompt-file frontmatter; the default ("")
+// resolves to regular.
+const VARIANT_STYLES: Record<
+  Exclude<SeparatorProps["style"], undefined | "">,
+  React.CSSProperties
+> = {
+  thin: {
+    ...baseStyle,
+    height: "1px",
+    backgroundColor: "var(--stagebook-text-faint, #9ca3af)",
+  },
+  regular: {
+    ...baseStyle,
+    height: "3px",
+    backgroundColor: "var(--stagebook-text-faint, #9ca3af)",
+  },
+  thick: {
+    ...baseStyle,
+    height: "5px",
+    backgroundColor: "var(--stagebook-text-muted, #6b7280)",
+  },
 };
 
 export function Separator({ style = "" }: SeparatorProps) {
-  return (
-    <div>
-      {style === "thin" && <hr style={thinStyle} />}
-      {(style === "" || style === "regular") && <hr style={regularStyle} />}
-      {style === "thick" && <hr style={thickStyle} />}
-    </div>
-  );
+  // `""` is the legacy "no style specified" sentinel from the
+  // prompt-file schema — resolves to the regular variant.
+  const variant = style === "" ? "regular" : style;
+  return <hr style={VARIANT_STYLES[variant]} />;
 }


### PR DESCRIPTION
Second component in tier 2 of the #350 polish sweep. Separator is a non-interactive horizontal rule, so most of the per-component checklist (hover / focus / keyboard / reduced-motion / touch-target / ARIA) doesn't apply — `<hr>` already carries implicit `role="separator"` with horizontal orientation. Polish here is internal cleanup + defensive fixes.

## Changes

- **Wrapper `<div>` dropped.** `<hr>` is already block-level, so the wrapper was a structurally pointless DOM node.

- **`border: "none"` shorthand → longhand (`borderStyle: "none"`).** React's inline-style diff has been observed to clear the `border` shorthand without re-emitting the longhand expansion when switching between styles — would surface here as a stray default border stripe overlapping the colored bar. Same defensive pattern as the #367 fixes in the form components.

- **Three ternaries → lookup map.** Three mutually-exclusive variant conditions collapse into a single `VARIANT_STYLES` table keyed by variant name. Slightly easier to extend if a future variant lands.

## Out of scope (intentional)

- Hover / focus / disabled / keyboard / reduced-motion / touch-target — `<hr>` isn't interactive.
- ARIA — `<hr>` already has implicit `role="separator"` + horizontal orientation.
- New `--stagebook-separator-color` token — current `--stagebook-text-faint` (thin/regular) and `--stagebook-text-muted` (thick) work; separator-specific variable is YAGNI without a real ask.
- Visual color tuning — would be a behavioral change without clear motivation.

## Tests

- Existing variant-height assertions updated to query `component` directly (when the root is the `<hr>` itself, `.locator("hr")` finds no nested hr and fails).
- **New** "renders <hr> directly (no wrapper div)" — guards against accidental reintroduction.
- **New** "uses border longhands, not the border shorthand" — reads the inline style attribute to confirm the #367 defense.
- **New** "legacy empty-string style resolves to regular" — locks in the prompt-file schema back-compat path.
- **New** "inline styles survive an aggressive host CSS reset" — mirror of the table inline-style test from issue #214; a Tailwind-style preflight `hr { background: transparent; height: 0 }` must not erase the visible rule.

All 8 Separator CT pass. 1035 unit + 519 of 520 CT pass (one unrelated `Timeline.ct.tsx:3085` flake passes on isolation re-run; the test is not touched here).

## Test plan

- [x] `npm run build -w stagebook`
- [x] `npm run test:ct -w stagebook -- --grep "Separator"` (8/8 pass)
- [x] `npm test` (1035/1035 pass)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)