### PR TITLE
Bump stagebook to 0.10.12

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.10.11",
+  "version": "0.10.12",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Patch release picking up two participant-facing fixes plus the cross-browser CT infrastructure work.

## What's in

- **#411** — Pin TextArea / Select font so it doesn't drift cross-browser. Adds a new \`--stagebook-font\` CSS variable (default \`\"Inter\", ui-sans-serif, system-ui, sans-serif\`) for host opt-out; resolves Chrome textarea defaulting to monospace while Safari rendered sans.
- **#421** — Safari Tab focus. Explicit \`tabIndex={0}\` on \`<button>\` / \`<a>\` / \`<input type=range|checkbox|radio>\` across Button, TrackedLink, RadioGroup, CheckboxGroup, Slider, Markdown link renderer, Timeline zoom/help/mute buttons, MediaPlayer HTML5+YouTube controls, and the play-once button. Safari participants can now keyboard-reach every interactive element — previously skipped from the default Tab order unless macOS's \"Use keyboard navigation\" system pref was on.
- **#423** — Defensive \`try/catch\` around \`setPointerCapture\` in MediaPlayer scrub bars (matches the pre-existing TimeRuler pattern). Minor production change.
- **#414, #422, #425-#428** — Cross-browser CT infrastructure: webkit + firefox now run as parallel CI matrix checks alongside chromium. Various test-only timing/normalization fixes to make the suite reliable across all three engines.

## Compatibility

- No API changes.
- New \`--stagebook-font\` CSS variable (additive — hosts can override at \`:root\`; default matches the previous hardcoded font stack).
- Explicit \`tabIndex={0}\` on interactive elements is a no-op on Chrome/Firefox; on Safari it brings the elements into the default Tab order where they belonged all along.

## Open follow-up

- **#424** — Stagebook only detects missing \`Accept-Ranges\` on Chrome. Firefox and Linux WebKit silently fail to seek instead. Needs a probe-seek or pre-flight HEAD product enhancement. One CT test is \`test.fixme\`'d on those engines until #424 lands.