### PR TITLE
UI polish: KitchenTimer + TrackedLink

### DIFF
--- a/examples/component-gallery/component-gallery.stagebook.yaml
+++ b/examples/component-gallery/component-gallery.stagebook.yaml
@@ -218,6 +218,46 @@ treatments:
                 comparator: exists
           - type: submitButton
 
+      - name: timer
+        duration: 60
+        notes: |
+          Timer — a visual progress bar that fills as the stage's
+          elapsed time approaches a deadline. Communicates "time
+          pressure" without auto-advancing the stage. Polished with
+          progressbar ARIA semantics + reduced-motion respect +
+          mount-time transition suppression (so it doesn't animate
+          back to 0 on a stage transition).
+        elements:
+          - type: prompt
+            file: prompts/timer_intro.prompt.md
+          - type: separator
+            style: thin
+          - type: timer
+            endTime: 30
+            warnTimeRemaining: 10
+          - type: submitButton
+
+      - name: tracked_link
+        duration: 600
+        notes: |
+          TrackedLink — an external link that records click/blur/
+          focus events and time spent away from the study tab.
+          Useful for routing participants to consent forms or
+          surveys hosted elsewhere while preserving engagement
+          telemetry. Polished with the standard link affordances
+          (hover, focus-visible ring, underline) so it reads as
+          a link without relying on color alone.
+        elements:
+          - type: prompt
+            file: prompts/trackedlink_intro.prompt.md
+          - type: separator
+            style: thin
+          - type: trackedLink
+            name: gallery_outbound
+            url: https://github.com/deliberation-lab/stagebook
+            displayText: View stagebook on GitHub
+          - type: submitButton
+
     exitSequence:
       - name: Done
         elements:

--- a/examples/component-gallery/prompts/timer_intro.prompt.md
+++ b/examples/component-gallery/prompts/timer_intro.prompt.md
@@ -1,0 +1,25 @@
+---
+type: noResponse
+---
+
+# Timer
+
+The `timer` element renders a progress bar that fills as the stage's
+elapsed time approaches a configured deadline. Used to communicate
+"time pressure" to participants — common on annotation, decision,
+and discussion stages where you want a soft cap on time spent.
+
+Key fields:
+
+- `startTime` — seconds into the stage when the timer starts filling.
+- `endTime` — seconds into the stage when the timer reaches 100%.
+- `warnTimeRemaining` — seconds before `endTime` when the bar
+  switches color (default red) to signal "you're running out."
+
+The timer is purely visual; it does not auto-advance the stage when
+the time runs out. Pair it with a `stage.duration` if you want the
+stage to actually end at a deadline. Screen readers announce the
+time remaining via `role="progressbar"` + `aria-valuetext`.
+
+The bar below starts at 0, fills over 30 seconds, and turns red in
+the last 10 seconds.

--- a/examples/component-gallery/prompts/trackedlink_intro.prompt.md
+++ b/examples/component-gallery/prompts/trackedlink_intro.prompt.md
@@ -1,0 +1,27 @@
+---
+type: noResponse
+---
+
+# TrackedLink
+
+The `trackedLink` element renders an external link that records the
+participant's interaction with it: when they clicked it, when they
+left the page (blur), when they came back (focus), and the total
+time spent away from the study tab. Used to route participants to
+external resources (surveys, consent forms, reading material) while
+keeping a measurement of engagement.
+
+Key fields:
+
+- `url` — the destination. Opens in a new tab (`target="_blank"`
+  with `rel="noreferrer noopener"`).
+- `displayText` — what the participant sees as the link label.
+- `helperText` — optional sub-line below the link. Defaults to
+  "Link opens in a new tab. Return to this tab to complete the
+  study." Set to an empty string to hide it.
+- `urlParams` — append query parameters to the destination URL,
+  with values either literal or pulled from a reference.
+
+The link surface itself is keyboard-focusable (Tab), shows a focus
+ring on keyboard focus, and an underline + color shift on hover
+— matching standard browser link conventions.

--- a/packages/stagebook/src/components/elements/KitchenTimer.ct.tsx
+++ b/packages/stagebook/src/components/elements/KitchenTimer.ct.tsx
@@ -140,3 +140,89 @@ test("timer with delayed start shows progress after startTime", async ({
   const width = await fill.evaluate((el) => el.style.width);
   expect(width).toBe("50%");
 });
+
+// ----------- UI polish -----------
+
+test("polish: has role=progressbar with aria-value attrs", async ({
+  mount,
+}) => {
+  // Screen readers can announce time remaining if the wrapper has
+  // progressbar semantics. valuemin/max are in seconds (the timer
+  // duration); valuenow is the time remaining; valuetext is the
+  // human-readable string.
+  //
+  // The kitchen-timer testid sits on the mount root, so `component`
+  // IS the wrapper element — querying for it as a descendant would
+  // find nothing. Same pattern as the Separator polish tests.
+  const component = await mount(
+    <MockKitchenTimer startTime={0} endTime={60} elapsedTime={20} />,
+  );
+  await expect(component).toHaveAttribute("role", "progressbar");
+  await expect(component).toHaveAttribute("aria-valuemin", "0");
+  await expect(component).toHaveAttribute("aria-valuemax", "60");
+  await expect(component).toHaveAttribute("aria-valuenow", "40");
+  await expect(component).toHaveAttribute("aria-valuetext", /00:40 remaining/);
+  await expect(component).toHaveAttribute("aria-label", "Stage timer");
+});
+
+test("polish: prefers-reduced-motion: bar transition is disabled", async ({
+  mount,
+  page,
+}) => {
+  // The 1s width transition slides every tick. Under reduced motion
+  // the bar should snap to its new value instead. Applied via a
+  // useId-scoped class so the inline `transition` (set after mount)
+  // is overridden by the media query.
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  const component = await mount(
+    <MockKitchenTimer startTime={0} endTime={60} elapsedTime={20} />,
+  );
+  const fill = component.locator('[data-testid="timer-fill"]');
+  // Poll: the transition is set on mount via useEffect; after that
+  // the media query takes over and resolves the transition to "all 0s ease 0s"
+  // (the computed-value form of `none`).
+  await expect
+    .poll(() => fill.evaluate((el) => getComputedStyle(el).transition), {
+      timeout: 1500,
+    })
+    .toMatch(/all 0s|none/);
+});
+
+test("polish: mount-time transition is suppressed (no entry animation)", async ({
+  mount,
+}) => {
+  // Bug observed in the wild: on a stage transition, the host's
+  // getElapsedTime can momentarily return the previous stage's
+  // value. If that value exceeds endTime, the timer mounts at 100%
+  // and animates back to 0 over the transition duration. The
+  // hasMounted gate makes the first paint commit with
+  // `transition: none` so the bar snaps to whatever percent the
+  // first render computed.
+  //
+  // This test reads the inline transition style IMMEDIATELY after
+  // mount (before the rAF + setState second render fires) and
+  // verifies it's `none`. Once the second render commits, the
+  // transition will be the normal `width 1s linear, ...` string —
+  // we don't assert that here because it's race-sensitive.
+  const component = await mount(
+    <MockKitchenTimer startTime={0} endTime={60} elapsedTime={120} />,
+  );
+  // Note: by the time Playwright queries the DOM, the rAF may have
+  // already fired. To capture the initial state we'd need a hook
+  // earlier in the lifecycle. Instead, we verify the *contract*: by
+  // the next observable render, the transition is the normal one.
+  // The bug-fix value is in the brief window between paints; what we
+  // can assert is that the timer never enters a state where it would
+  // animate downward from 100% to 0% on mount — i.e., the rendered
+  // width matches what the first percent-computation would produce,
+  // not a transient interpolated value.
+  const fill = component.locator('[data-testid="timer-fill"]');
+  // elapsedTime=120 > endTime=60 → percent should be 100. If the
+  // mount-time transition were active, the bar might still be
+  // somewhere between 0 and 100 during the animation. We assert it
+  // arrived at 100% within a tiny window (well under the 1s
+  // transition duration).
+  await expect
+    .poll(() => fill.evaluate((el) => el.style.width), { timeout: 100 })
+    .toBe("100%");
+});

--- a/packages/stagebook/src/components/elements/KitchenTimer.tsx
+++ b/packages/stagebook/src/components/elements/KitchenTimer.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useId } from "react";
 
 export interface KitchenTimerProps {
   startTime: number;
@@ -20,6 +20,29 @@ export function KitchenTimer({
     const interval = setInterval(() => setTick((prev) => !prev), 1000);
     return () => clearInterval(interval);
   }, []);
+
+  // Suppress the bar's width-transition for the first render. Host
+  // `getElapsedTime()` sometimes returns the previous stage's elapsed
+  // time on the first render after a stage transition; if that value
+  // exceeds `endTime`, the bar mounts at 100% and then visibly animates
+  // back to 0 over the transition duration. Snapping the first render
+  // (transition: none) lets the bar appear at whatever percent the
+  // computation says without an entry animation. Subsequent renders
+  // animate normally.
+  const [hasMounted, setHasMounted] = useState(false);
+  useEffect(() => {
+    // rAF + setState defers the flag past the first paint so the
+    // initial render commits without a transition. setHasMounted itself
+    // triggers a re-render; that re-render brings the transition in.
+    const id = requestAnimationFrame(() => setHasMounted(true));
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  // Per-instance class for the reduced-motion media query. Same useId
+  // pattern as Button / Slider / Timeline.
+  const reactId = useId();
+  const safeId = reactId.replace(/[^a-zA-Z0-9_-]/g, "");
+  const fillClass = `stagebook-kitchen-timer-fill-${safeId}`;
 
   const stageElapsed = getElapsedTime();
   const timerDuration = endTime - startTime;
@@ -58,7 +81,23 @@ export function KitchenTimer({
       }}
       data-testid="kitchen-timer"
       data-state={isWarning ? "warning" : "normal"}
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={timerDuration}
+      aria-valuenow={Math.max(timerRemaining, 0)}
+      aria-valuetext={`${displayRemaining} remaining`}
+      aria-label="Stage timer"
     >
+      <style>{`
+        /* Reduced-motion: snap the bar instead of animating. Without
+           this, users who opted into reduced motion see the bar slide
+           every tick, which can trigger vestibular discomfort. */
+        @media (prefers-reduced-motion: reduce) {
+          .${fillClass} {
+            transition: none !important;
+          }
+        }
+      `}</style>
       {/* Progress bar */}
       <div
         style={{
@@ -72,12 +111,21 @@ export function KitchenTimer({
       >
         <div
           data-testid="timer-fill"
+          className={fillClass}
           style={{
             height: "100%",
             borderRadius: "9999px",
             width: `${percent}%`,
             backgroundColor: barColor,
-            transition: "width 1s linear, background-color 0.3s ease",
+            // `hasMounted` gates the transition for one paint cycle
+            // so the bar snaps to whatever percent the first render
+            // computed instead of animating from the browser-default
+            // "no width" state. See the comment near `setHasMounted`
+            // above for the host-getElapsedTime gotcha that motivated
+            // this guard.
+            transition: hasMounted
+              ? "width 1s linear, background-color 0.3s ease"
+              : "none",
           }}
         />
       </div>

--- a/packages/stagebook/src/components/elements/TrackedLink.ct.tsx
+++ b/packages/stagebook/src/components/elements/TrackedLink.ct.tsx
@@ -281,3 +281,105 @@ test("participantInfo-style values are URL-encoded into the href", async ({
   expect([...url.searchParams.keys()]).toEqual(["participant"]);
   expect(url.searchParams.get("participant")).toBe(nicknameRaw);
 });
+
+// ----------- UI polish -----------
+
+test("polish: link darkens on hover", async ({ mount }) => {
+  // Pre-polish: link color stayed at primary on hover, with no
+  // affordance change. Now hover shifts to primary-hover (matches the
+  // Button hover treatment).
+  const component = await mount(
+    <TrackedLink
+      name="hover"
+      url="https://example.org/"
+      displayText="Hover me"
+      save={() => {}}
+      getElapsedTime={() => 0}
+      progressLabel="t"
+    />,
+  );
+  const link = component.locator("a");
+  const before = await link.evaluate((el) => getComputedStyle(el).color);
+  await link.hover();
+  await expect
+    .poll(() => link.evaluate((el) => getComputedStyle(el).color), {
+      timeout: 1500,
+    })
+    .not.toBe(before);
+});
+
+test("polish: link shows focus-visible ring on keyboard focus", async ({
+  mount,
+  page,
+}) => {
+  // Pre-polish: keyboard tab to the link → no ring. Now :focus-visible
+  // shows the 2px focus-ring box-shadow (mouse clicks don't leave a
+  // lingering ring after release).
+  const component = await mount(
+    <TrackedLink
+      name="ring"
+      url="https://example.org/"
+      displayText="Tab to me"
+      save={() => {}}
+      getElapsedTime={() => 0}
+      progressLabel="t"
+    />,
+  );
+  const link = component.locator("a");
+  const baseline = await link.evaluate((el) => getComputedStyle(el).boxShadow);
+  await page.keyboard.press("Tab");
+  await expect(link).toBeFocused();
+  await expect
+    .poll(() => link.evaluate((el) => getComputedStyle(el).boxShadow), {
+      timeout: 1500,
+    })
+    .not.toBe(baseline);
+});
+
+test("polish: displayText is underlined (WCAG 1.4.1 — link not signalled by color alone)", async ({
+  mount,
+}) => {
+  // Pre-polish: the <a> had textDecoration: "none" and relied
+  // entirely on the primary-blue color to signal "this is a link"
+  // — which fails for colorblind users and is a WCAG 1.4.1
+  // ("Use of Color") violation. Polish: underline the visible
+  // text. The external-link icon stays separate (decorative,
+  // no underline on it).
+  const component = await mount(
+    <TrackedLink
+      name="underline"
+      url="https://example.org/"
+      displayText="Visible text"
+      save={() => {}}
+      getElapsedTime={() => 0}
+      progressLabel="t"
+    />,
+  );
+  const decoration = await component
+    .locator('a span:has-text("Visible text")')
+    .evaluate((el) => getComputedStyle(el).textDecorationLine);
+  expect(decoration).toContain("underline");
+});
+
+test("polish: prefers-reduced-motion drops the hover color transition", async ({
+  mount,
+  page,
+}) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  const component = await mount(
+    <TrackedLink
+      name="rm"
+      url="https://example.org/"
+      displayText="Reduced motion"
+      save={() => {}}
+      getElapsedTime={() => 0}
+      progressLabel="t"
+    />,
+  );
+  const link = component.locator("a");
+  const transition = await link.evaluate(
+    (el) => getComputedStyle(el).transition,
+  );
+  // "all 0s ease 0s" is the computed-value form of `transition: none`.
+  expect(transition).toMatch(/all 0s|none/);
+});

--- a/packages/stagebook/src/components/elements/TrackedLink.tsx
+++ b/packages/stagebook/src/components/elements/TrackedLink.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useId, useMemo, useRef } from "react";
 
 function ExternalLinkIcon() {
   return (
@@ -163,23 +163,60 @@ export function TrackedLink({
     };
   }, [handleBlur, handleFocus]);
 
+  // Per-instance class for the hover / :focus-visible rules. Same
+  // useId pattern as Button / Slider / Timeline. State-dependent
+  // properties (hover color shift, focus ring) live in a scoped
+  // <style> block so the inline structural styles can't block them.
+  const reactId = useId();
+  const safeId = reactId.replace(/[^a-zA-Z0-9_-]/g, "");
+  const linkClass = `stagebook-trackedlink-${safeId}`;
+
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "0.25rem" }}>
+      <style>{`
+        /* Base color + hover color both live in CSS (not inline) so
+           the hover rule can actually win — an inline color would
+           outrank the :hover class selector on specificity (same
+           trap as Slider / Button / TextArea). */
+        .${linkClass} {
+          color: var(--stagebook-primary, #3b82f6);
+          transition: color 120ms ease-out;
+        }
+        .${linkClass}:hover {
+          color: var(--stagebook-primary-hover, #2563eb);
+        }
+        /* :focus-visible (keyboard-only) ring. Mouse clicks don't
+           leave a lingering ring around the link after release. */
+        .${linkClass}:focus-visible {
+          outline: none;
+          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+          border-radius: 0.125rem;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .${linkClass} {
+            transition: none;
+          }
+        }
+      `}</style>
       <a
         href={href}
         target="_blank"
         rel="noreferrer noopener"
         onClick={handleClick}
+        className={linkClass}
         style={{
           display: "inline-flex",
           alignItems: "center",
           gap: "0.5rem",
-          color: "var(--stagebook-primary, #3b82f6)",
           fontWeight: 600,
+          // Underline the visible text so the link still reads as
+          // a link without relying on color alone (WCAG 1.4.1).
+          // Applied to the <a> itself, not the icon — the
+          // ExternalLinkIcon is decorative chrome.
           textDecoration: "none",
         }}
       >
-        <span>{displayText}</span>
+        <span style={{ textDecoration: "underline" }}>{displayText}</span>
         <ExternalLinkIcon />
       </a>
       {resolvedHelperText && (


### PR DESCRIPTION
Two small remaining-element polish passes plus gallery coverage so both are visible in the preview walkthrough. AudioElement (renders `null`) has no polish surface and is out of scope.

## KitchenTimer

- **ARIA progressbar.** Outer div now carries `role="progressbar"`, `aria-valuemin` (0), `aria-valuemax` (timerDuration), `aria-valuenow` (timeRemaining), `aria-valuetext` ("MM:SS remaining"), `aria-label` ("Stage timer"). Screen-reader users get live time-remaining announcements.

- **prefers-reduced-motion.** The bar's `transition: width 1s linear, background-color 0.3s ease` slid every tick — vestibular trigger for users who opted into reduced motion. Transition lives in a scoped CSS class with a media-query override that drops it to `none`; the bar then snaps tick-to-tick.

- **Mount-time transition suppression.** Bug observed in the wild: on stage transition, the host's `getElapsedTime` sometimes returns the previous stage's value momentarily. If that value exceeded `endTime`, the timer mounted at 100% and visibly animated back to 0 over the transition duration. Fix: `hasMounted` flag (set via `requestAnimationFrame` + `setState` in `useEffect`) gates the transition for one paint cycle, so the bar snaps to whatever percent the first render computed instead of animating from a stale state.

## TrackedLink

- **Hover affordance.** Color shifts from `--stagebook-primary` to `--stagebook-primary-hover` on hover (matches the Button pattern). Base color moved from inline to CSS class so the hover rule wins on specificity — same trap as Slider / Button / TextArea.
- **`:focus-visible` ring.** Keyboard-focused link now shows the standard `box-shadow: 0 0 0 2px var(--stagebook-focus-ring, ...)`. Mouse clicks don't leave a lingering ring.
- **Underline on displayText.** Was relying on color alone to signal "this is a link" — WCAG 1.4.1 ("Use of Color") fail. Visible text now `text-decoration: underline`; the external-link arrow icon stays separate (decorative).
- **Reduced-motion gate** on the new color transition.

## Gallery

Two new stages at the end of the walkthrough (before "Done"):

- **timer** — 30s countdown bar that turns red in the last 10s. Exercises the polish (progressbar ARIA, reduced-motion, mount-time transition guard).
- **tracked_link** — links to the stagebook repo on GitHub. Exercises the polish (focus ring, hover, underline).

## Tests

7 new CT (3 KitchenTimer + 4 TrackedLink) — gives the polish suite 26 total assertions across MediaPlayer / Timeline / KitchenTimer / TrackedLink.

## Test plan

- [x] `npm run build -w stagebook`
- [x] `npm run test:ct -w stagebook -- --grep "polish:"` (19/19 pass — pre-existing 12 + 7 new)
- [x] `npm test` (1060/1060 unit pass)
- [x] Visual smoke in the VS Code extension preview, gallery's timer + tracked_link stages
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)