### PR TITLE
Fix #433: encode YAML file paths before passing to getAssetURL

### DIFF
--- a/packages/stagebook/src/components/Element.ct.tsx
+++ b/packages/stagebook/src/components/Element.ct.tsx
@@ -61,6 +61,48 @@ test.describe("Element router dispatch", () => {
     );
   });
 
+  test("type: image YAML file path with special chars is URL-encoded before resolve (#433)", async ({
+    mount,
+  }) => {
+    // YAML `file:` fields are researcher-authored — a filename like
+    // `My Photo!.png` or `round#3.png` must reach the host as URL-
+    // safe input. Without encoding, the special chars land literally
+    // in <img src> and either 404 or get misparsed by stricter
+    // backends (e.g. `?` would split into a query string).
+    const component = await mount(
+      <MockStageRenderer
+        stage={singleElementStage({
+          type: "image",
+          file: "shared/my pic.png",
+        })}
+      />,
+    );
+    await expect(component.locator("img")).toHaveAttribute(
+      "src",
+      "https://mock-cdn.test/shared/my%20pic.png",
+    );
+  });
+
+  test("type: image YAML file path with `asset://` scheme is NOT re-encoded (#433)", async ({
+    mount,
+  }) => {
+    // `asset://` is stagebook's platform-provided reference scheme
+    // (#188). The path encoder skips anything with a scheme prefix
+    // so the host's `asset://` handling stays intact.
+    const component = await mount(
+      <MockStageRenderer
+        stage={singleElementStage({
+          type: "image",
+          file: "asset://diagrams/flow.png",
+        })}
+      />,
+    );
+    await expect(component.locator("img")).toHaveAttribute(
+      "src",
+      "https://mock-cdn.test/asset://diagrams/flow.png",
+    );
+  });
+
   test("type: audio renders (invisible element)", async ({ mount }) => {
     const component = await mount(
       <MockStageRenderer

--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -20,6 +20,7 @@ import { Prompt } from "./elements/Prompt.js";
 import { Qualtrics } from "./elements/Qualtrics.js";
 import { Loading } from "./form/Loading.js";
 import { deriveStorageKeyName } from "../utils/deriveStorageKeyName.js";
+import { encodeAssetPath } from "../utils/encodeAssetPath.js";
 
 // Resolve element URL params using the StagebookProvider's resolve.
 // Plain function — no hooks — so it's safe to call conditionally (e.g. in
@@ -147,7 +148,7 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
     case "audio":
       return (
         <AudioElement
-          src={getAssetURL(element.file ?? "")}
+          src={getAssetURL(encodeAssetPath(element.file ?? ""))}
           save={wrappedSave}
           // When `name:` is omitted, fall back to a position-based
           // identifier (`<progressLabel>_<file>`) so two unnamed
@@ -201,7 +202,7 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
     case "image":
       return (
         <ImageElement
-          src={getAssetURL(element.file ?? "")}
+          src={getAssetURL(encodeAssetPath(element.file ?? ""))}
           width={element.width}
         />
       );
@@ -301,7 +302,7 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
       const resolvedURL =
         rawURL.startsWith("http://") || rawURL.startsWith("https://")
           ? rawURL
-          : getAssetURL(rawURL);
+          : getAssetURL(encodeAssetPath(rawURL));
       const rawCaptions =
         typeof element.captionsFile === "string" ? element.captionsFile : null;
       const resolvedCaptionsURL =
@@ -310,7 +311,7 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
           : rawCaptions.startsWith("http://") ||
               rawCaptions.startsWith("https://")
             ? rawCaptions
-            : getAssetURL(rawCaptions);
+            : getAssetURL(encodeAssetPath(rawCaptions));
       return (
         <MediaPlayer
           // Position-based fallback when `name:` is omitted — same

--- a/packages/stagebook/src/components/form/Markdown.tsx
+++ b/packages/stagebook/src/components/form/Markdown.tsx
@@ -1,6 +1,7 @@
 import React, { useId } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { encodeAssetPath } from "../../utils/encodeAssetPath.js";
 
 export interface MarkdownProps {
   text: string;
@@ -325,22 +326,13 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
         if (path.startsWith("http://") || path.startsWith("https://")) {
           return `![${alt}](${path})`;
         }
-        // Percent-encode the markdown source path BEFORE handing it
-        // to the host's resolver, segment-by-segment so `/` separators
-        // pass through. We encode here (not after resolve) because the
-        // markdown source is raw — researchers write paths like
-        // `images/my pic.jpg` — while the host's resolver returns an
-        // already-encoded base (e.g. VS Code's `asWebviewUri` yields
-        // `https://file%2B.vscode-resource.vscode-cdn.net/...`).
-        // Encoding the resolved URL would double-encode the `%2B` into
-        // `%252B` and break the host part. See #431.
-        //
-        // `encodeURIComponent` per segment (rather than `encodeURI` on
-        // the whole path) ensures `?`, `#`, and `&` get encoded too —
-        // those have URI-special meaning otherwise and would split the
-        // path from a query string / fragment / param.
-        const encodedPath = path.split("/").map(encodeURIComponent).join("/");
-        const resolved = resolveURL(encodedPath);
+        // Encode the markdown source path before handing it to the
+        // host's resolver — researchers write raw filesystem paths
+        // (`images/my pic.jpg`), while the host's resolver returns an
+        // already-encoded base. Encoding the resolved URL would
+        // double-encode the host's intentional `%XX` sequences
+        // (e.g. VS Code's `asWebviewUri` `%2B` → `%252B`). See #431.
+        const resolved = resolveURL(encodeAssetPath(path));
         // Reject non-http protocols (e.g., javascript:)
         if (
           !resolved.startsWith("http://") &&

--- a/packages/stagebook/src/utils/encodeAssetPath.test.ts
+++ b/packages/stagebook/src/utils/encodeAssetPath.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from "vitest";
+import { encodeAssetPath } from "./encodeAssetPath.js";
+
+describe("encodeAssetPath", () => {
+  test("plain ASCII filename unchanged", () => {
+    expect(encodeAssetPath("photo.jpg")).toBe("photo.jpg");
+  });
+
+  test("preserves `/` separators", () => {
+    expect(encodeAssetPath("a/b/c/image.png")).toBe("a/b/c/image.png");
+  });
+
+  test("encodes spaces", () => {
+    expect(encodeAssetPath("my pic.jpg")).toBe("my%20pic.jpg");
+    expect(encodeAssetPath("folder/my pic.jpg")).toBe("folder/my%20pic.jpg");
+  });
+
+  test("encodes `?` (would otherwise split into a query string)", () => {
+    expect(encodeAssetPath("confused?.png")).toBe("confused%3F.png");
+  });
+
+  test("encodes `#` (would otherwise split into a fragment)", () => {
+    expect(encodeAssetPath("sketch#1.png")).toBe("sketch%231.png");
+  });
+
+  test("encodes `+` (would otherwise be interpreted as space in queries)", () => {
+    expect(encodeAssetPath("version+1.png")).toBe("version%2B1.png");
+  });
+
+  test("encodes `&`", () => {
+    expect(encodeAssetPath("rock&roll.mp3")).toBe("rock%26roll.mp3");
+  });
+
+  test("encodes non-ASCII (UTF-8)", () => {
+    expect(encodeAssetPath("café.png")).toBe("caf%C3%A9.png");
+    expect(encodeAssetPath("日本.png")).toBe("%E6%97%A5%E6%9C%AC.png");
+  });
+
+  test("idempotent? — re-encoding already-encoded input DOES double-encode", () => {
+    // Documented limitation: per-segment encodeURIComponent is not
+    // idempotent because `%` itself gets encoded. Researchers
+    // shouldn't pre-encode their YAML paths; the encoder owns
+    // that responsibility.
+    expect(encodeAssetPath("my%20pic.jpg")).toBe("my%2520pic.jpg");
+  });
+
+  test("passes through http:// URLs unchanged", () => {
+    expect(encodeAssetPath("http://example.com/my pic.jpg")).toBe(
+      "http://example.com/my pic.jpg",
+    );
+  });
+
+  test("passes through https:// URLs unchanged", () => {
+    expect(encodeAssetPath("https://example.com/photo.png")).toBe(
+      "https://example.com/photo.png",
+    );
+  });
+
+  test("passes through asset:// URLs unchanged (preserves stagebook scheme)", () => {
+    expect(encodeAssetPath("asset://diagrams/flow.png")).toBe(
+      "asset://diagrams/flow.png",
+    );
+  });
+
+  test("passes through data: URLs unchanged", () => {
+    expect(encodeAssetPath("data:image/png;base64,iVBORw0KGgo=")).toBe(
+      "data:image/png;base64,iVBORw0KGgo=",
+    );
+  });
+
+  test("scheme detection is case-insensitive", () => {
+    expect(encodeAssetPath("HTTPS://example.com/foo.png")).toBe(
+      "HTTPS://example.com/foo.png",
+    );
+    expect(encodeAssetPath("Asset://x.png")).toBe("Asset://x.png");
+  });
+
+  test("does NOT misdetect a leading-colon-less path with a colon mid-segment", () => {
+    // `:` mid-filename should encode; the scheme regex needs an
+    // alphabetic first char before the colon.
+    expect(encodeAssetPath("file:notascheme/x.png")).toBe(
+      // matches scheme regex because `file` is a valid scheme name
+      "file:notascheme/x.png",
+    );
+    expect(encodeAssetPath("9file:bad.png")).toBe("9file%3Abad.png");
+  });
+
+  test("empty string returns empty string", () => {
+    expect(encodeAssetPath("")).toBe("");
+  });
+});

--- a/packages/stagebook/src/utils/encodeAssetPath.ts
+++ b/packages/stagebook/src/utils/encodeAssetPath.ts
@@ -1,0 +1,30 @@
+/**
+ * Percent-encode a researcher-authored asset path's segments so it's
+ * safe to concatenate with a host's already-encoded base URL.
+ *
+ * Researchers write filesystem-style paths in YAML (`file: my pic.jpg`)
+ * and in markdown image refs (`![](images/round#3.png)`). Those paths
+ * may contain spaces, `?`, `#`, `+`, non-ASCII — all valid in filenames
+ * but URI-special otherwise. The host's `getAssetURL` is contracted to
+ * concatenate with its already-encoded base without re-encoding (see
+ * the `getAssetURL` docstring on `StagebookProvider`), so encoding has
+ * to happen at the caller before we hand the path over.
+ *
+ * Per-segment `encodeURIComponent` (rather than `encodeURI` on the
+ * whole path) catches `?`, `#`, `&`, `+`, `:`, while preserving `/`
+ * separators. See #431 (markdown image refs) and #433 (YAML file
+ * fields) for the bugs this prevents.
+ *
+ * Paths that already look like an absolute URI (anything with a
+ * scheme prefix like `http://`, `https://`, `asset://`, `data:`) are
+ * returned as-is — encoding would corrupt the scheme delimiters.
+ */
+export function encodeAssetPath(path: string): string {
+  // Scheme detector: an ASCII letter followed by alphanumerics / `+.-`,
+  // terminated by `:`. Covers every IANA-registered URI scheme plus
+  // stagebook's `asset://` convention. Case-insensitive per RFC 3986.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(path)) {
+    return path;
+  }
+  return path.split("/").map(encodeURIComponent).join("/");
+}


### PR DESCRIPTION
Closes #433.

Symmetric companion to #431. That PR fixed markdown image refs (\`![](path)\`); this one fixes the direct YAML \`file:\` fields. Same root cause — researcher-authored paths reaching \`getAssetURL\` un-encoded — and the same fix shape (per-segment \`encodeURIComponent\` before resolve).

## Approach

Extracted the encoding logic from Markdown.tsx into a shared helper:

- \`packages/stagebook/src/utils/encodeAssetPath.ts\` — per-segment \`encodeURIComponent\`, skipping anything that looks like an absolute URI (\`http://\`, \`https://\`, \`asset://\`, \`data:\`, etc. via the RFC 3986 scheme regex \`^[a-z][a-z0-9+.-]*:\`)
- 16 unit tests pinning the helper's behavior

Then applied the helper at the 4 affected Element.tsx call sites:

- \`image\` element (line 205)
- \`audio\` element (line 151)
- \`mediaPlayer\` URL (line 305)
- \`mediaPlayer\` captionsURL (line 314)

The \`prompt\` element passes \`getAssetURL\` to Prompt as its \`resolveURL\` prop, which Prompt then forwards to Markdown — so prompt-body image refs go through the same encoding without needing a separate call site fix.

Markdown.tsx was refactored to use the helper too, replacing its inline encoding.

## Bonus from the refactor

Markdown image refs using \`asset://\` (e.g. \`![](asset://diagrams/flow.png)\`) were silently broken before. The inline encoding mangled the scheme delimiters into \`%3A%2F%2F\`, then the resulting string failed the \`http(s)?://\` / \`data:\` rejection check and silently fell back to the original path — which the host then couldn't resolve. The new helper passes \`asset://\` through unchanged, and the path reaches the host's \`asset://\` handler intact.

Latent bug, now fixed for free.

## Test plan

- [x] 16 helper unit tests cover: plain ASCII, spaces, \`?\`, \`#\`, \`+\`, \`&\`, non-ASCII (UTF-8), \`/\` preservation, all common URI schemes, scheme-detection edge cases, non-idempotency disclaimer
- [x] 2 new Element.ct.tsx integration tests: image with space in YAML path encodes correctly; image with \`asset://\` scheme passes through unchanged
- [x] All 7 #431 markdown regression tests still pass against the refactored markdown path
- [x] Vitest: 1076/1076 (was 1060, +16 from the new helper tests)
- [x] Chromium CT: 567/568 (1 pre-existing parallel-load flake on Prompt MC shuffle, passes in isolation)
- [x] WebKit CT: 566/568 (2 pre-existing flakes, both pass in isolation)
- [x] Firefox CT: 568/568

🤖 Generated with [Claude Code](https://claude.com/claude-code)