### PR TITLE
Add stagebook validate CLI + discoverability docs (closes #439)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,47 @@
+## Treatment authoring
+
+After editing any `.stagebook.yaml` or `.prompt.md` file, validate it before reporting the task as done:
+
+```bash
+npx --package=stagebook stagebook validate <file>
+```
+
+Resolve all errors. The CLI dispatches by suffix (`.stagebook.yaml` → treatment validator, `.prompt.md` → prompt validator), expands templates and resolves `imports:` by default, and exits non-zero on errors.
+
+For machine-readable output:
+
+```bash
+npx --package=stagebook stagebook validate --format=json <file>
+```
+
+JSON shape (one entry per file with any diagnostics):
+
+```json
+{
+  "files": [
+    {
+      "path": "study.stagebook.yaml",
+      "diagnostics": [
+        {
+          "severity": "error",
+          "message": "Game-stage conditions must use a cross-client position prefix…",
+          "range": {
+            "startLine": 353,
+            "startCol": 14,
+            "endLine": 353,
+            "endCol": 18
+          }
+        }
+      ]
+    }
+  ],
+  "unreadable": [],
+  "summary": { "errors": 1, "warnings": 0, "files": 1 }
+}
+```
+
+Positions in JSON are 0-based (LSP convention); the text output formats them 1-based for editor jump-to-location. Exit codes: `0` clean, `1` errors, `2` couldn't read / unparseable / glob matched zero files. Use `--no-expand` to skip template expansion when you want to check raw syntax only, and `-` (with `--type=treatment|prompt`) to read from stdin.
+
 ## Workflow
 
 ### TDD (Red/Green/Refactor)
@@ -120,5 +164,7 @@ stagebook/                          # workspace root
 
 - `stagebook` — schemas, utils, templates (no React dependency)
 - `stagebook/components` — React components, StagebookProvider (peer-depends on React)
+- `stagebook/validate` — `validateTreatmentSource`, `validatePromptSource`, `loadAndMergeImports`, `expandAndValidateWithImports`, `Diagnostic` type, and position-mapping helpers. Used by the VS Code extension, the viewer, and the CLI; consumed externally by manager / deliberation-lab / annotator
+- `stagebook` bin — the `stagebook` CLI (subcommands: `validate`). Reached via `npx --package=stagebook stagebook <cmd>` in study repos that don't otherwise have a JS toolchain
 
 Each directory has an `index.ts` barrel; `src/index.ts` re-exports the full public API for the main entrypoint.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,35 @@ Peer dependencies: `zod >= 3.23`, `js-yaml >= 4`. React components additionally 
 
 ## Usage
 
-### Validating a treatment file
+### Validating treatment + prompt files from the command line
+
+The fastest way to check a file is the bundled CLI, which works in any directory — even study repos that have no JS toolchain at all (Node is the only requirement):
+
+```bash
+# One file
+npx --package=stagebook stagebook validate study.stagebook.yaml
+
+# Mixed inputs (treatments + prompts) + globs
+npx --package=stagebook stagebook validate \
+  'stagebook/**/*.stagebook.yaml' prompts/intro.prompt.md
+
+# Stdin (for agents validating buffered content before writing)
+cat study.stagebook.yaml | \
+  npx --package=stagebook stagebook validate --type=treatment -
+
+# Machine-readable for CI / agents
+npx --package=stagebook stagebook validate --format=json study.stagebook.yaml
+```
+
+Default is **expand-and-validate**: the validator expands templates + resolves `imports:` before checking the schema, so errors that only appear after template substitution are caught. `--no-expand` skips that for faster pre-expansion checks.
+
+Exit codes: `0` clean (warnings OK), `1` schema errors, `2` couldn't read a file / YAML unparseable / glob matched nothing (use `--allow-empty` to opt out of the last).
+
+Diagnostics match what the [VS Code extension](apps/vscode/) shows in its Problems panel — same text, positions, severities — so an editor user and a CI bot see the same errors.
+
+### Validating from TypeScript
+
+For programmatic access (e.g. building tooling), import the validators directly:
 
 ```typescript
 import { treatmentFileSchema } from "stagebook";
@@ -40,6 +68,21 @@ const result = treatmentFileSchema.safeParse(config);
 
 if (!result.success) {
   console.error(result.error.issues);
+}
+```
+
+For rich diagnostics with source positions (the format used by the editor and CLI), import from the `validate` subpath:
+
+```typescript
+import {
+  validateTreatmentSource,
+  validatePromptSource,
+  type Diagnostic,
+} from "stagebook/validate";
+
+const { diagnostics } = validateTreatmentSource(yamlString);
+for (const d of diagnostics) {
+  console.log(`${d.severity}: ${d.message} (line ${d.range?.startLine})`);
 }
 ```
 
@@ -139,11 +182,11 @@ All schemas export corresponding TypeScript types (e.g., `TreatmentType`, `Stage
 
 ### Templates
 
-| Export                                          | Description                                                        |
-| ----------------------------------------------- | ------------------------------------------------------------------ |
-| `fillTemplates({ obj, templates })`             | Expand all template references and validate no placeholders remain |
-| `expandTemplate({ templates, context })`        | Expand a single template context with fields and broadcast         |
-| `substituteFields({ content, fields })`         | Replace `${key}` placeholders with values                          |
+| Export                                   | Description                                                        |
+| ---------------------------------------- | ------------------------------------------------------------------ |
+| `fillTemplates({ obj, templates })`      | Expand all template references and validate no placeholders remain |
+| `expandTemplate({ templates, context })` | Expand a single template context with fields and broadcast         |
+| `substituteFields({ content, fields })`  | Replace `${key}` placeholders with values                          |
 
 ## Documentation
 

--- a/docs/researcher/treatment-files.md
+++ b/docs/researcher/treatment-files.md
@@ -7,10 +7,10 @@ A treatment file is a YAML document (`.stagebook.yaml`) that defines the complet
 A Stagebook file may have any subset of these top-level sections:
 
 ```yaml
-imports:         # optional — relative paths to other Stagebook files whose templates: should be merged in
-templates:       # optional — reusable blocks of structure
-introSequences:  # used as the entry point — pre-randomization onboarding steps
-treatments:      # used as the entry point — post-randomization experiment flows
+imports: # optional — relative paths to other Stagebook files whose templates: should be merged in
+templates: # optional — reusable blocks of structure
+introSequences: # used as the entry point — pre-randomization onboarding steps
+treatments: # used as the entry point — post-randomization experiment flows
 ```
 
 A file with `treatments:` is a study **entry point** the runtime can launch. A file with only `templates:` (and optionally `imports:`) is a **module** — it can't be launched directly, but other files can `imports:` it to reuse its templates. The same file can play either role; there is no separate file type or extension.
@@ -40,7 +40,7 @@ treatments:
       - name: intro
         duration: 60
         elements:
-          - template: tipi_questions   # defined in surveys/tipi/tipi.stagebook.yaml
+          - template: tipi_questions # defined in surveys/tipi/tipi.stagebook.yaml
           - template: extra_local_template
 ```
 
@@ -125,13 +125,13 @@ treatments:
 
 Each game stage has:
 
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `name` | string | yes | Identifier for logging (not shown to participants) |
-| `duration` | integer | yes | Stage length in seconds |
-| `discussion` | object | no | Video/text chat configuration (see [Discussions](discussions.md)) |
-| `elements` | array | yes | UI elements displayed during the stage |
-| `notes` | string | no | Researcher-facing rationale, citations, or design decisions (see [Notes](#notes)) |
+| Field        | Type    | Required | Description                                                                       |
+| ------------ | ------- | -------- | --------------------------------------------------------------------------------- |
+| `name`       | string  | yes      | Identifier for logging (not shown to participants)                                |
+| `duration`   | integer | yes      | Stage length in seconds                                                           |
+| `discussion` | object  | no       | Video/text chat configuration (see [Discussions](discussions.md))                 |
+| `elements`   | array   | yes      | UI elements displayed during the stage                                            |
+| `notes`      | string  | no       | Researcher-facing rationale, citations, or design decisions (see [Notes](#notes)) |
 
 Intro and exit steps have `name` and `elements` but no `duration` (they are untimed).
 
@@ -230,7 +230,7 @@ The file lives in the treatment's own directory (or a sibling directory like `sh
   file: asset://group_recordings/session_001.mp4
 ```
 
-`asset://path/to/file` means *the platform will resolve this*. Stagebook passes the URI through `getAssetURL()`, and each host (annotator, viewer, VS Code extension) implements its own resolution strategy. `asset://` references are explicitly excluded from `getReferencedAssets()` — they aren't repo files.
+`asset://path/to/file` means _the platform will resolve this_. Stagebook passes the URI through `getAssetURL()`, and each host (annotator, viewer, VS Code extension) implements its own resolution strategy. `asset://` references are explicitly excluded from `getReferencedAssets()` — they aren't repo files.
 
 Use `asset://` for:
 
@@ -241,7 +241,7 @@ Use `asset://` for:
 
 ### `${field}` placeholders — per-task variable media
 
-Distinct from `asset://`: use a field when the asset *varies from task to task*.
+Distinct from `asset://`: use a field when the asset _varies from task to task_.
 
 ```yaml
 - type: mediaPlayer
@@ -255,15 +255,111 @@ The task definition supplies the value at creation time. The value itself can be
 ### Choosing between the three
 
 | Asset is the same every task? | Asset is in the repo? | Reference form |
-|---|---|---|
-| yes | yes | relative path |
-| yes | no — public URL | full URL |
-| yes | no — host storage | `asset://…` |
-| no (varies per task) | — | `${fieldName}` |
+| ----------------------------- | --------------------- | -------------- |
+| yes                           | yes                   | relative path  |
+| yes                           | no — public URL       | full URL       |
+| yes                           | no — host storage     | `asset://…`    |
+| no (varies per task)          | —                     | `${fieldName}` |
 
 ## Naming Rules
 
 Names (for stages, elements, treatments, etc.) must be:
+
 - 1 to 64 characters
 - Letters, numbers, spaces, `_`, `-`
 - May include template placeholders like `${fieldName}`
+
+## Validating
+
+The same validator the VS Code extension uses is available as a CLI you can run on any treatment or prompt file. It works without an `npm install` in your study repo — `npx` fetches the package on demand:
+
+```bash
+npx --package=stagebook stagebook validate study.stagebook.yaml
+```
+
+Dispatches by suffix: `.stagebook.yaml` → treatment validator, `.prompt.md` → prompt validator. Multiple files and globs both work:
+
+```bash
+npx --package=stagebook stagebook validate \
+  'stagebook/**/*.stagebook.yaml' \
+  'prompts/**/*.prompt.md'
+```
+
+### Flags
+
+| Flag                       | Effect                                                              |
+| -------------------------- | ------------------------------------------------------------------- |
+| `--format=json`            | Machine-readable output (see schema below)                          |
+| `--type=treatment\|prompt` | Required when reading from stdin (`-`)                              |
+| `--no-expand`              | Skip template expansion + import resolution; checks raw syntax only |
+| `--allow-empty`            | Exit 0 when a glob matches no files (default: exit 2)               |
+| `-h, --help`               | Print usage                                                         |
+
+### Exit codes
+
+| Code | Meaning                                                                     |
+| ---- | --------------------------------------------------------------------------- |
+| `0`  | No errors (warnings OK, or nothing to report)                               |
+| `1`  | At least one error in at least one file                                     |
+| `2`  | A file couldn't be read, YAML was unparseable, or a glob matched zero files |
+
+### JSON output schema
+
+```json
+{
+  "files": [
+    {
+      "path": "study.stagebook.yaml",
+      "diagnostics": [
+        {
+          "severity": "error",
+          "message": "Game-stage conditions must use a cross-client position prefix…",
+          "range": {
+            "startLine": 353,
+            "startCol": 14,
+            "endLine": 353,
+            "endCol": 18
+          }
+        }
+      ]
+    }
+  ],
+  "unreadable": [
+    { "path": "missing.stagebook.yaml", "message": "could not read: ENOENT…" }
+  ],
+  "summary": { "errors": 1, "warnings": 0, "files": 1 }
+}
+```
+
+Positions are **0-based** in JSON (LSP convention; same shape as the `Diagnostic` type exported from `stagebook/validate`). The default text output formats positions as **1-based** for editor jump-to-location.
+
+### Pre-commit hook in study repos
+
+If your study repo uses pre-commit hooks, add a stagebook-validate step. For [pre-commit](https://pre-commit.com):
+
+```yaml
+- repo: local
+  hooks:
+    - id: stagebook-validate
+      name: Validate Stagebook files
+      entry: npx --package=stagebook stagebook validate
+      language: system
+      files: '\.(stagebook\.yaml|prompt\.md)$'
+      pass_filenames: true
+```
+
+### Adding the agent-facing instruction to your study repo
+
+If your repo has a `CLAUDE.md` (or any agent-instruction file), add this block so agents validate their own work before declaring a task done:
+
+> ## Treatment authoring
+>
+> After editing any `.stagebook.yaml` or `.prompt.md` file, run:
+>
+> ```bash
+> npx --package=stagebook stagebook validate <file>
+> ```
+>
+> Resolve all errors. For machine-readable output use `--format=json`; the JSON schema is documented [here](https://github.com/deliberation-lab/stagebook/blob/main/docs/researcher/treatment-files.md#json-output-schema). Exit codes: `0` clean, `1` schema errors, `2` couldn't read.
+
+Without this hook agents can edit treatment files but have no way to check their own work — the only signal that something is wrong reaches them after you open VS Code, read the Problems panel, and paste the error back.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10591,7 +10591,6 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -10608,7 +10607,6 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -10626,7 +10624,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -13403,6 +13400,7 @@
         "js-yaml": "^4.1.0",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
+        "tinyglobby": "^0.2.16",
         "yaml": "^2.8.3"
       },
       "devDependencies": {

--- a/packages/stagebook/bin/stagebook.js
+++ b/packages/stagebook/bin/stagebook.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Thin dispatcher for the stagebook CLI. The actual command lives in
+// dist/cli/validate.js as a `run({argv, stdin, stdout, stderr})` function;
+// this wrapper exists so the bin entry can stay JS (no transpile step at
+// install time) while keeping the shebang.
+//
+// `npx --package=stagebook stagebook validate ...` resolves the bin via
+// the package's "bin" field, which points here.
+
+const subcommand = process.argv[2];
+
+if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+  process.stderr.write(
+    "Usage: stagebook <command> [options]\n\n" +
+      "Commands:\n" +
+      "  validate   Validate treatment (.stagebook.yaml) and prompt (.prompt.md) files\n" +
+      "\nRun 'stagebook <command> --help' for command-specific options.\n",
+  );
+  process.exit(subcommand ? 0 : 2);
+}
+
+if (subcommand === "validate") {
+  import("../dist/cli/validate.js")
+    .then(({ run }) =>
+      run({
+        argv: process.argv.slice(3),
+        stdin: process.stdin,
+        stdout: process.stdout,
+        stderr: process.stderr,
+      }),
+    )
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      process.stderr.write(
+        `stagebook validate: unexpected error: ${err && err.stack ? err.stack : err}\n`,
+      );
+      process.exit(2);
+    });
+} else {
+  process.stderr.write(`stagebook: unknown command '${subcommand}'.\n`);
+  process.stderr.write("Available commands: validate\n");
+  process.exit(2);
+}

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -42,9 +42,13 @@
   },
   "files": [
     "dist",
+    "bin",
     "src/styles.css",
     "src/host-typography.css"
   ],
+  "bin": {
+    "stagebook": "./bin/stagebook.js"
+  },
   "scripts": {
     "build": "tsup",
     "build:watch": "tsup --watch",
@@ -62,6 +66,7 @@
     "js-yaml": "^4.1.0",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
+    "tinyglobby": "^0.2.16",
     "yaml": "^2.8.3"
   },
   "peerDependencies": {
@@ -93,10 +98,10 @@
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
     "tsup": "^8.0.0",
-    "yaml": "^2.8.3",
     "typescript": "^5.5.0",
     "typescript-eslint": "^8.0.0",
     "vitest": "^2.0.0",
+    "yaml": "^2.8.3",
     "zod": "^3.23.0"
   },
   "repository": {

--- a/packages/stagebook/src/cli/validate.test.ts
+++ b/packages/stagebook/src/cli/validate.test.ts
@@ -282,10 +282,87 @@ describe("stagebook validate CLI", () => {
   });
 
   describe("--help", () => {
-    it("exits 0 and writes usage to stdout", async () => {
+    it("exits 0 and writes usage to stdout for --help", async () => {
       const r = await runCli(["--help"]);
       expect(r.code).toBe(0);
       expect(r.stdout).toContain("Usage: stagebook validate");
+    });
+
+    it("exits 0 and writes usage to stdout for -h short flag", async () => {
+      const r = await runCli(["-h"]);
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain("Usage: stagebook validate");
+    });
+  });
+
+  describe("argv parsing", () => {
+    it("exits 2 and writes USAGE on unknown flag", async () => {
+      const r = await runCli(["--bogus", join(tmp, "valid.stagebook.yaml")]);
+      expect(r.code).toBe(2);
+      expect(r.stderr).toContain("Error:");
+      expect(r.stderr).toContain("Usage: stagebook validate");
+    });
+  });
+
+  describe("template expansion failures", () => {
+    it("surfaces expansion errors as their own diagnostic, distinct from schema errors", async () => {
+      // A treatment with `imports:` pointing at a missing file fails
+      // expansion (loadImport throws → expandTreatmentSourceWithImports
+      // sets expanded.error). This exercises the synthesized
+      // "Template expansion failed:" diagnostic in validate.ts.
+      const treatment = `imports:
+  - ./nonexistent-import.stagebook.yaml
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: s
+        duration: 10
+        elements:
+          - type: submitButton
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+`;
+      const file = join(tmp, "missing-import.stagebook.yaml");
+      await writeFile(file, treatment);
+      const r = await runCli([file]);
+      expect(r.code).toBe(1);
+      expect(r.stdout).toContain("Template expansion failed");
+    });
+  });
+
+  describe("terminal-control sanitisation", () => {
+    it("strips ANSI / control chars from text-mode output", async () => {
+      // A YAML key containing a terminal-clear sequence would otherwise
+      // reach the researcher's terminal raw. Validator embeds the key
+      // verbatim in "Unrecognized key '<key>'" messages.
+      const evil = `treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: s
+        duration: 10
+        "evil\\u001b[2J\\u001b[Hkey": bad
+        elements:
+          - type: submitButton
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+`;
+      const file = join(tmp, "evil.stagebook.yaml");
+      await writeFile(file, evil);
+      const r = await runCli([file]);
+      // Whatever the validator does with the key, the CLI must not emit
+      // raw ESC (\x1b) into stdout. We don't assert anything about JSON
+      // since JSON.stringify already escapes control chars.
+      expect(r.stdout).not.toMatch(/\x1b/);
     });
   });
 

--- a/packages/stagebook/src/cli/validate.test.ts
+++ b/packages/stagebook/src/cli/validate.test.ts
@@ -1,0 +1,315 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { Readable, Writable } from "node:stream";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { run } from "./validate.js";
+
+interface CapturedRun {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+async function runCli(
+  argv: string[],
+  options: { stdin?: string; cwd?: string } = {},
+): Promise<CapturedRun> {
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+  const stdout = new Writable({
+    write(chunk: Buffer, _enc, cb) {
+      stdoutChunks.push(chunk.toString());
+      cb();
+    },
+  });
+  const stderr = new Writable({
+    write(chunk: Buffer, _enc, cb) {
+      stderrChunks.push(chunk.toString());
+      cb();
+    },
+  });
+  const stdin = Readable.from(options.stdin ?? "");
+  const code = await run({ argv, stdin, stdout, stderr, cwd: options.cwd });
+  return {
+    code,
+    stdout: stdoutChunks.join(""),
+    stderr: stderrChunks.join(""),
+  };
+}
+
+let tmp: string;
+
+const MINIMAL_TREATMENT = `treatments:
+  - name: t1
+    playerCount: 1
+    gameStages:
+      - name: s1
+        duration: 10
+        elements:
+          - type: submitButton
+introSequences:
+  - name: i1
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+`;
+
+const TREATMENT_WITH_SCHEMA_ERROR = `treatments:
+  - name: t1
+    playerCount: 1
+    gameStages:
+      - name: s1
+        duration: 10
+        elements:
+          - type: bogusElementType
+introSequences:
+  - name: i1
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+`;
+
+const VALID_PROMPT = `---
+type: noResponse
+---
+# Welcome
+Some markdown body.
+`;
+
+const PROMPT_WITH_BAD_TYPE = `---
+type: prompt
+---
+# Welcome
+Body.
+`;
+
+beforeAll(async () => {
+  tmp = await mkdtemp(join(tmpdir(), "stagebook-cli-"));
+  await writeFile(join(tmp, "valid.stagebook.yaml"), MINIMAL_TREATMENT);
+  await writeFile(join(tmp, "bad.stagebook.yaml"), TREATMENT_WITH_SCHEMA_ERROR);
+  await writeFile(join(tmp, "good.prompt.md"), VALID_PROMPT);
+  await writeFile(join(tmp, "bad.prompt.md"), PROMPT_WITH_BAD_TYPE);
+  await writeFile(join(tmp, "unknown.txt"), "hello");
+});
+
+afterAll(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+describe("stagebook validate CLI", () => {
+  describe("exit codes", () => {
+    it("exits 0 for a clean treatment file", async () => {
+      const r = await runCli([join(tmp, "valid.stagebook.yaml")]);
+      expect(r.code).toBe(0);
+      expect(r.stdout).toBe("");
+    });
+
+    it("exits 0 for a clean prompt file", async () => {
+      const r = await runCli([join(tmp, "good.prompt.md")]);
+      expect(r.code).toBe(0);
+      expect(r.stdout).toBe("");
+    });
+
+    it("exits 1 when a file has schema errors", async () => {
+      const r = await runCli([join(tmp, "bad.stagebook.yaml")]);
+      expect(r.code).toBe(1);
+      expect(r.stdout).toContain("error:");
+    });
+
+    it("exits 1 for a prompt with wrong type", async () => {
+      const r = await runCli([join(tmp, "bad.prompt.md")]);
+      expect(r.code).toBe(1);
+      expect(r.stdout).toContain("error:");
+    });
+
+    it("exits 2 when a literal file path doesn't exist", async () => {
+      const r = await runCli([join(tmp, "does-not-exist.stagebook.yaml")]);
+      expect(r.code).toBe(2);
+      expect(r.stdout).toContain("could not read");
+    });
+
+    it("exits 2 for unknown file suffix", async () => {
+      const r = await runCli([join(tmp, "unknown.txt")]);
+      expect(r.code).toBe(2);
+      expect(r.stdout).toContain("unknown file type");
+    });
+
+    it("exits 2 when no inputs are given", async () => {
+      const r = await runCli([]);
+      expect(r.code).toBe(2);
+      expect(r.stderr).toContain("no file paths");
+    });
+
+    it("exits 2 when --format is invalid", async () => {
+      const r = await runCli([
+        "--format=xml",
+        join(tmp, "valid.stagebook.yaml"),
+      ]);
+      expect(r.code).toBe(2);
+      expect(r.stderr).toContain("must be 'text' or 'json'");
+    });
+
+    it("exits 2 when a glob matches zero files", async () => {
+      const r = await runCli(["nothing-here-*.stagebook.yaml"], { cwd: tmp });
+      expect(r.code).toBe(2);
+      expect(r.stderr).toContain("matched no files");
+    });
+
+    it("exits 0 when --allow-empty is set and a glob matches zero files", async () => {
+      const r = await runCli(
+        ["--allow-empty", "nothing-here-*.stagebook.yaml"],
+        { cwd: tmp },
+      );
+      expect(r.code).toBe(0);
+    });
+  });
+
+  describe("text output", () => {
+    it("formats one diagnostic per line with 1-based line:col", async () => {
+      const r = await runCli([join(tmp, "bad.stagebook.yaml")]);
+      // Each diagnostic line should match path:line:col: severity: message
+      const lines = r.stdout.split("\n").filter((l) => l.includes(": error:"));
+      expect(lines.length).toBeGreaterThan(0);
+      for (const line of lines) {
+        expect(line).toMatch(/.+:\d+:\d+: error: /);
+      }
+    });
+
+    it("emits a per-run summary line", async () => {
+      const r = await runCli([join(tmp, "bad.stagebook.yaml")]);
+      expect(r.stdout).toMatch(/\d+ errors? in \d+ files?\./);
+    });
+  });
+
+  describe("JSON output", () => {
+    it("emits a parseable JSON object with files + summary + unreadable", async () => {
+      const r = await runCli([
+        "--format=json",
+        join(tmp, "bad.stagebook.yaml"),
+      ]);
+      expect(r.code).toBe(1);
+      const parsed = JSON.parse(r.stdout) as {
+        files: { path: string; diagnostics: unknown[] }[];
+        unreadable: { path: string; message: string }[];
+        summary: { errors: number; warnings: number; files: number };
+      };
+      expect(parsed.summary.errors).toBeGreaterThan(0);
+      expect(parsed.files).toHaveLength(1);
+      expect(parsed.files[0].diagnostics.length).toBeGreaterThan(0);
+      expect(parsed.unreadable).toEqual([]);
+    });
+
+    it("uses 0-based positions in JSON (matches Diagnostic shape)", async () => {
+      const r = await runCli([
+        "--format=json",
+        join(tmp, "bad.stagebook.yaml"),
+      ]);
+      const parsed = JSON.parse(r.stdout) as {
+        files: {
+          diagnostics: {
+            range: { startLine: number; startCol: number } | null;
+          }[];
+        }[];
+      };
+      const firstWithRange = parsed.files[0].diagnostics.find(
+        (d) => d.range !== null,
+      );
+      expect(firstWithRange?.range?.startLine).toBeGreaterThanOrEqual(0);
+    });
+
+    it("emits unreadable entries in their own list, not under files", async () => {
+      const r = await runCli([
+        "--format=json",
+        join(tmp, "does-not-exist.stagebook.yaml"),
+      ]);
+      expect(r.code).toBe(2);
+      const parsed = JSON.parse(r.stdout) as {
+        files: unknown[];
+        unreadable: { path: string; message: string }[];
+        summary: { errors: number };
+      };
+      expect(parsed.files).toEqual([]);
+      expect(parsed.unreadable).toHaveLength(1);
+      expect(parsed.unreadable[0].message).toContain("could not read");
+      expect(parsed.summary.errors).toBe(1);
+    });
+  });
+
+  describe("stdin", () => {
+    it("validates treatment YAML from stdin with --type=treatment", async () => {
+      const r = await runCli(["--type=treatment", "-"], {
+        stdin: MINIMAL_TREATMENT,
+      });
+      expect(r.code).toBe(0);
+    });
+
+    it("validates prompt markdown from stdin with --type=prompt", async () => {
+      const r = await runCli(["--type=prompt", "-"], { stdin: VALID_PROMPT });
+      expect(r.code).toBe(0);
+    });
+
+    it("surfaces schema errors from stdin", async () => {
+      const r = await runCli(["--type=treatment", "-"], {
+        stdin: TREATMENT_WITH_SCHEMA_ERROR,
+      });
+      expect(r.code).toBe(1);
+      expect(r.stdout).toContain("<stdin>:");
+    });
+
+    it("rejects stdin without --type", async () => {
+      const r = await runCli(["-"], { stdin: MINIMAL_TREATMENT });
+      expect(r.code).toBe(2);
+      expect(r.stderr).toContain("--type=treatment or --type=prompt");
+    });
+  });
+
+  describe("multiple inputs", () => {
+    it("groups output by file and surfaces errors from any", async () => {
+      const r = await runCli([
+        join(tmp, "valid.stagebook.yaml"),
+        join(tmp, "bad.stagebook.yaml"),
+        join(tmp, "good.prompt.md"),
+      ]);
+      expect(r.code).toBe(1);
+      expect(r.stdout).toContain("bad.stagebook.yaml:");
+      // valid + good produce no output (silent success)
+      expect(r.stdout).not.toContain("valid.stagebook.yaml:");
+      expect(r.stdout).not.toContain("good.prompt.md:");
+    });
+  });
+
+  describe("--help", () => {
+    it("exits 0 and writes usage to stdout", async () => {
+      const r = await runCli(["--help"]);
+      expect(r.code).toBe(0);
+      expect(r.stdout).toContain("Usage: stagebook validate");
+    });
+  });
+
+  describe("--no-expand", () => {
+    it("succeeds on a treatment that would fail expand-and-validate but passes raw schema", async () => {
+      // A treatment with an undefined template reference fails expansion
+      // but the raw schema accepts the template-reference shape.
+      const tplRefTreatment = `treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - template: missing_template
+introSequences:
+  - name: i
+    introSteps:
+      - template: missing_template
+`;
+      const file = join(tmp, "tpl-ref.stagebook.yaml");
+      await writeFile(file, tplRefTreatment);
+      const expanded = await runCli([file]);
+      const raw = await runCli(["--no-expand", file]);
+      // Expanded mode catches the missing template; raw mode doesn't try.
+      expect(expanded.code).toBe(1);
+      expect(raw.code).toBe(0);
+    });
+  });
+});

--- a/packages/stagebook/src/cli/validate.ts
+++ b/packages/stagebook/src/cli/validate.ts
@@ -1,0 +1,333 @@
+import { readFile } from "node:fs/promises";
+import { dirname, isAbsolute, resolve as resolvePath } from "node:path";
+import { parseArgs } from "node:util";
+import { text as readStream } from "node:stream/consumers";
+import { glob } from "tinyglobby";
+
+import type { Diagnostic } from "../validate/index.js";
+import {
+  validateTreatmentSource,
+  validatePromptSource,
+  expandAndValidateWithImports,
+} from "../validate/index.js";
+
+export type Format = "text" | "json";
+export type FileType = "treatment" | "prompt";
+
+export interface RunOptions {
+  argv: string[];
+  stdin: NodeJS.ReadableStream;
+  stdout: NodeJS.WritableStream;
+  stderr: NodeJS.WritableStream;
+  cwd?: string;
+}
+
+export interface FileResult {
+  path: string;
+  type: FileType;
+  diagnostics: Diagnostic[];
+  unreadable?: string;
+}
+
+const USAGE = `Usage: stagebook validate [options] <files...>
+
+Validate Stagebook treatment files (.stagebook.yaml) and prompt files
+(.prompt.md). Dispatches by suffix; for stdin, pass '-' and --type.
+
+Options:
+  --format=<text|json>   Output format. Default: text.
+  --type=<treatment|prompt>
+                         Required when reading from stdin ('-').
+  --no-expand            Skip template expansion + import resolution
+                         for treatment files. Catches fewer errors;
+                         default is expand-and-validate.
+  --allow-empty          Exit 0 when a glob matches no files instead
+                         of exit 2.
+  -h, --help             Print this message.
+
+Exit codes:
+  0   No errors (warnings OK, or nothing to report).
+  1   At least one error in at least one file.
+  2   A file couldn't be read, YAML was unparseable, a glob matched
+      zero files (override with --allow-empty), or argv was invalid.
+
+Examples:
+  stagebook validate study.stagebook.yaml prompt.prompt.md
+  stagebook validate 'stagebook/**/*.stagebook.yaml'
+  cat foo.stagebook.yaml | stagebook validate --type=treatment -
+  stagebook validate --format=json study.stagebook.yaml
+`;
+
+export async function run({
+  argv,
+  stdin,
+  stdout,
+  stderr,
+  cwd = process.cwd(),
+}: RunOptions): Promise<number> {
+  let parsed;
+  try {
+    parsed = parseArgs({
+      args: argv,
+      options: {
+        format: { type: "string", default: "text" },
+        type: { type: "string" },
+        "no-expand": { type: "boolean", default: false },
+        "allow-empty": { type: "boolean", default: false },
+        help: { type: "boolean", short: "h", default: false },
+      },
+      allowPositionals: true,
+      strict: true,
+    });
+  } catch (err) {
+    stderr.write(
+      `Error: ${err instanceof Error ? err.message : String(err)}\n\n`,
+    );
+    stderr.write(USAGE);
+    return 2;
+  }
+
+  const { values, positionals } = parsed;
+
+  if (values.help) {
+    stdout.write(USAGE);
+    return 0;
+  }
+  if (positionals.length === 0) {
+    stderr.write("Error: no file paths or stdin marker ('-') provided.\n\n");
+    stderr.write(USAGE);
+    return 2;
+  }
+
+  const format = values.format;
+  if (format !== "text" && format !== "json") {
+    stderr.write(
+      `Error: --format must be 'text' or 'json' (got '${String(format)}').\n`,
+    );
+    return 2;
+  }
+
+  // Expand globs (filesystem paths). Stdin ('-') and literal-path positionals
+  // are passed through; literal paths that don't exist surface as
+  // per-file "could not read" results so other inputs still validate.
+  const inputs: string[] = [];
+  for (const positional of positionals) {
+    if (positional === "-") {
+      inputs.push("-");
+      continue;
+    }
+    if (!hasGlobChars(positional)) {
+      inputs.push(positional);
+      continue;
+    }
+    const matched = await glob([positional], {
+      cwd,
+      onlyFiles: true,
+      dot: false,
+    });
+    if (matched.length === 0) {
+      if (values["allow-empty"]) continue;
+      stderr.write(
+        `Error: glob '${positional}' matched no files (override with --allow-empty).\n`,
+      );
+      return 2;
+    }
+    inputs.push(...matched);
+  }
+
+  if (inputs.length === 0) {
+    // All inputs were `--allow-empty`-suppressed globs that matched nothing.
+    return 0;
+  }
+
+  const results: FileResult[] = [];
+  let unreadable = false;
+  for (const input of inputs) {
+    let source: string;
+    let fileType: FileType;
+    let displayPath: string;
+
+    if (input === "-") {
+      const typeArg = values.type;
+      if (typeArg !== "treatment" && typeArg !== "prompt") {
+        stderr.write(
+          "Error: stdin ('-') requires --type=treatment or --type=prompt.\n",
+        );
+        return 2;
+      }
+      fileType = typeArg;
+      try {
+        source = await readStream(stdin);
+      } catch (err) {
+        stderr.write(
+          `Error reading stdin: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        return 2;
+      }
+      displayPath = "<stdin>";
+    } else {
+      const absPath = isAbsolute(input) ? input : resolvePath(cwd, input);
+      const detected = detectFileType(input);
+      if (!detected) {
+        results.push({
+          path: input,
+          type: "treatment",
+          diagnostics: [],
+          unreadable: `unknown file type (expected .stagebook.yaml or .prompt.md)`,
+        });
+        unreadable = true;
+        continue;
+      }
+      fileType = detected;
+      try {
+        source = await readFile(absPath, "utf8");
+      } catch (err) {
+        results.push({
+          path: input,
+          type: fileType,
+          diagnostics: [],
+          unreadable: `could not read: ${err instanceof Error ? err.message : String(err)}`,
+        });
+        unreadable = true;
+        continue;
+      }
+      displayPath = input;
+    }
+
+    if (fileType === "prompt") {
+      const result = validatePromptSource(source);
+      results.push({
+        path: displayPath,
+        type: "prompt",
+        diagnostics: result.diagnostics,
+      });
+      continue;
+    }
+
+    // Treatment file
+    const noExpand = values["no-expand"] === true;
+    if (noExpand || displayPath === "<stdin>") {
+      const result = validateTreatmentSource(source);
+      results.push({
+        path: displayPath,
+        type: "treatment",
+        diagnostics: result.diagnostics,
+      });
+      continue;
+    }
+
+    // Default: expand templates (resolving imports relative to the file's
+    // own directory) and validate the expansion. Catches errors that only
+    // surface after template substitution and import merging.
+    const dir = dirname(resolvePath(cwd, displayPath));
+    const result = await expandAndValidateWithImports({
+      source,
+      loadImport: async (importPath: string) => {
+        const target = isAbsolute(importPath)
+          ? importPath
+          : resolvePath(dir, importPath);
+        return await readFile(target, "utf8");
+      },
+    });
+    const diagnostics: Diagnostic[] = result.expandError
+      ? [
+          {
+            severity: "error",
+            message: `Template expansion failed: ${result.expandError}`,
+            range: null,
+          },
+          ...result.diagnostics,
+        ]
+      : result.diagnostics;
+    results.push({ path: displayPath, type: "treatment", diagnostics });
+  }
+
+  if (format === "json") {
+    writeJson(stdout, results);
+  } else {
+    writeText(stdout, results);
+  }
+
+  const hasErrors = results.some((r) =>
+    r.diagnostics.some((d) => d.severity === "error"),
+  );
+  if (unreadable) return 2;
+  if (hasErrors) return 1;
+  return 0;
+}
+
+function detectFileType(path: string): FileType | null {
+  if (path.endsWith(".stagebook.yaml")) return "treatment";
+  if (path.endsWith(".prompt.md")) return "prompt";
+  return null;
+}
+
+function hasGlobChars(s: string): boolean {
+  return /[*?[\]{}]/.test(s);
+}
+
+function writeText(stream: NodeJS.WritableStream, results: FileResult[]): void {
+  let errorCount = 0;
+  let warningCount = 0;
+  let fileCount = 0;
+  for (const r of results) {
+    if (r.unreadable) {
+      stream.write(`${r.path}: error: ${r.unreadable}\n`);
+      errorCount += 1;
+      fileCount += 1;
+      continue;
+    }
+    if (r.diagnostics.length === 0) continue;
+    fileCount += 1;
+    for (const d of r.diagnostics) {
+      // 1-based line:col for editor jump-to-location.
+      const line = d.range ? d.range.startLine + 1 : 1;
+      const col = d.range ? d.range.startCol + 1 : 1;
+      stream.write(`${r.path}:${line}:${col}: ${d.severity}: ${d.message}\n`);
+      if (d.severity === "error") errorCount += 1;
+      else warningCount += 1;
+    }
+  }
+  if (errorCount + warningCount > 0) {
+    const parts: string[] = [];
+    if (errorCount > 0)
+      parts.push(`${errorCount} error${errorCount === 1 ? "" : "s"}`);
+    if (warningCount > 0)
+      parts.push(`${warningCount} warning${warningCount === 1 ? "" : "s"}`);
+    stream.write(
+      `\n${parts.join(", ")} in ${fileCount} file${fileCount === 1 ? "" : "s"}.\n`,
+    );
+  }
+}
+
+function writeJson(stream: NodeJS.WritableStream, results: FileResult[]): void {
+  let errorCount = 0;
+  let warningCount = 0;
+  let fileCount = 0;
+
+  const files = results
+    .filter((r) => !r.unreadable && r.diagnostics.length > 0)
+    .map((r) => {
+      fileCount += 1;
+      for (const d of r.diagnostics) {
+        if (d.severity === "error") errorCount += 1;
+        else warningCount += 1;
+      }
+      return { path: r.path, diagnostics: r.diagnostics };
+    });
+
+  const unreadableFiles = results
+    .filter((r) => r.unreadable)
+    .map((r) => {
+      errorCount += 1;
+      fileCount += 1;
+      return { path: r.path, message: r.unreadable };
+    });
+
+  const output = {
+    files,
+    unreadable: unreadableFiles,
+    summary: { errors: errorCount, warnings: warningCount, files: fileCount },
+  };
+  stream.write(JSON.stringify(output, null, 2) + "\n");
+}

--- a/packages/stagebook/src/cli/validate.ts
+++ b/packages/stagebook/src/cli/validate.ts
@@ -266,13 +266,25 @@ function hasGlobChars(s: string): boolean {
   return /[*?[\]{}]/.test(s);
 }
 
+// Strip terminal-control + C1 chars before writing to stdout. Diagnostic
+// messages embed user-controlled YAML keys verbatim, so a crafted key like
+// `"foo[2J"` would otherwise clear the researcher's terminal. JSON
+// output is safe because JSON.stringify escapes control chars.
+function stripControl(s: string): string {
+  // Keeps \t (\x09) and \n (\x0a); strips other C0 (\x00-\x1f), DEL (\x7f),
+  // and C1 (\x80-\x9f).
+  return s.replace(/[\x00-\x08\x0b-\x1f\x7f-\x9f]/g, "");
+}
+
 function writeText(stream: NodeJS.WritableStream, results: FileResult[]): void {
   let errorCount = 0;
   let warningCount = 0;
   let fileCount = 0;
   for (const r of results) {
     if (r.unreadable) {
-      stream.write(`${r.path}: error: ${r.unreadable}\n`);
+      stream.write(
+        `${stripControl(r.path)}: error: ${stripControl(r.unreadable)}\n`,
+      );
       errorCount += 1;
       fileCount += 1;
       continue;
@@ -283,7 +295,9 @@ function writeText(stream: NodeJS.WritableStream, results: FileResult[]): void {
       // 1-based line:col for editor jump-to-location.
       const line = d.range ? d.range.startLine + 1 : 1;
       const col = d.range ? d.range.startCol + 1 : 1;
-      stream.write(`${r.path}:${line}:${col}: ${d.severity}: ${d.message}\n`);
+      stream.write(
+        `${stripControl(r.path)}:${line}:${col}: ${d.severity}: ${stripControl(d.message)}\n`,
+      );
       if (d.severity === "error") errorCount += 1;
       else warningCount += 1;
     }

--- a/packages/stagebook/tsup.config.ts
+++ b/packages/stagebook/tsup.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     index: "src/index.ts",
     "components/index": "src/components/index.ts",
     "validate/index": "src/validate/index.ts",
+    "cli/validate": "src/cli/validate.ts",
   },
   format: ["cjs", "esm"],
   dts: true,


### PR DESCRIPTION
Closes #439. Builds on the `stagebook/validate` subpath landed in #443 and exercised by the viewer migration in #445.

## What

The `stagebook` package now ships a CLI. Reachable from a study repo with no JS toolchain via `npx`:

```bash
# Validate one file
npx --package=stagebook stagebook validate study.stagebook.yaml

# Globs + mixed file types (suffix-dispatched)
npx --package=stagebook stagebook validate 'stagebook/**/*.stagebook.yaml' prompts/intro.prompt.md

# Stdin (for agents validating buffered content before writing)
cat foo.stagebook.yaml | npx --package=stagebook stagebook validate --type=treatment -

# Machine-readable for CI / agents
npx --package=stagebook stagebook validate --format=json study.stagebook.yaml
```

Reproduces the original gender-and-power-in-negotiation-corpus failure mode (`type: prompt` in a `.prompt.md` file) in a single pipeable command:

```
$ echo "type: prompt
---
Body" | npx --package=stagebook stagebook validate --format=json --type=prompt -
{
  "files": [{
    "path": "<stdin>",
    "diagnostics": [{
      "message": "Prompt file must have a `---`-delimited frontmatter and body. Use `***` or `___` for horizontal rules in the body, since `---` delimits sections.",
      "severity": "error",
      "range": { "startLine": 0, "startCol": 0, "endLine": 0, "endCol": 1 }
    }]
  }],
  "unreadable": [],
  "summary": { "errors": 1, "warnings": 0, "files": 1 }
}
# exit code: 1
```

## Implementation notes

- **`packages/stagebook/src/cli/validate.ts`** — pure `run({argv, stdin, stdout, stderr, cwd})` function. Testable without spawning a subprocess; the bin wrapper is the only thing that touches `process.*`.
- **`packages/stagebook/bin/stagebook.js`** — thin JS dispatcher with the shebang. Subcommands route to `dist/cli/validate.js`; lets the bin stay JS so it doesn't need transpilation at install time.
- **Default mode is expand-and-validate** for treatment files — runs the same `expandAndValidateWithImports` the editor uses, so errors that only surface after template substitution / import resolution are caught. `--no-expand` opts out for faster pre-expansion checks.
- **Position convention pinned**: JSON emits 0-based positions (matches LSP and the `Diagnostic` shape exported from `stagebook/validate`); text formatter converts to 1-based for editor jump-to-location. Locked by tests.
- **Stdin requires `--type=treatment|prompt`** since there's no suffix to dispatch on.
- **Globs via tinyglobby** (4 KB, zero deps). `--allow-empty` for CI workflows that want a no-match to exit 0.

## Discoverability

The whole point of the issue is making validation reachable for *non-human* callers. Three doc surfaces updated:

- **`README.md`** — new "Validating treatment + prompt files from the command line" section as the first thing under Usage. Leads with `npx --package=stagebook stagebook validate ...`.
- **`CLAUDE.md`** — new "Treatment authoring" section at the top with explicit agent-facing instructions and the JSON Diagnostic shape inline. This is the single line that determines whether an agent editing a treatment file *knows to validate it at all*.
- **`docs/researcher/treatment-files.md`** — new "Validating" section with the full flag reference, JSON schema, a pre-commit-hook example, and a **copy-pasteable block researchers can drop into their study repo's `CLAUDE.md`** so downstream agents pick up the validation step.

## Test plan

- [x] `npm test` — all **1,429** tests pass (stagebook 1,241 / viewer 100 / vscode 88). 22 new tests in `src/cli/validate.test.ts`.
- [x] `npm run lint` — clean.
- [x] `npx prettier --check` — clean.
- [x] Pre-commit + pre-push hooks pass.
- [x] End-to-end manual smoke test against `examples/prisoners-dilemma/prisoners-dilemma.stagebook.yaml` (clean, exit 0) and a known-broken prompt file (errors with positions, exit 1).

## Out of scope (linked from #439)

- Published GitHub Action wrapping this CLI — #441 (the killer CI path for non-JS researchers).
- Viewer autovalidate-on-load UX — #440.
- VS Code extension "Validate Workspace" palette command — #442.
- Auto-fix at the CLI; `--watch` mode; path-alias resolution (#26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)