### PR TITLE
Add stagebook/dispatch: urn + uniform-random + pluggable contract harness

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -38,6 +38,26 @@
         "types": "./dist/validate/index.d.cts",
         "default": "./dist/validate/index.cjs"
       }
+    },
+    "./dispatch": {
+      "import": {
+        "types": "./dist/dispatch/index.d.ts",
+        "default": "./dist/dispatch/index.js"
+      },
+      "require": {
+        "types": "./dist/dispatch/index.d.cts",
+        "default": "./dist/dispatch/index.cjs"
+      }
+    },
+    "./dispatch/contract": {
+      "import": {
+        "types": "./dist/dispatch/contract.d.ts",
+        "default": "./dist/dispatch/contract.js"
+      },
+      "require": {
+        "types": "./dist/dispatch/contract.d.cts",
+        "default": "./dist/dispatch/contract.cjs"
+      }
     }
   },
   "files": [

--- a/packages/stagebook/src/dispatch/contract.test.ts
+++ b/packages/stagebook/src/dispatch/contract.test.ts
@@ -1,0 +1,75 @@
+// Run the generic dispatcher-contract gauntlet (10 structural
+// invariants) against each dispatcher stagebook ships. Adding a new
+// dispatcher means appending one `runContractSuite(...)` call; the
+// same invariants run automatically.
+
+import { buildEligibilityForScenario, runContractSuite } from "./contract.js";
+import { uniformRandom } from "./uniformRandom.js";
+import { urnRandomization } from "./urnRandomization.js";
+
+runContractSuite("uniform-random", ({ scenario, rng }) => {
+  const eligibility = buildEligibilityForScenario(scenario);
+  return {
+    params: {},
+    dispatch: () =>
+      uniformRandom({
+        playerIds: scenario.players.map((p) => p.id),
+        treatments: scenario.treatments,
+        eligibility,
+        rng,
+      }),
+  };
+});
+
+runContractSuite("urn", ({ scenario, rng }) => {
+  const eligibility = buildEligibilityForScenario(scenario);
+  // Random per-scenario counts in [0, 5]. Some zeros so the dispatcher
+  // exercises the "no balls left for this treatment" branch.
+  const counts = scenario.treatments.map(() => Math.floor(rng() * 6));
+  // Random decrement matrix: either identity (50%) or a sparse matrix
+  // with integer entries small enough to avoid validation rejections.
+  let decrements: number[][] | undefined;
+  if (rng() < 0.5) {
+    decrements = undefined; // identity default
+  } else {
+    decrements = buildSafeDecrementMatrix(counts, rng);
+  }
+  return {
+    params: { counts, decrements },
+    dispatch: () =>
+      urnRandomization({
+        playerIds: scenario.players.map((p) => p.id),
+        treatments: scenario.treatments,
+        counts,
+        decrements,
+        eligibility,
+        rng,
+      }),
+  };
+});
+
+/** Build a random decrement matrix where each `decrements[i][j] ≤ counts[j]`
+ *  so the dispatcher doesn't immediately clamp to zero on the first use.
+ *  Diagonal entries are at least 1 so a treatment's own counter
+ *  actually decreases when the treatment is used. */
+function buildSafeDecrementMatrix(
+  counts: number[],
+  rng: () => number,
+): number[][] {
+  const n = counts.length;
+  const m: number[][] = [];
+  for (let i = 0; i < n; i += 1) {
+    const row: number[] = [];
+    for (let j = 0; j < n; j += 1) {
+      if (i === j) {
+        // Self-decrement at least 1 (when there's a ball to take).
+        row.push(counts[j] > 0 ? 1 : 0);
+      } else {
+        // Off-diagonal in [0, min(1, counts[j])] — usually 0, sometimes 1.
+        row.push(rng() < 0.25 && counts[j] > 0 ? 1 : 0);
+      }
+    }
+    m.push(row);
+  }
+  return m;
+}

--- a/packages/stagebook/src/dispatch/contract.ts
+++ b/packages/stagebook/src/dispatch/contract.ts
@@ -1,0 +1,485 @@
+// mulberry32 below uses bit ops by design (small fast PRNG, intentional).
+
+// Generic dispatcher contract harness (#448).
+//
+// Every dispatcher implementation — current and future, stagebook's
+// own (`uniform-random`, `urn`) and external (`local-penalization` in
+// deliberation-lab) — MUST satisfy the structural invariants pinned
+// here. The harness is parameterized over a *factory* so registering a
+// new algorithm is a matter of supplying its scenario-to-dispatcher
+// adapter and re-running the gauntlet.
+//
+// Scope: structural invariants only. Algorithm-specific statistical
+// claims (marginal target rate, irrelevant-attribute independence, …)
+// live in algorithm-specific test files because each algorithm makes a
+// different randomization claim worth a paper-defensible receipt.
+//
+// History: this harness is the generalization of
+// `dispatch.contract.test.js` in deliberation-lab (was tightly coupled
+// to payoffs+knockdowns shape). The scenario was shrunk to just
+// `{ players, treatments }`; algorithm-specific params come from the
+// registered factory (which can also generate them from the seeded
+// rng so the gauntlet's full input space remains deterministic).
+
+import { describe, test, expect } from "vitest";
+import type { DispatchResult, Treatment } from "./types.js";
+import { makeEligibilityTable } from "./makeEligibilityTable.js";
+import { evaluateConditions } from "../utils/evaluateConditions.js";
+import {
+  getNestedValueByPath,
+  getReferenceKeyAndPath,
+} from "../utils/reference.js";
+
+/** Mulberry32 — small, fast, fully deterministic PRNG. The bit ops are
+ *  intentional (PRNG); we don't need cryptographic quality, we need
+ *  reproducibility. Returned as a function so callers can pass it
+ *  anywhere a `() => number` rng is expected. */
+export function mulberry32(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** One harness scenario — players + treatments, nothing else. Each
+ *  registered dispatcher's factory builds its own algorithm-specific
+ *  params on top. */
+export interface ContractScenario {
+  players: {
+    id: string;
+    /** Storage-key indexed snapshot, populated for the keys returned
+     *  by `extractConditionKeys` over `treatments`. */
+    data: Record<string, Record<string, unknown>>;
+  }[];
+  treatments: Treatment[];
+}
+
+/** The harness calls the factory with a fresh seeded rng for each
+ *  scenario. The factory wires up algorithm-specific params and
+ *  returns a thunk that performs one dispatch tick. `params` rides
+ *  along on assertion-failure messages so the repro is informative
+ *  per-algorithm. */
+export type ContractDispatcherFactory = (input: {
+  scenario: ContractScenario;
+  rng: () => number;
+}) => {
+  dispatch: () => DispatchResult;
+  params: Record<string, unknown>;
+};
+
+export interface ContractSuiteOptions {
+  /** Seed for the scenario generator. Defaults to `0xdeadbeef`. */
+  seed?: number;
+  /** Number of scenarios to run per invariant test. Defaults to 200. */
+  n?: number;
+}
+
+const ROLES = ["a", "b", "c", "d"];
+
+function pick<T>(rng: () => number, arr: readonly T[]): T {
+  return arr[Math.floor(rng() * arr.length)];
+}
+
+function intRange(rng: () => number, min: number, max: number): number {
+  return min + Math.floor(rng() * (max - min + 1));
+}
+
+function genPlayer(
+  rng: () => number,
+  idx: number,
+): ContractScenario["players"][number] {
+  // ~1 in 5 chance of no role, otherwise a uniform pick. Players with
+  // no role can't satisfy role conditions — exercises ineligible
+  // branches in dispatchers.
+  const role = rng() < 0.2 ? null : pick(rng, ROLES);
+  return {
+    id: `p${idx}`,
+    data: role === null ? {} : { prompt_role: { value: role } },
+  };
+}
+
+function maybeRoleCondition(rng: () => number) {
+  // 50/50 whether the slot has a condition. When it does, equality
+  // on a random role. Only `equals` here on purpose — broader
+  // comparators would require valid value-shape per type, and we'd
+  // be testing the comparator surface, not the dispatcher.
+  if (rng() < 0.5) return [];
+  return [
+    {
+      reference: "self.prompt.role",
+      comparator: "equals",
+      value: pick(rng, ROLES),
+    },
+  ];
+}
+
+function genTreatment(rng: () => number, idx: number): Treatment {
+  const playerCount = intRange(rng, 1, 4);
+  // 30% of the time, omit groupComposition (every player eligible for
+  // every slot). Otherwise emit one entry per slot with a 50/50
+  // chance of a role condition. An EMPTY array would also be
+  // unconstrained but trips a different code path in some validators;
+  // either omit entirely or fill to playerCount.
+  if (rng() < 0.3) {
+    return { name: `t${idx}`, playerCount };
+  }
+  const groupComposition = [];
+  for (let i = 0; i < playerCount; i += 1) {
+    groupComposition.push({
+      position: i,
+      conditions: maybeRoleCondition(rng),
+    });
+  }
+  return { name: `t${idx}`, playerCount, groupComposition };
+}
+
+export function genScenario(rng: () => number): ContractScenario {
+  const nPlayers = intRange(rng, 0, 25);
+  const nTreatments = intRange(rng, 1, 4);
+  const players = Array.from({ length: nPlayers }, (_, i) => genPlayer(rng, i));
+  const treatments = Array.from({ length: nTreatments }, (_, i) =>
+    genTreatment(rng, i),
+  );
+  return { players, treatments };
+}
+
+/** Build the eligibility table the way a host would: extract condition
+ *  keys, snapshot each player's data, hand both to `makeEligibilityTable`.
+ *  Exposed so per-algorithm factories that wrap a pure dispatcher can
+ *  reuse it. */
+export function buildEligibilityForScenario(scenario: ContractScenario) {
+  const playerIds = scenario.players.map((p) => p.id);
+  const playerData: Record<string, Record<string, unknown>> = {};
+  for (const p of scenario.players) playerData[p.id] = p.data;
+  return makeEligibilityTable({
+    playerIds,
+    treatments: scenario.treatments,
+    playerData,
+  });
+}
+
+/** Self-resolve a single condition against a single player's data —
+ *  used by invariant #4 to verify the dispatcher's eligibility checks
+ *  match what the conditions say. Mirrors what `makeEligibilityTable`
+ *  does internally; kept as a separate path so the invariant test is
+ *  *checking* the table builder, not asking it to mark its own
+ *  homework. */
+function playerSatisfies(
+  player: ContractScenario["players"][number],
+  conditions: unknown,
+): boolean {
+  const resolve = (reference: string): unknown[] => {
+    if (!reference.startsWith("self.")) return [];
+    try {
+      const { referenceKey, path } = getReferenceKeyAndPath(reference);
+      const record = player.data[referenceKey];
+      if (record === undefined) return [];
+      const value = getNestedValueByPath(record, path);
+      if (value === undefined) return [];
+      return [value];
+    } catch {
+      return [];
+    }
+  };
+  // evaluateConditions accepts arrays / operator nodes / single leaves.
+  return evaluateConditions(
+    conditions as Parameters<typeof evaluateConditions>[0],
+    resolve,
+  );
+}
+
+function slotConditionsForAssignment(
+  treatment: Treatment,
+  position: number,
+): unknown {
+  const gc = treatment.groupComposition;
+  if (Array.isArray(gc)) {
+    const slot = gc.find((s) => s?.position === position);
+    return slot?.conditions ?? [];
+  }
+  return [];
+}
+
+function formatContext(
+  algorithm: string,
+  seed: number,
+  scenarioIdx: number,
+  scenario: ContractScenario,
+  params: Record<string, unknown>,
+): string {
+  return `[algorithm=${algorithm} seed=0x${seed.toString(16)} scenario=${scenarioIdx}]\nscenario: ${JSON.stringify(
+    {
+      players: scenario.players.map((p) => ({ id: p.id, data: p.data })),
+      treatments: scenario.treatments,
+    },
+    null,
+    2,
+  )}\nparams: ${JSON.stringify(params, null, 2)}`;
+}
+
+function deepClone<T>(obj: T): T {
+  return JSON.parse(JSON.stringify(obj)) as T;
+}
+
+interface Snapshots {
+  treatmentsBefore: Treatment[];
+  playerDataBefore: ContractScenario["players"][number]["data"][];
+  paramsBefore: Record<string, unknown>;
+}
+
+type InvariantCallback = (
+  scenario: ContractScenario,
+  result: DispatchResult,
+  scenarioIdx: number,
+  snapshots: Snapshots | null,
+  params: Record<string, unknown>,
+) => void;
+
+function forEachScenario(
+  algorithm: string,
+  factory: ContractDispatcherFactory,
+  seed: number,
+  n: number,
+  invariant: InvariantCallback,
+  opts: { snapshot?: boolean } = {},
+): void {
+  const rng = mulberry32(seed);
+  for (let i = 0; i < n; i += 1) {
+    const scenario = genScenario(rng);
+    let dispatchResult: DispatchResult;
+    let params: Record<string, unknown> = {};
+    let snapshots: Snapshots | null = null;
+    try {
+      const built = factory({
+        scenario,
+        // Each scenario gets a derived seed so per-scenario rng state
+        // doesn't leak across the suite.
+        rng: mulberry32(seed * 1_000_003 + i),
+      });
+      params = built.params;
+      // Snapshot AFTER factory construction (which may legitimately
+      // generate algorithm-specific params from the rng) but BEFORE
+      // dispatch — so the invariant check sees what dispatch was given.
+      if (opts.snapshot) {
+        snapshots = {
+          treatmentsBefore: deepClone(scenario.treatments),
+          playerDataBefore: scenario.players.map((p) => deepClone(p.data)),
+          paramsBefore: deepClone(built.params),
+        };
+      }
+      dispatchResult = built.dispatch();
+    } catch (err) {
+      const e = err as Error;
+      e.message = `dispatcher threw: ${e.message}\n${formatContext(algorithm, seed, i, scenario, params)}`;
+      throw e;
+    }
+    try {
+      invariant(scenario, dispatchResult, i, snapshots, params);
+    } catch (err) {
+      const e = err as Error;
+      e.message = `${e.message}\n${formatContext(algorithm, seed, i, scenario, params)}`;
+      throw e;
+    }
+  }
+}
+
+/**
+ * Run the 10 dispatcher-contract invariants against the supplied
+ * factory. Call from inside a registering test file:
+ *
+ * ```ts
+ * runContractSuite("urn", ({ scenario, rng }) => {
+ *   const eligibility = buildEligibilityForScenario(scenario);
+ *   const counts = scenario.treatments.map(() => 4);
+ *   return {
+ *     params: { counts },
+ *     dispatch: () =>
+ *       urnRandomization({
+ *         playerIds: scenario.players.map((p) => p.id),
+ *         treatments: scenario.treatments,
+ *         counts,
+ *         eligibility,
+ *         rng,
+ *       }),
+ *   };
+ * });
+ * ```
+ */
+export function runContractSuite(
+  algorithm: string,
+  factory: ContractDispatcherFactory,
+  options: ContractSuiteOptions = {},
+): void {
+  const seed = (options.seed ?? 0xdeadbeef) >>> 0;
+  const n = options.n ?? 200;
+
+  describe(`Dispatcher contract: ${algorithm} (seed=0x${seed.toString(16)}, N=${n})`, () => {
+    test("1. every assignment has exactly treatment.playerCount positionAssignments", () => {
+      forEachScenario(
+        algorithm,
+        factory,
+        seed + 0,
+        n,
+        (_scenario, { assignments }) => {
+          for (const a of assignments) {
+            expect(a.positionAssignments.length).toBe(a.treatment.playerCount);
+          }
+        },
+      );
+    });
+
+    test("2. no player id appears in more than one assignment", () => {
+      forEachScenario(
+        algorithm,
+        factory,
+        seed + 1,
+        n,
+        (_scenario, { assignments }) => {
+          const seen = new Set<string>();
+          for (const a of assignments) {
+            for (const pa of a.positionAssignments) {
+              expect(seen.has(pa.playerId)).toBe(false);
+              seen.add(pa.playerId);
+            }
+          }
+        },
+      );
+    });
+
+    test("3. every assignment's treatment is from the input set", () => {
+      forEachScenario(
+        algorithm,
+        factory,
+        seed + 2,
+        n,
+        (scenario, { assignments }) => {
+          const validNames = new Set(scenario.treatments.map((t) => t.name));
+          for (const a of assignments) {
+            expect(validNames.has(a.treatment.name)).toBe(true);
+          }
+        },
+      );
+    });
+
+    test("4. every assigned player satisfies the slot conditions they're placed in", () => {
+      forEachScenario(
+        algorithm,
+        factory,
+        seed + 3,
+        n,
+        (scenario, { assignments }) => {
+          const playersById = new Map(scenario.players.map((p) => [p.id, p]));
+          for (const a of assignments) {
+            for (const pa of a.positionAssignments) {
+              const player = playersById.get(pa.playerId);
+              expect(
+                player,
+                `assignment references unknown playerId ${pa.playerId}`,
+              ).toBeTruthy();
+              const conditions = slotConditionsForAssignment(
+                a.treatment,
+                pa.position,
+              );
+              expect(
+                playerSatisfies(player!, conditions),
+                `player ${pa.playerId} at position ${pa.position} of ${a.treatment.name} fails conditions ${JSON.stringify(conditions)}`,
+              ).toBe(true);
+            }
+          }
+        },
+      );
+    });
+
+    test("5. total assigned players never exceeds input player count", () => {
+      forEachScenario(
+        algorithm,
+        factory,
+        seed + 4,
+        n,
+        (scenario, { assignments }) => {
+          const total = assignments.reduce(
+            (sum, a) => sum + a.positionAssignments.length,
+            0,
+          );
+          expect(total).toBeLessThanOrEqual(scenario.players.length);
+        },
+      );
+    });
+
+    test("6. position uniqueness within an assignment", () => {
+      forEachScenario(
+        algorithm,
+        factory,
+        seed + 5,
+        n,
+        (_scenario, { assignments }) => {
+          for (const a of assignments) {
+            const positions = a.positionAssignments.map((pa) => pa.position);
+            expect(new Set(positions).size).toBe(positions.length);
+          }
+        },
+      );
+    });
+
+    test("7. result has an `assignments` array (algorithm extras allowed)", () => {
+      forEachScenario(algorithm, factory, seed + 6, n, (_scenario, result) => {
+        expect(result).toBeTruthy();
+        expect(Array.isArray(result.assignments)).toBe(true);
+      });
+    });
+
+    test("8. empty input → empty assignments (no crash, no null)", () => {
+      const empty: ContractScenario = {
+        players: [],
+        treatments: [{ name: "t0", playerCount: 2 }],
+      };
+      const { dispatch } = factory({
+        scenario: empty,
+        rng: mulberry32(seed + 7),
+      });
+      const result = dispatch();
+      expect(result.assignments).toEqual([]);
+    });
+
+    test("9. dispatcher does not mutate input treatments / player data / params", () => {
+      forEachScenario(
+        algorithm,
+        factory,
+        seed + 8,
+        n,
+        (scenario, _result, _idx, snapshots, params) => {
+          expect(scenario.treatments).toEqual(snapshots!.treatmentsBefore);
+          scenario.players.forEach((p, i) => {
+            expect(p.data).toEqual(snapshots!.playerDataBefore[i]);
+          });
+          // Algorithm-specific params (e.g. urn's `counts` array) must
+          // also be left intact — the host carries persistent state by
+          // passing the *result*, not by relying on dispatcher mutation.
+          expect(params).toEqual(snapshots!.paramsBefore);
+        },
+        { snapshot: true },
+      );
+    });
+
+    test("10. every position in positionAssignments is in [0, treatment.playerCount)", () => {
+      forEachScenario(
+        algorithm,
+        factory,
+        seed + 9,
+        n,
+        (_scenario, { assignments }) => {
+          for (const a of assignments) {
+            for (const pa of a.positionAssignments) {
+              expect(pa.position).toBeGreaterThanOrEqual(0);
+              expect(pa.position).toBeLessThan(a.treatment.playerCount);
+            }
+          }
+        },
+      );
+    });
+  });
+}

--- a/packages/stagebook/src/dispatch/extractConditionKeys.test.ts
+++ b/packages/stagebook/src/dispatch/extractConditionKeys.test.ts
@@ -1,0 +1,191 @@
+import { describe, test, expect } from "vitest";
+import { extractConditionKeys } from "./extractConditionKeys.js";
+import type { Treatment } from "./types.js";
+
+describe("extractConditionKeys", () => {
+  test("returns empty set for treatments with no groupComposition", () => {
+    const treatments: Treatment[] = [
+      { name: "t0", playerCount: 2 },
+      { name: "t1", playerCount: 3 },
+    ];
+    expect(extractConditionKeys(treatments)).toEqual(new Set());
+  });
+
+  test("returns empty set when groupComposition slots have no conditions", () => {
+    const treatments: Treatment[] = [
+      {
+        name: "t0",
+        playerCount: 2,
+        groupComposition: [{ position: 0 }, { position: 1 }],
+      },
+    ];
+    expect(extractConditionKeys(treatments)).toEqual(new Set());
+  });
+
+  test("collects storage-keys from flat-array condition lists", () => {
+    const treatments: Treatment[] = [
+      {
+        name: "t0",
+        playerCount: 2,
+        groupComposition: [
+          {
+            position: 0,
+            conditions: [
+              {
+                reference: "self.prompt.role",
+                comparator: "equals",
+                value: "moderator",
+              },
+            ],
+          },
+          {
+            position: 1,
+            conditions: [
+              {
+                reference: "self.prompt.role",
+                comparator: "equals",
+                value: "participant",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    expect(extractConditionKeys(treatments)).toEqual(new Set(["prompt_role"]));
+  });
+
+  test("descends into all/any/none operator nodes", () => {
+    const treatments: Treatment[] = [
+      {
+        name: "t0",
+        playerCount: 1,
+        groupComposition: [
+          {
+            position: 0,
+            conditions: {
+              any: [
+                {
+                  reference: "self.prompt.role",
+                  comparator: "equals",
+                  value: "a",
+                },
+                {
+                  none: [
+                    {
+                      reference: "self.survey.tipi",
+                      comparator: "exists",
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+    expect(extractConditionKeys(treatments)).toEqual(
+      new Set(["prompt_role", "survey_tipi"]),
+    );
+  });
+
+  test("collects external-source keys (entryUrl) as their bare source name", () => {
+    const treatments: Treatment[] = [
+      {
+        name: "t0",
+        playerCount: 1,
+        groupComposition: [
+          {
+            position: 0,
+            conditions: [
+              {
+                reference: "self.entryUrl.params.condition",
+                comparator: "equals",
+                value: "treatment",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    expect(extractConditionKeys(treatments)).toEqual(new Set(["entryUrl"]));
+  });
+
+  test("skips numeric / shared / all selectors (not resolvable from candidate alone)", () => {
+    const treatments: Treatment[] = [
+      {
+        name: "t0",
+        playerCount: 2,
+        groupComposition: [
+          {
+            position: 0,
+            conditions: [
+              { reference: "0.prompt.role", comparator: "equals", value: "a" },
+              { reference: "shared.prompt.x", comparator: "exists" },
+              { reference: "all.prompt.y", comparator: "exists" },
+            ],
+          },
+        ],
+      },
+    ];
+    expect(extractConditionKeys(treatments)).toEqual(new Set());
+  });
+
+  test("silently skips malformed references (validator surfaces them)", () => {
+    const treatments: Treatment[] = [
+      {
+        name: "t0",
+        playerCount: 1,
+        groupComposition: [
+          {
+            position: 0,
+            conditions: [
+              { reference: "self", comparator: "exists" },
+              {
+                reference: "self.prompt.role",
+                comparator: "equals",
+                value: "x",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    expect(extractConditionKeys(treatments)).toEqual(new Set(["prompt_role"]));
+  });
+
+  test("deduplicates across treatments and slots", () => {
+    const treatments: Treatment[] = [
+      {
+        name: "t0",
+        playerCount: 2,
+        groupComposition: [
+          {
+            position: 0,
+            conditions: [
+              { reference: "self.prompt.role", comparator: "exists" },
+            ],
+          },
+          {
+            position: 1,
+            conditions: [
+              { reference: "self.prompt.role", comparator: "exists" },
+            ],
+          },
+        ],
+      },
+      {
+        name: "t1",
+        playerCount: 1,
+        groupComposition: [
+          {
+            position: 0,
+            conditions: [
+              { reference: "self.prompt.role", comparator: "exists" },
+            ],
+          },
+        ],
+      },
+    ];
+    expect(extractConditionKeys(treatments)).toEqual(new Set(["prompt_role"]));
+  });
+});

--- a/packages/stagebook/src/dispatch/extractConditionKeys.ts
+++ b/packages/stagebook/src/dispatch/extractConditionKeys.ts
@@ -1,0 +1,70 @@
+import { getReferenceKeyAndPath } from "../utils/reference.js";
+import type { DispatchConditionNode, Treatment } from "./types.js";
+
+/**
+ * Walk every treatment's `groupComposition[].conditions` tree, parse the
+ * leaf references, and return the set of storage-keys that the host
+ * needs to populate for each candidate player before calling
+ * `makeEligibilityTable`.
+ *
+ * Per #298, leaf references begin with a position selector. Eligibility
+ * conditions on a slot are evaluated against the *candidate* — only
+ * `self.X.Y` references actually carry information. Numeric / `shared` /
+ * `all` selectors would require knowing the eventual group composition
+ * (a circular dependency) and so are skipped here with a comment rather
+ * than silently included in the key set.
+ *
+ * Malformed references are silently skipped: this helper is run in the
+ * dispatch hot path on already-validated treatments; raising would
+ * convert a recoverable empty-eligibility row into a fatal tick failure.
+ */
+export function extractConditionKeys(treatments: Treatment[]): Set<string> {
+  const keys = new Set<string>();
+  for (const t of treatments) {
+    const gc = t.groupComposition;
+    if (!Array.isArray(gc)) continue;
+    for (const slot of gc) {
+      walk(slot?.conditions, keys);
+    }
+  }
+  return keys;
+}
+
+function walk(
+  node: DispatchConditionNode | DispatchConditionNode[] | undefined,
+  keys: Set<string>,
+): void {
+  if (node === undefined || node === null) return;
+  if (Array.isArray(node)) {
+    for (const child of node) walk(child, keys);
+    return;
+  }
+  if (typeof node !== "object") return;
+  if ("all" in node && Array.isArray(node.all)) {
+    for (const child of node.all) walk(child, keys);
+    return;
+  }
+  if ("any" in node && Array.isArray(node.any)) {
+    for (const child of node.any) walk(child, keys);
+    return;
+  }
+  if ("none" in node && Array.isArray(node.none)) {
+    for (const child of node.none) walk(child, keys);
+    return;
+  }
+  if ("reference" in node && typeof node.reference === "string") {
+    try {
+      // Eligibility is per-candidate, so only `self.X.Y` references
+      // contribute a key the host can populate. Anything else (numeric
+      // slot, `shared`, `all`) would need the future group composition
+      // to resolve; those reads would have to be plumbed in through a
+      // different channel.
+      if (!node.reference.startsWith("self.")) return;
+      const { referenceKey } = getReferenceKeyAndPath(node.reference);
+      keys.add(referenceKey);
+    } catch {
+      // Malformed reference — let the validator surface it; do not
+      // crash the dispatcher hot path.
+    }
+  }
+}

--- a/packages/stagebook/src/dispatch/index.ts
+++ b/packages/stagebook/src/dispatch/index.ts
@@ -1,0 +1,20 @@
+// stagebook/dispatch
+// Pure-function dispatchers for assigning participants to treatments
+// (#448). The structural-invariant contract harness (`runContractSuite`)
+// lives at `stagebook/dispatch/contract` — a separate subpath so the
+// harness's vitest dependency stays out of the main runtime bundle.
+
+export * from "./types.js";
+export { extractConditionKeys } from "./extractConditionKeys.js";
+export { makeEligibilityTable } from "./makeEligibilityTable.js";
+export { uniformRandom, type UniformRandomArgs } from "./uniformRandom.js";
+export {
+  urnRandomization,
+  type UrnRandomizationArgs,
+  type UrnRandomizationResult,
+} from "./urnRandomization.js";
+export {
+  validateDispatcherConfig,
+  type DispatcherConfigDiagnostic,
+  type DispatcherConfigValidationResult,
+} from "./validateDispatcherConfig.js";

--- a/packages/stagebook/src/dispatch/makeEligibilityTable.test.ts
+++ b/packages/stagebook/src/dispatch/makeEligibilityTable.test.ts
@@ -1,0 +1,230 @@
+import { describe, test, expect } from "vitest";
+import { makeEligibilityTable } from "./makeEligibilityTable.js";
+import type { Treatment } from "./types.js";
+
+describe("makeEligibilityTable", () => {
+  test("treatments without groupComposition: every player eligible for every slot", () => {
+    const treatments: Treatment[] = [
+      { name: "t0", playerCount: 2 },
+      { name: "t1", playerCount: 3 },
+    ];
+    const table = makeEligibilityTable({
+      playerIds: ["p0", "p1"],
+      treatments,
+      playerData: {},
+    });
+    expect(table.isEligible("p0", 0, 0)).toBe(true);
+    expect(table.isEligible("p0", 0, 1)).toBe(true);
+    expect(table.isEligible("p1", 1, 2)).toBe(true);
+  });
+
+  test("slot without conditions: unconstrained", () => {
+    const treatments: Treatment[] = [
+      {
+        name: "t0",
+        playerCount: 2,
+        groupComposition: [{ position: 0 }, { position: 1 }],
+      },
+    ];
+    const table = makeEligibilityTable({
+      playerIds: ["p0"],
+      treatments,
+      playerData: {},
+    });
+    expect(table.isEligible("p0", 0, 0)).toBe(true);
+    expect(table.isEligible("p0", 0, 1)).toBe(true);
+  });
+
+  test("evaluates `self.prompt.X` equality conditions per candidate", () => {
+    const treatments: Treatment[] = [
+      {
+        name: "t0",
+        playerCount: 2,
+        groupComposition: [
+          {
+            position: 0,
+            conditions: [
+              {
+                reference: "self.prompt.role",
+                comparator: "equals",
+                value: "moderator",
+              },
+            ],
+          },
+          {
+            position: 1,
+            conditions: [
+              {
+                reference: "self.prompt.role",
+                comparator: "equals",
+                value: "participant",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const table = makeEligibilityTable({
+      playerIds: ["mod", "part"],
+      treatments,
+      playerData: {
+        mod: { prompt_role: { value: "moderator" } },
+        part: { prompt_role: { value: "participant" } },
+      },
+    });
+    expect(table.isEligible("mod", 0, 0)).toBe(true);
+    expect(table.isEligible("mod", 0, 1)).toBe(false);
+    expect(table.isEligible("part", 0, 0)).toBe(false);
+    expect(table.isEligible("part", 0, 1)).toBe(true);
+  });
+
+  test("unknown player returns false (defensive lookup)", () => {
+    const treatments: Treatment[] = [{ name: "t0", playerCount: 1 }];
+    const table = makeEligibilityTable({
+      playerIds: ["p0"],
+      treatments,
+      playerData: {},
+    });
+    expect(table.isEligible("never-seen", 0, 0)).toBe(false);
+  });
+
+  test("missing storage-key data → positive comparator fails, negative passes", () => {
+    const treatments: Treatment[] = [
+      {
+        name: "t0",
+        playerCount: 2,
+        groupComposition: [
+          {
+            position: 0,
+            conditions: [
+              {
+                reference: "self.prompt.role",
+                comparator: "equals",
+                value: "x",
+              },
+            ],
+          },
+          {
+            position: 1,
+            conditions: [
+              {
+                reference: "self.prompt.role",
+                comparator: "doesNotEqual",
+                value: "x",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const table = makeEligibilityTable({
+      playerIds: ["p0"],
+      treatments,
+      playerData: { p0: {} },
+    });
+    // No data → `equals` collapses to false at the boundary.
+    expect(table.isEligible("p0", 0, 0)).toBe(false);
+    // No data → `doesNotEqual` is satisfied by absence (#348).
+    expect(table.isEligible("p0", 0, 1)).toBe(true);
+  });
+
+  test("non-self references resolve to empty (no group composition yet)", () => {
+    const treatments: Treatment[] = [
+      {
+        name: "t0",
+        playerCount: 1,
+        groupComposition: [
+          {
+            position: 0,
+            conditions: [
+              {
+                // Numeric / shared / all selectors can't resolve from the
+                // candidate alone — they'd need the eventual group.
+                reference: "0.prompt.role",
+                comparator: "equals",
+                value: "anything",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const table = makeEligibilityTable({
+      playerIds: ["p0"],
+      treatments,
+      playerData: { p0: { prompt_role: { value: "anything" } } },
+    });
+    expect(table.isEligible("p0", 0, 0)).toBe(false);
+  });
+
+  test("operator-tree conditions (any/none) evaluate correctly", () => {
+    const treatments: Treatment[] = [
+      {
+        name: "t0",
+        playerCount: 1,
+        groupComposition: [
+          {
+            position: 0,
+            conditions: {
+              any: [
+                {
+                  reference: "self.prompt.role",
+                  comparator: "equals",
+                  value: "a",
+                },
+                {
+                  reference: "self.prompt.role",
+                  comparator: "equals",
+                  value: "b",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ];
+    const table = makeEligibilityTable({
+      playerIds: ["pa", "pb", "pc"],
+      treatments,
+      playerData: {
+        pa: { prompt_role: { value: "a" } },
+        pb: { prompt_role: { value: "b" } },
+        pc: { prompt_role: { value: "c" } },
+      },
+    });
+    expect(table.isEligible("pa", 0, 0)).toBe(true);
+    expect(table.isEligible("pb", 0, 0)).toBe(true);
+    expect(table.isEligible("pc", 0, 0)).toBe(false);
+  });
+
+  test("external-source reference (`self.entryUrl.params.X`)", () => {
+    const treatments: Treatment[] = [
+      {
+        name: "t0",
+        playerCount: 1,
+        groupComposition: [
+          {
+            position: 0,
+            conditions: [
+              {
+                reference: "self.entryUrl.params.condition",
+                comparator: "equals",
+                value: "treatment",
+              },
+            ],
+          },
+        ],
+      },
+    ];
+    const table = makeEligibilityTable({
+      playerIds: ["p0", "p1"],
+      treatments,
+      playerData: {
+        p0: { entryUrl: { params: { condition: "treatment" } } },
+        p1: { entryUrl: { params: { condition: "control" } } },
+      },
+    });
+    expect(table.isEligible("p0", 0, 0)).toBe(true);
+    expect(table.isEligible("p1", 0, 0)).toBe(false);
+  });
+});

--- a/packages/stagebook/src/dispatch/makeEligibilityTable.ts
+++ b/packages/stagebook/src/dispatch/makeEligibilityTable.ts
@@ -1,0 +1,110 @@
+import {
+  getNestedValueByPath,
+  getReferenceKeyAndPath,
+} from "../utils/reference.js";
+import {
+  evaluateConditions,
+  type Condition,
+  type ConditionNode,
+} from "../utils/evaluateConditions.js";
+import type {
+  DispatchConditionNode,
+  EligibilityTable,
+  PlayerDataSnapshot,
+  Treatment,
+} from "./types.js";
+
+interface MakeEligibilityTableArgs {
+  playerIds: string[];
+  treatments: Treatment[];
+  /** Per-player storage-key map. Keys come from `extractConditionKeys`. */
+  playerData: PlayerDataSnapshot;
+}
+
+/**
+ * Build a `(playerId, treatmentIndex, position) → boolean` lookup once
+ * per dispatch tick. The host has already fetched each candidate's data
+ * for the storage-keys returned by `extractConditionKeys`; here we run
+ * the same condition-tree evaluator stagebook uses elsewhere
+ * (`evaluateConditions`) against the candidate's data, and cache the
+ * answer.
+ *
+ * Only `self.X.Y` references are resolved — eligibility is a per-
+ * candidate question, and numeric/`shared`/`all` selectors would
+ * require the eventual group composition (a circular dependency). Those
+ * reads return `undefined` from the resolve callback, which the tri-
+ * state evaluator collapses to "data not yet" → false at the boundary.
+ * Treatments without `groupComposition`, and slots without
+ * `conditions`, are unconstrained (everyone eligible).
+ *
+ * The returned table is read-only. The dispatcher consumes it strictly
+ * through `isEligible(...)` and never inspects the underlying data.
+ */
+export function makeEligibilityTable({
+  playerIds,
+  treatments,
+  playerData,
+}: MakeEligibilityTableArgs): EligibilityTable {
+  // Map<playerId, Map<treatmentIndex, Map<position, bool>>>.
+  // A nested map (rather than a flat string-keyed cache) keeps the
+  // membership probes O(1) without the GC pressure of building one
+  // composite string per (player, treatment, position) tuple.
+  const cache = new Map<string, Map<number, Map<number, boolean>>>();
+
+  for (const pid of playerIds) {
+    const dataForPlayer = playerData[pid] ?? {};
+    const resolveForPlayer = (reference: string): unknown[] => {
+      // Eligibility resolves only `self.*` references. Anything else
+      // collapses to "no values resolved" — the tri-state leaf
+      // evaluator then returns false (positive comparators) or true
+      // (`doesNotEqual` family) per `compare`'s undefined-lhs policy.
+      if (!reference.startsWith("self.")) return [];
+      let referenceKey: string;
+      let path: string[];
+      try {
+        ({ referenceKey, path } = getReferenceKeyAndPath(reference));
+      } catch {
+        return [];
+      }
+      const record = dataForPlayer[referenceKey];
+      if (record === undefined) return [];
+      const value = getNestedValueByPath(record, path);
+      if (value === undefined) return [];
+      return [value];
+    };
+
+    const treatmentMap = new Map<number, Map<number, boolean>>();
+    cache.set(pid, treatmentMap);
+
+    treatments.forEach((treatment, treatmentIdx) => {
+      const positionMap = new Map<number, boolean>();
+      treatmentMap.set(treatmentIdx, positionMap);
+      const gc = treatment.groupComposition;
+      for (let pos = 0; pos < treatment.playerCount; pos += 1) {
+        let conditions:
+          | DispatchConditionNode
+          | DispatchConditionNode[]
+          | undefined;
+        if (Array.isArray(gc)) {
+          const slot = gc.find((s) => s?.position === pos);
+          conditions = slot?.conditions;
+        }
+        if (conditions === undefined || conditions === null) {
+          positionMap.set(pos, true);
+          continue;
+        }
+        const ok = evaluateConditions(
+          conditions as ConditionNode | ConditionNode[] | Condition,
+          resolveForPlayer,
+        );
+        positionMap.set(pos, ok);
+      }
+    });
+  }
+
+  return {
+    isEligible(playerId, treatmentIndex, position) {
+      return cache.get(playerId)?.get(treatmentIndex)?.get(position) ?? false;
+    },
+  };
+}

--- a/packages/stagebook/src/dispatch/randomization.test.ts
+++ b/packages/stagebook/src/dispatch/randomization.test.ts
@@ -1,0 +1,506 @@
+// Statistical-properties suite for stagebook's pure dispatchers (#448).
+//
+// These tests verify the claims a randomization story makes to a
+// reviewer: assignment is unbiased w.r.t. arrival order, position
+// within a group, irrelevant player attributes, and pairwise co-
+// occurrence. Mirrors the 8-test reference suite that landed in
+// deliberation-lab#268 for the BO-style dispatcher.
+//
+// Sizing rationale (same as deliberation-lab):
+//   - M chosen so binomial SE is small enough to catch ≥2% absolute
+//     deviations at α=1e-4, while staying within ~30s per test.
+//   - chi-square critical values pinned via lookup table — keeps the
+//     test file free of a stats dependency.
+
+import { test, expect, describe } from "vitest";
+import { mulberry32 } from "./contract.js";
+import { makeEligibilityTable } from "./makeEligibilityTable.js";
+import { uniformRandom } from "./uniformRandom.js";
+import { urnRandomization } from "./urnRandomization.js";
+import type { DispatchResult, Treatment } from "./types.js";
+
+// ─── Shared statistics helpers ─────────────────────────────────────
+
+function chiSquareUniform(observedCounts: number[]): number {
+  const total = observedCounts.reduce((s, x) => s + x, 0);
+  const exp = total / observedCounts.length;
+  return observedCounts.reduce((s, x) => s + (x - exp) ** 2 / exp, 0);
+}
+
+// Critical χ² values at α=1e-4. Below these → fail to reject H0 (data
+// consistent with uniform); above → reject (biased).
+const CHI2_CRITICAL_ALPHA_1E4: Record<number, number> = {
+  1: 15.14,
+  2: 18.42,
+  3: 21.11,
+  4: 23.51,
+  5: 25.74,
+};
+// Z critical value at α=1e-4 (two-sided).
+const Z_CRITICAL_ALPHA_1E4 = 3.89;
+
+function emptyEligibility(playerIds: string[], treatments: Treatment[]) {
+  // Empty playerData → eligibility for every (player, treatment, position)
+  // is true when the treatment has no groupComposition conditions.
+  return makeEligibilityTable({ playerIds, treatments, playerData: {} });
+}
+
+// ─── Uniform-random suite ──────────────────────────────────────────
+
+describe("uniformRandom: randomization properties (α=1e-4)", () => {
+  const T_ONE: Treatment[] = [{ name: "T", playerCount: 2 }];
+
+  function runOneUniform(
+    players: { id: string; data?: Record<string, Record<string, unknown>> }[],
+    seed: number,
+    treatments = T_ONE,
+  ): DispatchResult {
+    const playerIds = players.map((p) => p.id);
+    const eligibility = emptyEligibility(playerIds, treatments);
+    return uniformRandom({
+      playerIds,
+      treatments,
+      eligibility,
+      rng: mulberry32(seed),
+    });
+  }
+
+  test("1. seeded determinism: identical seed + inputs ⇒ identical assignments", () => {
+    const makePlayers = () =>
+      Array.from({ length: 4 }, (_, i) => ({ id: `p_${i}` }));
+    const a = runOneUniform(makePlayers(), 42);
+    const b = runOneUniform(makePlayers(), 42);
+    const c = runOneUniform(makePlayers(), 43);
+    expect(a.assignments).toEqual(b.assignments);
+    expect(a.assignments).not.toEqual(c.assignments);
+  });
+
+  test("2. marginal target rate: equal treatments sampled uniformly (χ²)", () => {
+    const K = 4;
+    const M = 1000;
+    const playersPerTick = 6;
+    const treatments: Treatment[] = Array.from({ length: K }, (_, i) => ({
+      name: `T${i}`,
+      playerCount: 2,
+    }));
+
+    const useCount = treatments.map(() => 0);
+    for (let m = 0; m < M; m += 1) {
+      const players = Array.from({ length: playersPerTick }, (_, i) => ({
+        id: `p_${m}_${i}`,
+      }));
+      const { assignments } = runOneUniform(players, 6000 + m, treatments);
+      for (const a of assignments) {
+        const idx = treatments.findIndex((t) => t.name === a.treatment.name);
+        useCount[idx] += 1;
+      }
+    }
+    const chi2 = chiSquareUniform(useCount);
+    expect(chi2).toBeLessThan(CHI2_CRITICAL_ALPHA_1E4[K - 1]);
+  });
+
+  test("3. position uniformity: per-player position-0 distribution is uniform (χ²)", () => {
+    const N = 4;
+    const M = 20000;
+    const posCounts: Record<string, { 0: number; 1: number }> = {};
+    for (let i = 0; i < N; i += 1) posCounts[`p_${i}`] = { 0: 0, 1: 0 };
+
+    for (let m = 0; m < M; m += 1) {
+      const players = Array.from({ length: N }, (_, i) => ({ id: `p_${i}` }));
+      const { assignments } = runOneUniform(players, 1000 + m);
+      for (const a of assignments) {
+        for (const pa of a.positionAssignments) {
+          posCounts[pa.playerId][pa.position as 0 | 1] += 1;
+        }
+      }
+    }
+    const pos0 = Array.from({ length: N }, (_, i) => posCounts[`p_${i}`][0]);
+    const chi2 = pos0.reduce((s, x) => s + (x - M / 2) ** 2 / (M / 4), 0);
+    expect(chi2).toBeLessThan(CHI2_CRITICAL_ALPHA_1E4[N]);
+  });
+
+  test("4. equal opportunity within eligibility class: leftover-rate uniform (χ²)", () => {
+    const N = 5;
+    const M = 2000;
+    const leftoverCount: Record<string, number> = {};
+    for (let i = 0; i < N; i += 1) leftoverCount[`p_${i}`] = 0;
+
+    for (let m = 0; m < M; m += 1) {
+      const players = Array.from({ length: N }, (_, i) => ({ id: `p_${i}` }));
+      const { assignments } = runOneUniform(players, 2000 + m);
+      const assigned = new Set(
+        assignments.flatMap((a) =>
+          a.positionAssignments.map((pa) => pa.playerId),
+        ),
+      );
+      for (let i = 0; i < N; i += 1) {
+        if (!assigned.has(`p_${i}`)) leftoverCount[`p_${i}`] += 1;
+      }
+    }
+    const counts = Array.from({ length: N }, (_, i) => leftoverCount[`p_${i}`]);
+    const chi2 = chiSquareUniform(counts);
+    expect(chi2).toBeLessThan(CHI2_CRITICAL_ALPHA_1E4[N - 1]);
+  });
+
+  test("5. arrival-order independence: forward vs reverse give same aggregate (binomial)", () => {
+    const M = 10000;
+    function simulate(playerIds: string[], seedOffset: number) {
+      const counts: Record<string, number> = {};
+      playerIds.forEach((pid) => {
+        counts[pid] = 0;
+      });
+      for (let m = 0; m < M; m += 1) {
+        const players = playerIds.map((id) => ({ id }));
+        const { assignments } = runOneUniform(players, seedOffset + m);
+        for (const a of assignments) {
+          for (const pa of a.positionAssignments) {
+            if (pa.position === 0) counts[pa.playerId] += 1;
+          }
+        }
+      }
+      return counts;
+    }
+    const forward = simulate(["p_0", "p_1", "p_2", "p_3"], 4000);
+    const reverse = simulate(["p_3", "p_2", "p_1", "p_0"], 4000);
+    // Under H0 forward − reverse ~ N(0, M/2).
+    const seDiff = Math.sqrt(M / 2);
+    const ids = ["p_0", "p_1", "p_2", "p_3"];
+    const maxAbsZ = Math.max(
+      ...ids.map((pid) => Math.abs((forward[pid] - reverse[pid]) / seDiff)),
+    );
+    // Bonferroni over 4 comparisons: α'=2.5e-5 → z'=4.21.
+    expect(maxAbsZ).toBeLessThan(4.21);
+  });
+
+  test("6. irrelevant-attribute independence: tag does not predict leftover (binomial)", () => {
+    const M = 10000;
+    let bAsLeftover = 0;
+    for (let m = 0; m < M; m += 1) {
+      const players = [
+        { id: "p_0" },
+        { id: "p_1" },
+        { id: "p_2" },
+        { id: "p_3" },
+        { id: "p_4" },
+      ];
+      const tag = ["A", "A", "A", "B", "B"] as const;
+      const { assignments } = runOneUniform(players, 3000 + m);
+      const assigned = new Set(
+        assignments.flatMap((a) =>
+          a.positionAssignments.map((pa) => pa.playerId),
+        ),
+      );
+      const leftoverIdx = players.findIndex((p) => !assigned.has(p.id));
+      if (leftoverIdx >= 0 && tag[leftoverIdx] === "B") bAsLeftover += 1;
+    }
+    const p0 = 2 / 5;
+    const expected = M * p0;
+    const se = Math.sqrt(M * p0 * (1 - p0));
+    const z = (bAsLeftover - expected) / se;
+    expect(Math.abs(z)).toBeLessThan(Z_CRITICAL_ALPHA_1E4);
+  });
+
+  test("7. pairwise co-assignment independence: pair co-occurrence uniform (χ²)", () => {
+    const N = 4;
+    const M = 10000;
+    const pairKey = (a: string, b: string) =>
+      a < b ? `${a}-${b}` : `${b}-${a}`;
+    const pairCounts: Record<string, number> = {};
+    for (let i = 0; i < N; i += 1) {
+      for (let j = i + 1; j < N; j += 1) {
+        pairCounts[pairKey(`p_${i}`, `p_${j}`)] = 0;
+      }
+    }
+    for (let m = 0; m < M; m += 1) {
+      const players = Array.from({ length: N }, (_, i) => ({ id: `p_${i}` }));
+      const { assignments } = runOneUniform(players, 5000 + m);
+      for (const a of assignments) {
+        const ids = a.positionAssignments.map((pa) => pa.playerId);
+        for (let i = 0; i < ids.length; i += 1) {
+          for (let j = i + 1; j < ids.length; j += 1) {
+            pairCounts[pairKey(ids[i], ids[j])] += 1;
+          }
+        }
+      }
+    }
+    const counts = Object.values(pairCounts);
+    const chi2 = chiSquareUniform(counts);
+    expect(chi2).toBeLessThan(CHI2_CRITICAL_ALPHA_1E4[5]);
+  });
+
+  // Property 8 (variant balance within label) is matrix-decrement-
+  // specific and does not apply to uniform-random; covered in the urn
+  // suite below.
+});
+
+// ─── Urn suite ─────────────────────────────────────────────────────
+
+describe("urnRandomization: randomization properties (α=1e-4)", () => {
+  function runOneUrn(
+    players: { id: string }[],
+    treatments: Treatment[],
+    counts: number[],
+    seed: number,
+    decrements?: number[][],
+  ): DispatchResult {
+    const playerIds = players.map((p) => p.id);
+    const eligibility = emptyEligibility(playerIds, treatments);
+    return urnRandomization({
+      playerIds,
+      treatments,
+      counts,
+      decrements,
+      eligibility,
+      rng: mulberry32(seed),
+    });
+  }
+
+  const T_ONE: Treatment[] = [{ name: "T", playerCount: 2 }];
+
+  test("1. seeded determinism: identical seed + inputs ⇒ identical assignments", () => {
+    const makePlayers = () =>
+      Array.from({ length: 4 }, (_, i) => ({ id: `p_${i}` }));
+    const a = runOneUrn(makePlayers(), T_ONE, [10], 42);
+    const b = runOneUrn(makePlayers(), T_ONE, [10], 42);
+    const c = runOneUrn(makePlayers(), T_ONE, [10], 43);
+    expect(a.assignments).toEqual(b.assignments);
+    expect(a.assignments).not.toEqual(c.assignments);
+    expect(a.remainingCounts).toEqual(b.remainingCounts);
+  });
+
+  test("2. marginal target rate: counts are honored exactly across runs", () => {
+    // Central claim of urn randomization: over the run, treatment i is
+    // used exactly `counts[i]` times.
+    const targetCounts = [25, 25, 25, 25];
+    const K = targetCounts.length;
+    const treatments: Treatment[] = Array.from({ length: K }, (_, i) => ({
+      name: `T${i}`,
+      playerCount: 2,
+    }));
+    const totalSlots = targetCounts.reduce((a, b) => a + 2 * b, 0);
+    // Provide enough players to drain the urn. Over-supply is fine —
+    // dispatcher stops when no positive-count treatment fits.
+    const players = Array.from({ length: totalSlots + 10 }, (_, i) => ({
+      id: `p_${i}`,
+    }));
+    const { assignments, remainingCounts } = runOneUrn(
+      players,
+      treatments,
+      targetCounts,
+      9000,
+    );
+    const useCount = treatments.map(() => 0);
+    for (const a of assignments) {
+      const idx = treatments.findIndex((t) => t.name === a.treatment.name);
+      useCount[idx] += 1;
+    }
+    expect(useCount).toEqual(targetCounts);
+    expect(remainingCounts).toEqual([0, 0, 0, 0]);
+  });
+
+  test("3. position uniformity: per-player position-0 distribution is uniform (χ²)", () => {
+    const N = 4;
+    const M = 20000;
+    const posCounts: Record<string, { 0: number; 1: number }> = {};
+    for (let i = 0; i < N; i += 1) posCounts[`p_${i}`] = { 0: 0, 1: 0 };
+
+    for (let m = 0; m < M; m += 1) {
+      const players = Array.from({ length: N }, (_, i) => ({ id: `p_${i}` }));
+      const { assignments } = runOneUrn(players, T_ONE, [2], 1000 + m);
+      for (const a of assignments) {
+        for (const pa of a.positionAssignments) {
+          posCounts[pa.playerId][pa.position as 0 | 1] += 1;
+        }
+      }
+    }
+    const pos0 = Array.from({ length: N }, (_, i) => posCounts[`p_${i}`][0]);
+    const chi2 = pos0.reduce((s, x) => s + (x - M / 2) ** 2 / (M / 4), 0);
+    expect(chi2).toBeLessThan(CHI2_CRITICAL_ALPHA_1E4[N]);
+  });
+
+  test("4. equal opportunity within eligibility class: leftover-rate uniform (χ²)", () => {
+    const N = 5;
+    const M = 2000;
+    const leftoverCount: Record<string, number> = {};
+    for (let i = 0; i < N; i += 1) leftoverCount[`p_${i}`] = 0;
+
+    for (let m = 0; m < M; m += 1) {
+      const players = Array.from({ length: N }, (_, i) => ({ id: `p_${i}` }));
+      // Counts: 2 means "fill twice", but with only 5 players in T(pc=2)
+      // we'll fill exactly twice; one player is leftover each tick.
+      const { assignments } = runOneUrn(players, T_ONE, [2], 2000 + m);
+      const assigned = new Set(
+        assignments.flatMap((a) =>
+          a.positionAssignments.map((pa) => pa.playerId),
+        ),
+      );
+      for (let i = 0; i < N; i += 1) {
+        if (!assigned.has(`p_${i}`)) leftoverCount[`p_${i}`] += 1;
+      }
+    }
+    const counts = Array.from({ length: N }, (_, i) => leftoverCount[`p_${i}`]);
+    const chi2 = chiSquareUniform(counts);
+    expect(chi2).toBeLessThan(CHI2_CRITICAL_ALPHA_1E4[N - 1]);
+  });
+
+  test("5. arrival-order independence: forward vs reverse give same aggregate (binomial)", () => {
+    const M = 10000;
+    function simulate(playerIds: string[], seedOffset: number) {
+      const counts: Record<string, number> = {};
+      playerIds.forEach((pid) => {
+        counts[pid] = 0;
+      });
+      for (let m = 0; m < M; m += 1) {
+        const players = playerIds.map((id) => ({ id }));
+        const { assignments } = runOneUrn(players, T_ONE, [10], seedOffset + m);
+        for (const a of assignments) {
+          for (const pa of a.positionAssignments) {
+            if (pa.position === 0) counts[pa.playerId] += 1;
+          }
+        }
+      }
+      return counts;
+    }
+    const forward = simulate(["p_0", "p_1", "p_2", "p_3"], 4000);
+    const reverse = simulate(["p_3", "p_2", "p_1", "p_0"], 4000);
+    const seDiff = Math.sqrt(M / 2);
+    const ids = ["p_0", "p_1", "p_2", "p_3"];
+    const maxAbsZ = Math.max(
+      ...ids.map((pid) => Math.abs((forward[pid] - reverse[pid]) / seDiff)),
+    );
+    expect(maxAbsZ).toBeLessThan(4.21);
+  });
+
+  test("6. irrelevant-attribute independence: tag does not predict leftover (binomial)", () => {
+    const M = 10000;
+    let bAsLeftover = 0;
+    for (let m = 0; m < M; m += 1) {
+      const players = [
+        { id: "p_0" },
+        { id: "p_1" },
+        { id: "p_2" },
+        { id: "p_3" },
+        { id: "p_4" },
+      ];
+      const tag = ["A", "A", "A", "B", "B"] as const;
+      const { assignments } = runOneUrn(players, T_ONE, [2], 3000 + m);
+      const assigned = new Set(
+        assignments.flatMap((a) =>
+          a.positionAssignments.map((pa) => pa.playerId),
+        ),
+      );
+      const leftoverIdx = players.findIndex((p) => !assigned.has(p.id));
+      if (leftoverIdx >= 0 && tag[leftoverIdx] === "B") bAsLeftover += 1;
+    }
+    const p0 = 2 / 5;
+    const expected = M * p0;
+    const se = Math.sqrt(M * p0 * (1 - p0));
+    const z = (bAsLeftover - expected) / se;
+    expect(Math.abs(z)).toBeLessThan(Z_CRITICAL_ALPHA_1E4);
+  });
+
+  test("7. pairwise co-assignment independence: pair co-occurrence uniform (χ²)", () => {
+    const N = 4;
+    const M = 10000;
+    const pairKey = (a: string, b: string) =>
+      a < b ? `${a}-${b}` : `${b}-${a}`;
+    const pairCounts: Record<string, number> = {};
+    for (let i = 0; i < N; i += 1) {
+      for (let j = i + 1; j < N; j += 1) {
+        pairCounts[pairKey(`p_${i}`, `p_${j}`)] = 0;
+      }
+    }
+    for (let m = 0; m < M; m += 1) {
+      const players = Array.from({ length: N }, (_, i) => ({ id: `p_${i}` }));
+      const { assignments } = runOneUrn(players, T_ONE, [2], 5000 + m);
+      for (const a of assignments) {
+        const ids = a.positionAssignments.map((pa) => pa.playerId);
+        for (let i = 0; i < ids.length; i += 1) {
+          for (let j = i + 1; j < ids.length; j += 1) {
+            pairCounts[pairKey(ids[i], ids[j])] += 1;
+          }
+        }
+      }
+    }
+    const counts = Object.values(pairCounts);
+    const chi2 = chiSquareUniform(counts);
+    expect(chi2).toBeLessThan(CHI2_CRITICAL_ALPHA_1E4[5]);
+  });
+
+  test("8. variant balance within label: matrix decrement distributes variants uniformly (χ²)", () => {
+    // 2 labels × 5 variants, decrement matrix penalizes same-label
+    // cells. Per-label, the 5 variants should be used uniformly across
+    // the batch (label rotation, not variant preference).
+    const NLABELS = 2;
+    const NVARIANTS = 5;
+    // Target counts that produce many label-uses per variant: each
+    // variant balls = 20, so per label total = 100 uses.
+    const treatments: Treatment[] = [];
+    for (let i = 0; i < NLABELS; i += 1) {
+      for (let j = 0; j < NVARIANTS; j += 1) {
+        treatments.push({
+          name: `L${i}V${j}`,
+          label: `L${i}`,
+          variant: `V${j}`,
+          playerCount: 2,
+        });
+      }
+    }
+    const counts = treatments.map(() => 20);
+    // Decrement matrix: when L0Vk is used, decrement all L0V* by 1 (same
+    // label coupling) and leave L1V* alone.
+    const decrements = treatments.map((ti) =>
+      treatments.map((tj) => (ti.label === tj.label ? 1 : 0)),
+    );
+
+    // Two players per tick; enough ticks to drain the urn under same-
+    // label coupling.
+    let totalUses = 0;
+    const useCount: Record<string, number> = {};
+    for (const t of treatments) useCount[t.name] = 0;
+
+    let runningCounts = counts.slice();
+    let seed = 7000;
+    const HARD_CAP = 20_000;
+    while (runningCounts.some((c) => c > 0)) {
+      const players = [{ id: `p_${seed}_0` }, { id: `p_${seed}_1` }];
+      const playerIds = players.map((p) => p.id);
+      const eligibility = emptyEligibility(playerIds, treatments);
+      const { assignments, remainingCounts } = urnRandomization({
+        playerIds,
+        treatments,
+        counts: runningCounts,
+        decrements,
+        eligibility,
+        rng: mulberry32(seed),
+      });
+      for (const a of assignments) {
+        useCount[a.treatment.name] += 1;
+        totalUses += 1;
+      }
+      runningCounts = remainingCounts;
+      seed += 1;
+      if (seed > HARD_CAP) {
+        // Regression guard: the urn must drain under these inputs.
+        // Falling out of the loop with positive counts would let the
+        // χ² test below pass on a partial sample, hiding a bug.
+        throw new Error(
+          `urn did not drain within ${HARD_CAP - 7000} ticks; remainingCounts=${JSON.stringify(runningCounts)}`,
+        );
+      }
+    }
+    expect(runningCounts.every((c) => c === 0)).toBe(true);
+    expect(totalUses).toBeGreaterThan(0);
+
+    // Per-label variant uniformity: χ² over the 5 variant-counts inside
+    // each label, with α=1e-4.
+    for (let i = 0; i < NLABELS; i += 1) {
+      const variantCounts = Array.from(
+        { length: NVARIANTS },
+        (_, j) => useCount[`L${i}V${j}`],
+      );
+      const chi2 = chiSquareUniform(variantCounts);
+      expect(chi2).toBeLessThan(CHI2_CRITICAL_ALPHA_1E4[NVARIANTS - 1]);
+    }
+  });
+});

--- a/packages/stagebook/src/dispatch/tryFillTreatment.ts
+++ b/packages/stagebook/src/dispatch/tryFillTreatment.ts
@@ -1,0 +1,78 @@
+import type {
+  EligibilityTable,
+  PositionAssignment,
+  Treatment,
+} from "./types.js";
+
+/**
+ * Greedy-randomized attempt to fill a treatment's `playerCount` slots
+ * from the available player pool, respecting per-slot eligibility.
+ *
+ * Algorithm:
+ *   1. Shuffle the positions [0, playerCount).
+ *   2. For each position in shuffled order, list available players who
+ *      are eligible and haven't been claimed by an earlier position in
+ *      this same proposal, then pick one uniformly at random.
+ *   3. If any position has no eligible candidate, abort and return
+ *      `null` — the caller decides whether to retry a different
+ *      treatment.
+ *
+ * Why greedy + shuffled positions:
+ *   - Shuffled positions remove the systematic bias that would arise
+ *     from always assigning position 0 first when eligibility classes
+ *     overlap (e.g. a strict-eligibility position would always be
+ *     filled before an unconstrained position even though the
+ *     unconstrained position has a much larger candidate pool).
+ *   - Greedy can theoretically miss a bipartite matching that exists
+ *     when eligibility classes are tightly coupled; the caller is
+ *     expected to handle the `null` case (skip + try another treatment).
+ *     For the loose eligibility patterns we see in practice this is
+ *     never a problem.
+ *
+ * The returned `positionAssignments` is a fresh array — the caller
+ * owns mutating the available-players pool based on the result.
+ */
+export function tryFillTreatment(
+  treatmentIndex: number,
+  treatment: Treatment,
+  available: ReadonlySet<string>,
+  eligibility: EligibilityTable,
+  rng: () => number,
+): PositionAssignment[] | null {
+  if (treatment.playerCount > available.size) return null;
+
+  const positions: number[] = [];
+  for (let i = 0; i < treatment.playerCount; i += 1) positions.push(i);
+  fisherYatesShuffle(positions, rng);
+
+  const used = new Set<string>();
+  const result: PositionAssignment[] = [];
+  for (const position of positions) {
+    const candidates: string[] = [];
+    for (const pid of available) {
+      if (used.has(pid)) continue;
+      if (eligibility.isEligible(pid, treatmentIndex, position)) {
+        candidates.push(pid);
+      }
+    }
+    if (candidates.length === 0) return null;
+    const pick = candidates[Math.floor(rng() * candidates.length)];
+    used.add(pick);
+    result.push({ playerId: pick, position });
+  }
+  // Sort by position for deterministic output order (the algorithm
+  // randomized which slot was filled first, but the returned assignment
+  // ought not to leak that processing order).
+  result.sort((a, b) => a.position - b.position);
+  return result;
+}
+
+/** In-place Fisher-Yates shuffle using the supplied PRNG. */
+export function fisherYatesShuffle<T>(arr: T[], rng: () => number): void {
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rng() * (i + 1));
+    const tmp = arr[i];
+    arr[i] = arr[j];
+    arr[j] = tmp;
+  }
+}

--- a/packages/stagebook/src/dispatch/types.ts
+++ b/packages/stagebook/src/dispatch/types.ts
@@ -1,0 +1,130 @@
+// Types used by stagebook's dispatcher module (#448).
+//
+// Three concerns live here:
+//   - The structural Treatment / Assignment shapes the dispatchers consume
+//     and produce. They mirror the deliberation-lab dispatcher shapes so
+//     hosts can call into either without translating.
+//   - The EligibilityTable interface — a pre-computed lookup for "is
+//     player P eligible for treatment T's position p?" Decouples the
+//     dispatcher from reference-resolution; see makeEligibilityTable.ts.
+//   - The dispatcher-config discriminated unions surfaced in batch
+//     configs (`dispatcher: { type: ..., ... }`).
+//
+// We deliberately keep these types loose at the boundary. A `Treatment`
+// only needs `name`, `playerCount`, and an optional `groupComposition`;
+// callers may carry extra fields (gameStages, exitSequence, …) and the
+// dispatcher passes them through untouched on each returned assignment.
+
+/** A single condition leaf as it appears on a `groupComposition[i].conditions` entry. */
+export interface DispatchCondition {
+  reference: string;
+  comparator: string;
+  value?: unknown;
+}
+
+/** Mirror of stagebook's tree-of-conditions shape on a groupComposition slot.
+ *  We don't re-export the schema-derived `ConditionNode` to keep this module
+ *  importable without zod. */
+export type DispatchConditionNode =
+  | { all: DispatchConditionNode[] }
+  | { any: DispatchConditionNode[] }
+  | { none: DispatchConditionNode[] }
+  | DispatchCondition;
+
+/** A single slot description inside a treatment's `groupComposition`. */
+export interface DispatchSlot {
+  position: number;
+  conditions?: DispatchConditionNode[] | DispatchConditionNode;
+}
+
+/** Minimum-viable Treatment shape consumed by the dispatcher.
+ *
+ *  Callers typically pass the full resolved treatment object straight
+ *  from the treatment file — the dispatcher only reads `name`,
+ *  `playerCount`, and `groupComposition`. Everything else rides along
+ *  on the returned assignment.position. */
+export interface Treatment {
+  name: string;
+  playerCount: number;
+  /** Optional. When omitted, every player is eligible for every slot. */
+  groupComposition?: DispatchSlot[];
+  // Pass-through extras (gameStages, exitSequence, label, variant, …).
+  [extra: string]: unknown;
+}
+
+/** One slot assignment inside a group. */
+export interface PositionAssignment {
+  playerId: string;
+  position: number;
+}
+
+/** One game/group to create. */
+export interface Assignment {
+  treatment: Treatment;
+  positionAssignments: PositionAssignment[];
+}
+
+/** Base shape returned by every dispatcher. Algorithm-specific extras
+ *  (e.g. urn's `remainingCounts`) ride along on the same object — see
+ *  per-dispatcher result types below. */
+export interface DispatchResult {
+  assignments: Assignment[];
+}
+
+/** Pre-computed eligibility lookup for `(playerId, treatmentIndex, position)`.
+ *
+ *  Built once per dispatch tick by `makeEligibilityTable`, then handed to
+ *  the dispatcher so the algorithm itself sees only structural facts
+ *  (IDs + booleans) — no PlayerView, no reference resolution. */
+export interface EligibilityTable {
+  isEligible(
+    playerId: string,
+    treatmentIndex: number,
+    position: number,
+  ): boolean;
+}
+
+/** Snapshot of each candidate player's data, keyed by storage-key.
+ *
+ *  Storage-keys follow stagebook's `<source>_<name>` convention for
+ *  named sources (`prompt_role`) and the bare source name for external
+ *  sources (`entryUrl`). See `getReferenceKeyAndPath`. The host populates
+ *  this map for keys returned by `extractConditionKeys`. */
+export type PlayerDataSnapshot = Record<string, Record<string, unknown>>;
+
+// ─── Dispatcher configs (discriminated union by `type`) ───────────────
+
+/** Reference to data carried in a sibling file alongside the batch config.
+ *  The host resolves the reference and substitutes the literal value at
+ *  config-load time; the dispatcher itself only ever sees the resolved
+ *  numbers. The type lives here so `validateDispatcherConfig` can accept
+ *  either form at the boundary. */
+export interface FileReference {
+  from: string;
+}
+
+export interface UniformRandomDispatcherConfig {
+  type: "uniform-random";
+}
+
+export interface UrnDispatcherConfig {
+  type: "urn";
+  counts: number[] | FileReference;
+  /** Square matrix; defaults to identity (decrement self by 1) when omitted. */
+  decrements?: number[][] | FileReference;
+}
+
+/** Placeholder for the `local-penalization` dispatcher that stays in
+ *  deliberation-lab. Stagebook only carries the *config shape* so the
+ *  union in `DispatcherConfig` is closed; the implementation lives at
+ *  the call site. */
+export interface LocalPenalizationDispatcherConfig {
+  type: "local-penalization";
+  payoffs: number[] | "equal" | FileReference;
+  knockdowns: number | number[] | number[][] | "none" | FileReference;
+}
+
+export type DispatcherConfig =
+  | UniformRandomDispatcherConfig
+  | UrnDispatcherConfig
+  | LocalPenalizationDispatcherConfig;

--- a/packages/stagebook/src/dispatch/uniformRandom.ts
+++ b/packages/stagebook/src/dispatch/uniformRandom.ts
@@ -1,0 +1,86 @@
+import type {
+  Assignment,
+  DispatchResult,
+  EligibilityTable,
+  Treatment,
+} from "./types.js";
+import { tryFillTreatment } from "./tryFillTreatment.js";
+
+export interface UniformRandomArgs {
+  playerIds: string[];
+  treatments: Treatment[];
+  eligibility: EligibilityTable;
+  rng: () => number;
+}
+
+/**
+ * Trivial "no-balance" dispatcher: each group's treatment is an
+ * independent uniform draw from the treatment list. Intended for quick
+ * prototypes and as the explicit-name replacement for legacy
+ * `payoffs: "equal", knockdowns: "none"` configs.
+ *
+ * Algorithm (per round):
+ *   1. From treatments with `playerCount ≤ available.size`, sample one
+ *      uniformly at random.
+ *   2. Try to fill its slots from the available eligible players via
+ *      the shared `tryFillTreatment` helper.
+ *   3. On success, emit the assignment and remove its players. On
+ *      failure (no greedy matching) mark the treatment "tried this
+ *      round" and try a different one; if every remaining-size-feasible
+ *      treatment fails, stop.
+ *
+ * Termination: each successful round shrinks `available` by at least 1
+ * (treatments with playerCount = 0 are skipped); each failed round
+ * shrinks the "feasible-but-untried" set by at least 1. The combined
+ * outer + inner loops are bounded by `O(treatments² + playerIds)`.
+ *
+ * Not in scope:
+ *   - Balance guarantees (use `urnRandomization` for that).
+ *   - Optimal bipartite matching (greedy can rarely miss a matching
+ *     under tightly-coupled eligibility; the caller's data shape and
+ *     condition tree determine whether this matters).
+ */
+export function uniformRandom({
+  playerIds,
+  treatments,
+  eligibility,
+  rng,
+}: UniformRandomArgs): DispatchResult {
+  const assignments: Assignment[] = [];
+  const available = new Set(playerIds);
+
+  while (available.size > 0) {
+    const tried = new Set<number>();
+    let progress = false;
+    while (true) {
+      // Build the "size-feasible, not-yet-tried" treatment pool.
+      const pool: number[] = [];
+      for (let i = 0; i < treatments.length; i += 1) {
+        if (tried.has(i)) continue;
+        if (treatments[i].playerCount === 0) continue;
+        if (treatments[i].playerCount > available.size) continue;
+        pool.push(i);
+      }
+      if (pool.length === 0) break;
+      const treatmentIdx = pool[Math.floor(rng() * pool.length)];
+      const treatment = treatments[treatmentIdx];
+      const filled = tryFillTreatment(
+        treatmentIdx,
+        treatment,
+        available,
+        eligibility,
+        rng,
+      );
+      if (filled) {
+        assignments.push({ treatment, positionAssignments: filled });
+        for (const pa of filled) available.delete(pa.playerId);
+        progress = true;
+        break; // restart the outer round
+      }
+      tried.add(treatmentIdx);
+    }
+    if (!progress) break;
+  }
+
+  return { assignments };
+}

--- a/packages/stagebook/src/dispatch/urnRandomization.ts
+++ b/packages/stagebook/src/dispatch/urnRandomization.ts
@@ -1,0 +1,152 @@
+import type { Assignment, EligibilityTable, Treatment } from "./types.js";
+import { tryFillTreatment } from "./tryFillTreatment.js";
+
+export interface UrnRandomizationArgs {
+  playerIds: string[];
+  treatments: Treatment[];
+  /** Per-treatment remaining-balls. Mutated *by copy* — input is not modified. */
+  counts: number[];
+  /** Optional square N×N matrix of non-negative integer decrements.
+   *  `decrements[i][j]` = how many balls to subtract from treatment j
+   *  when treatment i is used. When omitted, defaults to the identity
+   *  matrix (decrement self by 1, leave others alone). */
+  decrements?: number[][];
+  eligibility: EligibilityTable;
+  rng: () => number;
+}
+
+export interface UrnRandomizationResult {
+  assignments: Assignment[];
+  /** Persist this across ticks. The host wires it back into the next
+   *  call's `counts`; the dispatcher itself is pure. */
+  remainingCounts: number[];
+}
+
+/**
+ * Sampling-without-replacement dispatcher: each treatment has a target
+ * count of "balls" (target-N for that arm); each successful assignment
+ * draws one ball and decrements per the decrement matrix. Over the run
+ * of the batch, each treatment is used at its target count exactly —
+ * this is THE central randomization claim for ordinary experimental
+ * work.
+ *
+ * Algorithm (per round, per call):
+ *   1. Eligible-treatment pool = treatments where
+ *      `counts[i] > 0 ∧ playerCount ≤ available.size ∧ playerCount > 0`.
+ *   2. Sample one treatment from the pool with probability proportional
+ *      to `counts[i]` (urn draw — *not* uniform).
+ *   3. Try to fill its slots via `tryFillTreatment`. On success, emit
+ *      the assignment, remove the players, and decrement the urn per
+ *      `decrements[i][*]` (clamped to zero on mid-dispatch underflow).
+ *   4. On greedy failure, mark this treatment "tried this round" and
+ *      sample again from the remaining pool; if every untried
+ *      treatment fails, stop.
+ *
+ * Counts are host-persistent state — call N times across N dispatch
+ * ticks; thread `result.remainingCounts` back into each successor's
+ * `counts` argument. The dispatcher itself never mutates its inputs.
+ *
+ * Underflow handling: if a decrement would push `counts[j]` below zero
+ * we clamp to zero. The issue's design discussion notes this can
+ * legitimately happen mid-dispatch when multiple picks decrement the
+ * same off-diagonal entry. We do not emit a warning at the dispatcher
+ * level — the host can detect the same condition by comparing input vs.
+ * output counts and surface it however its observability stack prefers.
+ */
+export function urnRandomization({
+  playerIds,
+  treatments,
+  counts,
+  decrements,
+  eligibility,
+  rng,
+}: UrnRandomizationArgs): UrnRandomizationResult {
+  const n = treatments.length;
+  if (counts.length !== n) {
+    throw new Error(
+      `urnRandomization: counts.length (${counts.length}) must equal treatments.length (${n})`,
+    );
+  }
+  const remainingCounts = counts.slice();
+  const decrementMatrix = decrements ?? identityMatrix(n);
+  if (decrementMatrix.length !== n) {
+    throw new Error(
+      `urnRandomization: decrements is not a square ${n}×${n} matrix (rows=${decrementMatrix.length})`,
+    );
+  }
+  for (let i = 0; i < n; i += 1) {
+    if (decrementMatrix[i].length !== n) {
+      throw new Error(
+        `urnRandomization: decrements row ${i} has length ${decrementMatrix[i].length}, expected ${n}`,
+      );
+    }
+  }
+
+  const assignments: Assignment[] = [];
+  const available = new Set(playerIds);
+
+  while (available.size > 0) {
+    const tried = new Set<number>();
+    let progress = false;
+    while (true) {
+      // Build the "positive-count, size-feasible, not-yet-tried" pool.
+      const pool: number[] = [];
+      let totalWeight = 0;
+      for (let i = 0; i < n; i += 1) {
+        if (tried.has(i)) continue;
+        if (remainingCounts[i] <= 0) continue;
+        if (treatments[i].playerCount === 0) continue;
+        if (treatments[i].playerCount > available.size) continue;
+        pool.push(i);
+        totalWeight += remainingCounts[i];
+      }
+      if (pool.length === 0 || totalWeight === 0) break;
+
+      // Weighted sample by remaining counts.
+      const target = rng() * totalWeight;
+      let cumulative = 0;
+      let treatmentIdx = pool[pool.length - 1];
+      for (const i of pool) {
+        cumulative += remainingCounts[i];
+        if (target < cumulative) {
+          treatmentIdx = i;
+          break;
+        }
+      }
+      const treatment = treatments[treatmentIdx];
+
+      const filled = tryFillTreatment(
+        treatmentIdx,
+        treatment,
+        available,
+        eligibility,
+        rng,
+      );
+      if (filled) {
+        assignments.push({ treatment, positionAssignments: filled });
+        for (const pa of filled) available.delete(pa.playerId);
+        const row = decrementMatrix[treatmentIdx];
+        for (let j = 0; j < n; j += 1) {
+          const next = remainingCounts[j] - row[j];
+          remainingCounts[j] = next < 0 ? 0 : next;
+        }
+        progress = true;
+        break; // restart the outer round
+      }
+      tried.add(treatmentIdx);
+    }
+    if (!progress) break;
+  }
+
+  return { assignments, remainingCounts };
+}
+
+function identityMatrix(n: number): number[][] {
+  const m: number[][] = [];
+  for (let i = 0; i < n; i += 1) {
+    const row: number[] = [];
+    for (let j = 0; j < n; j += 1) row.push(i === j ? 1 : 0);
+    m.push(row);
+  }
+  return m;
+}

--- a/packages/stagebook/src/dispatch/validateDispatcherConfig.test.ts
+++ b/packages/stagebook/src/dispatch/validateDispatcherConfig.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect } from "vitest";
+import { validateDispatcherConfig } from "./validateDispatcherConfig.js";
+
+describe("validateDispatcherConfig", () => {
+  test("rejects non-object configs", () => {
+    expect(validateDispatcherConfig(null, 2).ok).toBe(false);
+    expect(validateDispatcherConfig("urn", 2).ok).toBe(false);
+    expect(validateDispatcherConfig(42, 2).ok).toBe(false);
+  });
+
+  test("rejects missing or non-string `type`", () => {
+    expect(validateDispatcherConfig({}, 2).ok).toBe(false);
+    expect(validateDispatcherConfig({ type: "" }, 2).ok).toBe(false);
+  });
+
+  test("rejects unknown `type`", () => {
+    const r = validateDispatcherConfig({ type: "nope" }, 2);
+    expect(r.ok).toBe(false);
+    expect(r.diagnostics[0].path).toBe("type");
+  });
+
+  describe("uniform-random", () => {
+    test("accepts the bare `type` form", () => {
+      const r = validateDispatcherConfig({ type: "uniform-random" }, 3);
+      expect(r.ok).toBe(true);
+      expect(r.diagnostics).toEqual([]);
+    });
+
+    test("rejects stray fields (would mislead the author)", () => {
+      const r = validateDispatcherConfig(
+        { type: "uniform-random", counts: [1, 2, 3] },
+        3,
+      );
+      expect(r.ok).toBe(false);
+      expect(r.diagnostics[0].path).toBe("counts");
+    });
+  });
+
+  describe("urn", () => {
+    test("accepts a well-formed counts array", () => {
+      const r = validateDispatcherConfig({ type: "urn", counts: [2, 2, 2] }, 3);
+      expect(r.ok).toBe(true);
+    });
+
+    test("rejects unresolved file references on `counts`", () => {
+      const r = validateDispatcherConfig(
+        { type: "urn", counts: { from: "./counts.json" } },
+        3,
+      );
+      expect(r.ok).toBe(false);
+      expect(r.diagnostics[0].path).toBe("counts");
+    });
+
+    test("rejects mismatched counts.length vs treatments", () => {
+      const r = validateDispatcherConfig({ type: "urn", counts: [1, 2, 3] }, 2);
+      expect(r.ok).toBe(false);
+      const messages = r.diagnostics.map((d) => d.message);
+      expect(messages.some((m) => m.includes("counts.length"))).toBe(true);
+    });
+
+    test("rejects non-integer / negative count entries", () => {
+      const r = validateDispatcherConfig(
+        { type: "urn", counts: [2, -1, 1.5] },
+        3,
+      );
+      expect(r.ok).toBe(false);
+      const paths = r.diagnostics.map((d) => d.path).sort();
+      expect(paths).toContain("counts.1");
+      expect(paths).toContain("counts.2");
+    });
+
+    test("accepts a well-formed identity-decrement matrix", () => {
+      const r = validateDispatcherConfig(
+        {
+          type: "urn",
+          counts: [4, 4, 4],
+          decrements: [
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+          ],
+        },
+        3,
+      );
+      expect(r.ok).toBe(true);
+    });
+
+    test("rejects non-square decrement matrix", () => {
+      const r = validateDispatcherConfig(
+        {
+          type: "urn",
+          counts: [2, 2, 2],
+          decrements: [
+            [1, 0],
+            [0, 1],
+          ],
+        },
+        3,
+      );
+      expect(r.ok).toBe(false);
+    });
+
+    test("rejects decrement[i][j] > counts[j] (would underflow on first use)", () => {
+      const r = validateDispatcherConfig(
+        {
+          type: "urn",
+          counts: [1, 1],
+          decrements: [
+            [1, 2],
+            [0, 1],
+          ],
+        },
+        2,
+      );
+      expect(r.ok).toBe(false);
+      const messages = r.diagnostics.map((d) => d.message).join("\n");
+      expect(messages).toMatch(/underflow|exceeds counts/);
+    });
+  });
+
+  describe("local-penalization", () => {
+    test("is recognized but not deeply validated by stagebook", () => {
+      // Stagebook just confirms the discriminator; deliberation-lab
+      // owns the payoffs/knockdowns shape check.
+      const r = validateDispatcherConfig(
+        { type: "local-penalization", payoffs: "equal", knockdowns: "none" },
+        2,
+      );
+      expect(r.ok).toBe(true);
+    });
+  });
+});

--- a/packages/stagebook/src/dispatch/validateDispatcherConfig.ts
+++ b/packages/stagebook/src/dispatch/validateDispatcherConfig.ts
@@ -1,0 +1,228 @@
+import type {
+  DispatcherConfig,
+  UniformRandomDispatcherConfig,
+  UrnDispatcherConfig,
+} from "./types.js";
+
+/** One validation diagnostic. `path` points into the config object using
+ *  the same dotted convention zod does (`"counts"`, `"decrements.2.1"`)
+ *  so callers can surface it the same way they surface zod issues. */
+export interface DispatcherConfigDiagnostic {
+  path: string;
+  message: string;
+}
+
+export interface DispatcherConfigValidationResult {
+  ok: boolean;
+  diagnostics: DispatcherConfigDiagnostic[];
+}
+
+/**
+ * Validate the parameter shape of a dispatcher config that the host has
+ * already resolved (file-reference `{from: "./counts.json"}` shapes
+ * substituted with the concrete arrays). Catches the things the
+ * dispatcher itself trusts but the issue body calls out as config-time
+ * checks:
+ *
+ *   - `urn.counts[i]` non-negative integer
+ *   - `urn.decrements` (when present) square N×N of non-negative
+ *     integers
+ *   - `urn.decrements[i][j] <= counts[j]` — can't subtract more balls
+ *     than exist initially
+ *
+ * The function is intentionally tolerant of dispatchers it doesn't
+ * recognize (returns `ok: true` with a single warning-style diagnostic)
+ * so deliberation-lab can register `local-penalization` against the
+ * same validator without stagebook needing to know its parameter shape.
+ *
+ * @param config Resolved dispatcher config (file refs already substituted).
+ * @param treatmentCount Number of treatments in the batch (square-matrix check).
+ */
+export function validateDispatcherConfig(
+  config: unknown,
+  treatmentCount: number,
+): DispatcherConfigValidationResult {
+  const diagnostics: DispatcherConfigDiagnostic[] = [];
+  const push = (path: string, message: string) =>
+    diagnostics.push({ path, message });
+
+  if (config === null || typeof config !== "object") {
+    push("", "dispatcher config must be an object");
+    return { ok: false, diagnostics };
+  }
+  const c = config as { type?: unknown };
+  if (typeof c.type !== "string" || c.type.length === 0) {
+    push("type", "dispatcher `type` must be a non-empty string");
+    return { ok: false, diagnostics };
+  }
+
+  switch (c.type) {
+    case "uniform-random":
+      return validateUniformRandom(config as UniformRandomDispatcherConfig);
+    case "urn":
+      return validateUrn(config as UrnDispatcherConfig, treatmentCount);
+    case "local-penalization":
+      // Implementation lives in deliberation-lab; stagebook only checks
+      // that the discriminator is recognized. The host validator there
+      // will catch payoffs/knockdowns shape issues.
+      return { ok: true, diagnostics: [] };
+    default:
+      push(
+        "type",
+        `unknown dispatcher type "${c.type}" — expected one of: uniform-random, urn, local-penalization`,
+      );
+      return { ok: false, diagnostics };
+  }
+}
+
+function validateUniformRandom(
+  config: UniformRandomDispatcherConfig,
+): DispatcherConfigValidationResult {
+  // The trivial-case dispatcher carries no params beyond `type`. Extra
+  // keys would silently mislead the author into thinking a counts/
+  // decrements field had an effect, so we reject them here.
+  const allowed = new Set(["type"]);
+  const diagnostics: DispatcherConfigDiagnostic[] = [];
+  for (const k of Object.keys(config)) {
+    if (!allowed.has(k)) {
+      diagnostics.push({
+        path: k,
+        message: `\`uniform-random\` dispatcher does not accept a \`${k}\` field. Use \`urn\` for count-based targets.`,
+      });
+    }
+  }
+  return { ok: diagnostics.length === 0, diagnostics };
+}
+
+function validateUrn(
+  config: UrnDispatcherConfig,
+  treatmentCount: number,
+): DispatcherConfigValidationResult {
+  const diagnostics: DispatcherConfigDiagnostic[] = [];
+  const push = (path: string, message: string) =>
+    diagnostics.push({ path, message });
+
+  if (!("counts" in config)) {
+    push("counts", "`urn` dispatcher requires a `counts` array");
+    return { ok: false, diagnostics };
+  }
+  if (isFileReference(config.counts)) {
+    push(
+      "counts",
+      "`counts` is still a file reference — the host must resolve `{from: ...}` before calling the validator",
+    );
+    return { ok: false, diagnostics };
+  }
+  if (!Array.isArray(config.counts)) {
+    push("counts", "`counts` must be an array of non-negative integers");
+    return { ok: false, diagnostics };
+  }
+  const counts = config.counts as unknown[];
+  if (counts.length !== treatmentCount) {
+    push(
+      "counts",
+      `\`counts.length\` (${counts.length}) must equal the number of treatments (${treatmentCount})`,
+    );
+  }
+  counts.forEach((v, i) => {
+    if (!isNonNegativeInteger(v)) {
+      push(
+        `counts.${i}`,
+        `counts[${i}] must be a non-negative integer, got ${formatValue(v)}`,
+      );
+    }
+  });
+
+  if (config.decrements !== undefined) {
+    if (isFileReference(config.decrements)) {
+      push(
+        "decrements",
+        "`decrements` is still a file reference — the host must resolve `{from: ...}` before calling the validator",
+      );
+      return { ok: false, diagnostics };
+    }
+    if (!Array.isArray(config.decrements)) {
+      push(
+        "decrements",
+        "`decrements` must be a square N×N matrix of non-negative integers (or omitted for the identity-matrix default)",
+      );
+      return { ok: diagnostics.length === 0, diagnostics };
+    }
+    const matrix = config.decrements as unknown[];
+    if (matrix.length !== counts.length) {
+      push(
+        "decrements",
+        `\`decrements\` must be a square ${counts.length}×${counts.length} matrix; got ${matrix.length} rows`,
+      );
+    }
+    matrix.forEach((row, i) => {
+      if (!Array.isArray(row)) {
+        push(
+          `decrements.${i}`,
+          `decrements row ${i} must be an array of non-negative integers`,
+        );
+        return;
+      }
+      const r = row as unknown[];
+      if (r.length !== counts.length) {
+        push(
+          `decrements.${i}`,
+          `decrements row ${i} has length ${r.length}; expected ${counts.length} (matrix must be square)`,
+        );
+      }
+      r.forEach((v, j) => {
+        if (!isNonNegativeInteger(v)) {
+          push(
+            `decrements.${i}.${j}`,
+            `decrements[${i}][${j}] must be a non-negative integer, got ${formatValue(v)}`,
+          );
+          return;
+        }
+        // Initial-balance check: can't decrement more than the column's
+        // starting balls. Mid-dispatch underflow (after multiple picks)
+        // is clamped at the dispatcher; this check catches obvious
+        // misconfigurations at config-time.
+        const colCount = counts[j];
+        if (
+          isNonNegativeInteger(colCount) &&
+          (v as number) > (colCount as number)
+        ) {
+          push(
+            `decrements.${i}.${j}`,
+            `decrements[${i}][${j}] = ${v as number} exceeds counts[${j}] = ${colCount as number} — would underflow on the first use of treatment ${i}`,
+          );
+        }
+      });
+    });
+  }
+
+  return { ok: diagnostics.length === 0, diagnostics };
+}
+
+function isNonNegativeInteger(v: unknown): boolean {
+  return typeof v === "number" && Number.isInteger(v) && v >= 0;
+}
+
+function isFileReference(v: unknown): v is { from: string } {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    "from" in v &&
+    typeof (v as { from: unknown }).from === "string"
+  );
+}
+
+function formatValue(v: unknown): string {
+  if (typeof v === "string") return JSON.stringify(v);
+  if (typeof v === "number" || typeof v === "boolean") return String(v);
+  if (v === null || v === undefined) return String(v);
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return Object.prototype.toString.call(v);
+  }
+}
+
+// Re-export the result type from the public DispatcherConfig union so
+// hosts have a single import for the discriminator + validator.
+export type { DispatcherConfig };

--- a/packages/stagebook/tsup.config.ts
+++ b/packages/stagebook/tsup.config.ts
@@ -5,6 +5,8 @@ export default defineConfig({
     index: "src/index.ts",
     "components/index": "src/components/index.ts",
     "validate/index": "src/validate/index.ts",
+    "dispatch/index": "src/dispatch/index.ts",
+    "dispatch/contract": "src/dispatch/contract.ts",
     "cli/validate": "src/cli/validate.ts",
   },
   format: ["cjs", "esm"],


### PR DESCRIPTION
## Summary

Adds the new `stagebook/dispatch` module from #448:

- **`uniform-random`** — trivial iid-by-treatment dispatcher; explicit name for what `payoffs: "equal", knockdowns: "none"` actually was.
- **`urn`** — sampling-without-replacement against per-treatment target counts, with an optional N×N integer decrement matrix for cross-treatment locality. Pure function; host carries `remainingCounts` across ticks.
- **Generic contract harness** (`stagebook/dispatch/contract`) — the 10 structural invariants from deliberation-lab's `dispatch.contract.test.js`, scenario-shrunk to `{ players, treatments }` and parameterized over a dispatcher factory. deliberation-lab will register its existing `local-penalization` against this same gauntlet in a follow-up PR.
- **Pre-computed eligibility** — `extractConditionKeys` + `makeEligibilityTable` decouple the dispatcher from reference resolution per the issue's design constraints; the algorithms themselves see only IDs + structural facts.
- **Config validator** — `validateDispatcherConfig` checks the discriminated-union shape; recognizes `local-penalization` without deep-validating its shape (deliberation-lab owns that).

Package exports added: `stagebook/dispatch` (main API, vitest-free) and `stagebook/dispatch/contract` (harness — depends on vitest).

### Test coverage

- **Contract gauntlet (20 tests):** 10 invariants × 2 dispatchers × 200 random scenarios each. Invariant #9 now snapshots `params` too (so e.g. urn's `counts` input immutability is asserted as part of the contract).
- **Statistical-properties suite (15 tests, α=1e-4):** mirrors the 8-test pattern from deliberation-lab#268 — seeded determinism, marginal target rate, position uniformity, equal-opportunity-within-class, arrival-order independence, irrelevant-attribute independence, pairwise co-assignment independence; plus the matrix-decrement variant-balance test for urn (uniform-random has no decrement matrix, so this one is urn-only).
- **Unit tests (29 tests):** `extractConditionKeys`, `makeEligibilityTable`, `validateDispatcherConfig`.

64 new tests; all 1309 stagebook tests pass.

### Out of scope (per the issue's Non-scope section)

- Migrating `local-penalization` itself into stagebook (stays in deliberation-lab).
- Batch-config schema integration + backward-compat shim that rewrites legacy `payoffs`/`knockdowns` into the new `dispatcher: { type, ... }` shape — that lives in deliberation-lab.
- Monte-Carlo assignment-probability wrapper for IPW.

### Notes for reviewers

- Mid-dispatch underflow on `decrements[i][j]` clamps to zero (matches the issue body). The issue mentions an optional `info()` log; the implementation skips that — hosts can detect the same condition by diffing input vs. output counts and surface it however their observability stack prefers.
- The greedy fill in `tryFillTreatment` shuffles positions before assigning so strict-eligibility positions don't always win the race with unconstrained positions in the same treatment.

Closes #448.

## Test plan

- [x] `npm run lint -w stagebook` clean
- [x] `npm test -w stagebook` — 1309/1309 pass (new 64 + existing 1245)
- [x] `npm run build -w stagebook` succeeds; new bundle entries `dist/dispatch/index.{js,cjs,d.ts}` and `dist/dispatch/contract.{js,cjs,d.ts}` produced
- [x] Both dispatchers pass the contract gauntlet (10 invariants × 200 scenarios)
- [x] All 15 statistical properties pass at α=1e-4

🤖 Generated with [Claude Code](https://claude.com/claude-code)