### PR TITLE
Bump stagebook to 0.10.9

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Patch release closing out tier 2 of the #350 UI polish sweep (Separator + Stage), shipping a parser bug fix (#380), a ScrollIndicator polish + gallery scroll-indicator demo (#394), the post-fill validation infrastructure (#398), and a docs sweep that makes the required position prefix in reference strings explicit across the researcher- and engineer-facing pages.

## What's in

- **#392** (closes #350 tier 2 item) — Separator polish. Border longhand defense (#367 pattern), wrapper-div drop, lookup-map refactor, host-CSS-reset regression test. No visible change to the rendered rule; defensive cleanup.

- **#393** — docs: position-prefix requirement (#298) made explicit across syntax-reference, conditions, ADR, README, elements, treatment-files, architecture, integration-guide, api-reference, principles. The pre-fill schema already rejected un-prefixed references; the docs now match what the parser actually accepts.

- **#395** (closes #350 tier 2 item) — Stage polish. Reduced-motion override on the discussion-content column's smooth-scroll behavior; inline-style consolidation across the single-column / discussion-fallback paths.

- **#396** (closes #380) — Prompt parser ignores `---` lines inside fenced code blocks. Researchers can now embed stagebook syntax examples inside `noResponse` prompts without the inner `---` silently shredding the file into pseudo-sections.

- **#397** (closes #394) — ScrollIndicator polish + gallery demo. Color tokens for host theming, prefers-reduced-motion override on both keyframes, per-instance keyframe scope via `useId`. The gallery's new scroll-indicator stage exercises both the scroll-to-dismiss path and the growth-triggered re-appearance path.

- **#400** (closes #398) — Post-fill validation. The pre-fill `promptFilePathSchema` now defers extension / shape checks when the path contains a `${field}` placeholder; the strict checks live in the new resolved-schema layer (`resolvedElementSchema`, `resolvedTreatmentFileSchema`). The viewer's `PreviewHost` runs strict post-fill validation after the field-binding form submits; the VS Code extension runs it with `skipUnresolved: true` so authoring-time `${field}` placeholders aren't flagged as errors. Unblocks the annotation-workflow path (e.g. `*.stagebook.yaml` with `file: ${field}`).

## New CSS variables (additive)

- `--stagebook-scroll-indicator-bg` (`rgba(229, 231, 235, 0.8)`)
- `--stagebook-scroll-indicator-fg` (`#4b5563`)

## New exports (additive)

- `splitOnTopLevelHrules(input)` from `stagebook` — fence-aware section splitter used by `promptFileSchema`. Exposed for hosts that want to split prompt files themselves with the same rules.
- `validateResolvedTreatmentFile(filled, { skipUnresolved? })` from `stagebook` — validates a fully-filled treatment file against the post-fill resolved-schema contract.
- `resolvedTreatmentFileSchema`, `ResolvedTreatmentFileType`, `ValidateResolvedOptions`, `ValidateResolvedIssue` types.
- `ValidationDiffResult.hydrated` — `runValidationDiff` now exposes the hydrated tree so callers can run further post-fill checks without re-running `fillTemplates`.

## Compatibility

- No API removals, no schema removals.
- Pre-fill schema is now **more permissive** for `prompt.file:` values containing `${field}` placeholders. The strict `.prompt.md` extension check still runs — just at post-fill time, via `validateResolvedTreatmentFile`. A YAML that passed pre-fill validation under v0.10.8 still passes; a YAML that was rejected purely because it contained `${field}` in a path now passes pre-fill but is caught at post-fill if the bound value violates the contract.
- `--stagebook-blockquote-border` default unchanged from v0.10.8 (still `#9ca3af`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)