### PR TITLE
Bump stagebook to 0.12.0

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Minor release adding the new dispatcher module.

## What's in

- **#449** — New `stagebook/dispatch` subpath export with two pure-function dispatchers (`uniform-random`, `urn`) plus pre-computed `EligibilityTable`, config validator, and a generic 10-invariant contract harness at `stagebook/dispatch/contract` (closes #448).

## Compatibility

- Additive. No existing exports changed.
- New public subpaths: `stagebook/dispatch` (runtime; vitest-free) and `stagebook/dispatch/contract` (test harness; depends on vitest as a peer of the consumer).