### PR TITLE
UI polish: MediaPlayer focus ring + visible controls in gallery

### DIFF
--- a/examples/component-gallery/component-gallery.stagebook.yaml
+++ b/examples/component-gallery/component-gallery.stagebook.yaml
@@ -173,6 +173,11 @@ treatments:
             name: gallery_clip
             file: media/sample-video.mp4
             playVideo: true
+            controls:
+              playPause: true
+              seek: true
+              step: true
+              speed: true
           - type: timeline
             source: gallery_clip
             name: gallery_clip_ranges

--- a/packages/stagebook/src/components/elements/MediaPlayer.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.tsx
@@ -2,6 +2,7 @@ import React, {
   useRef,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useState,
 } from "react";
@@ -135,6 +136,13 @@ export function MediaPlayer({
   const eventsRef = useRef<VideoEvent[]>([]);
   const videoRef = useRef<HTMLVideoElement>(null);
   const autoplayAttemptedRef = useRef(false);
+  // Per-instance class for the container's `:focus` ring. Same useId
+  // pattern as Timeline / Button / Slider — pairs with the Timeline
+  // ring so the two stacked components feel visually coherent and the
+  // "keyboard shortcuts are live" signal is identical across both.
+  const reactId = useId();
+  const safeId = reactId.replace(/[^a-zA-Z0-9_-]/g, "");
+  const containerClass = `stagebook-mediaplayer-${safeId}`;
 
   // Ref unstable callbacks so `recordEvent`, `handleEnded`, and
   // `handleTimeUpdate` stay identity-stable even when the parent passes
@@ -998,6 +1006,7 @@ export function MediaPlayer({
 
     return (
       <div
+        className={containerClass}
         data-testid="mediaPlayer"
         role="region"
         aria-label="Media player"
@@ -1006,8 +1015,49 @@ export function MediaPlayer({
         onKeyUp={handleKeyUp}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
-        style={{ position: "relative" }}
+        style={{
+          position: "relative",
+          // outline:none + the scoped :focus ring below — same pattern
+          // as the Timeline so the two stacked components share an
+          // identical "keyboard shortcuts are live" affordance.
+          outline: "none",
+          // Border-radius matches the focus-ring outset so the ring
+          // doesn't appear as sharp corners around an unrounded box;
+          // YouTube's iframe is itself rectangular, but the ring sits
+          // 2px outside via box-shadow, so a slight radius here keeps
+          // the ring visually consistent with the Timeline's rounded
+          // container.
+          borderRadius: "0.5rem",
+        }}
       >
+        <style>{`
+          /* MediaPlayer focus ring (#382 follow-up).
+             Two design choices versus the Timeline / form-input
+             rings (which use a single faint blue stroke):
+
+             1. Halo pattern. The video frame can be any color —
+                dark on most clips, but sometimes blue or light. A
+                single-color ring washes out against same-color
+                content (the gallery's test clip happens to be blue,
+                which kills a blue ring). Stacked shadows render a
+                white inner halo + brand-blue outer ring, robust
+                against any background.
+             2. focus-within (not :focus). The container is
+                tabbable, but clicking interior controls (play /
+                scrub / etc.) moves focus to those children, which
+                drops :focus on the parent. The user is still
+                "in" the MediaPlayer though — keyboard shortcuts
+                still fire via the container handlers if they
+                bubble up. :focus-within keeps the ring visible
+                while any descendant has focus, so the "this is the
+                active component" affordance doesn't flicker as
+                the user moves between sub-controls. */
+          .${containerClass}:focus-within {
+            box-shadow:
+              0 0 0 2px var(--stagebook-bg, #fff),
+              0 0 0 5px var(--stagebook-primary, #3b82f6);
+          }
+        `}</style>
         <div data-testid="mediaPlayer-viewport" style={VIEWPORT_STYLE}>
           <YouTubePlayer
             videoId={youtubeVideoId}
@@ -1084,6 +1134,7 @@ export function MediaPlayer({
 
   return (
     <div
+      className={containerClass}
       data-testid="mediaPlayer"
       role="region"
       aria-label="Media player"
@@ -1092,8 +1143,22 @@ export function MediaPlayer({
       onKeyUp={handleKeyUp}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
-      style={{ position: "relative" }}
+      style={{
+        position: "relative",
+        outline: "none",
+        borderRadius: "0.5rem",
+      }}
     >
+      <style>{`
+        /* See the comment on the YouTube-path branch above for the
+           design rationale (halo pattern + :focus-within). Identical
+           rule here so both render paths get the same affordance. */
+        .${containerClass}:focus-within {
+          box-shadow:
+            0 0 0 2px var(--stagebook-bg, #fff),
+            0 0 0 5px var(--stagebook-primary, #3b82f6);
+        }
+      `}</style>
       {/* Audio-only: hidden video element (no viewport div) */}
       {!playVideo && (
         <video

--- a/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
+++ b/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
@@ -2209,3 +2209,115 @@ test("default playback is 'once' when no controls or syncToStageTime", async ({
     component.locator('[data-testid="mediaPlayer-playOnce"]'),
   ).toBeVisible();
 });
+
+// ----------- UI polish: container focus ring -----------
+//
+// The MediaPlayer container is `tabIndex={0}` so keyboard shortcuts
+// (Space play/pause, J/L scrub, K toggle, etc.) become live once
+// focused. Pre-polish: no replacement for the browser default
+// outline — platform-dependent (Chromium blue, Safari light,
+// Firefox dotted) and visually inconsistent with the Timeline
+// container's `:focus` ring. Polish: useId-scoped `:focus` ring
+// matching the Timeline pattern. Fires on both Tab and click so
+// the affordance is identical across input modalities.
+
+test("polish: container shows focus ring on keyboard focus (Tab)", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <MockMediaPlayer url="/sample-video.mp4" name="ring_kbd" />,
+  );
+  const mp = component.locator('[data-testid="mediaPlayer"]');
+  const baseline = await mp.evaluate((el) => getComputedStyle(el).boxShadow);
+  await page.keyboard.press("Tab");
+  await expect(mp).toBeFocused();
+  await expect
+    .poll(() => mp.evaluate((el) => getComputedStyle(el).boxShadow), {
+      timeout: 1500,
+    })
+    .not.toBe(baseline);
+});
+
+test("polish: container shows focus ring on mouse / programmatic focus too", async ({
+  mount,
+}) => {
+  // Uses `:focus` (not `:focus-visible`) for the same reason the
+  // Timeline does: keyboard shortcuts go live whether you got
+  // there by click or by Tab, so the affordance has to match.
+  const component = await mount(
+    <MockMediaPlayer url="/sample-video.mp4" name="ring_mouse" />,
+  );
+  const mp = component.locator('[data-testid="mediaPlayer"]');
+  const baseline = await mp.evaluate((el) => getComputedStyle(el).boxShadow);
+  await mp.focus();
+  await expect(mp).toBeFocused();
+  await expect
+    .poll(() => mp.evaluate((el) => getComputedStyle(el).boxShadow), {
+      timeout: 1500,
+    })
+    .not.toBe(baseline);
+});
+
+test("polish: focus ring stays when an interior control takes focus (focus-within)", async ({
+  mount,
+}) => {
+  // The MediaPlayer uses `:focus-within` rather than `:focus` so
+  // the ring persists while a descendant (play button, scrubber,
+  // step button, etc.) has focus. Without this, the ring would
+  // flicker out the moment the user clicks a control — but the
+  // user is still "in" the MediaPlayer, just delegating to a
+  // sub-control, so the affordance should stay.
+  const component = await mount(
+    <MockMediaPlayer
+      url="/sample-video.mp4"
+      name="ring_within"
+      controls={{ playPause: true }}
+    />,
+  );
+  // Trigger loadedmetadata so the controls render.
+  await component
+    .locator('[data-testid="mediaPlayer-video"]')
+    .evaluate((el) => {
+      Object.defineProperty(el, "duration", {
+        get: () => 60,
+        configurable: true,
+      });
+      el.dispatchEvent(new Event("loadedmetadata"));
+    });
+  const mp = component.locator('[data-testid="mediaPlayer"]');
+
+  // Focus the container first; capture the ring's box-shadow.
+  await mp.focus();
+  const withContainerFocus = await mp.evaluate(
+    (el) => getComputedStyle(el).boxShadow,
+  );
+  expect(withContainerFocus).not.toBe("none");
+
+  // Now move focus into a descendant button. The container's
+  // :focus is gone but :focus-within is still active, so the ring
+  // should remain.
+  const playBtn = component.locator('[data-testid="mediaPlayer-playPause"]');
+  await expect(playBtn).toBeVisible();
+  await playBtn.focus();
+  await expect(playBtn).toBeFocused();
+  const withDescendantFocus = await mp.evaluate(
+    (el) => getComputedStyle(el).boxShadow,
+  );
+  expect(withDescendantFocus).toBe(withContainerFocus);
+});
+
+test("polish: container has scoped focus class (visible to consumers)", async ({
+  mount,
+}) => {
+  // The useId-scoped class is part of the public DOM contract for
+  // tests / debug tooling. Lock in the prefix so a future refactor
+  // doesn't silently rename it.
+  const component = await mount(
+    <MockMediaPlayer url="/sample-video.mp4" name="ring_class" />,
+  );
+  const className = await component
+    .locator('[data-testid="mediaPlayer"]')
+    .evaluate((el) => el.className);
+  expect(className).toContain("stagebook-mediaplayer-");
+});


### PR DESCRIPTION
Mirrors the Timeline container focus-ring polish (#402) onto the MediaPlayer so the two stacked components share a coherent "keyboard shortcuts are live" affordance.

## Two design choices vs. the Timeline / form-input rings

1. **Halo pattern** (stacked box-shadow) instead of single-stroke. The video frame can be any color — dark on most clips, but sometimes blue or light. A single-color ring washes out against same-color content (the gallery's test clip happens to have a blue background, which kills a single blue ring). Stacked shadows render a 2px white inner halo + 3px brand-blue outer ring, robust against any background.

2. **`:focus-within` (not `:focus`)** so the ring stays visible while a descendant (play / pause / scrub / step button) has focus. The user is still "in" the MediaPlayer when they click a sub-control — they're just delegating to it. Without focus-within the ring would flicker out the moment any button was clicked.

Applied to both render paths (YouTube embed + direct video).

## Gallery

The existing `media_timeline` stage's mediaPlayer now declares `controls: { playPause, seek, step, speed }` so all the playback affordances are visible in the preview walkthrough.

## Tests

4 new CT tests in [MediaPlayer.ct.tsx](packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx):
- Container shows ring on **Tab focus**
- Container shows ring on **mouse / programmatic focus**
- Ring **stays when an interior control takes focus** (focus-within contract — clicks playPause, verifies box-shadow stays equal to the container-focus state)
- Container has scoped `stagebook-mediaplayer-` class

Full polish suite (12 tests across MediaPlayer + Timeline) passes.

## Test plan

- [x] `npm run build -w stagebook`
- [x] `npm run test:ct -w stagebook -- --grep "polish:"` (12/12 pass)
- [x] Visual smoke in the VS Code extension preview, gallery's media_timeline stage
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)