### PR TITLE
Bump stagebook to 0.10.13

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.10.12",
+  "version": "0.10.13",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Patch release picking up three asset-URL handling fixes.

## What's in

- **#430 (closes #424)** — Pre-flight HEAD request detects missing \`Accept-Ranges\` on every engine. The existing seekable-based detection only fired on Chrome; Firefox and Linux WebKit silently lied about \`seekable=[0,duration]\`, so researchers got zero diagnostic for a real server misconfig and participants saw broken seeks. Now: HEAD response headers are inspected on mount, warning fires across all engines. CORS-failure-safe (falls through to existing detection).
- **#432 (closes #431)** — Markdown image refs (\`![](path)\`) encode correctly across browsers. The previous \`encodeURI(resolved)\` re-encoded \`%XX\` sequences in the host's already-encoded base — VS Code preview broke every markdown image. New approach encodes the markdown source path before resolve, leaving the host base intact. Also fixes \`?\`, \`#\`, \`+\`, non-ASCII filenames.
- **#434 (closes #433)** — Direct YAML \`file:\` fields on \`image\`, \`audio\`, and \`mediaPlayer\` (URL + captions) elements now URL-encode the same way as markdown image refs. Bonus from the refactor: a new shared \`encodeAssetPath\` helper fixes a latent bug where markdown \`asset://\` image refs silently failed.

## Compatibility

- No API changes.
- New \`getAssetURL\` contract clarification (already documented in StagebookProvider): callers pass URL-safe input; hosts should concatenate with their base without re-encoding. Every in-repo host already follows this. Cross-host implication: hosts that did their own internal encoding on top of stagebook input would double-encode going forward; none in this repo did.
- The new pre-flight HEAD request adds one network round-trip per \`<MediaPlayer>\` mount. Negligible — headers only, no body, CORS-failure-safe.