### PR TITLE
Fix #424: pre-flight HEAD detects missing Accept-Ranges on every engine

### DIFF
--- a/packages/stagebook/src/components/elements/MediaPlayer.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.tsx
@@ -179,6 +179,51 @@ export function MediaPlayer({
     setShowPlayOnce(false);
   }, [url]);
 
+  // Pre-flight HEAD check for `Accept-Ranges` (#424). The existing
+  // detection at handleLoadedMetadata can only catch the case when
+  // the browser exposes the broken state via `seekable.length=0`
+  // (Chrome). Firefox and Linux WebKit both falsely report
+  // `seekable=[0, duration]` even when ranges aren't supported —
+  // their seek would silently fail with no diagnostic.
+  //
+  // The HEAD response's `Accept-Ranges` header is the authoritative
+  // signal across every engine, so we probe it on mount and warn
+  // proactively if missing. Failures (CORS, network, server doesn't
+  // support HEAD) fall through silently to the existing
+  // loadedmetadata-based check — no worse than today.
+  const acceptRangesWarnedRef = useRef(false);
+  useEffect(() => {
+    acceptRangesWarnedRef.current = false;
+    if (youtubeVideoId || !url || !isSafeURL(url)) return;
+    const controller = new AbortController();
+    fetch(url, { method: "HEAD", signal: controller.signal })
+      .then((response) => {
+        if (!response.ok) return;
+        const acceptRanges = response.headers.get("accept-ranges");
+        if (!acceptRanges || acceptRanges.toLowerCase() === "none") {
+          acceptRangesWarnedRef.current = true;
+          console.warn(
+            `[MediaPlayer] ${url} returned without "Accept-Ranges: bytes". ` +
+              `The browser may not be able to seek the video — researchers ` +
+              `may see seek controls snap back toward the start. Check the ` +
+              `asset server's range-request configuration. If the asset is ` +
+              `cross-origin and seeking actually works, the server may need ` +
+              `to expose the header via "Access-Control-Expose-Headers: ` +
+              `Accept-Ranges" — without that, this check sees null and ` +
+              `false-positives.`,
+          );
+        }
+      })
+      .catch(() => {
+        // Best-effort. CORS blocks header reads from cross-origin
+        // responses that don't expose them, the network may be
+        // offline, the server may not support HEAD, etc. — in any
+        // of those cases we fall through to the loadedmetadata-
+        // based check (which works on Chrome at least).
+      });
+    return () => controller.abort();
+  }, [url, youtubeVideoId]);
+
   // YouTube-only: handle registered by YouTubePlayer once the IFrame API is ready
   const [ytHandle, setYtHandle] = useState<PlaybackHandle | null>(null);
 
@@ -564,6 +609,12 @@ export function MediaPlayer({
       const hasFiniteDuration = Number.isFinite(v.duration) && v.duration > 0;
       if (!hasFiniteDuration) return;
 
+      // Suppress this derived warning when the pre-flight HEAD check
+      // already surfaced the same problem (#424) — the HEAD response
+      // headers are the authoritative source; this seekable-based
+      // signal is a fallback for cases where HEAD wasn't readable
+      // (CORS, network failure, server doesn't support HEAD).
+      if (acceptRangesWarnedRef.current) return;
       const seekable = v.seekable;
       const fullySeekable =
         seekable.length > 0 &&

--- a/packages/stagebook/src/components/elements/mediaPlayer/realVideo.ct.tsx
+++ b/packages/stagebook/src/components/elements/mediaPlayer/realVideo.ct.tsx
@@ -165,49 +165,27 @@ test("audio-only renders an error placeholder when the audio fails to load", asy
 test("stagebook surfaces the problem when server doesn't advertise Accept-Ranges", async ({
   mount,
   page,
-  browserName,
 }) => {
-  // Firefox AND Linux-CI webkit both load the metadata even without
-  // Accept-Ranges and don't expose any signal to stagebook —
-  // `seekable` falsely reports [0, duration] on firefox; webkit on
-  // Linux (Playwright CI runner) behaves the same (different from
-  // macOS Safari, which surfaces an error overlay). Detecting either
-  // case needs a deeper product change (probe-seek or pre-flight
-  // HEAD) — tracked in #424. Until that lands, mark this expected-
-  // to-fail on the affected engines so CI stays green while still
-  // reporting (via fixme) that the gap exists. `fixme` is the
-  // standard Playwright idiom for "we know it's broken, please fix
-  // it" — semantically different from `skip`: it documents the
-  // known regression in test output, and Playwright flags it if the
-  // test ever starts passing (so we know to remove the gate).
-  test.fixme(
-    browserName === "firefox" || browserName === "webkit",
-    "tracked in #424",
-  );
   // Intercept the fixture and strip Accept-Ranges from the response.
-  // Cross-engine behavior diverges here:
+  // Stagebook surfaces the problem to the researcher via two paths:
   //
-  // - **Chromium** still loads the file (no range request → fetches
-  //   the whole thing), fires `loadedmetadata`, and exposes
-  //   `seekable.length=0`. Stagebook detects this and logs a warning.
+  // 1. **Pre-flight HEAD warning** (#424): on mount, MediaPlayer
+  //    issues a HEAD on the URL and inspects the response's
+  //    `Accept-Ranges` header. Missing or "none" → console warning.
+  //    This is the authoritative signal and fires across every
+  //    engine since it reads headers directly.
   //
-  // - **WebKit (Safari)** refuses to load a media response without
-  //   Accept-Ranges (it requires ranges for media buffering). The
-  //   browser dispatches `error` on the <video> element, MediaPlayer's
-  //   `handleError` flips into loadError state, and the user sees
-  //   "Video unavailable".
+  // 2. **loadedmetadata-derived warning** (#32): a fallback for cases
+  //    where the HEAD couldn't be read (CORS, network failure, server
+  //    doesn't support HEAD). Checks `v.seekable` after metadata
+  //    loads; fires on Chrome which reports seekable.length=0.
   //
-  // - **Firefox** loads the metadata AND falsely reports `seekable =
-  //   [0, duration]` even though range-requests aren't actually
-  //   supported. Stagebook's existing seekable check passes through,
-  //   so neither path fires. The seek will fail silently when the
-  //   user tries it. Detecting this needs a deeper product change
-  //   (probe-seek or pre-flight HEAD) — tracked in #424. This test
-  //   covers the chromium + webkit signals; firefox is parked.
+  // Plus, on macOS Safari the video element refuses to load entirely
+  // without Accept-Ranges → user sees the "Video unavailable" error
+  // overlay. The test accepts either the warning OR the error overlay
+  // — both communicate the problem.
   //
-  // The test asserts the universal contract for the covered engines:
-  // SOMETHING tells the researcher the video can't be served
-  // properly. Refs #418; firefox tracked in #424.
+  // Closes #424.
   await page.route("**/sample-video.mp4", async (route) => {
     const response = await route.fetch();
     const body = await response.body();


### PR DESCRIPTION
Closes #424.

## What this PR does

Stagebook's existing Accept-Ranges-missing detection at \`handleLoadedMetadata\` only fires on Chrome — Firefox and Linux WebKit falsely report \`seekable=[0, duration]\` even when range requests aren't supported, leaving researchers on those engines with **zero diagnostic** for a real server misconfig and participants who silently fail to seek.

The fix issues a pre-flight HEAD request on mount (for non-YouTube URLs) and inspects the response's \`Accept-Ranges\` header directly. Headers are the authoritative source — works on every engine since it doesn't rely on browser-derived \`seekable\` state.

The existing \`loadedmetadata\`-based check stays as a fallback for cases where HEAD couldn't be read (CORS-blocked headers, network failure, server doesn't support HEAD). A ref flag suppresses it when HEAD already warned to avoid duplicates.

## Edge cases handled

- **YouTube URLs:** skipped — the IFrame API handles its own load path.
- **Unsafe schemes (\`javascript:\`, \`data:\`, \`file:\`):** skipped via existing \`isSafeURL\` guard.
- **CORS-blocked header reads:** \`fetch\` with default \`mode:cors\` rejects → caught → falls through to existing loadedmetadata check.
- **Server doesn't support HEAD:** non-2xx response → no warning → falls through.
- **AbortController on unmount / URL change:** cleans up in-flight HEAD probes so the previous URL's response can't warn after a swap.
- **Cross-origin server that gates header reads:** the warning documents the false-positive case and points researchers at \`Access-Control-Expose-Headers: Accept-Ranges\` as the fix.

## Test plan

- [x] \`test.fixme(firefox|webkit, ...)\` removed from the realVideo Accept-Ranges test — now passes universally
- [x] Chromium full CT suite: 559/559
- [x] WebKit full CT suite: 554/559 + 5 pre-existing parallel-load flakes (CI's \`retries: 2\` handles them; same flakes from #413's sub-issues, not introduced by this PR)
- [x] Firefox full CT suite: 559/559
- [x] Vitest unit suite: 1060 pass
- [x] No production behavior change with a properly-configured server — HEAD succeeds with \`Accept-Ranges: bytes\` → no warning fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)