### PR TITLE
Fix #300: keep MediaPlayer focused when controls auto-hide

### DIFF
--- a/packages/stagebook/src/components/elements/MediaPlayer.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.tsx
@@ -135,6 +135,7 @@ export function MediaPlayer({
 
   const eventsRef = useRef<VideoEvent[]>([]);
   const videoRef = useRef<HTMLVideoElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const autoplayAttemptedRef = useRef(false);
   // Per-instance class for the container's `:focus` ring. Same useId
   // pattern as Timeline / Button / Slider — pairs with the Timeline
@@ -948,6 +949,30 @@ export function MediaPlayer({
   // In audio-only mode (playVideo:false) there's no video to obscure, so always show.
   const controlsVisible = hasControls && (isPaused || isHovered || !playVideo);
 
+  // Focus rescue (#300): when the controls overlay hides (mouse leaves while
+  // playing), any control that currently held focus — e.g. the play/pause
+  // button the user just keyboard-toggled — unmounts. The browser drops focus
+  // to <body>, and a subsequent Space press scrolls the page instead of
+  // pausing. We catch that exact transition and move focus to the container
+  // (tabIndex=0), which is always mounted; :focus-within keeps the ring lit
+  // and the keydown handler keeps Space wired to play/pause.
+  const prevControlsVisibleRef = useRef(controlsVisible);
+  useEffect(() => {
+    const prev = prevControlsVisibleRef.current;
+    prevControlsVisibleRef.current = controlsVisible;
+    if (!prev || controlsVisible) return;
+    // Only rescue when the orphaned focus landed on <body>. If the user
+    // tabbed or clicked elsewhere, activeElement would be that element and
+    // we leave it alone.
+    if (
+      typeof document !== "undefined" &&
+      document.activeElement === document.body &&
+      containerRef.current
+    ) {
+      containerRef.current.focus({ preventScroll: true });
+    }
+  }, [controlsVisible]);
+
   // Scrub bar bounds
   const scrubMin = allowScrubOutsideBounds ? 0 : (startAt ?? 0);
   const scrubMax = allowScrubOutsideBounds
@@ -1006,6 +1031,7 @@ export function MediaPlayer({
 
     return (
       <div
+        ref={containerRef}
         className={containerClass}
         data-testid="mediaPlayer"
         role="region"
@@ -1134,6 +1160,7 @@ export function MediaPlayer({
 
   return (
     <div
+      ref={containerRef}
       className={containerClass}
       data-testid="mediaPlayer"
       role="region"

--- a/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
+++ b/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
@@ -2321,3 +2321,91 @@ test("polish: container has scoped focus class (visible to consumers)", async ({
     .evaluate((el) => el.className);
   expect(className).toContain("stagebook-mediaplayer-");
 });
+
+// -- #300: focus survives controls auto-hide --
+
+test("focus moves to container when the focused control unmounts on mouse-leave", async ({
+  mount,
+  page,
+}) => {
+  // Repro: user toggles play/pause via keyboard so the button is the
+  // active element, then the mouse leaves the player. The controls
+  // overlay unmounts while playing, the focused button goes with it,
+  // and a follow-up Space keypress lands on <body> and scrolls the
+  // page instead of pausing the video. The fix watches for that
+  // exact transition (controls visible → hidden with activeElement
+  // orphaned to <body>) and refocuses the container, which is always
+  // mounted and tabbable.
+  const component = await mount(
+    <MockMediaPlayer
+      url={FIXTURE_VIDEO}
+      name="test"
+      controls={{ playPause: true }}
+    />,
+  );
+  const mp = component.locator('[data-testid="mediaPlayer"]');
+  const playBtn = component.locator('[data-testid="mediaPlayer-playPause"]');
+
+  // 1. Hover the player (real mouse — React's onMouseLeave is driven
+  //    from delegated mouseout, so a synthetic dispatch wouldn't fire
+  //    it). Then focus the play button as if reached by keyboard.
+  await mp.hover();
+  await playBtn.focus();
+  await expect(playBtn).toBeFocused();
+
+  // 2. Start playback by dispatching the video's play event directly.
+  //    The MockMediaPlayer wires onPlay through, flipping isPaused=false.
+  await component
+    .locator('[data-testid="mediaPlayer-video"]')
+    .evaluate((el) => el.dispatchEvent(new Event("play")));
+
+  // 3. Move the mouse off the player. With isPaused=false and
+  //    isHovered=false, controlsVisible flips false and the controls
+  //    overlay unmounts — taking the focused play/pause button with it.
+  await page.mouse.move(0, 0);
+
+  // Controls really did unmount (sanity check).
+  await expect(playBtn).not.toBeAttached();
+
+  // 4. The container should now hold focus — not <body>. The keydown
+  //    handler is attached here, so Space will still pause the video.
+  await expect(mp).toBeFocused();
+});
+
+test("focus is left alone when activeElement is somewhere else entirely", async ({
+  mount,
+  page,
+}) => {
+  // The rescue should ONLY fire when focus orphaned to <body>. If the
+  // user deliberately moved focus elsewhere (tabbed to another input,
+  // clicked a different control), we must not yank it back.
+  const component = await mount(
+    <div>
+      <MockMediaPlayer
+        url={FIXTURE_VIDEO}
+        name="test"
+        controls={{ playPause: true }}
+      />
+      <input data-testid="other-input" />
+    </div>,
+  );
+  const mp = component.locator('[data-testid="mediaPlayer"]');
+  const playBtn = component.locator('[data-testid="mediaPlayer-playPause"]');
+  const other = component.locator('[data-testid="other-input"]');
+
+  await mp.hover();
+  await playBtn.focus();
+  await component
+    .locator('[data-testid="mediaPlayer-video"]')
+    .evaluate((el) => el.dispatchEvent(new Event("play")));
+
+  // User moves focus to the other input BEFORE controls hide.
+  await other.focus();
+  await expect(other).toBeFocused();
+
+  // Now trigger controls hide via real mouse-leave.
+  await page.mouse.move(0, 0);
+
+  // Focus should stay on the other input, not get stolen.
+  await expect(other).toBeFocused();
+});


### PR DESCRIPTION
## Summary

Closes #300.

When a user keyboard-toggles play/pause and then moves the mouse off the player, the controls overlay unmounts while the video keeps playing. The focused play/pause button goes with it, focus orphans to `<body>`, and the next Space press scrolls the page instead of pausing.

This catches that exact transition — `controlsVisible` flipping true→false with `document.activeElement === document.body` — and transfers focus to the container (`tabIndex=0`, always mounted). `:focus-within` keeps the ring lit (from #405) and the container's `onKeyDown` keeps Space wired to play/pause.

The check `activeElement === document.body` is the load-bearing guard: if the user deliberately moved focus elsewhere before the controls hid (tabbed to another input, clicked outside), activeElement isn't `<body>`, so the rescue no-ops and we don't steal focus.

## Why this approach over a global keydown handler (#303)

#303 proposed a window-level Space handler that pauses the player regardless of where focus is. That works but assumes Space-always-pauses-the-MediaPlayer-on-this-page, which breaks if there are multiple players or other components that want Space. With the explicit focus ring shipped in #405, focus is now a visible affordance — keeping focus correctly on the player is the more direct fix, and #303's broader hammer isn't needed.

## Test plan

- [x] CT: focus moves to container when the focused control unmounts on mouse-leave (full repro of #300)
- [x] CT: focus is left alone when activeElement is somewhere else entirely (no-steal guarantee)
- [x] Full MediaPlayer CT suite (90 tests) passes
- [x] Vitest unit suite (1060 tests) passes
- [x] No new TypeScript errors (106 → 106, pre-existing in `reference.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)