### PR TITLE
Fix #415: explicit tabIndex={0} so Safari includes Stagebook interactive elements in Tab order

### DIFF
--- a/packages/stagebook/src/components/elements/MediaPlayer.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.tsx
@@ -1320,6 +1320,7 @@ export function MediaPlayer({
               type="button"
               data-testid="mediaPlayer-playOnce"
               aria-label="Play video"
+              tabIndex={0}
               onClick={() => {
                 setShowPlayOnce(false);
                 const v = videoRef.current;
@@ -1368,6 +1369,7 @@ export function MediaPlayer({
           type="button"
           data-testid="mediaPlayer-playOnce"
           aria-label="Play audio"
+          tabIndex={0}
           onClick={() => {
             setShowPlayOnce(false);
             const v = videoRef.current;

--- a/packages/stagebook/src/components/elements/TrackedLink.tsx
+++ b/packages/stagebook/src/components/elements/TrackedLink.tsx
@@ -204,6 +204,11 @@ export function TrackedLink({
         rel="noreferrer noopener"
         onClick={handleClick}
         className={linkClass}
+        // Safari excludes <a> from the default tab order unless the
+        // macOS "Use keyboard navigation" preference is on; explicit
+        // tabIndex={0} overrides that so Safari participants can
+        // reach the link via keyboard (#415 / #413).
+        tabIndex={0}
         style={{
           display: "inline-flex",
           alignItems: "center",

--- a/packages/stagebook/src/components/elements/mediaPlayer/controls.tsx
+++ b/packages/stagebook/src/components/elements/mediaPlayer/controls.tsx
@@ -135,6 +135,7 @@ export function HTML5Controls({
             data-testid="mediaPlayer-seekBack"
             aria-label="Back 1s"
             title="Back 1s (←) · Hold to scrub · J for 10s"
+            tabIndex={0}
             style={controlBtnSmall}
             onMouseDown={() => onSeekButtonPress(-1)}
             onMouseUp={() => onSeekButtonRelease(-1)}
@@ -149,6 +150,7 @@ export function HTML5Controls({
             data-testid="mediaPlayer-stepBack"
             aria-label={`Step back ${String(stepDuration)}s`}
             title={`Step back ${String(stepDuration)}s (,)`}
+            tabIndex={0}
             style={controlBtnSmall}
             onClick={() => onSeek(-stepDuration)}
           >
@@ -161,6 +163,7 @@ export function HTML5Controls({
             data-testid="mediaPlayer-playPause"
             aria-label={isPaused ? "Play" : "Pause"}
             title={isPaused ? "Play (Space)" : "Pause (Space)"}
+            tabIndex={0}
             style={controlBtnLarge}
             onClick={onPlayPause}
           >
@@ -173,6 +176,7 @@ export function HTML5Controls({
             data-testid="mediaPlayer-stepForward"
             aria-label={`Step forward ${String(stepDuration)}s`}
             title={`Step forward ${String(stepDuration)}s (.)`}
+            tabIndex={0}
             style={controlBtnSmall}
             onClick={() => onSeek(stepDuration)}
           >
@@ -185,6 +189,7 @@ export function HTML5Controls({
             data-testid="mediaPlayer-seekForward"
             aria-label="Forward 1s"
             title="Forward 1s (→) · Hold to scrub · L for 10s"
+            tabIndex={0}
             style={controlBtnSmall}
             onMouseDown={() => onSeekButtonPress(1)}
             onMouseUp={() => onSeekButtonRelease(1)}
@@ -199,6 +204,7 @@ export function HTML5Controls({
             data-testid="mediaPlayer-speed"
             aria-label="Playback speed"
             title="Playback speed (< / >)"
+            tabIndex={0}
             style={{
               ...controlBtnSmall,
               fontSize: "0.875rem",
@@ -376,6 +382,7 @@ export function YouTubeControls({
             data-testid="mediaPlayer-seekBack"
             aria-label="Back 1s"
             title="Back 1s · J for 10s"
+            tabIndex={0}
             style={controlBtnSmall}
             onClick={onSeekBack}
           >
@@ -388,6 +395,7 @@ export function YouTubeControls({
             data-testid="mediaPlayer-playPause"
             aria-label={isPaused ? "Play" : "Pause"}
             title={isPaused ? "Play (Space)" : "Pause (Space)"}
+            tabIndex={0}
             style={controlBtnLarge}
             onClick={onPlayPause}
           >
@@ -400,6 +408,7 @@ export function YouTubeControls({
             data-testid="mediaPlayer-seekForward"
             aria-label="Forward 1s"
             title="Forward 1s · L for 10s"
+            tabIndex={0}
             style={controlBtnSmall}
             onClick={onSeekForward}
           >

--- a/packages/stagebook/src/components/elements/timeline/TimelineFooter.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineFooter.tsx
@@ -126,6 +126,8 @@ export function TimelineFooter({
           onClick={onHelpToggle}
           aria-label="Show keyboard shortcuts"
           aria-pressed={helpOpen}
+          // Explicit tabIndex for Safari Tab-focus (#415 / #413).
+          tabIndex={0}
           style={buttonStyle}
         >
           ?

--- a/packages/stagebook/src/components/elements/timeline/TimelineHeader.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineHeader.tsx
@@ -88,6 +88,10 @@ export function TimelineHeader({
           onClick={onZoomOut}
           disabled={zoomLevel <= MIN_ZOOM}
           aria-label="Zoom out"
+          // Explicit tabIndex so Safari includes the button in the
+          // Tab order (default keyboard nav on macOS Safari skips
+          // <button>) — see #415 / #413.
+          tabIndex={zoomLevel <= MIN_ZOOM ? -1 : 0}
           style={zoomLevel <= MIN_ZOOM ? disabledStyle : buttonStyle}
         >
           −
@@ -99,6 +103,7 @@ export function TimelineHeader({
           onClick={onZoomIn}
           disabled={zoomLevel >= MAX_ZOOM}
           aria-label="Zoom in"
+          tabIndex={zoomLevel >= MAX_ZOOM ? -1 : 0}
           style={zoomLevel >= MAX_ZOOM ? disabledStyle : buttonStyle}
         >
           +

--- a/packages/stagebook/src/components/elements/timeline/TimelineTrack.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineTrack.tsx
@@ -86,6 +86,8 @@ export function TimelineTrack({
           aria-label={muted ? `Unmute ${label}` : `Mute ${label}`}
           aria-pressed={muted}
           onClick={() => onToggleMute(!muted)}
+          // Explicit tabIndex for Safari Tab-focus (#415 / #413).
+          tabIndex={0}
           style={{
             width: `${String(MUTE_BUTTON_WIDTH)}px`,
             minWidth: `${String(MUTE_BUTTON_WIDTH)}px`,

--- a/packages/stagebook/src/components/form/Button.tsx
+++ b/packages/stagebook/src/components/form/Button.tsx
@@ -139,6 +139,13 @@ export function Button({
         className={`${buttonClass} ${className}`.trim()}
         data-variant={variant}
         autoFocus={autoFocus}
+        // Explicit tabIndex={0} so Safari includes the button in the
+        // Tab order. macOS Safari's default keyboard navigation skips
+        // <button> (and <a>) unless the system "Use keyboard
+        // navigation" preference is on — explicit tabindex overrides
+        // that, so participants on Safari can keyboard-reach the
+        // SubmitButton and other Stagebook buttons (#415 / #413).
+        tabIndex={disabled ? -1 : 0}
         style={{ ...baseInlineStyle, ...stateStyle, ...style }}
         id={buttonId}
         data-testid={dataTestId}

--- a/packages/stagebook/src/components/form/CheckboxGroup.tsx
+++ b/packages/stagebook/src/components/form/CheckboxGroup.tsx
@@ -182,6 +182,10 @@ export function CheckboxGroup({
                 id={`${groupId}_${key}`}
                 checked={checked}
                 onChange={() => handleToggle(key)}
+                // Safari excludes <input type=checkbox> from the
+                // default tab order unless macOS keyboard-nav is on;
+                // explicit tabIndex overrides that (#415 / #413).
+                tabIndex={0}
                 style={{
                   ...checkboxBaseStyle,
                   ...(checked ? checkboxCheckedStyle : {}),

--- a/packages/stagebook/src/components/form/Markdown.tsx
+++ b/packages/stagebook/src/components/form/Markdown.tsx
@@ -499,6 +499,14 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
                 target={target}
                 rel={computeSafeRel(target, rel)}
                 {...props}
+                // Explicit tabIndex={0} so Safari includes the link
+                // in the Tab order. macOS Safari skips <a> from the
+                // default keyboard navigation unless the system
+                // setting is on — explicit tabindex overrides that
+                // (#419 / #415 / #413). Placed after {...props} so a
+                // future rehype-raw integration with raw-HTML tabindex
+                // can't accidentally re-enable the Safari skip.
+                tabIndex={0}
               />
             ),
             blockquote: ({ node: _node, ...props }) => (

--- a/packages/stagebook/src/components/form/RadioGroup.tsx
+++ b/packages/stagebook/src/components/form/RadioGroup.tsx
@@ -181,6 +181,12 @@ export function RadioGroup({
                 value={key}
                 checked={checked}
                 onChange={onChange}
+                // Safari excludes <input type=radio> from the default
+                // tab order unless macOS keyboard-nav is on; explicit
+                // tabIndex overrides that. The browser's native
+                // arrow-key navigation within the group still works
+                // (#415 / #413).
+                tabIndex={0}
                 style={{
                   ...radioBaseStyle,
                   ...(checked ? radioCheckedStyle : {}),

--- a/packages/stagebook/src/components/form/Slider.tsx
+++ b/packages/stagebook/src/components/form/Slider.tsx
@@ -353,6 +353,11 @@ export function Slider({
                 step={interval}
                 value={localValue}
                 onChange={handleChange}
+                // Safari excludes <input type=range> from the default
+                // tab order unless macOS keyboard-nav is on; explicit
+                // tabIndex overrides that so Safari participants can
+                // keyboard-reach the slider thumb (#415 / #413).
+                tabIndex={0}
                 style={{
                   position: "absolute",
                   top: "50%",


### PR DESCRIPTION
Closes #415.

## Background

Safari / WebKit excludes \`<button>\`, \`<a>\`, \`<input type=range>\`, \`<input type=checkbox>\`, and \`<input type=radio>\` from the default Tab order unless macOS's \"Use keyboard navigation\" system setting is enabled. The setting defaults to **off** — so Safari participants in Stagebook studies cannot keyboard-reach interactive elements; they can only click. Focus rings via \`:focus-visible\` never appear via Tab.

Explicit \`tabIndex={0}\` overrides Safari's implicit-tab-order skip. The change is a no-op on Chrome / Firefox — those engines already treat the elements as \`tabindex=0\` implicitly.

## Touched

- \`Button.tsx\` — \`tabIndex={disabled ? -1 : 0}\`
- \`TrackedLink.tsx\` — \`tabIndex={0}\`
- \`CheckboxGroup.tsx\` / \`RadioGroup.tsx\` / \`Slider.tsx\` — \`tabIndex={0}\` on the underlying inputs
- \`Markdown.tsx\` — \`tabIndex={0}\` on the react-markdown \`a\` renderer (after \`{...props}\` so future raw-HTML pipelines can't accidentally re-enable the Safari skip)
- \`TimelineHeader.tsx\` — \`tabIndex\` on zoom in/out (with \`disabled\` → -1)
- \`TimelineFooter.tsx\` — \`tabIndex={0}\` on help button
- \`TimelineTrack.tsx\` — \`tabIndex={0}\` on track-mute button
- \`mediaPlayer/controls.tsx\` — \`tabIndex={0}\` on all 9 HTML5 + YouTube control buttons (caught by subagent review — these were not in the original #415 list but had the same issue)
- \`MediaPlayer.tsx\` — \`tabIndex={0}\` on both play-once buttons (video / audio)

## Test plan

- [x] All 8 tests originally listed in #415 pass on webkit (Button focus ×2, CheckboxGroup focus, RadioGroup focus, Slider thumb focus, TrackedLink focus, Markdown link focus, Timeline zoom-in focus)
- [x] No regressions on chromium — 348 form/timeline/mediaPlayer tests pass
- [x] No regressions on firefox — same suite passes
- [x] Vitest unit suite (1060 tests) passes
- [x] Subagent code review caught + addressed missed mediaPlayer controls and Markdown defensive ordering

Remaining webkit failures (Timeline ruler keys, Markdown code-block bg, Slider track click, MediaPlayer Accept-Ranges) are tracked separately in #416 / #418 / #419 / #420.

🤖 Generated with [Claude Code](https://claude.com/claude-code)