### PR TITLE
Timeline: click in point mode no longer seeks the playhead

### DIFF
--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -942,6 +942,58 @@ test("range mode: multiSelect true — ranges accumulate sorted", async ({
   expect(last[1]?.start).toBeCloseTo(36, 0);
 });
 
+test("point mode: click does NOT move the playhead (matches range mode)", async ({
+  mount,
+}) => {
+  // Previously a click in point mode placed the point AND seeked the
+  // playhead to that time; range mode left the playhead alone. The
+  // asymmetry confused users — the ruler is the dedicated seek surface
+  // (standard NLE convention), so creation gestures on the overlay
+  // should leave the playhead where it was for both modes.
+  const component = await mount(
+    <MockTimeline
+      source="player"
+      playerName="player"
+      name="points_no_seek"
+      selectionType="point"
+      multiSelect={true}
+      mockDuration={60}
+      mockCurrentTime={0}
+    />,
+  );
+  const overlay = component.locator('[data-testid="selection-overlay"]');
+  const playhead = component.locator('[data-testid="playhead"]');
+  const box = await overlay.boundingBox();
+  if (!box) throw new Error("overlay not found");
+
+  const beforeLeft = await playhead.evaluate(
+    (el) => parseFloat((el as HTMLElement).style.left) || 0,
+  );
+
+  await overlay.dispatchEvent("pointerdown", {
+    clientX: box.x + box.width * 0.7,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+  await overlay.dispatchEvent("pointerup", {
+    clientX: box.x + box.width * 0.7,
+    clientY: box.y + box.height * 0.5,
+    button: 0,
+    buttons: 1,
+    pointerId: 1,
+    isPrimary: true,
+  });
+
+  await expect(component.locator('[data-testid="point-0"]')).toBeAttached();
+  const afterLeft = await playhead.evaluate(
+    (el) => parseFloat((el as HTMLElement).style.left) || 0,
+  );
+  expect(afterLeft).toBe(beforeLeft);
+});
+
 test("point mode: click places a point and saves", async ({ mount }) => {
   const component = await mount(
     <MockTimeline

--- a/packages/stagebook/src/components/elements/Timeline.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.tsx
@@ -975,7 +975,6 @@ export function Timeline({
             selections={state.selections}
             activeIndex={state.activeIndex}
             activeHandle={state.activeHandle}
-            onSeek={(t) => handle.seekTo(t)}
             onCreateRange={(start, end, track) =>
               dispatch({
                 type: "CREATE_RANGE",

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -33,8 +33,7 @@ export interface SelectionOverlayProps {
   /** Active handle in range mode. */
   activeHandle: "start" | "end" | null;
 
-  // ── Callbacks (Timeline.tsx wires these to dispatch + seek) ──
-  onSeek: (time: number) => void;
+  // ── Callbacks (Timeline.tsx wires these to dispatch) ──
   onCreateRange: (
     start: number,
     end: number,
@@ -226,7 +225,6 @@ export function SelectionOverlay({
   selections,
   activeIndex,
   activeHandle,
-  onSeek,
   onCreateRange,
   onCreatePoint,
   onAdjustHandle,
@@ -405,8 +403,9 @@ export function SelectionOverlay({
           // Point mode: click anywhere creates a point. The reducer
           // enforces multiSelect (replacing an existing point in single
           // mode, appending otherwise), so this one path covers both.
+          // Match range mode and leave the playhead alone — the ruler is
+          // the dedicated seek surface (standard NLE convention).
           onCreatePoint(time, track);
-          onSeek(time);
           onRequestFocus();
         } else {
           // Range mode: click creates a default-width range starting at
@@ -487,7 +486,6 @@ export function SelectionOverlay({
       selections,
       multiSelect,
       onCreatePoint,
-      onSeek,
       onDeselect,
       onCreateRange,
       onEndDrag,


### PR DESCRIPTION
## Summary

Click on the selection overlay now leaves the playhead alone in both point and range modes.

Previously:
- **Range mode:** click creates a default-width range, playhead stays put.
- **Point mode:** click creates a point AND seeks the playhead to that time.

After this PR both modes leave the playhead alone. The ruler remains the dedicated seek surface (standard NLE convention) — that path is untouched. Dragging existing points / range handles still calls seekTo to sync the video to the new position, which is desirable when adjusting.

The now-unused `onSeek` prop is dropped from `SelectionOverlay` and the wire is removed from `Timeline.tsx`.

## Test plan

- [x] New CT: `point mode: click does NOT move the playhead (matches range mode)` — captures playhead `left` before/after, asserts equality
- [x] Existing range-mode pure-click test still passes (covers the symmetric range path)
- [x] Existing ruler-click seek test still passes (ruler still seeks)
- [x] Full Timeline CT suite (129 tests) passes
- [x] Vitest unit suite (1060 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)