### PR TITLE
Gallery: radio + checkbox horizontal-layout demos

### DIFF
--- a/examples/component-gallery/component-gallery.stagebook.yaml
+++ b/examples/component-gallery/component-gallery.stagebook.yaml
@@ -60,6 +60,18 @@ treatments:
             file: prompts/radio_demo.prompt.md
           - type: submitButton
 
+      - name: radio_group_horizontal
+        duration: 600
+        notes: |
+          RadioGroup — horizontal variant. Add `layout: horizontal` to
+          the frontmatter to render options side-by-side. Sweet spot:
+          3–7 short labels (Likert scales, traffic-light codes).
+          Defaults to `vertical`.
+        elements:
+          - type: prompt
+            file: prompts/radio_horizontal_demo.prompt.md
+          - type: submitButton
+
       - name: checkbox_group
         duration: 600
         notes: |
@@ -73,6 +85,17 @@ treatments:
           - type: prompt
             name: checkbox_demo
             file: prompts/checkbox_demo.prompt.md
+          - type: submitButton
+
+      - name: checkbox_group_horizontal
+        duration: 600
+        notes: |
+          CheckboxGroup — horizontal variant. Same `layout: horizontal`
+          knob as the radio variant. Wraps onto multiple rows if the
+          options overflow the container width.
+        elements:
+          - type: prompt
+            file: prompts/checkbox_horizontal_demo.prompt.md
           - type: submitButton
 
       - name: select

--- a/examples/component-gallery/prompts/checkbox_horizontal_demo.prompt.md
+++ b/examples/component-gallery/prompts/checkbox_horizontal_demo.prompt.md
@@ -1,0 +1,21 @@
+---
+type: multipleChoice
+name: checkbox_horizontal_demo
+select: multiple
+layout: horizontal
+---
+
+# Which weekdays work for the next session?
+
+Same `layout: horizontal` knob as the radio variant — flips the
+options from a vertical column to a wrapping horizontal row. Right
+for short tag-like labels (day names, traffic-light codes, single-
+character ratings). Pick all that apply.
+
+---
+
+- Mon
+- Tue
+- Wed
+- Thu
+- Fri

--- a/examples/component-gallery/prompts/radio_horizontal_demo.prompt.md
+++ b/examples/component-gallery/prompts/radio_horizontal_demo.prompt.md
@@ -1,0 +1,23 @@
+---
+type: multipleChoice
+name: radio_horizontal_demo
+layout: horizontal
+---
+
+# How strongly do you agree with the following statement?
+
+> "Component galleries make better measurement instruments."
+
+Setting `layout: horizontal` in the frontmatter renders the options
+side-by-side instead of stacked. The right shape for Likert-style
+scales (3–7 short labels read left-to-right). For options that need
+to wrap to multiple lines or vary in length, stick with the default
+vertical layout.
+
+---
+
+- Strongly disagree
+- Disagree
+- Neutral
+- Agree
+- Strongly agree


### PR DESCRIPTION
Adds two new stages to the component gallery that demonstrate \`layout: horizontal\` on \`multipleChoice\` prompts:

- **\`radio_group_horizontal\`** — Likert scale (Strongly disagree → Strongly agree). Shows the canonical \"3-7 short labels read left-to-right\" use case that horizontal layout exists for.
- **\`checkbox_group_horizontal\`** — weekday picker. Demonstrates that \`layout: horizontal\` works with \`select: multiple\` and wraps to multiple rows when options overflow the container.

Each demo prompt's body inlines guidance on when horizontal fits vs. the default vertical (short labels read left-to-right vs. variable-length options that need their own row).

## What this isn't

Examples-only. No production code change. The \`layout\` field on \`multipleChoice\` has been in the schema since the RadioGroup/CheckboxGroup polish landed; this PR just surfaces it in the gallery so authors can see the option exists and copy the syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)