### PR TITLE
Bump stagebook to 0.13.0

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Minor release adding the third pure-function dispatcher + companion docs.

## What's in

- **#453** — New `weighted-random` dispatcher: stateless iid categorical sampler at `P(T) ∝ weight(T)`. Sits between `uniform-random` (no balance claim) and `urn` (exact-N targets). Validator now supports warning-severity diagnostics (used for the "all-zero weights = temporarily gated batch" case). Includes a new `docs/researcher/dispatchers.md` page with a verified worked example of the realized-vs-target-rates trap (closes #451).
- **#455** — Docs expansion in `docs/researcher/dispatchers.md`: full "`urn` in detail" section covering counts, decrement matrices, and cross-treatment locality patterns.

## Compatibility

- Additive. No existing exports changed.
- `DispatcherConfigDiagnostic` gains an optional `severity?: "error" | "warning"` field; absent severity defaults to `"error"` so v0.12.0 callers see unchanged behavior.