### PR TITLE
Bump stagebook to 0.11.0

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.10.13",
+  "version": "0.11.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Minor release adding the `stagebook/validate` subpath export, the `stagebook` CLI, and consolidating the viewer's hydration loader onto the shared primitive.

## What's in

- **#443** — Lift the validators (`validateTreatmentSource`, `validatePromptSource`, `loadAndMergeImports`, `expandAndValidateWithImports`, position-mapping helpers, the `Diagnostic` type) out of the VS Code extension and into a new subpath export `stagebook/validate`. Consumed by the editor, viewer, CLI, and downstream tooling (deliberation-lab manager / annotator / the platform itself) so every context produces the same diagnostics from the same code.
- **#445** — Replace the viewer's standalone `loadAndMergeTreatmentFile` with `loadAndMergeImports` from `stagebook/validate`. Proof of concept for the cross-context consolidation. -84 / +18 lines.
- **#446** — Ship the `stagebook` CLI. Reachable as `npx --package=stagebook stagebook validate <files...>` from study repos with no JS toolchain. Dispatches by suffix (`.stagebook.yaml` / `.prompt.md`), supports globs, stdin, `--format=json`, and expand-and-validate by default. Discoverability hooks added to README, CLAUDE.md, and docs/researcher/treatment-files.md so agents editing treatment files can validate their own work.

## Compatibility

- **No breaking changes.** All additive.
- **New subpath**: `import { validateTreatmentSource, validatePromptSource, type Diagnostic } from "stagebook/validate"`. The main `stagebook` entry is unchanged.
- **New bin**: `stagebook` (subcommands: `validate`). Reachable via `npx --package=stagebook stagebook ...`.
- **New runtime deps**: `yaml@^2.8.3` (eemeli/yaml, was already an editor transitive); `tinyglobby@^0.2.16` (for CLI glob expansion).
- The `Diagnostic` type emitted by JSON output uses **0-based positions** (LSP convention). Text output formats positions **1-based** for editor jump-to-location.

## Unblocks downstream

This release unblocks the three downstream consolidation issues that have been waiting on the subpath being published:

- deliberation-lab/manager#302 — replace `hydrateTreatmentYaml.ts` with `loadAndMergeImports`
- deliberation-lab/deliberation-lab#265 — server-side `validatePromptSource` for richer error messages
- deliberation-lab/annotator#197 — `orchestration.ts` consolidation