### PR TITLE
UI polish: ScrollIndicator (#394)

### DIFF
--- a/examples/component-gallery/component-gallery.stagebook.yaml
+++ b/examples/component-gallery/component-gallery.stagebook.yaml
@@ -154,6 +154,32 @@ treatments:
             file: prompts/listsorter_demo.prompt.md
           - type: submitButton
 
+      - name: scroll_indicator
+        duration: 600
+        notes: |
+          ScrollIndicator — the chevron pill that appears at the
+          bottom of a Stage column when there's content below the
+          fold. The conditional second slab exercises the
+          growth-triggered re-appearance path: after the participant
+          selects a response, more content reveals and the indicator
+          re-shows even if they'd scrolled to the bottom previously.
+        elements:
+          - type: prompt
+            file: prompts/scroll_intro.prompt.md
+          - type: separator
+            style: thin
+          - type: prompt
+            name: scroll_demo_choice
+            file: prompts/scroll_demo_choice.prompt.md
+          - type: prompt
+            file: prompts/scroll_filler.prompt.md
+          - type: prompt
+            file: prompts/scroll_extra.prompt.md
+            conditions:
+              - reference: self.prompt.scroll_demo_choice
+                comparator: exists
+          - type: submitButton
+
     exitSequence:
       - name: Done
         elements:

--- a/examples/component-gallery/prompts/scroll_demo_choice.prompt.md
+++ b/examples/component-gallery/prompts/scroll_demo_choice.prompt.md
@@ -1,0 +1,11 @@
+---
+type: multipleChoice
+name: scroll_demo_choice
+---
+
+Reveal more content?
+
+---
+
+- yes: Yes, show me more
+- no: No, this is enough

--- a/examples/component-gallery/prompts/scroll_extra.prompt.md
+++ b/examples/component-gallery/prompts/scroll_extra.prompt.md
@@ -1,0 +1,55 @@
+---
+type: noResponse
+---
+
+## Newly revealed content
+
+You selected a response above, so this section just grew in. The
+ScrollIndicator chevron should have re-appeared at the bottom even
+if you'd previously scrolled all the way down — that's the
+"growth-triggered" path. Scrolling to the new bottom dismisses it
+again.
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
+quae ab illo inventore veritatis et quasi architecto beatae vitae
+dicta sunt explicabo.
+
+### Section five
+
+Curabitur pretium tincidunt lacus. Nulla gravida orci a odio. Nullam
+varius, turpis et commodo pharetra, est eros bibendum elit, nec
+luctus magna felis sollicitudin mauris. Integer in mauris eu nibh
+euismod gravida.
+
+Duis ac tellus et risus vulputate vehicula. Donec lobortis risus a
+elit. Etiam tempor. Ut ullamcorper, ligula eu tempor congue, eros
+est euismod turpis, id tincidunt sapien risus a quam.
+
+### Section six
+
+Maecenas fermentum consequat mi. Donec fermentum. Pellentesque
+malesuada nulla a mi. Duis sapien sem, aliquet nec, commodo eget,
+consequat quis, neque. Aliquam faucibus, elit ut dictum aliquet,
+felis nisl adipiscing sapien, sed malesuada diam lacus eget erat.
+
+Cras mollis scelerisque nunc. Nullam arcu. Aliquam consequat. Curabitur
+augue lorem, dapibus quis, laoreet et, pretium ac, nisi. Aenean magna
+nisl, mollis quis, molestie eu, feugiat in, orci.
+
+### Section seven
+
+In hac habitasse platea dictumst. Fusce convallis, mauris imperdiet
+gravida bibendum, nisl turpis suscipit mauris, sed placerat ipsum
+urna sed risus. In convallis tellus a mauris. Curabitur non elit ut
+libero tristique sodales.
+
+Mauris a lacus. Donec mattis semper leo. In hac habitasse platea
+dictumst. Vivamus facilisis diam at odio. Mauris dictum, nisi eget
+consequat elementum, lacus ligula molestie metus, non feugiat orci
+magna ac sem.
+
+### End
+
+OK, you've reached the bottom of the newly-revealed slab. The
+indicator should be gone. Hit submit when you're done playing.

--- a/examples/component-gallery/prompts/scroll_filler.prompt.md
+++ b/examples/component-gallery/prompts/scroll_filler.prompt.md
@@ -1,0 +1,50 @@
+---
+type: noResponse
+---
+
+## Always-visible content
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim
+ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse
+cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+cupidatat non proident, sunt in culpa qui officia deserunt mollit
+anim id est laborum.
+
+### Section two
+
+Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
+quae ab illo inventore veritatis et quasi architecto beatae vitae
+dicta sunt explicabo.
+
+Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit
+aut fugit, sed quia consequuntur magni dolores eos qui ratione
+voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem
+ipsum quia dolor sit amet, consectetur, adipisci velit.
+
+### Section three
+
+At vero eos et accusamus et iusto odio dignissimos ducimus qui
+blanditiis praesentium voluptatum deleniti atque corrupti quos
+dolores et quas molestias excepturi sint occaecati cupiditate non
+provident, similique sunt in culpa qui officia deserunt mollitia
+animi, id est laborum et dolorum fuga.
+
+Et harum quidem rerum facilis est et expedita distinctio. Nam libero
+tempore, cum soluta nobis est eligendi optio cumque nihil impedit
+quo minus id quod maxime placeat facere possimus, omnis voluptas
+assumenda est, omnis dolor repellendus.
+
+### Section four
+
+Temporibus autem quibusdam et aut officiis debitis aut rerum
+necessitatibus saepe eveniet ut et voluptates repudiandae sint et
+molestiae non recusandae. Itaque earum rerum hic tenetur a sapiente
+delectus, ut aut reiciendis voluptatibus maiores alias consequatur.
+
+End of always-visible content. Pick a response on the prompt above
+to reveal the next slab.

--- a/examples/component-gallery/prompts/scroll_intro.prompt.md
+++ b/examples/component-gallery/prompts/scroll_intro.prompt.md
@@ -1,0 +1,19 @@
+---
+type: noResponse
+---
+
+# ScrollIndicator
+
+The chevron pill at the bottom-center of this column appears when
+there's content below the fold. It dismisses when you scroll to the
+bottom, and re-appears if new content grows in (e.g. when a
+conditional element reveals).
+
+Try it:
+
+1. **Scroll down** — the indicator should disappear once you reach
+   the bottom.
+2. **Pick a response** to the prompt below — that reveals an extra
+   slab of content, and the indicator should re-appear because
+   you're suddenly no-longer-at-the-bottom.
+3. Scroll to the new bottom — indicator dismisses again.

--- a/packages/stagebook/src/components/scroll/ScrollIndicator.ct.tsx
+++ b/packages/stagebook/src/components/scroll/ScrollIndicator.ct.tsx
@@ -27,4 +27,114 @@ test.describe("ScrollIndicator", () => {
     const component = await mount(<ScrollIndicator visible={true} />);
     await expect(component.locator("svg")).toBeVisible();
   });
+
+  // ----------- UI polish (#394) -----------
+
+  test("svg background uses --stagebook-scroll-indicator-bg token", async ({
+    mount,
+  }) => {
+    // Polish: the hardcoded rgba(229,231,235,0.8) is now backed by a
+    // CSS variable so hosts can retune without overriding selectors.
+    const component = await mount(<ScrollIndicator visible={true} />);
+    const inlineBg = await component
+      .locator("svg")
+      .evaluate((el) => (el as SVGElement).style.backgroundColor);
+    // The inline style references the var() with the default rgba.
+    // Different browsers serialize var(...) slightly differently;
+    // the contract is that the inline string contains the variable
+    // name.
+    expect(inlineBg).toContain("--stagebook-scroll-indicator-bg");
+  });
+
+  test("svg color uses --stagebook-scroll-indicator-fg token", async ({
+    mount,
+  }) => {
+    const component = await mount(<ScrollIndicator visible={true} />);
+    const inlineColor = await component
+      .locator("svg")
+      .evaluate((el) => (el as SVGElement).style.color);
+    expect(inlineColor).toContain("--stagebook-scroll-indicator-fg");
+  });
+
+  test("CSS variable override changes the indicator background", async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <div
+        style={
+          {
+            "--stagebook-scroll-indicator-bg": "rgb(0, 128, 0)",
+          } as React.CSSProperties
+        }
+      >
+        <ScrollIndicator visible={true} />
+      </div>,
+    );
+    const computed = await component
+      .locator("svg")
+      .evaluate((el) => getComputedStyle(el).backgroundColor);
+    expect(computed).toBe("rgb(0, 128, 0)");
+  });
+
+  test("prefers-reduced-motion: animations disabled", async ({
+    mount,
+    page,
+  }) => {
+    // Polish: the indicator's fade-in slide and the perpetual pulse
+    // both vestibular-trigger for users who opted into reduced
+    // motion. Under the media query both should resolve to
+    // `animation: none`.
+    await page.emulateMedia({ reducedMotion: "reduce" });
+    const component = await mount(<ScrollIndicator visible={true} />);
+    const wrapperAnimation = await component
+      .locator('[data-testid="scroll-indicator"]')
+      .evaluate((el) => getComputedStyle(el).animationName);
+    const svgAnimation = await component
+      .locator("svg")
+      .evaluate((el) => getComputedStyle(el).animationName);
+    expect(wrapperAnimation).toBe("none");
+    expect(svgAnimation).toBe("none");
+  });
+
+  test("default media: animations are active (negative-case companion)", async ({
+    mount,
+    page,
+  }) => {
+    // Catches future changes that accidentally disable animations
+    // outside the reduced-motion path (e.g. a typo in the media
+    // query).
+    await page.emulateMedia({ reducedMotion: "no-preference" });
+    const component = await mount(<ScrollIndicator visible={true} />);
+    const wrapperAnimation = await component
+      .locator('[data-testid="scroll-indicator"]')
+      .evaluate((el) => getComputedStyle(el).animationName);
+    const svgAnimation = await component
+      .locator("svg")
+      .evaluate((el) => getComputedStyle(el).animationName);
+    expect(wrapperAnimation).not.toBe("none");
+    expect(svgAnimation).not.toBe("none");
+  });
+
+  test("two ScrollIndicator instances get unique keyframe scopes", async ({
+    mount,
+  }) => {
+    // Polish: `@keyframes scrollIndicatorFadeIn` (and `Pulse`) used
+    // to be global identifiers. If a host had a same-named keyframe,
+    // the last definition would win. Now each instance scopes its
+    // keyframes via useId, so two indicators (or a host's existing
+    // keyframes) can coexist.
+    const component = await mount(
+      <div>
+        <ScrollIndicator visible={true} />
+        <ScrollIndicator visible={true} />
+      </div>,
+    );
+    const animationNames = await component
+      .locator('[data-testid="scroll-indicator"]')
+      .evaluateAll((els) =>
+        els.map((el) => getComputedStyle(el as HTMLElement).animationName),
+      );
+    expect(animationNames).toHaveLength(2);
+    expect(animationNames[0]).not.toBe(animationNames[1]);
+  });
 });

--- a/packages/stagebook/src/components/scroll/ScrollIndicator.tsx
+++ b/packages/stagebook/src/components/scroll/ScrollIndicator.tsx
@@ -1,25 +1,68 @@
-import React from "react";
+import React, { useId } from "react";
 
 export interface ScrollIndicatorProps {
   visible: boolean;
 }
 
+// "More content below" chevron pill that appears at the bottom of an
+// internally-scrolling Stage column when new content has grown out of
+// view. `useScrollAwareness` toggles `visible`; this component owns
+// only the rendering and the (small) animations.
+//
+// Polish notes (#394):
+// - Color tokens (`--stagebook-scroll-indicator-bg` / `-fg`) live in
+//   styles.css so hosts can retune without overriding selectors.
+// - `@keyframes` names are scoped via `useId()` per-instance so they
+//   can't collide with host-defined keyframes of the same name.
+//   (Two Stage columns mounting at once each get their own scope.)
+// - `prefers-reduced-motion: reduce` disables the fade-in slide and
+//   the perpetual pulse. The indicator still appears, just without
+//   animation — participants who opted out of motion shouldn't see
+//   a continuously pulsing element.
+//
+// `pointer-events: none` and `aria-hidden="true"` are intentional —
+// the indicator is a visual cue, not an interactive control. Adding
+// a click-to-scroll-to-bottom affordance would be a UX change worth
+// its own design discussion (see comment in PR #397 thread).
 export function ScrollIndicator({ visible }: ScrollIndicatorProps) {
+  // Hooks must run unconditionally; the early-return below is after.
+  const reactId = useId();
+  const safeId = reactId.replace(/[^a-zA-Z0-9_-]/g, "");
+  const fadeInName = `stagebook-scroll-indicator-fadein-${safeId}`;
+  const pulseName = `stagebook-scroll-indicator-pulse-${safeId}`;
+  const rootClass = `stagebook-scroll-indicator-${safeId}`;
+
   if (!visible) return null;
 
   return (
     <>
       <style>{`
-        @keyframes scrollIndicatorFadeIn {
+        @keyframes ${fadeInName} {
           from { opacity: 0; transform: translateY(10px); }
           to { opacity: 1; transform: translateY(0); }
         }
-        @keyframes scrollIndicatorPulse {
+        @keyframes ${pulseName} {
           0%, 100% { transform: scale(1); opacity: 1; }
           50% { transform: scale(1.05); opacity: 0.85; }
         }
+        .${rootClass} {
+          animation: ${fadeInName} 0.3s ease-out;
+        }
+        .${rootClass} > svg {
+          animation: ${pulseName} 2s ease-in-out infinite;
+        }
+        /* Participants who opted into reduced motion see the
+           indicator appear, but without the fade-in slide or the
+           perpetual pulse — both are vestibular triggers. */
+        @media (prefers-reduced-motion: reduce) {
+          .${rootClass},
+          .${rootClass} > svg {
+            animation: none;
+          }
+        }
       `}</style>
       <div
+        className={rootClass}
         style={{
           position: "sticky",
           bottom: 0,
@@ -30,7 +73,6 @@ export function ScrollIndicator({ visible }: ScrollIndicatorProps) {
           padding: "0.75rem",
           pointerEvents: "none",
           zIndex: 50,
-          animation: "scrollIndicatorFadeIn 0.3s ease-out",
         }}
         aria-hidden="true"
         data-testid="scroll-indicator"
@@ -46,13 +88,13 @@ export function ScrollIndicator({ visible }: ScrollIndicatorProps) {
           strokeLinecap="round"
           strokeLinejoin="round"
           style={{
-            backgroundColor: "rgba(229, 231, 235, 0.8)",
-            color: "#4b5563",
+            backgroundColor:
+              "var(--stagebook-scroll-indicator-bg, rgba(229, 231, 235, 0.8))",
+            color: "var(--stagebook-scroll-indicator-fg, #4b5563)",
             borderRadius: "9999px",
             padding: "0.5rem",
             boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
             backdropFilter: "blur(4px)",
-            animation: "scrollIndicatorPulse 2s ease-in-out infinite",
           }}
         >
           <polyline points="6 9 12 15 18 9" />

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -128,6 +128,14 @@
   --stagebook-spinner-track: #e5e7eb;
   --stagebook-spinner-arc: #9ca3af;
 
+  /* Scroll-indicator pill (the "more content below" chevron at the
+   * bottom of an internally-scrolling Stage column). Lives behind a
+   * `pointer-events: none` div so it never intercepts clicks; the
+   * pill itself is a rounded button-like background with a chevron
+   * icon. Defaults are tuned to read on white backgrounds. */
+  --stagebook-scroll-indicator-bg: rgba(229, 231, 235, 0.8);
+  --stagebook-scroll-indicator-fg: #4b5563;
+
   /* Markdown / prompt typography (used by the Markdown component) */
   --stagebook-prompt-max-width: 36rem;
   --stagebook-prompt-text-size: 1rem;


### PR DESCRIPTION
Fixes #394. Follow-up to the Stage polish (#395) that landed in v0.10.9-staging. The ScrollIndicator chevron pill at the bottom of an internally-scrolling Stage column gets the same polish-checklist treatment as the rest of the sweep.

## Visible changes

- **Color tokens.** Hardcoded `rgba(229, 231, 235, 0.8)` (background) and `#4b5563` (icon color) → `--stagebook-scroll-indicator-bg` / `-fg` variables in `styles.css` with the same defaults. Hosts can retune via `:root` override without writing selector-based CSS.

- **`prefers-reduced-motion`.** The indicator had two unconditional animations: a 0.3s fade-in slide on mount and a 2s `Pulse` that ran *forever* while visible. The continuous pulse can trigger vestibular discomfort for users who opted into reduced motion. Added a `@media (prefers-reduced-motion: reduce)` rule that sets `animation: none` on both. Indicator still appears, just without animation.

- **Per-instance keyframe scope.** `@keyframes scrollIndicatorFadeIn` / `Pulse` were global identifiers — a host with same-named keyframes would have the last definition win. Now each instance scopes its keyframes via `useId()` (same pattern as Button / Slider / ListSorter / Markdown).

## Out of scope (intentional)

- **Click-to-scroll-to-bottom** — behavioral change; needs its own design discussion (does it consume the click? does it interact with `pointer-events: none`? what does it mean if the user is already scrolling?).
- **`aria-live="polite"` announcement** — would need product thought on wording and frequency; the indicator is currently `aria-hidden` for an intentional reason (pure visual cue, not a structural element).
- **Focus ring** — element is `pointer-events: none`; not interactive.

## Tests

11 ScrollIndicator CT pass (4 existing + 7 new):
- svg background uses `--stagebook-scroll-indicator-bg`
- svg color uses `--stagebook-scroll-indicator-fg`
- CSS variable override changes background (host-theming contract)
- `prefers-reduced-motion: reduce` disables both animations
- default media: both animations active (negative-case companion)
- two instances get unique keyframe scopes (useId contract)

Full unit (1035) + CT (528) all pass.

## Test plan

- [x] `npm run build -w stagebook`
- [x] `npm run test:ct -w stagebook -- --grep "ScrollIndicator"` (11/11 pass)
- [x] `npm test` (1035/1035 pass)
- [x] `npm run test:ct -w stagebook` (528/528 pass)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)