### PR TITLE
Add weighted-random dispatcher (stateless categorical sampler)

### DIFF
--- a/docs/researcher/dispatchers.md
+++ b/docs/researcher/dispatchers.md
@@ -1,0 +1,79 @@
+# Choosing a Dispatcher
+
+A **dispatcher** is the algorithm that decides which treatment each group of participants gets routed to. Stagebook ships four:
+
+| Dispatcher | What you provide | What it guarantees | When to reach for it |
+|---|---|---|---|
+| `uniform-random` | nothing | Each group's treatment is an independent uniform draw | Quick prototypes; you have no balance claim to make in a methods section |
+| `weighted-random` | one weight per treatment | Each group's treatment is an independent draw with `P(T) ∝ weight(T)` | You want unequal long-run rates (e.g. 80/10/10) but don't need exact-N targets |
+| `urn` | target counts per treatment (+ optional decrement matrix) | Each treatment is used exactly its target count over the batch | You want exact target Ns or cross-treatment locality (e.g. "don't pick the same label twice in a row") |
+| `local-penalization` | acquisition values + penalization matrix | One batch step of an iterated Bayesian-optimization loop | You're running a researcher-managed BO surrogate between batches |
+
+The first three are stateless or carry only a small piece of state (urn's remaining counts). All four pre-compute eligibility from each participant's data; the algorithm itself sees only IDs, treatment structure, and a boolean eligibility lookup — never the underlying responses.
+
+## `weighted-random` in detail
+
+This is the dispatcher most ordinary randomized experiments want when the allocation isn't 50/50. You specify weights up to scale:
+
+```yaml
+dispatcher:
+  type: weighted-random
+  weights: [4, 1, 1]   # T0 four times as often as T1 or T2 long-run
+```
+
+The weights are interpreted up to scale — `[4, 1, 1]`, `[80, 20, 20]`, and `[0.67, 0.17, 0.17]` are all the same sampler. Each round, the dispatcher draws a treatment with probability proportional to its weight, independently of every other round. There is no memory of which treatment was picked last; in particular, a run of three consecutive `T0` draws is not "balanced out" by extra `T1`/`T2` draws afterward.
+
+A zero weight means "never pick this treatment." This is useful when you want to keep a condition in the file but turn it off for a particular batch without renumbering everything.
+
+## Realized vs. target rates under eligibility constraints
+
+The most common gotcha with `weighted-random` (and with `urn`, for the same underlying reason) is that the realized rates only match your target weights when **every round is feasible for every treatment**. Two things can break feasibility:
+
+1. **Tight eligibility conditions** filter the candidate pool down. If only 20% of recruits satisfy treatment T0's role condition, T0 won't see its full target rate no matter how high you set its weight — there aren't enough eligible participants to fill it.
+2. **Per-tick player-pool size** can be too small for some treatments. If a treatment requires 6 players but the dispatch tick has only 4 available, that treatment is excluded from this round's pool.
+
+When a treatment drops out of a round's pool, the weight mass is implicitly renormalized across the surviving treatments. So a 4:1:1 batch with a too-tight eligibility on T0 won't deliver 67/17/17 — it'll deliver something more like 0/50/50 conditional on the tight rounds. The dispatcher is doing what you asked at every round; the design constraint is what's biting.
+
+### A worked example
+
+Suppose you set:
+
+```yaml
+dispatcher:
+  type: weighted-random
+  weights: [4, 1, 1]
+```
+
+with three two-player treatments. T0 requires *both* slots to be moderators (`self.prompt.role equals "moderator"`); T1 and T2 have no conditions. Recruitment pulls in 100 participants of whom 20 self-report as moderators (a 20% marginal rate).
+
+Each dispatch tick draws 6 available players. For T0 to be picked *and* fillable, the tick needs at least 2 moderators among its 6 players. Under independent arrival that's a binomial probability — ~**34%** of ticks.[^1] In the other 66%, T0 drops out of the pool, and the dispatcher renormalizes the surviving weights `[1, 1]` over T1 and T2 — so T1 and T2 each absorb half the mass T0 would have taken.
+
+Working that out per round:
+
+- **T0 picked & filled**: `0.34 × (4/6) = 23%`
+- **T1 picked**: `0.34 × (1/6) + 0.66 × (1/2) ≈ 39%`
+- **T2 picked**: `0.34 × (1/6) + 0.66 × (1/2) ≈ 39%`
+
+Compared to the target weights:
+
+| | Target (weights/sum) | Realized | Gap |
+|---|---|---|---|
+| T0 | 67% | 23% | **−44 pp** |
+| T1 | 17% | 39% | +22 pp |
+| T2 | 17% | 39% | +22 pp |
+
+The dispatcher is honoring `weights: [4, 1, 1]` at every feasible round. The 44-percentage-point shortfall on T0 is a study-design issue — you've asked for more moderator-condition assignments than your recruitment can supply.
+
+[^1]: `P(K ≥ 2 | n=6, p=0.2) = 1 − P(0) − P(1) = 1 − 0.8⁶ − 6·0.2·0.8⁵ ≈ 0.345`. The exact number depends on your tick size and your moderator marginal rate; the qualitative point — that tight eligibility on a high-weight treatment causes its realized rate to fall well below its weight — holds across this whole regime.
+
+### What to do about it
+
+Three options, in increasing order of effort:
+
+1. **Recruit until the rates match.** If your downstream analysis doesn't depend on exact N per cell, just let the batch run longer. Realized rates converge to weights *conditional on feasibility*; the slope is whatever your recruitment pipeline delivers.
+2. **Loosen eligibility on the constrained treatment** if the condition is over-specified for what you actually need. The most common case: a condition that *could* be evaluated post-hoc as a covariate instead of gated upstream.
+3. **Use `urn` instead** if you need *exact* target Ns per treatment. `urn` keeps allocating to a treatment until its target count is drained, so it will sit on a tight-eligibility condition until enough qualifying participants arrive. That comes with the tradeoff that other treatments stop receiving allocations once they hit their targets, even if more participants arrive.
+
+### Diagnostics
+
+The host (deliberation-lab in our deployment) gets the assignments back after every dispatch tick and can compute realized rates directly. If you're partway through a batch and the realized rate looks off relative to your target weights, the most likely cause is one of the two feasibility issues above. Check what fraction of your participants satisfy the constrained treatment's conditions; that fraction is roughly the ceiling on its realized rate.

--- a/packages/stagebook/src/dispatch/contract.test.ts
+++ b/packages/stagebook/src/dispatch/contract.test.ts
@@ -5,6 +5,7 @@
 
 import { buildEligibilityForScenario, runContractSuite } from "./contract.js";
 import { uniformRandom } from "./uniformRandom.js";
+import { weightedRandom } from "./weightedRandom.js";
 import { urnRandomization } from "./urnRandomization.js";
 
 runContractSuite("uniform-random", ({ scenario, rng }) => {
@@ -15,6 +16,33 @@ runContractSuite("uniform-random", ({ scenario, rng }) => {
       uniformRandom({
         playerIds: scenario.players.map((p) => p.id),
         treatments: scenario.treatments,
+        eligibility,
+        rng,
+      }),
+  };
+});
+
+runContractSuite("weighted-random", ({ scenario, rng }) => {
+  const eligibility = buildEligibilityForScenario(scenario);
+  // Random per-scenario weights. Mix of distributions:
+  //   - 25% all-equal (degenerate uniform-random case)
+  //   - 25% one zero weight (de-activated treatment)
+  //   - 50% random floats in [0.1, 4.0]
+  // Avoids all-zero (which yields no assignments, trivially passing
+  // invariants but not exercising the algorithm).
+  const r = rng();
+  const weights = scenario.treatments.map((_, i) => {
+    if (r < 0.25) return 1;
+    if (r < 0.5 && i === 0) return 0;
+    return 0.1 + rng() * 3.9;
+  });
+  return {
+    params: { weights },
+    dispatch: () =>
+      weightedRandom({
+        playerIds: scenario.players.map((p) => p.id),
+        treatments: scenario.treatments,
+        weights,
         eligibility,
         rng,
       }),

--- a/packages/stagebook/src/dispatch/index.ts
+++ b/packages/stagebook/src/dispatch/index.ts
@@ -8,6 +8,7 @@ export * from "./types.js";
 export { extractConditionKeys } from "./extractConditionKeys.js";
 export { makeEligibilityTable } from "./makeEligibilityTable.js";
 export { uniformRandom, type UniformRandomArgs } from "./uniformRandom.js";
+export { weightedRandom, type WeightedRandomArgs } from "./weightedRandom.js";
 export {
   urnRandomization,
   type UrnRandomizationArgs,

--- a/packages/stagebook/src/dispatch/randomization.test.ts
+++ b/packages/stagebook/src/dispatch/randomization.test.ts
@@ -17,6 +17,7 @@ import { mulberry32 } from "./contract.js";
 import { makeEligibilityTable } from "./makeEligibilityTable.js";
 import { uniformRandom } from "./uniformRandom.js";
 import { urnRandomization } from "./urnRandomization.js";
+import { weightedRandom } from "./weightedRandom.js";
 import type { DispatchResult, Treatment } from "./types.js";
 
 // ─── Shared statistics helpers ─────────────────────────────────────
@@ -230,6 +231,208 @@ describe("uniformRandom: randomization properties (α=1e-4)", () => {
 
   // Property 8 (variant balance within label) is matrix-decrement-
   // specific and does not apply to uniform-random; covered in the urn
+  // suite below.
+});
+
+// ─── Weighted-random suite ─────────────────────────────────────────
+
+describe("weightedRandom: randomization properties (α=1e-4)", () => {
+  const T_ONE: Treatment[] = [{ name: "T", playerCount: 2 }];
+
+  function runOneWeighted(
+    players: { id: string }[],
+    seed: number,
+    treatments = T_ONE,
+    weights = treatments.map(() => 1),
+  ): DispatchResult {
+    const playerIds = players.map((p) => p.id);
+    const eligibility = emptyEligibility(playerIds, treatments);
+    return weightedRandom({
+      playerIds,
+      treatments,
+      weights,
+      eligibility,
+      rng: mulberry32(seed),
+    });
+  }
+
+  test("1. seeded determinism: identical seed + inputs ⇒ identical assignments", () => {
+    const makePlayers = () =>
+      Array.from({ length: 4 }, (_, i) => ({ id: `p_${i}` }));
+    const a = runOneWeighted(makePlayers(), 42);
+    const b = runOneWeighted(makePlayers(), 42);
+    const c = runOneWeighted(makePlayers(), 43);
+    expect(a.assignments).toEqual(b.assignments);
+    expect(a.assignments).not.toEqual(c.assignments);
+  });
+
+  test("2. marginal target rate: treatments sampled at weight ratio (χ²)", () => {
+    // 4:1:1 weights → expected use share 0.667 / 0.167 / 0.167.
+    // χ² against weighted expectation (not uniform); same df = K-1.
+    const K = 3;
+    const M = 2000;
+    const playersPerTick = 4;
+    const treatments: Treatment[] = Array.from({ length: K }, (_, i) => ({
+      name: `T${i}`,
+      playerCount: 2,
+    }));
+    const weights = [4, 1, 1];
+    const totalWeight = weights.reduce((s, w) => s + w, 0);
+
+    const useCount = treatments.map(() => 0);
+    for (let m = 0; m < M; m += 1) {
+      const players = Array.from({ length: playersPerTick }, (_, i) => ({
+        id: `p_${m}_${i}`,
+      }));
+      const { assignments } = runOneWeighted(
+        players,
+        6000 + m,
+        treatments,
+        weights,
+      );
+      for (const a of assignments) {
+        const idx = treatments.findIndex((t) => t.name === a.treatment.name);
+        useCount[idx] += 1;
+      }
+    }
+    // χ² statistic against weighted expectation.
+    const total = useCount.reduce((s, x) => s + x, 0);
+    const chi2 = useCount.reduce((s, observed, i) => {
+      const expected = (total * weights[i]) / totalWeight;
+      return s + (observed - expected) ** 2 / expected;
+    }, 0);
+    expect(chi2).toBeLessThan(CHI2_CRITICAL_ALPHA_1E4[K - 1]);
+  });
+
+  test("3. position uniformity: per-player position-0 distribution is uniform (χ²)", () => {
+    const N = 4;
+    const M = 20000;
+    const posCounts: Record<string, { 0: number; 1: number }> = {};
+    for (let i = 0; i < N; i += 1) posCounts[`p_${i}`] = { 0: 0, 1: 0 };
+
+    for (let m = 0; m < M; m += 1) {
+      const players = Array.from({ length: N }, (_, i) => ({ id: `p_${i}` }));
+      const { assignments } = runOneWeighted(players, 1000 + m);
+      for (const a of assignments) {
+        for (const pa of a.positionAssignments) {
+          posCounts[pa.playerId][pa.position as 0 | 1] += 1;
+        }
+      }
+    }
+    const pos0 = Array.from({ length: N }, (_, i) => posCounts[`p_${i}`][0]);
+    const chi2 = pos0.reduce((s, x) => s + (x - M / 2) ** 2 / (M / 4), 0);
+    expect(chi2).toBeLessThan(CHI2_CRITICAL_ALPHA_1E4[N]);
+  });
+
+  test("4. equal opportunity within eligibility class: leftover-rate uniform (χ²)", () => {
+    const N = 5;
+    const M = 2000;
+    const leftoverCount: Record<string, number> = {};
+    for (let i = 0; i < N; i += 1) leftoverCount[`p_${i}`] = 0;
+
+    for (let m = 0; m < M; m += 1) {
+      const players = Array.from({ length: N }, (_, i) => ({ id: `p_${i}` }));
+      const { assignments } = runOneWeighted(players, 2000 + m);
+      const assigned = new Set(
+        assignments.flatMap((a) =>
+          a.positionAssignments.map((pa) => pa.playerId),
+        ),
+      );
+      for (let i = 0; i < N; i += 1) {
+        if (!assigned.has(`p_${i}`)) leftoverCount[`p_${i}`] += 1;
+      }
+    }
+    const counts = Array.from({ length: N }, (_, i) => leftoverCount[`p_${i}`]);
+    const chi2 = chiSquareUniform(counts);
+    expect(chi2).toBeLessThan(CHI2_CRITICAL_ALPHA_1E4[N - 1]);
+  });
+
+  test("5. arrival-order independence: forward vs reverse give same aggregate (binomial)", () => {
+    const M = 10000;
+    function simulate(playerIds: string[], seedOffset: number) {
+      const counts: Record<string, number> = {};
+      playerIds.forEach((pid) => {
+        counts[pid] = 0;
+      });
+      for (let m = 0; m < M; m += 1) {
+        const players = playerIds.map((id) => ({ id }));
+        const { assignments } = runOneWeighted(players, seedOffset + m);
+        for (const a of assignments) {
+          for (const pa of a.positionAssignments) {
+            if (pa.position === 0) counts[pa.playerId] += 1;
+          }
+        }
+      }
+      return counts;
+    }
+    const forward = simulate(["p_0", "p_1", "p_2", "p_3"], 4000);
+    const reverse = simulate(["p_3", "p_2", "p_1", "p_0"], 4000);
+    const seDiff = Math.sqrt(M / 2);
+    const ids = ["p_0", "p_1", "p_2", "p_3"];
+    const maxAbsZ = Math.max(
+      ...ids.map((pid) => Math.abs((forward[pid] - reverse[pid]) / seDiff)),
+    );
+    expect(maxAbsZ).toBeLessThan(4.21);
+  });
+
+  test("6. irrelevant-attribute independence: tag does not predict leftover (binomial)", () => {
+    const M = 10000;
+    let bAsLeftover = 0;
+    for (let m = 0; m < M; m += 1) {
+      const players = [
+        { id: "p_0" },
+        { id: "p_1" },
+        { id: "p_2" },
+        { id: "p_3" },
+        { id: "p_4" },
+      ];
+      const tag = ["A", "A", "A", "B", "B"] as const;
+      const { assignments } = runOneWeighted(players, 3000 + m);
+      const assigned = new Set(
+        assignments.flatMap((a) =>
+          a.positionAssignments.map((pa) => pa.playerId),
+        ),
+      );
+      const leftoverIdx = players.findIndex((p) => !assigned.has(p.id));
+      if (leftoverIdx >= 0 && tag[leftoverIdx] === "B") bAsLeftover += 1;
+    }
+    const p0 = 2 / 5;
+    const expected = M * p0;
+    const se = Math.sqrt(M * p0 * (1 - p0));
+    const z = (bAsLeftover - expected) / se;
+    expect(Math.abs(z)).toBeLessThan(Z_CRITICAL_ALPHA_1E4);
+  });
+
+  test("7. pairwise co-assignment independence: pair co-occurrence uniform (χ²)", () => {
+    const N = 4;
+    const M = 10000;
+    const pairKey = (a: string, b: string) =>
+      a < b ? `${a}-${b}` : `${b}-${a}`;
+    const pairCounts: Record<string, number> = {};
+    for (let i = 0; i < N; i += 1) {
+      for (let j = i + 1; j < N; j += 1) {
+        pairCounts[pairKey(`p_${i}`, `p_${j}`)] = 0;
+      }
+    }
+    for (let m = 0; m < M; m += 1) {
+      const players = Array.from({ length: N }, (_, i) => ({ id: `p_${i}` }));
+      const { assignments } = runOneWeighted(players, 5000 + m);
+      for (const a of assignments) {
+        const ids = a.positionAssignments.map((pa) => pa.playerId);
+        for (let i = 0; i < ids.length; i += 1) {
+          for (let j = i + 1; j < ids.length; j += 1) {
+            pairCounts[pairKey(ids[i], ids[j])] += 1;
+          }
+        }
+      }
+    }
+    const counts = Object.values(pairCounts);
+    const chi2 = chiSquareUniform(counts);
+    expect(chi2).toBeLessThan(CHI2_CRITICAL_ALPHA_1E4[5]);
+  });
+
+  // Property 8 (variant balance within label) is matrix-decrement-
+  // specific and does not apply to weighted-random; covered in the urn
   // suite below.
 });
 

--- a/packages/stagebook/src/dispatch/types.ts
+++ b/packages/stagebook/src/dispatch/types.ts
@@ -107,6 +107,15 @@ export interface UniformRandomDispatcherConfig {
   type: "uniform-random";
 }
 
+export interface WeightedRandomDispatcherConfig {
+  type: "weighted-random";
+  /** Non-negative reals interpreted up to scale. `[1, 1, 1]`, `[100, 100, 100]`,
+   *  and `[0.33, 0.33, 0.33]` produce identical samplers. Length must match
+   *  the treatment count. A zero weight means "never pick this treatment"
+   *  (useful for de-activating a condition without renumbering). */
+  weights: number[] | FileReference;
+}
+
 export interface UrnDispatcherConfig {
   type: "urn";
   counts: number[] | FileReference;
@@ -126,5 +135,6 @@ export interface LocalPenalizationDispatcherConfig {
 
 export type DispatcherConfig =
   | UniformRandomDispatcherConfig
+  | WeightedRandomDispatcherConfig
   | UrnDispatcherConfig
   | LocalPenalizationDispatcherConfig;

--- a/packages/stagebook/src/dispatch/validateDispatcherConfig.test.ts
+++ b/packages/stagebook/src/dispatch/validateDispatcherConfig.test.ts
@@ -36,6 +36,81 @@ describe("validateDispatcherConfig", () => {
     });
   });
 
+  describe("weighted-random", () => {
+    test("accepts a well-formed weights array", () => {
+      const r = validateDispatcherConfig(
+        { type: "weighted-random", weights: [4, 1, 1] },
+        3,
+      );
+      expect(r.ok).toBe(true);
+    });
+
+    test("accepts float weights", () => {
+      const r = validateDispatcherConfig(
+        { type: "weighted-random", weights: [0.8, 0.1, 0.1] },
+        3,
+      );
+      expect(r.ok).toBe(true);
+    });
+
+    test("rejects unresolved file references on `weights`", () => {
+      const r = validateDispatcherConfig(
+        { type: "weighted-random", weights: { from: "./weights.json" } },
+        3,
+      );
+      expect(r.ok).toBe(false);
+      expect(r.diagnostics[0].path).toBe("weights");
+    });
+
+    test("rejects mismatched weights.length vs treatments", () => {
+      const r = validateDispatcherConfig(
+        { type: "weighted-random", weights: [1, 2, 3] },
+        2,
+      );
+      expect(r.ok).toBe(false);
+      const messages = r.diagnostics.map((d) => d.message);
+      expect(messages.some((m) => m.includes("weights.length"))).toBe(true);
+    });
+
+    test("rejects negative / NaN / non-finite entries", () => {
+      const r = validateDispatcherConfig(
+        {
+          type: "weighted-random",
+          weights: [1, -1, Number.NaN, Infinity],
+        },
+        4,
+      );
+      expect(r.ok).toBe(false);
+      const paths = r.diagnostics.map((d) => d.path).sort();
+      expect(paths).toContain("weights.1");
+      expect(paths).toContain("weights.2");
+      expect(paths).toContain("weights.3");
+    });
+
+    test("zero entries are allowed (deactivate a treatment)", () => {
+      const r = validateDispatcherConfig(
+        { type: "weighted-random", weights: [4, 0, 1] },
+        3,
+      );
+      expect(r.ok).toBe(true);
+    });
+
+    test("all-zero weights warn but don't fail validation (gated-off batch)", () => {
+      // Per #451, a researcher may legitimately gate a batch off
+      // temporarily by zeroing every weight. We surface a warning so
+      // the empty-batch isn't surprising, but `ok` stays true so the
+      // batch can still be deployed.
+      const r = validateDispatcherConfig(
+        { type: "weighted-random", weights: [0, 0, 0] },
+        3,
+      );
+      expect(r.ok).toBe(true);
+      const warnings = r.diagnostics.filter((d) => d.severity === "warning");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toMatch(/all zero|no assignments/i);
+    });
+  });
+
   describe("urn", () => {
     test("accepts a well-formed counts array", () => {
       const r = validateDispatcherConfig({ type: "urn", counts: [2, 2, 2] }, 3);

--- a/packages/stagebook/src/dispatch/validateDispatcherConfig.ts
+++ b/packages/stagebook/src/dispatch/validateDispatcherConfig.ts
@@ -2,17 +2,28 @@ import type {
   DispatcherConfig,
   UniformRandomDispatcherConfig,
   UrnDispatcherConfig,
+  WeightedRandomDispatcherConfig,
 } from "./types.js";
 
 /** One validation diagnostic. `path` points into the config object using
  *  the same dotted convention zod does (`"counts"`, `"decrements.2.1"`)
- *  so callers can surface it the same way they surface zod issues. */
+ *  so callers can surface it the same way they surface zod issues.
+ *
+ *  `severity` defaults to `"error"` when omitted, preserving the v0.12.0
+ *  contract where every diagnostic was treated as a hard failure. Some
+ *  validations (e.g. `weighted-random` with all-zero weights — the
+ *  "batch is temporarily gated off" case) emit `"warning"` instead; those
+ *  surface to authors but don't fail `ok`. */
 export interface DispatcherConfigDiagnostic {
   path: string;
   message: string;
+  severity?: "error" | "warning";
 }
 
 export interface DispatcherConfigValidationResult {
+  /** True iff there are no error-severity diagnostics. Warnings do not
+   *  affect `ok` — callers that want to be strict can scan the
+   *  `diagnostics` array directly. */
   ok: boolean;
   diagnostics: DispatcherConfigDiagnostic[];
 }
@@ -59,6 +70,11 @@ export function validateDispatcherConfig(
   switch (c.type) {
     case "uniform-random":
       return validateUniformRandom(config as UniformRandomDispatcherConfig);
+    case "weighted-random":
+      return validateWeightedRandom(
+        config as WeightedRandomDispatcherConfig,
+        treatmentCount,
+      );
     case "urn":
       return validateUrn(config as UrnDispatcherConfig, treatmentCount);
     case "local-penalization":
@@ -69,7 +85,7 @@ export function validateDispatcherConfig(
     default:
       push(
         "type",
-        `unknown dispatcher type "${c.type}" — expected one of: uniform-random, urn, local-penalization`,
+        `unknown dispatcher type "${c.type}" — expected one of: uniform-random, weighted-random, urn, local-penalization`,
       );
       return { ok: false, diagnostics };
   }
@@ -87,11 +103,69 @@ function validateUniformRandom(
     if (!allowed.has(k)) {
       diagnostics.push({
         path: k,
-        message: `\`uniform-random\` dispatcher does not accept a \`${k}\` field. Use \`urn\` for count-based targets.`,
+        message: `\`uniform-random\` dispatcher does not accept a \`${k}\` field. Use \`weighted-random\` for unequal-ratio sampling, or \`urn\` for exact-N targets.`,
       });
     }
   }
   return { ok: diagnostics.length === 0, diagnostics };
+}
+
+function validateWeightedRandom(
+  config: WeightedRandomDispatcherConfig,
+  treatmentCount: number,
+): DispatcherConfigValidationResult {
+  const diagnostics: DispatcherConfigDiagnostic[] = [];
+  const push = (path: string, message: string) =>
+    diagnostics.push({ path, message });
+
+  if (!("weights" in config)) {
+    push("weights", "`weighted-random` dispatcher requires a `weights` array");
+    return { ok: false, diagnostics };
+  }
+  if (isFileReference(config.weights)) {
+    push(
+      "weights",
+      "`weights` is still a file reference — the host must resolve `{from: ...}` before calling the validator",
+    );
+    return { ok: false, diagnostics };
+  }
+  if (!Array.isArray(config.weights)) {
+    push("weights", "`weights` must be an array of non-negative reals");
+    return { ok: false, diagnostics };
+  }
+  const weights = config.weights as unknown[];
+  if (weights.length !== treatmentCount) {
+    push(
+      "weights",
+      `\`weights.length\` (${weights.length}) must equal the number of treatments (${treatmentCount})`,
+    );
+  }
+  weights.forEach((v, i) => {
+    if (!isNonNegativeFiniteNumber(v)) {
+      push(
+        `weights.${i}`,
+        `weights[${i}] must be a non-negative finite number, got ${formatValue(v)}`,
+      );
+    }
+  });
+
+  // All-zero is allowed (silent no-op — useful for gating a batch off
+  // temporarily without renumbering treatments). Surface as a
+  // *warning* so the author isn't surprised when the batch returns
+  // empty, but don't fail validation — see issue #451 item 3.
+  const allZero =
+    weights.length > 0 &&
+    weights.every((v) => isNonNegativeFiniteNumber(v) && (v as number) === 0);
+  if (allZero) {
+    diagnostics.push({
+      path: "weights",
+      message:
+        "`weights` are all zero — `weighted-random` will produce no assignments. Set at least one weight > 0 to enable a treatment.",
+      severity: "warning",
+    });
+  }
+
+  return { ok: isOk(diagnostics), diagnostics };
 }
 
 function validateUrn(
@@ -199,8 +273,19 @@ function validateUrn(
   return { ok: diagnostics.length === 0, diagnostics };
 }
 
+/** True iff `diagnostics` has no error-severity entries. Diagnostics
+ *  without an explicit `severity` are treated as errors (preserving the
+ *  v0.12.0 contract). */
+function isOk(diagnostics: DispatcherConfigDiagnostic[]): boolean {
+  return !diagnostics.some((d) => (d.severity ?? "error") === "error");
+}
+
 function isNonNegativeInteger(v: unknown): boolean {
   return typeof v === "number" && Number.isInteger(v) && v >= 0;
+}
+
+function isNonNegativeFiniteNumber(v: unknown): boolean {
+  return typeof v === "number" && Number.isFinite(v) && v >= 0;
 }
 
 function isFileReference(v: unknown): v is { from: string } {

--- a/packages/stagebook/src/dispatch/weightedRandom.test.ts
+++ b/packages/stagebook/src/dispatch/weightedRandom.test.ts
@@ -1,0 +1,303 @@
+import { describe, test, expect } from "vitest";
+import { weightedRandom } from "./weightedRandom.js";
+import { makeEligibilityTable } from "./makeEligibilityTable.js";
+import { mulberry32 } from "./contract.js";
+import type { Treatment } from "./types.js";
+
+function emptyEligibility(playerIds: string[], treatments: Treatment[]) {
+  return makeEligibilityTable({ playerIds, treatments, playerData: {} });
+}
+
+describe("weightedRandom", () => {
+  test("rejects mismatched weights/treatments length", () => {
+    const treatments: Treatment[] = [
+      { name: "t0", playerCount: 1 },
+      { name: "t1", playerCount: 1 },
+    ];
+    expect(() =>
+      weightedRandom({
+        playerIds: ["p0"],
+        treatments,
+        weights: [1],
+        eligibility: emptyEligibility(["p0"], treatments),
+        rng: mulberry32(0),
+      }),
+    ).toThrow(/weights.length/);
+  });
+
+  test("empty players → empty assignments", () => {
+    const treatments: Treatment[] = [{ name: "t0", playerCount: 2 }];
+    const result = weightedRandom({
+      playerIds: [],
+      treatments,
+      weights: [1],
+      eligibility: emptyEligibility([], treatments),
+      rng: mulberry32(0),
+    });
+    expect(result.assignments).toEqual([]);
+  });
+
+  test("all-zero weights → no assignments (silent, not error)", () => {
+    const treatments: Treatment[] = [
+      { name: "t0", playerCount: 2 },
+      { name: "t1", playerCount: 2 },
+    ];
+    const playerIds = ["p0", "p1", "p2", "p3"];
+    const result = weightedRandom({
+      playerIds,
+      treatments,
+      weights: [0, 0],
+      eligibility: emptyEligibility(playerIds, treatments),
+      rng: mulberry32(0),
+    });
+    expect(result.assignments).toEqual([]);
+  });
+
+  test("zero weight on one treatment → that treatment is never picked", () => {
+    const treatments: Treatment[] = [
+      { name: "t0", playerCount: 2 },
+      { name: "t1", playerCount: 2 },
+    ];
+    const playerIds = Array.from({ length: 100 }, (_, i) => `p${i}`);
+    const result = weightedRandom({
+      playerIds,
+      treatments,
+      weights: [0, 1],
+      eligibility: emptyEligibility(playerIds, treatments),
+      rng: mulberry32(42),
+    });
+    for (const a of result.assignments) {
+      expect(a.treatment.name).toBe("t1");
+    }
+  });
+
+  test("equal weights produce equal long-run rates (sanity)", () => {
+    const K = 3;
+    const treatments: Treatment[] = Array.from({ length: K }, (_, i) => ({
+      name: `t${i}`,
+      playerCount: 2,
+    }));
+    const weights = [1, 1, 1];
+    const counts = treatments.map(() => 0);
+    const M = 500;
+    for (let m = 0; m < M; m += 1) {
+      const playerIds = Array.from({ length: 6 }, (_, i) => `p_${m}_${i}`);
+      const result = weightedRandom({
+        playerIds,
+        treatments,
+        weights,
+        eligibility: emptyEligibility(playerIds, treatments),
+        rng: mulberry32(m + 1),
+      });
+      for (const a of result.assignments) {
+        const idx = treatments.findIndex((t) => t.name === a.treatment.name);
+        counts[idx] += 1;
+      }
+    }
+    const total = counts.reduce((s, x) => s + x, 0);
+    // Loose bounds; the statistical-properties suite tightens this to
+    // α=1e-4. Here we just sanity-check the algorithm runs and
+    // produces roughly equal counts.
+    expect(total).toBeGreaterThan(0);
+    for (const c of counts) {
+      expect(c / total).toBeGreaterThan(0.25);
+      expect(c / total).toBeLessThan(0.42);
+    }
+  });
+
+  test("4:1 weights produce roughly 4:1 long-run rates (sanity)", () => {
+    const treatments: Treatment[] = [
+      { name: "tA", playerCount: 2 },
+      { name: "tB", playerCount: 2 },
+    ];
+    const weights = [4, 1];
+    const counts = [0, 0];
+    const M = 2000;
+    for (let m = 0; m < M; m += 1) {
+      const playerIds = [`p_${m}_0`, `p_${m}_1`];
+      const result = weightedRandom({
+        playerIds,
+        treatments,
+        weights,
+        eligibility: emptyEligibility(playerIds, treatments),
+        rng: mulberry32(m + 1),
+      });
+      for (const a of result.assignments) {
+        const idx = treatments.findIndex((t) => t.name === a.treatment.name);
+        counts[idx] += 1;
+      }
+    }
+    const total = counts.reduce((s, x) => s + x, 0);
+    // Target 4/5 = 0.80, 1/5 = 0.20. ±0.05 is well outside the binomial
+    // noise floor at M=2000 (SE ≈ 0.009) but inside any plausible bug.
+    expect(counts[0] / total).toBeGreaterThan(0.75);
+    expect(counts[0] / total).toBeLessThan(0.85);
+  });
+
+  test("seeded determinism: same seed + inputs → identical assignments", () => {
+    const treatments: Treatment[] = [
+      { name: "t0", playerCount: 2 },
+      { name: "t1", playerCount: 2 },
+    ];
+    const playerIds = ["p0", "p1", "p2", "p3"];
+    const weights = [3, 1];
+    const a = weightedRandom({
+      playerIds,
+      treatments,
+      weights,
+      eligibility: emptyEligibility(playerIds, treatments),
+      rng: mulberry32(42),
+    });
+    const b = weightedRandom({
+      playerIds,
+      treatments,
+      weights,
+      eligibility: emptyEligibility(playerIds, treatments),
+      rng: mulberry32(42),
+    });
+    const c = weightedRandom({
+      playerIds,
+      treatments,
+      weights,
+      eligibility: emptyEligibility(playerIds, treatments),
+      rng: mulberry32(43),
+    });
+    expect(a.assignments).toEqual(b.assignments);
+    expect(a.assignments).not.toEqual(c.assignments);
+  });
+
+  test("rejects NaN / ±Infinity weights at the per-round filter", () => {
+    // Non-finite weights are validated out by validateDispatcherConfig
+    // at config-time; if one slips through, the dispatcher's filter
+    // excludes the treatment rather than producing a corrupt weighted
+    // sample (an Infinity would make totalWeight=∞ and the fallback
+    // would always pick the last pool entry). Pinning that defense.
+    const treatments: Treatment[] = [
+      { name: "t0", playerCount: 2 },
+      { name: "t1", playerCount: 2 },
+    ];
+    const playerIds = ["p0", "p1", "p2", "p3"];
+
+    const nan = weightedRandom({
+      playerIds,
+      treatments,
+      weights: [Number.NaN, 1],
+      eligibility: emptyEligibility(playerIds, treatments),
+      rng: mulberry32(42),
+    });
+    for (const a of nan.assignments) expect(a.treatment.name).toBe("t1");
+
+    const inf = weightedRandom({
+      playerIds,
+      treatments,
+      weights: [Number.POSITIVE_INFINITY, 1],
+      eligibility: emptyEligibility(playerIds, treatments),
+      rng: mulberry32(42),
+    });
+    for (const a of inf.assignments) expect(a.treatment.name).toBe("t1");
+
+    const negInf = weightedRandom({
+      playerIds,
+      treatments,
+      weights: [Number.NEGATIVE_INFINITY, 1],
+      eligibility: emptyEligibility(playerIds, treatments),
+      rng: mulberry32(42),
+    });
+    for (const a of negInf.assignments) expect(a.treatment.name).toBe("t1");
+  });
+
+  test("renormalization when a treatment drops out of the pool", () => {
+    // Three treatments, weights [1, 1, 5]. T2 needs 6 players; ticks
+    // only supply 4. So every tick's pool is {T0, T1} weighted [1, 1]
+    // (T2 dropped for size-infeasibility); the absorbed mass from T2
+    // is split 50/50 between T0 and T1, *not* allocated to T2 with
+    // the rest of the round failing. Confirms the docstring claim that
+    // renormalization is implicit-proportional over the surviving pool.
+    const treatments: Treatment[] = [
+      { name: "t0", playerCount: 2 },
+      { name: "t1", playerCount: 2 },
+      { name: "t2", playerCount: 6 },
+    ];
+    const weights = [1, 1, 5];
+    const counts = [0, 0, 0];
+    const M = 1000;
+    for (let m = 0; m < M; m += 1) {
+      const playerIds = [`p_${m}_0`, `p_${m}_1`, `p_${m}_2`, `p_${m}_3`];
+      const result = weightedRandom({
+        playerIds,
+        treatments,
+        weights,
+        eligibility: emptyEligibility(playerIds, treatments),
+        rng: mulberry32(m + 1),
+      });
+      for (const a of result.assignments) {
+        const idx = treatments.findIndex((t) => t.name === a.treatment.name);
+        counts[idx] += 1;
+      }
+    }
+    const total = counts.reduce((s, x) => s + x, 0);
+    // T2 should never be picked (playerCount > tick size). T0 and T1
+    // should split the runs ~50/50.
+    expect(counts[2]).toBe(0);
+    expect(total).toBeGreaterThan(0);
+    expect(counts[0] / total).toBeGreaterThan(0.42);
+    expect(counts[0] / total).toBeLessThan(0.58);
+  });
+
+  test("greedy-fill failure on the picked treatment re-samples from the rest", () => {
+    // Set up: two treatments, weights [9, 1]. T0 has a strict role
+    // condition that NO player satisfies, so greedy-fill always fails
+    // on T0. The dispatcher must mark T0 "tried this round" and pick
+    // T1 from the remaining pool — every successful round must end up
+    // on T1, even though T0 was picked first 90% of the time.
+    const treatments: Treatment[] = [
+      {
+        name: "t0",
+        playerCount: 2,
+        groupComposition: [
+          {
+            position: 0,
+            conditions: [
+              {
+                reference: "self.prompt.role",
+                comparator: "equals",
+                value: "nonexistent",
+              },
+            ],
+          },
+          {
+            position: 1,
+            conditions: [
+              {
+                reference: "self.prompt.role",
+                comparator: "equals",
+                value: "nonexistent",
+              },
+            ],
+          },
+        ],
+      },
+      { name: "t1", playerCount: 2 },
+    ];
+    const playerIds = ["p0", "p1", "p2", "p3"];
+    const eligibility = emptyEligibility(playerIds, treatments);
+    let t1Count = 0;
+    let totalAssignments = 0;
+    for (let m = 0; m < 200; m += 1) {
+      const result = weightedRandom({
+        playerIds,
+        treatments,
+        weights: [9, 1],
+        eligibility,
+        rng: mulberry32(m + 1),
+      });
+      for (const a of result.assignments) {
+        totalAssignments += 1;
+        if (a.treatment.name === "t1") t1Count += 1;
+      }
+    }
+    // Every assignment must be on t1 (t0 was never fillable).
+    expect(totalAssignments).toBeGreaterThan(0);
+    expect(t1Count).toBe(totalAssignments);
+  });
+});

--- a/packages/stagebook/src/dispatch/weightedRandom.ts
+++ b/packages/stagebook/src/dispatch/weightedRandom.ts
@@ -1,0 +1,140 @@
+import type {
+  Assignment,
+  DispatchResult,
+  EligibilityTable,
+  Treatment,
+} from "./types.js";
+import { tryFillTreatment } from "./tryFillTreatment.js";
+
+export interface WeightedRandomArgs {
+  playerIds: string[];
+  treatments: Treatment[];
+  /** Non-negative reals interpreted up to scale. Length must equal
+   *  `treatments.length`. Zero entries are allowed and mean "never pick
+   *  this treatment." All-zero is allowed and yields no assignments. */
+  weights: number[];
+  eligibility: EligibilityTable;
+  rng: () => number;
+}
+
+/**
+ * Stateless categorical sampler (#451): each round draws a treatment
+ * iid with probability proportional to `weights[i]`, then attempts a
+ * greedy fill. The dispatcher carries no state across rounds — each
+ * draw is independent of every prior draw, of the round number, and of
+ * any host-persisted bookkeeping. This is the property that
+ * distinguishes it from `urn` (where prior draws shift the distribution)
+ * and that justifies skipping host state plumbing entirely.
+ *
+ * Relationship to the sibling dispatchers:
+ *   - `weighted-random` with all-equal weights is observationally
+ *     identical to `uniform-random`. Authors should still prefer
+ *     `uniform-random` when they have no balance claim — the
+ *     discriminator self-documents the absence of a claim.
+ *   - `urn` with very large integer counts and an identity decrement
+ *     matrix approximates `weighted-random` (and converges as counts
+ *     grow), but pays integer-ball cognitive overhead for a use case
+ *     that doesn't need exact-N guarantees.
+ *
+ * Algorithm (per round):
+ *   1. Build the per-round pool: treatments with `weights[i] > 0 ∧
+ *      playerCount ≤ available.size ∧ playerCount > 0 ∧
+ *      not-yet-tried-this-round`.
+ *   2. Sample one treatment from the pool with probability proportional
+ *      to its weight.
+ *   3. Try to fill its slots via `tryFillTreatment`. On success, emit
+ *      the assignment and remove its players. On greedy failure, mark
+ *      "tried this round" and re-sample from the remaining weighted
+ *      pool; if every untried treatment fails, stop.
+ *
+ * Realized rate vs. target rate:
+ *   The long-run rate matches `weights[i] / sum(weights)` only when
+ *   every round is size-feasible for every treatment and every player
+ *   is eligible for every position. When eligibility is tight (or the
+ *   per-tick player pool is small), the per-round pool gets filtered
+ *   for size-feasibility and the marginal rate is implicitly
+ *   renormalized over the surviving treatments. Hosts can detect the
+ *   divergence by computing realized rates from the returned
+ *   `assignments` and comparing against the target weights — see
+ *   `docs/researcher/dispatchers.md` for a worked example.
+ *
+ * Termination: each successful round shrinks `available` by at least
+ * 1; each failed round shrinks the "weighted, feasible, untried" set
+ * by at least 1. Bounded by `O(treatments² + playerIds)`.
+ */
+export function weightedRandom({
+  playerIds,
+  treatments,
+  weights,
+  eligibility,
+  rng,
+}: WeightedRandomArgs): DispatchResult {
+  const n = treatments.length;
+  if (weights.length !== n) {
+    throw new Error(
+      `weightedRandom: weights.length (${weights.length}) must equal treatments.length (${n})`,
+    );
+  }
+
+  const assignments: Assignment[] = [];
+  const available = new Set(playerIds);
+
+  while (available.size > 0) {
+    const tried = new Set<number>();
+    let progress = false;
+    while (true) {
+      // Build the "positive-weight, size-feasible, not-yet-tried" pool.
+      const pool: number[] = [];
+      let totalWeight = 0;
+      for (let i = 0; i < n; i += 1) {
+        if (tried.has(i)) continue;
+        // Reject 0, negative, NaN, and ±Infinity. Validation rejects
+        // these at config-time but the per-round filter defends in
+        // depth — an Infinity that slipped through would make
+        // `totalWeight = ∞` and the weighted-sample fallback would
+        // always select the last pool entry.
+        if (!Number.isFinite(weights[i]) || weights[i] <= 0) continue;
+        if (treatments[i].playerCount === 0) continue;
+        if (treatments[i].playerCount > available.size) continue;
+        pool.push(i);
+        totalWeight += weights[i];
+      }
+      if (pool.length === 0 || totalWeight <= 0) break;
+
+      // Weighted sample by weights[i]. The strict `<` on cumulative
+      // means the floating-point edge case `target === totalWeight`
+      // falls through to the last-pool-entry fallback — same pattern
+      // as urnRandomization, kept consistent so readers don't have to
+      // re-verify per dispatcher.
+      const target = rng() * totalWeight;
+      let cumulative = 0;
+      let treatmentIdx = pool[pool.length - 1];
+      for (const i of pool) {
+        cumulative += weights[i];
+        if (target < cumulative) {
+          treatmentIdx = i;
+          break;
+        }
+      }
+      const treatment = treatments[treatmentIdx];
+
+      const filled = tryFillTreatment(
+        treatmentIdx,
+        treatment,
+        available,
+        eligibility,
+        rng,
+      );
+      if (filled) {
+        assignments.push({ treatment, positionAssignments: filled });
+        for (const pa of filled) available.delete(pa.playerId);
+        progress = true;
+        break; // restart the outer round
+      }
+      tried.add(treatmentIdx);
+    }
+    if (!progress) break;
+  }
+
+  return { assignments };
+}


### PR DESCRIPTION
## Summary

New `weighted-random` dispatcher — iid categorical draws from treatments with `P(T) ∝ weight(T)`. Sits between `uniform-random` (no balance claim) and `urn` (exact-N targets); the natural fit for unequal long-run rates without urn's integer-ball framing.

```yaml
dispatcher:
  type: weighted-random
  weights: [4, 1, 1]   # T0 ~67%, T1 ~17%, T2 ~17% long-run
```

Pure function, same `(playerIds, treatments, eligibility, rng)` shape as the other dispatchers. The weighted-sample inner loop is the same one urn uses — kept consistent so readers don't have to re-verify the cumulative-and-fallback pattern per dispatcher.

## Validator: severity field

Added an optional `severity: "error" | "warning"` to `DispatcherConfigDiagnostic`. Defaults to `"error"` when omitted, so v0.12.0 callers see unchanged behavior. The all-zero-weights case (intentionally gating a batch off temporarily) now emits a warning and leaves `ok: true` — per the #451 design decision.

## Test coverage

- **10 unit tests** — arg validation, zero/NaN/±Infinity per-round filtering, seeded determinism, renormalization when a treatment drops out of the pool, greedy-fill failure → re-sample stays weight-correct.
- **Contract gauntlet** — registered against the existing 10-invariant harness, runs 10 × 200 random scenarios.
- **Statistical-properties suite (7 tests at α=1e-4)** — mirrors the uniform-random/urn suites. The marginal-rate test is χ² against the weighted expectation (`weights/sum`), not uniform. Tests 3-7 (position uniformity, leftover, arrival-order, irrelevant-attribute, pairwise) reuse the same fixtures as uniform-random since their claims are weight-independent.

96 dispatch tests pass; 1341 stagebook tests overall; lint and build clean.

## Docs

New `docs/researcher/dispatchers.md` covers all four dispatchers in one place and walks through a concrete realized-vs-target-rates example. Numbers verified via binomial calculation (footnoted), so an author who does the math can replicate.

The example shows what happens when a high-weight treatment has tight eligibility: with `weights: [4, 1, 1]` and only ~34% of ticks satisfying T0's role condition, realized rates land at ~23/39/39 instead of 67/17/17. The dispatcher is honoring the weights at every feasible round — the deviation is a study-design issue the author needs to anticipate.

## Out of scope

Per the issue, the deliberation-lab legacy-shim split (rewriting `payoffs: <array>` + `knockdowns: "none"` to `weighted-random` instead of `local-penalization`) lives in deliberation-lab and depends on this landing first.

Closes #451.

## Test plan

- [x] `npm run lint -w stagebook` clean
- [x] `npm test -w stagebook` — 1341/1341 pass
- [x] `npm run build -w stagebook` succeeds; dispatch bundle picks up the new export
- [x] Contract gauntlet runs against weighted-random (10 invariants × 200 scenarios)
- [x] All 7 statistical-properties tests pass at α=1e-4
- [x] Renormalization + greedy-fallback unit tests pin the runtime claims from the docstring/docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)