### PR TITLE
Fix #419: accept webkit's normalization of background:transparent

### DIFF
--- a/packages/stagebook/src/components/form/Markdown.ct.tsx
+++ b/packages/stagebook/src/components/form/Markdown.ct.tsx
@@ -466,6 +466,12 @@ test("fenced code block: inner <code> background is explicitly transparent (defe
   // `code { background-color: var(--vscode-textPreformat-background) }`)
   // doesn't render a per-line tint behind the text inside our chip.
   // Asserts inline-style values, which beat any host CSS rule.
+  //
+  // Browsers normalize `background: transparent` differently when read
+  // back from `el.style.background`: chromium/firefox keep
+  // "transparent", webkit normalizes to "none". Both are equivalent
+  // (zero painting) per the CSS background shorthand spec — accept
+  // either (#419).
   const component = await mount(<Markdown text={"```js\nconst x = 1;\n```"} />);
   const innerCodeInline = await component
     .locator("pre > code")
@@ -473,7 +479,7 @@ test("fenced code block: inner <code> background is explicitly transparent (defe
       background: (el as HTMLElement).style.background,
       padding: (el as HTMLElement).style.padding,
     }));
-  expect(innerCodeInline.background).toBe("transparent");
+  expect(["transparent", "none"]).toContain(innerCodeInline.background);
   expect(innerCodeInline.padding).toBe("0px");
 });
 


### PR DESCRIPTION
Closes #419.

The two tests originally listed under #419:

- **Markdown link focus ring** — already passes on webkit after #415 added explicit \`tabIndex={0}\` to the react-markdown \`<a>\` renderer. No change needed here.
- **Fenced code block inner-\<code\> background** — was asserting \`el.style.background === \"transparent\"\` after setting \`background: \"transparent\"\` inline. WebKit normalizes the background shorthand to \`\"none\"\` when read back, while chromium / firefox keep \`\"transparent\"\`. Both values are semantically equivalent (no painting) per the CSS background shorthand spec.

This PR loosens the assertion to \`expect([\"transparent\", \"none\"]).toContain(value)\`. The test still catches the regression of someone removing the inline \`background\` style entirely (empty string matches neither).

Test-only change. Production code untouched.

## Test plan

- [x] Chromium Markdown: 47/47
- [x] WebKit Markdown: 47/47 (was 1 failing)
- [x] Firefox Markdown: 47/47

🤖 Generated with [Claude Code](https://claude.com/claude-code)