### PR TITLE
Bump stagebook to 0.10.10

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Patch release rolling up the remaining-component polish wave that followed v0.10.9's Markdown polish. Timeline now has tier-1 visible polish (focus rings, color tokens, reduced-motion, aria-hidden, focus-on-click ring) plus a couple of UX bug fixes that showed up in the gallery preview. MediaPlayer, KitchenTimer, and TrackedLink got the same treatment so the rest of the interactive surfaces feel cohesive.

## What's in

- **#402** (closes #382) — Timeline polish. Focus ring on the container (mirrors the TextArea pattern from #381), focus-visible rings on the mute / zoom / help buttons, reduced-motion fix on the blocked-pulse animation, aria-hidden on the minimap's decorative marks, and ~13 new CSS variables for theming the selection overlay / minimap chrome. The container ring fires on `:focus` (not `:focus-visible`) so it also lights up on mouse click — clicking grabs the keyboard shortcuts, so the affordance has to match. Includes a gallery `media_timeline` stage that exercises the polish.

- **#404** — Timeline active range z-order. Bug: when two range selections abut, the handle on the shared boundary was hard to grab — clicking the visible handle landed on the neighbor's body, which switched the active selection. Fix: active range gets `zIndex: 1` so its handles stay above siblings.

- **#405** — MediaPlayer focus ring. Same useId-scoped pattern as the Timeline. Uses a halo (white inner + brand-blue outer) + `:focus-within` (not `:focus`) so the ring stays visible while the user clicks interior controls. The gallery's mediaPlayer now declares `controls: { playPause, seek, step, speed }` so all playback affordances are visible in the preview.

- **#406** — KitchenTimer + TrackedLink polish. KitchenTimer gets progressbar ARIA + reduced-motion gate + **mount-time transition suppression** (fixes a bug where the bar would mount at 100% and animate back to 0 if the host's `getElapsedTime` returned a stale value during a stage transition). TrackedLink gets the standard link affordances (hover color shift, `:focus-visible` ring, **underline on displayText** — WCAG 1.4.1 fix so links aren't signalled by color alone). Gallery covers both.

## New CSS variables (additive)

Timeline:
- `--stagebook-timeline-range-active` / `-range-active-border`
- `--stagebook-timeline-range-inactive` / `-range-inactive-border`
- `--stagebook-timeline-handle-active` / `-handle-inactive`
- `--stagebook-timeline-preview-bg` / `-preview-border`
- `--stagebook-timeline-tooltip-bg`
- `--stagebook-timeline-track-label-bg`
- `--stagebook-timeline-minimap-viewport-border`
- `--stagebook-timeline-minimap-range` / `-minimap-point`

## Compatibility

- No API removals, no schema changes, no behavior changes for existing prompt content.
- KitchenTimer's mount-time transition fix is the only behavior change visible to consumers — and it's strictly an improvement (no entry animation when the host's `getElapsedTime` is stale). Hosts whose `getElapsedTime` is always correct on first render see no difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)