### PR TITLE
UI polish: Stage (#350 tier 2)

### DIFF
--- a/packages/stagebook/src/components/Stage.ct.tsx
+++ b/packages/stagebook/src/components/Stage.ct.tsx
@@ -494,3 +494,54 @@ test('scrollMode "host" still renders all elements correctly', async ({
   await expect(component.locator("hr")).toBeVisible();
   await expect(component).toContainText("Continue");
 });
+
+// ----------------------------------------------------------------
+// Reduced motion (#350 tier 2 polish)
+// ----------------------------------------------------------------
+//
+// The discussion content column gets `scroll-behavior: smooth` at the
+// md breakpoint so anchor jumps / programmatic scrolls animate. For
+// participants who opted into reduced motion (OS setting), that
+// animation can trigger vestibular discomfort — gate it on
+// `prefers-reduced-motion: reduce` and fall back to instant.
+//
+// The single-column path uses the browser default (instant) already,
+// so no override needed there.
+
+test("prefers-reduced-motion: discussion content column drops smooth scroll", async ({
+  mount,
+  page,
+}) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  // Set a viewport wide enough to trigger the md breakpoint where
+  // the smooth-scroll rule is active.
+  await page.setViewportSize({ width: 1024, height: 800 });
+  const component = await mount(
+    <MockStageRenderer stage={discussionStage} position={0} />,
+  );
+  const content = component.locator('[data-testid="stageContent"]');
+  const scrollBehavior = await content.evaluate(
+    (el) => getComputedStyle(el).scrollBehavior,
+  );
+  expect(scrollBehavior).toBe("auto");
+});
+
+test("default media: discussion content column uses smooth scroll at md+", async ({
+  mount,
+  page,
+}) => {
+  // Negative-case companion to the test above. Without reduced-motion
+  // emulation, the md+ breakpoint applies smooth scroll. If a future
+  // change inverts the rule (e.g. swaps the @media query), this test
+  // catches it.
+  await page.emulateMedia({ reducedMotion: "no-preference" });
+  await page.setViewportSize({ width: 1024, height: 800 });
+  const component = await mount(
+    <MockStageRenderer stage={discussionStage} position={0} />,
+  );
+  const content = component.locator('[data-testid="stageContent"]');
+  const scrollBehavior = await content.evaluate(
+    (el) => getComputedStyle(el).scrollBehavior,
+  );
+  expect(scrollBehavior).toBe("smooth");
+});

--- a/packages/stagebook/src/components/Stage.tsx
+++ b/packages/stagebook/src/components/Stage.tsx
@@ -27,6 +27,23 @@ function laneFor(type: string): string {
   return ELEMENT_LANES[type] ?? DEFAULT_LANE;
 }
 
+// Shared layout for the stage's content column. Used by both the
+// single-column path and the discussion-fallback path so a future
+// layout tweak only has to land in one place. Internal-scroll mode
+// adds `height: 100%; overflow: auto; padding-bottom: 0.5rem` so the
+// column behaves as the scroll container; host-scroll mode drops
+// them so the host's own container governs scroll (#236).
+const stageContentBaseStyle: React.CSSProperties = {
+  display: "flex",
+  width: "100%",
+  flexDirection: "column",
+};
+const stageContentInternalScrollExtras: React.CSSProperties = {
+  height: "100%",
+  paddingBottom: "0.5rem",
+  overflow: "auto",
+};
+
 /**
  * Compute the max-width lane for an element. Separators span at least as
  * wide as the widest non-separator sibling on the stage so they read as
@@ -320,6 +337,15 @@ export function Stage({
               scroll-behavior: smooth;
             }
           }
+          /* Participants who opted into reduced motion get instant
+             scroll-to instead of the animated smooth scroll on the
+             discussion content column. Single-column / fallback paths
+             use the browser default (instant) already. */
+          @media (prefers-reduced-motion: reduce) {
+            .stagebook-discussion-content[data-internal-scroll="true"] {
+              scroll-behavior: auto;
+            }
+          }
         `}</style>
       </div>
     );
@@ -339,16 +365,8 @@ export function Stage({
                   <div
                     data-testid="stageContent"
                     style={{
-                      display: "flex",
-                      width: "100%",
-                      flexDirection: "column",
-                      ...(isHostScroll
-                        ? {}
-                        : {
-                            height: "100%",
-                            paddingBottom: "0.5rem",
-                            overflow: "auto",
-                          }),
+                      ...stageContentBaseStyle,
+                      ...(isHostScroll ? {} : stageContentInternalScrollExtras),
                     }}
                   >
                     {elementsColumn}
@@ -378,16 +396,8 @@ export function Stage({
             ref={isHostScroll ? null : singleColumnRef}
             data-testid="stageContent"
             style={{
-              display: "flex",
-              width: "100%",
-              flexDirection: "column",
-              ...(isHostScroll
-                ? {}
-                : {
-                    height: "100%",
-                    paddingBottom: "0.5rem",
-                    overflow: "auto",
-                  }),
+              ...stageContentBaseStyle,
+              ...(isHostScroll ? {} : stageContentInternalScrollExtras),
             }}
           >
             {elementsColumn}


### PR DESCRIPTION
Third and final component in tier 2 of the #350 polish sweep. Stage is a layout/router — most of the per-component checklist (hover / focus / disabled / keyboard / touch-target / ARIA) doesn't apply, so the in-scope items are narrow.

## Visible changes

- **Reduced motion** — the discussion-content column at the md+ breakpoint shipped `scroll-behavior: smooth`. Added a `@media (prefers-reduced-motion: reduce)` override that falls back to instant scroll. Helps participants who opted into reduced motion via their OS setting avoid vestibular discomfort from animated scrolls. The single-column path uses the browser default (instant) already, so no override needed there.

## Refactor

- **Inline-style consolidation** — the single-column path and the discussion-fallback path each defined the same content-wrapper style (display, width, flex direction + the internal-scroll extras) inline twice. Extracted to `stageContentBaseStyle` + `stageContentInternalScrollExtras` constants. Output identical, but future layout tweaks now only land in one place.

## Out of scope (intentional)

- Hover / focus / disabled / keyboard / touch-target — Stage owns no interactive surfaces.
- ARIA role assignments — host-level concern; injecting `role="main"` here would conflict with hosts that wrap stages in `<main>`.
- Renaming `stagebook-discussion-*` class names to useId-scoped classes — hosts may rely on them for external styling; renaming is silently breaking.
- Conditional-render wrapping pyramid — #350 tier 3 territory.
- ScrollIndicator polish — filed as #394 follow-up per user note.

## Tests

40 Stage CT pass (38 existing + 2 new):
- prefers-reduced-motion: discussion content column drops smooth scroll (asserts `scroll-behavior: auto` under reduced-motion emulation at the md+ breakpoint)
- default media: discussion content column uses smooth scroll at md+ (negative-case companion; catches future @media-query inversions)

Full unit (1035) + CT (522) suites also pass.

## Test plan

- [x] `npm run build -w stagebook`
- [x] `npm run test:ct -w stagebook -- --grep "Stage"` (40/40 pass)
- [x] `npm test` (1035/1035 pass)
- [x] `npm run test:ct -w stagebook` (522/522 pass)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)