### PR TITLE
Fix #417: scrub bar resilient to synthetic events + audio mock fits firefox

### DIFF
--- a/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
+++ b/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
@@ -2011,11 +2011,19 @@ test("audio-only: controls always visible while playing (no hover needed)", asyn
   // set loadError and hide controls (see #72).
   // Serve a minimal valid WAV so the video element doesn't fire onerror
   // (which would set loadError and hide controls — see #72).
-  await page.route("**/test.mp3", (route) =>
+  // Use .wav for the URL extension to match the served content-type —
+  // firefox is stricter than chromium / webkit about extension/MIME
+  // alignment and refuses to load otherwise, triggering the
+  // loadError path (#417).
+  await page.route("**/test.wav", (route) =>
     route.fulfill({
       contentType: "audio/wav",
+      // Minimal valid WAV: 44-byte PCM header + 2 bytes of silent
+      // sample data. Firefox rejects header-only WAVs with a
+      // 0-byte data chunk and flips the MediaPlayer into its
+      // loadError state, which hides controls (#417).
       body: Buffer.from(
-        "UklGRiQAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQAAAAA=",
+        "UklGRiYAAABXQVZFZm10IBAAAAABAAEARKwAAIhYAQACABAAZGF0YQIAAAAAAA==",
         "base64",
       ),
     }),
@@ -2023,7 +2031,7 @@ test("audio-only: controls always visible while playing (no hover needed)", asyn
 
   const component = await mount(
     <MockMediaPlayer
-      url="https://example.com/test.mp3"
+      url="https://example.com/test.wav"
       name="test"
       playVideo={false}
       controls={{ playPause: true, seek: true }}

--- a/packages/stagebook/src/components/elements/mediaPlayer/controls.tsx
+++ b/packages/stagebook/src/components/elements/mediaPlayer/controls.tsx
@@ -239,7 +239,14 @@ export function HTML5Controls({
               alignItems: "center",
             }}
             onPointerDown={(e) => {
-              e.currentTarget.setPointerCapture(e.pointerId);
+              try {
+                e.currentTarget.setPointerCapture(e.pointerId);
+              } catch {
+                // setPointerCapture throws on firefox if the pointerId
+                // came from a synthetic dispatchEvent (#417). Real
+                // mouse events always succeed. Matches the defensive
+                // pattern in timeline/TimeRuler.tsx:88-92.
+              }
               onScrubStart(posFromEvent(e));
             }}
             onPointerMove={(e) => {
@@ -437,7 +444,14 @@ export function YouTubeControls({
               alignItems: "center",
             }}
             onPointerDown={(e) => {
-              e.currentTarget.setPointerCapture(e.pointerId);
+              try {
+                e.currentTarget.setPointerCapture(e.pointerId);
+              } catch {
+                // setPointerCapture throws on firefox if the pointerId
+                // came from a synthetic dispatchEvent (#417). Real
+                // mouse events always succeed. Matches the defensive
+                // pattern in timeline/TimeRuler.tsx:88-92.
+              }
               onScrubStart(posFromEvent(e));
             }}
             onPointerMove={(e) => {


### PR DESCRIPTION
Closes #417.

Three firefox MediaPlayer failures resolved via two minimal changes — one production fix (try/catch around setPointerCapture, matching the pre-existing TimeRuler pattern), one test mock improvement (WAV with valid sample data + matching extension).

## Root causes

**1. Scrub bar `setPointerCapture` threw on synthetic events.** The HTML5 + YouTube scrub bar handlers in [controls.tsx:241-249](packages/stagebook/src/components/elements/mediaPlayer/controls.tsx#L241-L249) called \`e.currentTarget.setPointerCapture(e.pointerId)\` unguarded. On firefox, a synthetic \`dispatchEvent("pointerdown", { pointerId: 1 })\` produces a pointerId that doesn't match a real active pointer — \`setPointerCapture\` throws, the exception aborts the handler, and \`onScrubStart(posFromEvent(e))\` never fires.

Fix: wrap in \`try/catch\`, matching the defensive pattern already in [TimeRuler.tsx:88-92](packages/stagebook/src/components/elements/timeline/TimeRuler.tsx#L88-L92). This is a one-line resilience change — real-browser pointer events continue to work identically.

**2. Audio mock was malformed for firefox.** The audio-only test served a header-only WAV (subchunk2Size=0) at URL \`https://example.com/test.mp3\` with \`Content-Type: audio/wav\`. Firefox is stricter than chromium/webkit on both the data-size and the extension/MIME mismatch — it fires \`onerror\`, trips \`loadError\`, and hides controls.

Fix: rename URL+route to \`.wav\` and extend the WAV body with one silent 16-bit sample (44+2 bytes total). The mock is now a structurally valid PCM WAV file.

## Test plan

- [x] All 3 originally failing #417 tests now pass on firefox
- [x] Full MediaPlayer CT suite (90 tests): chromium 90/90, webkit 90/90, firefox 90/90
- [x] Vitest unit suite: 1060 pass
- [x] No production behavior change with real mouse/touch input — \`setPointerCapture\` succeeds, \`try/catch\` is a no-op
- [x] Subagent review caught the root cause (synthetic pointerId → setPointerCapture throws) and steered away from a test-only workaround toward the production fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)