### PR TITLE
Fix #380: prompt parser ignores `---` inside fenced code blocks

### DIFF
--- a/examples/component-gallery/README.md
+++ b/examples/component-gallery/README.md
@@ -158,12 +158,3 @@ shuffle: true
 - option_c: Third option
 ```
 
-## Known limitation
-
-Stagebook's prompt-file parser splits on any `---` line in the file,
-including lines inside fenced code blocks. That means you can't put
-prompt-syntax examples (like those above) inside a `noResponse`
-prompt body — the `---` inside the code block gets read as a section
-delimiter. Worked around here by keeping the syntax examples in this
-README rather than inside the prompts themselves. See the follow-up
-issue linked from the gallery's PR for the parser fix.

--- a/packages/stagebook/src/schemas/promptFile.test.ts
+++ b/packages/stagebook/src/schemas/promptFile.test.ts
@@ -6,6 +6,7 @@ import {
   metadataLogicalSchema,
   validateSliderLabels,
   promptFileSchema,
+  splitOnTopLevelHrules,
 } from "./promptFile.js";
 
 // Back-compat aliases all point at `promptMetadataSchema` after #243; the
@@ -1000,6 +1001,143 @@ Body.`;
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.metadata.name).toBe(okName);
+    }
+  });
+});
+
+// ----------- Issue #380 — fenced code blocks containing `---` ------
+
+// The pre-#380 splitter was a single regex split that matched any line
+// of three-or-more hyphens anywhere in the file, including inside
+// fenced code blocks. Researchers writing meta-documentation prompts
+// (e.g. the component-gallery's per-component descriptions) couldn't
+// quote stagebook's own prompt-file syntax inside a `noResponse`
+// prompt without the inner `---` lines silently shredding the file
+// into pseudo-sections.
+
+describe("splitOnTopLevelHrules", () => {
+  test("matches the legacy regex split on inputs without fences", () => {
+    const input = "---\nmeta\n---\nbody\n---\nresponses";
+    expect(splitOnTopLevelHrules(input)).toEqual(input.split(/^-{3,}$/gm));
+  });
+
+  test("leading `---` produces a leading empty-string section (back-compat)", () => {
+    const input = "---\nmeta\n---\nbody";
+    const sections = splitOnTopLevelHrules(input);
+    expect(sections[0]).toBe("");
+    expect(sections).toHaveLength(3);
+  });
+
+  test("ignores `---` lines inside a backtick-fenced code block", () => {
+    const input = `---
+type: noResponse
+---
+Some body.
+
+\`\`\`yaml
+---
+type: multipleChoice
+---
+\`\`\`
+
+More body.`;
+    const sections = splitOnTopLevelHrules(input);
+    // Three sections: leading empty, frontmatter, body. The two `---`
+    // lines inside the fence must NOT have produced extra sections.
+    expect(sections).toHaveLength(3);
+    expect(sections[2]).toContain("```yaml");
+    expect(sections[2]).toContain("type: multipleChoice");
+  });
+
+  test("toggles fence state in/out across multiple fenced blocks", () => {
+    const input = `---
+meta
+---
+\`\`\`
+---
+\`\`\`
+between
+\`\`\`yaml
+---
+\`\`\``;
+    const sections = splitOnTopLevelHrules(input);
+    // Two fences each containing one `---` line — both should be
+    // suppressed. Result: leading empty, frontmatter, body.
+    expect(sections).toHaveLength(3);
+    expect(sections[2]).toContain("between");
+  });
+
+  test("a closing fence on the last line still toggles cleanly", () => {
+    // Documents the current behavior — an unclosed fence (terminating
+    // file inside the fence) suppresses any `---` from there to EOF.
+    // Stagebook prompts always close their fences in practice; this
+    // test pins the simple behavior so a future refactor doesn't
+    // silently change it.
+    const input = "---\nmeta\n---\nbody\n```\n---\nin fence";
+    const sections = splitOnTopLevelHrules(input);
+    expect(sections).toHaveLength(3);
+    expect(sections[2]).toContain("in fence");
+  });
+});
+
+describe("promptFileSchema — fenced code with `---` inside (#380)", () => {
+  test("noResponse body containing a fenced code block with `---` parses", () => {
+    const markdown = `---
+type: noResponse
+name: gallery_demo
+---
+
+# RadioGroup
+
+Authoring shape:
+
+\`\`\`yaml
+---
+type: multipleChoice
+name: my_question
+---
+\`\`\`
+
+That's the gist.`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.metadata.type).toBe("noResponse");
+      // The body must include the fenced code block verbatim.
+      expect(result.data.body).toContain("```yaml");
+      expect(result.data.body).toContain("type: multipleChoice");
+    }
+  });
+
+  test("multipleChoice prompt body containing fenced `---` still parses (responses follow)", () => {
+    // Three-section format: frontmatter / body / responses. The fenced
+    // `---` in the body must not be misread as the body/responses
+    // boundary.
+    const markdown = `---
+type: multipleChoice
+name: q1
+---
+
+Pick one. The Stagebook authoring shape is:
+
+\`\`\`yaml
+---
+type: noResponse
+---
+\`\`\`
+
+Now your answer:
+
+---
+
+- alpha
+- bravo`;
+    const result = promptFileSchema.safeParse(markdown);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.metadata.type).toBe("multipleChoice");
+      expect(result.data.body).toContain("```yaml");
+      expect(result.data.responseItems).toEqual(["alpha", "bravo"]);
     }
   });
 });

--- a/packages/stagebook/src/schemas/promptFile.ts
+++ b/packages/stagebook/src/schemas/promptFile.ts
@@ -292,6 +292,56 @@ export interface ParsedPromptFile {
   sliderPoints: number[];
 }
 
+/**
+ * Split a prompt-file string on top-level `---` section delimiters,
+ * skipping any `---` lines that appear inside a fenced code block.
+ *
+ * The previous implementation was a single regex split — `trimmed.
+ * split(/^-{3,}$/gm)` — which matched any line of three-or-more
+ * hyphens anywhere in the file, including inside fenced code
+ * (#380). A researcher quoting Stagebook's prompt-file syntax inside
+ * a `noResponse` prompt would have their body silently shredded into
+ * pseudo-sections and rejected with "must have exactly two sections."
+ *
+ * This walks line-by-line, tracking whether the cursor is inside a
+ * fence opened by ```` ``` ```` (any info-string allowed). Only `---`
+ * lines outside the fence count as section boundaries. Matches the
+ * regex split's output shape: a file starting with `---` produces a
+ * leading empty string section (sections[0]), the metadata YAML is
+ * sections[1], the body is sections[2], and the optional response
+ * string is sections[3].
+ *
+ * Edge cases not handled (deliberate, to keep the rule simple):
+ * - Indented fences (CommonMark allows up to 3 spaces). Stagebook
+ *   prompts don't author indented fences in practice.
+ * - Tilde-fenced code (`~~~`). Same reasoning; backtick is the only
+ *   form Stagebook prompts use.
+ */
+export function splitOnTopLevelHrules(input: string): string[] {
+  // Mask any in-fence `^-{3,}$` lines so the legacy regex split can't
+  // see them. The mask prepends a null byte ( ), which makes
+  // `^-{3,}$` no longer match (the line no longer starts with `-`),
+  // and won't collide with any byte in a real prompt file. After the
+  // split, strip the null bytes back out to restore the original
+  // line. This preserves the exact byte shape the regex split
+  // produced pre-#380 — leading / trailing newlines around each
+  // section stay where they were — so any future consumer that
+  // depends on the legacy output shape isn't silently broken.
+  const MASK = " ";
+  const lines = input.split("\n");
+  let insideFence = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.startsWith("```")) {
+      insideFence = !insideFence;
+    } else if (insideFence && /^-{3,}$/.test(line)) {
+      lines[i] = MASK + line;
+    }
+  }
+  const sections = lines.join("\n").split(/^-{3,}$/gm);
+  return sections.map((s) => s.replaceAll(MASK, ""));
+}
+
 export const promptFileSchema: z.ZodType<
   ParsedPromptFile,
   z.ZodTypeDef,
@@ -309,7 +359,7 @@ export const promptFileSchema: z.ZodType<
       return z.NEVER;
     }
 
-    const sections = trimmed.split(/^-{3,}$/gm);
+    const sections = splitOnTopLevelHrules(trimmed);
 
     // First section is the empty string before the leading `---`.
     if (sections.length < 3) {


### PR DESCRIPTION
Fixes #380.

## Diagnosis

The section splitter at [promptFile.ts:312](packages/stagebook/src/schemas/promptFile.ts#L312) was a single regex split — `trimmed.split(/^-{3,}$/gm)` — which matched any line of three-or-more hyphens anywhere in the file, including inside fenced code blocks. A researcher quoting Stagebook's own prompt-file syntax inside a \`noResponse\` prompt would have their body silently shredded into pseudo-sections, then rejected with *"must have exactly two sections."*

Hit during the component-gallery work (#379) and worked around by moving syntax examples into the README. This PR removes the workaround.

## Fix

Extracted the split into \`splitOnTopLevelHrules\`, a single-pass walker that:
1. Splits the input by \`\n\` and iterates lines, tracking backtick fence state (toggle on any line starting with ` ``` `).
2. Lines matching \`^-{3,}$\` *while inside a fence* are masked with a single null-byte (\` \`) prefix so the regex's \`^\` anchor can't match.
3. Joins the masked lines back, runs the original regex split, then strips the null bytes from the resulting sections.

This preserves the exact byte shape the legacy regex produced — including the leading / trailing newlines around each section — so no downstream consumer that happens to depend on the shape is silently affected.

## Edge cases deliberately not handled

- **Indented fences** (CommonMark allows up to 3 leading spaces). Stagebook prompts don't author indented fences in practice.
- **Tilde-fenced code** (\`~~~\`). Same reasoning; backtick is the only fence form Stagebook prompts use.

## Tests

7 new unit tests in [promptFile.test.ts](packages/stagebook/src/schemas/promptFile.test.ts):
- \`splitOnTopLevelHrules\` matches the legacy regex split on inputs without fences (back-compat).
- Leading \`---\` produces a leading empty-string section.
- Ignores \`---\` lines inside a backtick-fenced code block.
- Toggles fence state cleanly across multiple fences.
- An unclosed fence suppresses any \`---\` from there to EOF (documents the simple behavior).
- Full schema round-trip: \`noResponse\` body containing fenced code with \`---\` parses.
- Full schema round-trip: \`multipleChoice\` with fenced \`---\` in body still parses (responses follow correctly).

Full unit (1042) + CT (522) all green.

## Also drops

The "Known limitation" workaround note from [examples/component-gallery/README.md](examples/component-gallery/README.md), since the limitation no longer exists.

## Test plan

- [x] \`npm test\` — 1042/1042 pass
- [x] \`npm run test:ct -w stagebook\` — 522/522 pass
- [x] \`npm run build -w stagebook\`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)