### PR TITLE
Fix #420: real mouse driving for Slider track-click test (webkit)

### DIFF
--- a/packages/stagebook/src/components/form/Slider.ct.tsx
+++ b/packages/stagebook/src/components/form/Slider.ct.tsx
@@ -10,12 +10,17 @@ test("renders without thumb initially (no anchoring)", async ({ mount }) => {
   await expect(component).toContainText("Click the bar to select a value");
 });
 
-test("shows range input after clicking the track", async ({ mount }) => {
+test("shows range input after clicking the track", async ({ mount, page }) => {
   const component = await mount(<Slider min={0} max={100} interval={1} />);
-  // Dispatch a click event on the track (element may be thin/outside viewport)
-  await component
-    .locator('[role="presentation"]')
-    .dispatchEvent("click", { clientX: 150, clientY: 5 });
+  // Real mouse click instead of dispatchEvent — webkit doesn't route a
+  // synthetic `dispatchEvent("click", { clientX })` through React's
+  // delegated click listener reliably, so the onClick handler on the
+  // wrapper never fires and the slider stays in its unanchored state
+  // (#420). page.mouse.click drives the full native event sequence.
+  const wrapper = component.locator('[role="presentation"]');
+  const box = await wrapper.boundingBox();
+  if (!box) throw new Error("slider wrapper not found");
+  await page.mouse.click(box.x + box.width * 0.5, box.y + box.height * 0.5);
   // Now the range input should be in the DOM
   await expect(component.locator('input[type="range"]')).toHaveCount(1);
   // Instruction text should be gone


### PR DESCRIPTION
Closes #420.

The Slider track-click test mounted a bare \`<Slider>\` and dispatched a synthetic click via \`dispatchEvent(\"click\", { clientX: 150, clientY: 5 })\`. WebKit didn't reliably route that event through React's delegated click listener, so the wrapper's onClick handler never fired and the slider stayed in its unanchored state — \`<input type=range>\` never rendered.

Switching to \`page.mouse.click(x, y)\` at the center of the wrapper's bounding box drives the full native event sequence and works across all three engines.

The second #420 test (focus ring on the thumb when keyboard-focused) was already passing after #415 added explicit \`tabIndex={0}\` to the range input.

The two other \`dispatchEvent(\"click\")\` sites in Slider.ct.tsx (lines 86 and 303) mount via \`MockSlider\` and pass reliably on webkit (stress-tested 10/10), so they're left alone.

Test-only change. Production code untouched.

## Test plan

- [x] Chromium Slider: 21/21
- [x] WebKit Slider: 21/21 (was 1 failing)
- [x] Firefox Slider: 21/21

🤖 Generated with [Claude Code](https://claude.com/claude-code)