### PR TITLE
Timeline: active range stacks above siblings so handles stay reachable

### DIFF
--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -1092,6 +1092,134 @@ test("point mode: click ON an existing point selects it (no duplicate)", async (
   await expect(point0).toHaveAttribute("data-active", "true");
 });
 
+test("range mode: active range stacks above siblings (handle stays reachable when ranges abut)", async ({
+  mount,
+}) => {
+  // Regression for the "can't grab a handle on the abutting side"
+  // UX bug: range handles overhang 4px outside the range body
+  // (left: -4 / right: -4 with HANDLE_HIT_WIDTH=8). If two ranges
+  // abut, the second range's body covers the first range's right
+  // handle — and clicking the visible handle would land on the
+  // neighbor's body instead, switching the active selection rather
+  // than starting a handle drag. Fix: active range gets zIndex: 1
+  // so it floats above its siblings.
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="ranges"
+      selectionType="range"
+      multiSelect={true}
+      mockDuration={60}
+      initialSelections={[
+        { start: 10, end: 20 },
+        { start: 20, end: 30 },
+      ]}
+    />,
+  );
+  const range0 = component.locator('[data-testid="range-0"]');
+  const range1 = component.locator('[data-testid="range-1"]');
+  await expect(range0).toBeAttached();
+  await expect(range1).toBeAttached();
+
+  // Click range 0 to make it active.
+  const r0Box = await range0.boundingBox();
+  if (!r0Box) throw new Error("range-0 box not found");
+  await range0.dispatchEvent("pointerdown", {
+    clientX: r0Box.x + r0Box.width / 2,
+    clientY: r0Box.y + r0Box.height / 2,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+  await range0.dispatchEvent("pointerup", {
+    clientX: r0Box.x + r0Box.width / 2,
+    clientY: r0Box.y + r0Box.height / 2,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+
+  // Active range's zIndex should be 1; inactive sibling's zIndex
+  // should be 0 (or 'auto', which resolves to 0 in the cascade).
+  const r0Z = await range0.evaluate((el) =>
+    parseInt(getComputedStyle(el).zIndex, 10),
+  );
+  const r1Z = await range1.evaluate((el) => getComputedStyle(el).zIndex);
+  expect(r0Z).toBe(1);
+  // r1 is inactive — z-index is 0 or "auto" depending on browser; both
+  // are below the active range.
+  expect(["0", "auto"]).toContain(r1Z);
+});
+
+test("range mode: clicking the handle of an active range that abuts another range hits the handle (not the neighbor)", async ({
+  mount,
+  page,
+}) => {
+  // Stronger version of the z-order test: use elementFromPoint at
+  // the active range's right-handle visible position and confirm
+  // the topmost element is the handle (or a descendant), not the
+  // abutting range's body. This is the actual user-visible
+  // contract that motivated the fix.
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="ranges"
+      selectionType="range"
+      multiSelect={true}
+      mockDuration={60}
+      initialSelections={[
+        { start: 10, end: 20 },
+        { start: 20, end: 30 },
+      ]}
+    />,
+  );
+  const range0 = component.locator('[data-testid="range-0"]');
+  // Activate range 0.
+  const r0Box = await range0.boundingBox();
+  if (!r0Box) throw new Error("range-0 box not found");
+  await range0.dispatchEvent("pointerdown", {
+    clientX: r0Box.x + r0Box.width / 2,
+    clientY: r0Box.y + r0Box.height / 2,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+  await range0.dispatchEvent("pointerup", {
+    clientX: r0Box.x + r0Box.width / 2,
+    clientY: r0Box.y + r0Box.height / 2,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+
+  // The right-edge handle of range-0 overhangs into range-1's
+  // territory. Hit-test at the very rightmost pixel of range-0.
+  const handleEnd = component.locator('[data-testid="range-0-handle-end"]');
+  const hBox = await handleEnd.boundingBox();
+  if (!hBox) throw new Error("range-0 handle-end box not found");
+  const hitTestId = await page.evaluate(
+    ({ x, y }: { x: number; y: number }) => {
+      const el = document.elementFromPoint(x, y);
+      // Walk up to find a data-testid ancestor.
+      let cur: Element | null = el;
+      while (cur && !(cur as HTMLElement).dataset.testid) {
+        cur = cur.parentElement;
+      }
+      return (cur as HTMLElement | null)?.dataset.testid ?? null;
+    },
+    { x: hBox.x + hBox.width / 2, y: hBox.y + hBox.height / 2 },
+  );
+  // Pre-fix: this would be "range-1" (the neighbor's body covered
+  // the handle). Post-fix: it's the handle itself.
+  expect(hitTestId).toBe("range-0-handle-end");
+});
+
 test("point mode: click ON existing point → Delete removes it (the use case that motivated the fix)", async ({
   mount,
   page,

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -637,6 +637,15 @@ export function SelectionOverlay({
             boxSizing: "border-box",
             cursor: "pointer",
             pointerEvents: "auto",
+            // Active range floats above siblings so its handles (which
+            // overhang 4px outside the range body via `left: -4` /
+            // `right: -4` with HANDLE_HIT_WIDTH=8) remain reachable
+            // when another range abuts. Without this, clicking the
+            // visible handle of an active range would hit the neighbor's
+            // body — and the neighbor's `handleRangeBodyPointerDown`
+            // would switch the active selection to the neighbor before
+            // the handle drag could begin.
+            zIndex: isActive ? 1 : 0,
           }}
         >
           {/* Start handle */}


### PR DESCRIPTION
Follow-up to PR #402. Splitting out the active-range z-order fix that I added after the last push but never committed before the polish PR merged. My mistake — should have caught it.

## Problem

Reported during gallery smoke-testing of #402: when two range selections abut (end of range A meets start of range B), the handle on the shared boundary is hard to grab — clicking what looks like the active range's handle lands on the neighbor's body, which switches the active selection rather than starting the handle drag.

## Root cause

Range handles overhang 4px outside their range body ([SelectionOverlay.tsx](packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx): `left: -4` / `right: -4` with `HANDLE_HIT_WIDTH=8`). With no z-index on range bodies, DOM order wins — and a later-rendered neighbor ends up covering the active range's handle overhang.

## Fix

Active range gets `zIndex: 1` (inactive ranges remain at 0). The handles inherit the floated stack so they're reachable above neighbors.

## Tests

Two new regression tests:

- **"active range stacks above siblings"** — asserts active range `zIndex=1`, inactive sibling `zIndex=0` / `"auto"`.
- **"clicking the handle of an active range that abuts another range hits the handle (not the neighbor)"** — uses `document.elementFromPoint` on the active range's right-handle pixel position to verify the topmost element is the handle, not the neighbor's body. This is the user-visible contract that motivated the fix.

129 Timeline CT pass on a clean run (was 127 before; +2 new tests).

## Test plan

- [x] `npm run build -w stagebook`
- [x] `npm run test:ct -w stagebook -- --grep "Timeline"` (129/129 pass)
- [x] Visual smoke in the VS Code extension preview, gallery's media_timeline stage
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)