### PR TITLE
Bump stagebook to 0.10.11

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.10.10",
+  "version": "0.10.11",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Patch release picking up two MediaPlayer / Timeline fixes.

## What's in

- **#408** — Fix #300: MediaPlayer keeps focus when its auto-hiding controls overlay unmounts on mouse-leave, so a follow-up Space press still pauses the video instead of scrolling the page.
- **#409** — Timeline: click in point mode no longer seeks the playhead — matches range-mode behavior. The ruler remains the dedicated seek surface.

## Compatibility

- No API changes.
- `SelectionOverlay`'s `onSeek` prop is removed (was internal to the timeline directory; not part of the published surface).