### PR TITLE
Fix #431: encode markdown image path, not the resolved URL

### DIFF
--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -74,7 +74,20 @@ export interface StagebookContext {
    */
   stageId?: string;
 
-  // Content resolution — platform handles fetching, caching, retries
+  // Content resolution — platform handles fetching, caching, retries.
+  //
+  // `getAssetURL(path)` returns a browser-safe URL for `path`.
+  //
+  // Contract:
+  // - Callers pass `path` as URL-safe (segments percent-encoded if
+  //   needed). The Markdown component does this segment encoding for
+  //   image refs before calling here (#431); host-direct callers
+  //   pass already-resolved file fields straight through.
+  // - Implementations should concatenate `path` with their base URL
+  //   without further re-encoding — the base URL may itself contain
+  //   intentional `%XX` sequences (e.g. VS Code's `asWebviewUri`
+  //   yields `https://file%2B.vscode-resource.vscode-cdn.net/...`),
+  //   and re-encoding would double-encode the `%`.
   getAssetURL(path: string): string;
   getTextContent(path: string): Promise<string>;
 

--- a/packages/stagebook/src/components/form/Markdown.ct.tsx
+++ b/packages/stagebook/src/components/form/Markdown.ct.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { test, expect } from "@playwright/experimental-ct-react";
 import { Markdown } from "./Markdown";
+import { MockMarkdown } from "../testing/MockMarkdown";
 
 test("renders markdown text", async ({ mount }) => {
   const component = await mount(<Markdown text="**Bold text**" />);
@@ -26,6 +27,131 @@ test("passes through relative image paths without resolveURL", async ({
     "src",
     "images/test.png",
   );
+});
+
+// -- Image URL encoding (#431) --
+//
+// Playwright CT can't serialize inline arrow-function props across
+// the mount boundary, so these tests use `MockMarkdown` (a tiny
+// wrapper that builds the `resolveURL` callback from a serializable
+// `baseUrl` string) instead of <Markdown> directly.
+
+test("resolveURL: does NOT double-encode %XX sequences in the host's already-encoded base", async ({
+  mount,
+}) => {
+  // Regression for #431: VS Code's `asWebviewUri` returns URLs like
+  // `https://file%2B.vscode-resource.vscode-cdn.net/...` where the
+  // `%2B` is the encoded `+` in the synthetic host name. The old
+  // `encodeURI(resolved)` re-encoded `%` → `%25` so `%2B` became
+  // `%252B` and the image 404'd. The fix encodes the markdown PATH
+  // (the part we know is raw) before passing to resolveURL, leaving
+  // the host's already-encoded base alone.
+  const component = await mount(
+    <MockMarkdown
+      text="![photo](images/test.png)"
+      baseUrl="https://file%2B.example.cdn.net/dir/"
+    />,
+  );
+  const src = await component.locator("img").getAttribute("src");
+  // Exactly one `%2B`, never `%252B`.
+  expect(src).toContain("%2B");
+  expect(src).not.toContain("%252B");
+});
+
+test("resolveURL: encodes spaces in researcher-authored filenames", async ({
+  mount,
+}) => {
+  // Markdown source is raw — researchers write paths like
+  // `![](my pic.jpg)`. The fix encodes the path segment(s) before
+  // resolving, so spaces (and other URI-special chars) become
+  // `%20` rather than landing literally in the <img src>.
+  const component = await mount(
+    <MockMarkdown
+      text="![photo](folder/my pic.jpg)"
+      baseUrl="https://example.com/"
+    />,
+  );
+  const src = await component.locator("img").getAttribute("src");
+  expect(src).toBe("https://example.com/folder/my%20pic.jpg");
+});
+
+test("resolveURL: encodes ? and # in path (would otherwise split into query/fragment)", async ({
+  mount,
+}) => {
+  // `encodeURI` (the previous approach) left `?` and `#` alone since
+  // both have URI-special meaning. That's wrong here because the
+  // markdown path IS a path, not a URI — `confused?.png` is a
+  // filename. Per-segment `encodeURIComponent` catches these (#431).
+  const component = await mount(
+    <MockMarkdown
+      text="![photo](confused?.png)"
+      baseUrl="https://example.com/"
+    />,
+  );
+  const src = await component.locator("img").getAttribute("src");
+  expect(src).toBe("https://example.com/confused%3F.png");
+});
+
+test("resolveURL: preserves `/` separators when encoding the path", async ({
+  mount,
+}) => {
+  // Encoding via `encodeURIComponent` on the whole path would mangle
+  // the `/` separators. Per-segment encoding preserves them.
+  const component = await mount(
+    <MockMarkdown
+      text="![photo](a/b/c/image.png)"
+      baseUrl="https://example.com/"
+    />,
+  );
+  const src = await component.locator("img").getAttribute("src");
+  expect(src).toBe("https://example.com/a/b/c/image.png");
+});
+
+test("resolveURL: encodes `#` in path (would otherwise split into a fragment)", async ({
+  mount,
+}) => {
+  // Parallel to the `?` case — `#` in a path means "this file is named
+  // foo#bar.png", not "navigate to fragment bar". `encodeURI` left this
+  // alone; per-segment `encodeURIComponent` catches it.
+  const component = await mount(
+    <MockMarkdown
+      text="![photo](sketch#1.png)"
+      baseUrl="https://example.com/"
+    />,
+  );
+  const src = await component.locator("img").getAttribute("src");
+  expect(src).toBe("https://example.com/sketch%231.png");
+});
+
+test("resolveURL: encodes `+` in path (close to the bug's root)", async ({
+  mount,
+}) => {
+  // `+` is in `encodeURI`'s pass-through set (it's "reserved"), so the
+  // previous approach left `+` literal in URLs. Most servers treat `+`
+  // as space in query strings, which can cause real-world breakage for
+  // a file literally named `version+1.png`. Per-segment
+  // `encodeURIComponent` encodes to `%2B`, which is also the same
+  // sequence at the root of #431 — exercised here to confirm we
+  // produce exactly one `%2B`, never `%252B`.
+  const component = await mount(
+    <MockMarkdown
+      text="![photo](version+1.png)"
+      baseUrl="https://example.com/"
+    />,
+  );
+  const src = await component.locator("img").getAttribute("src");
+  expect(src).toBe("https://example.com/version%2B1.png");
+});
+
+test("resolveURL: encodes non-ASCII characters in path", async ({ mount }) => {
+  // Researchers may name files in non-English alphabets (`café.png`,
+  // `日本.png`, …). `encodeURIComponent` UTF-8-encodes these to
+  // `%XX` sequences correctly.
+  const component = await mount(
+    <MockMarkdown text="![photo](café.png)" baseUrl="https://example.com/" />,
+  );
+  const src = await component.locator("img").getAttribute("src");
+  expect(src).toBe("https://example.com/caf%C3%A9.png");
 });
 
 test("img renders with inline max-width: 100% and height: auto so it can't overflow the prompt (issue #211)", async ({

--- a/packages/stagebook/src/components/form/Markdown.tsx
+++ b/packages/stagebook/src/components/form/Markdown.tsx
@@ -325,7 +325,22 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
         if (path.startsWith("http://") || path.startsWith("https://")) {
           return `![${alt}](${path})`;
         }
-        const resolved = resolveURL(path);
+        // Percent-encode the markdown source path BEFORE handing it
+        // to the host's resolver, segment-by-segment so `/` separators
+        // pass through. We encode here (not after resolve) because the
+        // markdown source is raw — researchers write paths like
+        // `images/my pic.jpg` — while the host's resolver returns an
+        // already-encoded base (e.g. VS Code's `asWebviewUri` yields
+        // `https://file%2B.vscode-resource.vscode-cdn.net/...`).
+        // Encoding the resolved URL would double-encode the `%2B` into
+        // `%252B` and break the host part. See #431.
+        //
+        // `encodeURIComponent` per segment (rather than `encodeURI` on
+        // the whole path) ensures `?`, `#`, and `&` get encoded too —
+        // those have URI-special meaning otherwise and would split the
+        // path from a query string / fragment / param.
+        const encodedPath = path.split("/").map(encodeURIComponent).join("/");
+        const resolved = resolveURL(encodedPath);
         // Reject non-http protocols (e.g., javascript:)
         if (
           !resolved.startsWith("http://") &&
@@ -334,8 +349,7 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
         ) {
           return `![${alt}](${path})`; // fall back to original path
         }
-        const url = encodeURI(resolved);
-        return `![${alt}](${url})`;
+        return `![${alt}](${resolved})`;
       },
     );
   }

--- a/packages/stagebook/src/components/testing/MockMarkdown.tsx
+++ b/packages/stagebook/src/components/testing/MockMarkdown.tsx
@@ -1,0 +1,17 @@
+/**
+ * Test wrapper for Markdown that builds a `resolveURL` callback from
+ * a serializable `baseUrl` string. Playwright CT can't pass inline
+ * arrow-function props across the mount boundary, so we accept a
+ * string and create the callback here.
+ */
+import React from "react";
+import { Markdown } from "../form/Markdown.js";
+
+export interface MockMarkdownProps {
+  text: string;
+  baseUrl: string;
+}
+
+export function MockMarkdown({ text, baseUrl }: MockMarkdownProps) {
+  return <Markdown text={text} resolveURL={(p) => baseUrl + p} />;
+}


### PR DESCRIPTION
Closes #431.

## The bug

\`Markdown.tsx\` ran \`encodeURI(resolved)\` on the host-resolved image URL. VS Code's \`asWebviewUri\` returns \`https://file%2B.vscode-resource.vscode-cdn.net/...\` — the \`%2B\` is the encoded \`+\` in the synthetic host name. \`encodeURI\` re-encodes the \`%\` → \`%25\`, so \`%2B\` becomes \`%252B\` and every markdown-embedded image 404'd in the VS Code preview.

## Why the filer's "just remove encodeURI" was nearly right but myopic

Removing \`encodeURI\` fixes VS Code immediately. But the encode was there for a real reason — researchers write raw paths like \`![](my pic.jpg)\`. Without ANY encoding, the literal space ends up in \`<img src>\` and we rely on browser leniency (which works on Chrome but not in all engines / strict-parsing contexts).

The fix puts encoding at the right layer:

\`\`\`diff
-const resolved = resolveURL(path);
-const url = encodeURI(resolved);
-return \`![\${alt}](\${url})\`;
+const encodedPath = path.split(\"/\").map(encodeURIComponent).join(\"/\");
+const resolved = resolveURL(encodedPath);
+return \`![\${alt}](\${resolved})\`;
\`\`\`

Encode the part we know is raw (researcher's path), let the host concatenate with its already-encoded base. No double-encoding, no reliance on browser leniency. \`encodeURIComponent\` per segment (rather than \`encodeURI\` on the whole path) also catches \`?\`, \`#\`, \`&\`, \`+\` — all valid in filenames but URI-special otherwise.

## The contract

[StagebookProvider.tsx:78](packages/stagebook/src/components/StagebookProvider.tsx#L78) — \`getAssetURL\` docstring now spells this out:

> Callers pass \`path\` as URL-safe (segments percent-encoded if needed). Implementations should concatenate with their base URL without re-encoding — the base may itself contain intentional \`%XX\` sequences.

Every in-repo host already follows this: VS Code (\`base + path\`), web viewer (\`rawBaseUrl + path\`), all the mocks. Documenting it prevents a future host from breaking the contract.

## Test plan

7 regression tests covering:

- \`%XX\`-not-double-encoded (the original bug — VS Code-style \`%2B\` in base, encoded exactly once in output)
- Space in filename (\`my pic.jpg\` → \`my%20pic.jpg\`)
- \`?\` in filename (\`confused?.png\` → \`confused%3F.png\` — \`encodeURI\` left this alone)
- \`#\` in filename (\`sketch#1.png\` → \`sketch%231.png\` — same family)
- \`+\` in filename (\`version+1.png\` → \`version%2B1.png\` — same sequence as the bug's root)
- Non-ASCII (\`café.png\` → \`caf%C3%A9.png\` — UTF-8 paths)
- \`/\` preserved (per-segment encoding doesn't mangle separators)

- [x] Chromium Markdown suite: 51/51
- [x] WebKit Markdown suite: 51/51
- [x] Firefox Markdown suite: 51/51
- [x] Vitest unit suite: 1060 pass

## Follow-up worth filing separately

\`Element.tsx\` lines 150, 204, 268, 304, 313 pass YAML \`element.file\` raw to \`getAssetURL\` with no encoding. Researchers with filenames containing spaces / special chars in non-markdown fields would still see broken assets. Pre-existing, out of scope for this PR — worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)