### PR TITLE
Fix #416: Timeline tests reliable on webkit + firefox (test-only)

### DIFF
--- a/packages/stagebook/src/components/elements/Timeline.ct.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.ct.tsx
@@ -812,6 +812,12 @@ test("range mode: multiSelect false — drag-create preserves existing range", a
     isPrimary: true,
   });
 
+  // Wait for the post-drag save to settle before snapshotting; on
+  // webkit / heavy parallel load it lands a tick later than chromium
+  // (#416).
+  await expect
+    .poll(async () => (await readSaveLog(component)).length, { timeout: 1500 })
+    .toBeGreaterThan(0);
   const savesBefore = await readSaveLog(component);
   const before = savesBefore[savesBefore.length - 1]?.value as {
     start: number;
@@ -931,6 +937,18 @@ test("range mode: multiSelect true — ranges accumulate sorted", async ({
     isPrimary: true,
   });
 
+  // Wait for both range saves to land — under webkit / heavy parallel
+  // load the second save trails the read otherwise (#416).
+  await expect
+    .poll(
+      async () => {
+        const ss = await readSaveLog(component);
+        const v = ss[ss.length - 1]?.value as { start: number }[] | undefined;
+        return v?.length ?? 0;
+      },
+      { timeout: 1500 },
+    )
+    .toBe(2);
   const saves = await readSaveLog(component);
   const last = saves[saves.length - 1]?.value as {
     start: number;
@@ -1368,6 +1386,10 @@ test("save key is timeline_${name}", async ({ mount }) => {
     isPrimary: true,
   });
 
+  // Poll for the save to land (#416 — webkit / parallel-load timing).
+  await expect
+    .poll(async () => (await readSaveLog(component)).length, { timeout: 1500 })
+    .toBeGreaterThan(0);
   const saves = await readSaveLog(component);
   expect(saves[saves.length - 1]?.key).toBe("timeline_my_annotations");
 });
@@ -1657,6 +1679,18 @@ test("track scope: clicking different tracks creates ranges with track field", a
     isPrimary: true,
   });
 
+  // Poll for both range saves to land (#416 — webkit / parallel-load
+  // timing).
+  await expect
+    .poll(
+      async () => {
+        const ss = await readSaveLog(component);
+        const v = ss[ss.length - 1]?.value as { track: number }[] | undefined;
+        return v?.length ?? 0;
+      },
+      { timeout: 1500 },
+    )
+    .toBe(2);
   const saves = await readSaveLog(component);
   const last = saves[saves.length - 1]?.value as {
     track: number;
@@ -2017,6 +2051,13 @@ test("Space key never intercepted by timeline", async ({ mount }) => {
     />,
   );
   await createRangeViaDrag(component, 0.3, 0.5);
+  // Wait for the drag's save to settle before snapshotting — on webkit
+  // the post-drag save lands a tick later than on chromium, and if we
+  // read too early we'd misattribute it to the Space press below
+  // (#416).
+  await expect
+    .poll(async () => (await readSaveLog(component)).length, { timeout: 1500 })
+    .toBeGreaterThan(0);
   const beforeSaves = await readSaveLog(component);
 
   const timeline = component.locator('[data-testid="timeline"]');
@@ -2854,6 +2895,12 @@ test("multiple timelines on the same player share peaks but save independently",
     pointerId: 1,
     isPrimary: true,
   });
+  // Poll for the save to land — under webkit / heavy parallel test
+  // load the debounced save lands a tick later than chromium, and
+  // reading too early returns an empty log.
+  await expect
+    .poll(async () => (await readSaveLog(component)).length, { timeout: 1500 })
+    .toBeGreaterThan(0);
   const saves = await readSaveLog(component);
   expect(saves[saves.length - 1]?.key).toBe(
     "timeline_my_unique_timeline_name_42",
@@ -3418,15 +3465,32 @@ test("clicking the time ruler seeks the playhead", async ({ mount, page }) => {
   const playhead = component.locator('[data-testid="playhead"]');
   await expect(playhead).toBeAttached();
 
+  // Wait for the ResizeObserver in Timeline to publish a non-zero width
+  // to the ruler — under webkit / heavy parallel load the first
+  // bounding-box read can land before that effect fires, leaving the
+  // ruler at 0px wide and the click missing its target. Polling the
+  // box width is the most direct signal that the ruler is layout-ready.
+  await expect
+    .poll(async () => (await ruler.boundingBox())?.width ?? 0, {
+      timeout: 1500,
+    })
+    .toBeGreaterThan(0);
   const rulerBox = await ruler.boundingBox();
   if (!rulerBox) throw new Error("ruler not found");
 
   // Click ~50% of the ruler. With duration=60 zoom=1, that lands near 30s
   // and playhead's `left` should land near rulerBox.width / 2.
-  await page.mouse.click(
+  //
+  // On webkit, `page.mouse.click()` after a previous test leaves the
+  // pointer in a stale spot sometimes skips the pointerdown synthesis
+  // — splitting into explicit move → down → up forces the full pointer
+  // event sequence and makes the test reliable cross-engine (#416).
+  await page.mouse.move(
     rulerBox.x + rulerBox.width * 0.5,
     rulerBox.y + rulerBox.height / 2,
   );
+  await page.mouse.down();
+  await page.mouse.up();
 
   await expect
     .poll(async () =>
@@ -3454,6 +3518,13 @@ test("ruler drag scrubs the playhead", async ({ mount, page }) => {
   );
   const ruler = component.locator('[data-testid="time-ruler"]');
   const playhead = component.locator('[data-testid="playhead"]');
+  // Wait for ResizeObserver-driven layout so the ruler has a non-zero
+  // width before we start mouse-driving against its bounding box (#416).
+  await expect
+    .poll(async () => (await ruler.boundingBox())?.width ?? 0, {
+      timeout: 1500,
+    })
+    .toBeGreaterThan(0);
   const rulerBox = await ruler.boundingBox();
   if (!rulerBox) throw new Error("ruler not found");
 
@@ -4132,6 +4203,12 @@ test("range mode: Enter press-and-hold creates a range from press time to releas
     cancelable: true,
   });
 
+  // Poll for the save — the dispatched keyup runs an effect tick later
+  // on webkit / heavy parallel load (#416), so reading too early would
+  // see the pre-commit log.
+  await expect
+    .poll(async () => (await readSaveLog(component)).length, { timeout: 1500 })
+    .toBeGreaterThan(0);
   const saves = await readSaveLog(component);
   const value = saves[saves.length - 1]?.value as {
     start: number;


### PR DESCRIPTION
Closes #416.

The five tests originally listed in #416 (Space key intercepted, multi-timeline save key, ruler click/drag, Enter press-and-hold) all turned out to be timing-related, not real Timeline behavior bugs. **Production code is untouched** — \`git diff main..HEAD\` shows only changes to \`Timeline.ct.tsx\`.

## Three timing patterns

1. **Save-log read-too-early.** Webkit dispatches the post-gesture save a tick later than chromium. Tests that read \`readSaveLog\` immediately after a pointerup / keyup grab a snapshot from before the save lands. Fix: poll for \`savesLength > 0\` (or \`=== N\` where the assertion expects an exact count) before the read.

2. **Ruler bounding-box width = 0.** The time-ruler's React-state \`width\` is published by Timeline's ResizeObserver and lands a tick after first paint. On webkit the initial \`boundingBox()\` read can land in that window; mouse coords computed from a 0-width ruler miss the element. Fix: poll for \`boundingBox()?.width > 0\` before reading the box for click coords.

3. **\`page.mouse.click()\` after stale pointer state.** Webkit occasionally skips the pointerdown synthesis from \`click()\` when prior tests left the cursor in an odd spot. Splitting into explicit \`move → down → up\` forces the full pointer event sequence and is semantically equivalent for our handler (\`TimeRuler.tsx:147\` binds \`onPointerDown\`, not \`onClick\`).

## Test plan

- [x] All 5 original #416 tests pass on webkit (in isolation, repeat-each=5, workers=1)
- [x] Webkit Timeline suite: 129/129 pass
- [x] Firefox Timeline suite: 129/129 pass
- [x] Chromium full suite: 559/559 pass
- [x] Vitest unit suite: 1060 pass
- [x] No production code touched

## Out of scope

Chromium has a couple of pre-existing parallel-load flakes (\`ruler drag scrubs the playhead\`, \`wheel pan: negative deltaX\`) that surface ~1 in 10 runs at full parallelism. These existed before #416 work and aren't introduced by this PR. They pass in isolation. Tracked as a broader test-infra concern, not a Timeline behavior bug.

Subagent review caught the comment-inconsistency (#416 reference missing from one block) and 11 other tests that share the same read-too-early pattern but don't currently flake — those are parked for follow-up if they ever surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)