### PR TITLE
Switch dispatcher params to labeled objects (breaking change for 0.14)

### DIFF
--- a/docs/researcher/dispatchers.md
+++ b/docs/researcher/dispatchers.md
@@ -2,12 +2,12 @@
 
 A **dispatcher** is the algorithm that decides which treatment each group of participants gets routed to. Stagebook ships four:
 
-| Dispatcher | What you provide | What it guarantees | When to reach for it |
-|---|---|---|---|
-| `uniform-random` | nothing | Each group's treatment is an independent uniform draw | Quick prototypes; you have no balance claim to make in a methods section |
-| `weighted-random` | one weight per treatment | Each group's treatment is an independent draw with `P(T) ∝ weight(T)` | You want unequal long-run rates (e.g. 80/10/10) but don't need exact-N targets |
-| `urn` | target counts per treatment (+ optional decrement matrix) | Each treatment is used exactly its target count over the batch | You want exact target Ns or cross-treatment locality (e.g. "don't pick the same label twice in a row") |
-| `local-penalization` | acquisition values + penalization matrix | One batch step of an iterated Bayesian-optimization loop | You're running a researcher-managed BO surrogate between batches |
+| Dispatcher           | What you provide                                          | What it guarantees                                                    | When to reach for it                                                                                   |
+| -------------------- | --------------------------------------------------------- | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `uniform-random`     | nothing                                                   | Each group's treatment is an independent uniform draw                 | Quick prototypes; you have no balance claim to make in a methods section                               |
+| `weighted-random`    | one weight per treatment                                  | Each group's treatment is an independent draw with `P(T) ∝ weight(T)` | You want unequal long-run rates (e.g. 80/10/10) but don't need exact-N targets                         |
+| `urn`                | target counts per treatment (+ optional decrement matrix) | Each treatment is used exactly its target count over the batch        | You want exact target Ns or cross-treatment locality (e.g. "don't pick the same label twice in a row") |
+| `local-penalization` | acquisition values + penalization matrix                  | One batch step of an iterated Bayesian-optimization loop              | You're running a researcher-managed BO surrogate between batches                                       |
 
 The first three are stateless or carry only a small piece of state (urn's remaining counts). All four pre-compute eligibility from each participant's data; the algorithm itself sees only IDs, treatment structure, and a boolean eligibility lookup — never the underlying responses.
 
@@ -21,7 +21,7 @@ This is the dispatcher most ordinary randomized experiments want when the alloca
 dispatcher:
   type: weighted-random
   weights:
-    T_moderated: 4    # picked four times as often as either of the controls long-run
+    T_moderated: 4 # picked four times as often as either of the controls long-run
     T_control_A: 1
     T_control_B: 1
 ```
@@ -56,9 +56,9 @@ dispatcher:
     T_control_B: 1
 ```
 
-with three two-player treatments. `T_moderated` requires *both* slots to be moderators (`self.prompt.role equals "moderator"`); the two controls have no conditions. Recruitment pulls in 100 participants of whom 20 self-report as moderators (a 20% marginal rate).
+with three two-player treatments. `T_moderated` requires _both_ slots to be moderators (`self.prompt.role equals "moderator"`); the two controls have no conditions. Recruitment pulls in 100 participants of whom 20 self-report as moderators (a 20% marginal rate).
 
-Each dispatch tick draws 6 available players. For `T_moderated` to be picked *and* fillable, the tick needs at least 2 moderators among its 6 players. Under independent arrival that's a binomial probability — ~**34%** of ticks.[^1] In the other 66%, `T_moderated` drops out of the pool, and the dispatcher renormalizes the surviving weights `[1, 1]` over the two controls — so they each absorb half the mass `T_moderated` would have taken.
+Each dispatch tick draws 6 available players. For `T_moderated` to be picked _and_ fillable, the tick needs at least 2 moderators among its 6 players. Under independent arrival that's a binomial probability — ~**34%** of ticks.[^1] In the other 66%, `T_moderated` drops out of the pool, and the dispatcher renormalizes the surviving weights `[1, 1]` over the two controls — so they each absorb half the mass `T_moderated` would have taken.
 
 Working that out per round:
 
@@ -68,11 +68,11 @@ Working that out per round:
 
 Compared to the target weights:
 
-| Treatment | Target (weight/sum) | Realized | Gap |
-|---|---|---|---|
-| T_moderated | 67% | 23% | **−44 pp** |
-| T_control_A | 17% | 39% | +22 pp |
-| T_control_B | 17% | 39% | +22 pp |
+| Treatment   | Target (weight/sum) | Realized | Gap        |
+| ----------- | ------------------- | -------- | ---------- |
+| T_moderated | 67%                 | 23%      | **−44 pp** |
+| T_control_A | 17%                 | 39%      | +22 pp     |
+| T_control_B | 17%                 | 39%      | +22 pp     |
 
 The dispatcher is honoring `weights: {T_moderated: 4, T_control_A: 1, T_control_B: 1}` at every feasible round. The 44-percentage-point shortfall on `T_moderated` is a study-design issue — you've asked for more moderator-condition assignments than your recruitment can supply.
 
@@ -82,9 +82,9 @@ The dispatcher is honoring `weights: {T_moderated: 4, T_control_A: 1, T_control_
 
 Three options, in increasing order of effort:
 
-1. **Recruit until the rates match.** If your downstream analysis doesn't depend on exact N per cell, just let the batch run longer. Realized rates converge to weights *conditional on feasibility*; the slope is whatever your recruitment pipeline delivers.
-2. **Loosen eligibility on the constrained treatment** if the condition is over-specified for what you actually need. The most common case: a condition that *could* be evaluated post-hoc as a covariate instead of gated upstream.
-3. **Use `urn` instead** if you need *exact* target Ns per treatment. `urn` keeps allocating to a treatment until its target count is drained, so it will sit on a tight-eligibility condition until enough qualifying participants arrive. That comes with the tradeoff that other treatments stop receiving allocations once they hit their targets, even if more participants arrive.
+1. **Recruit until the rates match.** If your downstream analysis doesn't depend on exact N per cell, just let the batch run longer. Realized rates converge to weights _conditional on feasibility_; the slope is whatever your recruitment pipeline delivers.
+2. **Loosen eligibility on the constrained treatment** if the condition is over-specified for what you actually need. The most common case: a condition that _could_ be evaluated post-hoc as a covariate instead of gated upstream.
+3. **Use `urn` instead** if you need _exact_ target Ns per treatment. `urn` keeps allocating to a treatment until its target count is drained, so it will sit on a tight-eligibility condition until enough qualifying participants arrive. That comes with the tradeoff that other treatments stop receiving allocations once they hit their targets, even if more participants arrive.
 
 ### Diagnostics
 
@@ -112,7 +112,7 @@ That delivers exactly 10 assignments to each treatment over the batch, then stop
 
 Each round, the dispatcher samples one treatment from the size-feasible pool with probability **proportional to its remaining count**. Early in the batch when all counts are equal, the draws look uniform. As one treatment fills up, its count shrinks and it's picked less often; once a count hits zero the treatment drops out of the pool entirely. The arithmetic guarantees that, over the whole batch, each treatment is used exactly its target count of times — there's no slack to converge over a long run, because the urn enforces the target deterministically.
 
-This is the central difference from `weighted-random`: that dispatcher hits target *rates* in expectation given infinite recruitment; `urn` hits target *counts* exactly given enough eligible participants.
+This is the central difference from `weighted-random`: that dispatcher hits target _rates_ in expectation given infinite recruitment; `urn` hits target _counts_ exactly given enough eligible participants.
 
 ### Building `counts`
 
@@ -149,7 +149,7 @@ The pilot conditions stop drawing once their 10 balls are gone; the main conditi
 
 ### Building `decrements`
 
-`decrements` is an **optional** labeled matrix that controls how many balls get removed from each bucket after a successful assignment. The shape is `decrements[row][col]` = "how many balls to remove from treatment `col` when treatment `row` is picked." Rows are the *picked* treatment; columns are the *affected* buckets.
+`decrements` is an **optional** labeled matrix that controls how many balls get removed from each bucket after a successful assignment. The shape is `decrements[row][col]` = "how many balls to remove from treatment `col` when treatment `row` is picked." Rows are the _picked_ treatment; columns are the _affected_ buckets.
 
 The choice to specify `decrements` is binary:
 
@@ -158,7 +158,7 @@ The choice to specify `decrements` is binary:
 
 The "matrix on or off" framing keeps the mental model simple and avoids the footgun where a partial row would silently zero out a self-decrement.
 
-The non-default cases — i.e., the reasons to specify `decrements` at all — are about *coupling*: when picking one treatment should also decrement another, because they share something.
+The non-default cases — i.e., the reasons to specify `decrements` at all — are about _coupling_: when picking one treatment should also decrement another, because they share something.
 
 > **Heads-up.** If a treatment's row has a zero (or missing) self-decrement entry, the treatment will never deplete from its own picks — it can only deplete via cross-coupled rows, if any. The validator surfaces this as a warning. This is intentional behavior for cross-coupled-only designs, but it's much more often a typo, so it's worth checking the warning when you see it.
 
@@ -168,7 +168,7 @@ For three treatments, the implicit matrix is:
 
 ```yaml
 decrements:
-  control:    { control: 1 }
+  control: { control: 1 }
   exposure_A: { exposure_A: 1 }
   exposure_B: { exposure_B: 1 }
 ```
@@ -177,7 +177,7 @@ Each draw consumes exactly one ball from its own bucket. Equivalent to omitting 
 
 #### Pattern 2: Coupled draws (shared resource)
 
-Suppose `moderated_A` and `moderated_B` both consume the same hard-to-recruit pool — both require participants who self-report as professional moderators, and your overall recruitment ceiling on moderators is 30 people. A naive `counts: {moderated_A: 30, moderated_B: 30, unmoderated: 60}` would imply *60* moderator assignments, more than your pipeline can supply. Use off-diagonal decrements to encode the shared resource:
+Suppose `moderated_A` and `moderated_B` both consume the same hard-to-recruit pool — both require participants who self-report as professional moderators, and your overall recruitment ceiling on moderators is 30 people. A naive `counts: {moderated_A: 30, moderated_B: 30, unmoderated: 60}` would imply _60_ moderator assignments, more than your pipeline can supply. Use off-diagonal decrements to encode the shared resource:
 
 ```yaml
 treatments: [moderated_A, moderated_B, unmoderated]
@@ -189,13 +189,13 @@ dispatcher:
     unmoderated: 60
   decrements:
     moderated_A:
-      moderated_A: 1   # self-decrement
-      moderated_B: 1   # cross-decrement: picking A also depletes B's bucket
+      moderated_A: 1 # self-decrement
+      moderated_B: 1 # cross-decrement: picking A also depletes B's bucket
     moderated_B:
-      moderated_A: 1   # cross-decrement: picking B also depletes A's bucket
+      moderated_A: 1 # cross-decrement: picking B also depletes A's bucket
       moderated_B: 1
     unmoderated:
-      unmoderated: 1   # explicit identity — required because we specified `decrements`
+      unmoderated: 1 # explicit identity — required because we specified `decrements`
 ```
 
 Now `moderated_A` and `moderated_B` deplete together: across the two combined, only 30 moderator assignments are made, matching the actual ceiling. Within those 30, the split between A and B is roughly even because both buckets decrement at the same rate.
@@ -256,7 +256,7 @@ Both `counts` and `decrements` can be supplied inline (as in the examples above)
 ```yaml
 dispatcher:
   type: urn
-  counts:     { from: "study1/counts.json" }
+  counts: { from: "study1/counts.json" }
   decrements: { from: "study1/decrements.json" }
 ```
 
@@ -311,6 +311,6 @@ Once every bucket in the urn hits zero, no further assignments can be made. New 
 
 ### Realized vs. target Ns under eligibility constraints
 
-The same feasibility caveat applies to `urn` as it does to `weighted-random` (see [above](#realized-vs-target-rates-under-eligibility-constraints)), with one important difference: `urn` *doesn't renormalize away* from a constrained treatment. If `T_moderated` has 30 balls and a tight eligibility condition that only 20% of recruits satisfy, the urn keeps `T_moderated` in the pool — and draws it every time the tick happens to include enough eligible players. The other treatments still fill in parallel, and `T_moderated` keeps holding out for qualifying arrivals.
+The same feasibility caveat applies to `urn` as it does to `weighted-random` (see [above](#realized-vs-target-rates-under-eligibility-constraints)), with one important difference: `urn` _doesn't renormalize away_ from a constrained treatment. If `T_moderated` has 30 balls and a tight eligibility condition that only 20% of recruits satisfy, the urn keeps `T_moderated` in the pool — and draws it every time the tick happens to include enough eligible players. The other treatments still fill in parallel, and `T_moderated` keeps holding out for qualifying arrivals.
 
 That's the point. The tradeoff is that the batch can't complete until `T_moderated`'s count is drained or no more eligible participants arrive — so either over-recruit by enough margin to satisfy your tightest condition, or accept that the batch may stall on `T_moderated` with un-assignable participants accumulating in the lobby.

--- a/docs/researcher/dispatchers.md
+++ b/docs/researcher/dispatchers.md
@@ -11,19 +11,28 @@ A **dispatcher** is the algorithm that decides which treatment each group of par
 
 The first three are stateless or carry only a small piece of state (urn's remaining counts). All four pre-compute eligibility from each participant's data; the algorithm itself sees only IDs, treatment structure, and a boolean eligibility lookup — never the underlying responses.
 
+> **Stagebook 0.14 breaking change.** `weighted-random`'s `weights` and `urn`'s `counts` and `decrements` are now **labeled objects** keyed by treatment name. The previous positional-array form (`counts: [10, 10, 10]`, `decrements: [[1,0,0], ...]`) was removed because it silently mis-mapped when treatments were renamed or reordered. The validator now rejects old positional configs with a migration hint pointing to this document; see [Why labels?](#why-labels) for the rationale.
+
 ## `weighted-random` in detail
 
-This is the dispatcher most ordinary randomized experiments want when the allocation isn't 50/50. You specify weights up to scale:
+This is the dispatcher most ordinary randomized experiments want when the allocation isn't 50/50. You specify weights up to scale, keyed by treatment name:
 
 ```yaml
 dispatcher:
   type: weighted-random
-  weights: [4, 1, 1]   # T0 four times as often as T1 or T2 long-run
+  weights:
+    T_moderated: 4    # picked four times as often as either of the controls long-run
+    T_control_A: 1
+    T_control_B: 1
 ```
 
-The weights are interpreted up to scale — `[4, 1, 1]`, `[80, 20, 20]`, and `[0.67, 0.17, 0.17]` are all the same sampler. Each round, the dispatcher draws a treatment with probability proportional to its weight, independently of every other round. There is no memory of which treatment was picked last; in particular, a run of three consecutive `T0` draws is not "balanced out" by extra `T1`/`T2` draws afterward.
+The weights are interpreted up to scale — `{T_a: 4, T_b: 1}`, `{T_a: 80, T_b: 20}`, and `{T_a: 0.8, T_b: 0.2}` are all the same sampler. Each round, the dispatcher draws a treatment with probability proportional to its weight, independently of every other round. There is no memory of which treatment was picked last; in particular, a run of three consecutive `T_moderated` draws is not "balanced out" by extra `T_control_*` draws afterward.
 
-A zero weight means "never pick this treatment." This is useful when you want to keep a condition in the file but turn it off for a particular batch without renumbering everything.
+A zero weight means "never pick this treatment." This is useful when you want to keep a condition in the file but turn it off for a particular batch without removing it.
+
+### Label discipline
+
+The keys of `weights` must exactly match the names in your `treatments:` block — no missing names (the validator will tell you which are absent) and no extra names (the validator will tell you which don't correspond to a real treatment). This protects you from the silent failure mode where renaming or reordering treatments quietly remaps your weights to the wrong arms.
 
 ## Realized vs. target rates under eligibility constraints
 
@@ -32,7 +41,7 @@ The most common gotcha with `weighted-random` (and with `urn`, for the same unde
 1. **Tight eligibility conditions** filter the candidate pool down. If only 20% of recruits satisfy treatment T0's role condition, T0 won't see its full target rate no matter how high you set its weight — there aren't enough eligible participants to fill it.
 2. **Per-tick player-pool size** can be too small for some treatments. If a treatment requires 6 players but the dispatch tick has only 4 available, that treatment is excluded from this round's pool.
 
-When a treatment drops out of a round's pool, the weight mass is implicitly renormalized across the surviving treatments. So a 4:1:1 batch with a too-tight eligibility on T0 won't deliver 67/17/17 — it'll deliver something more like 0/50/50 conditional on the tight rounds. The dispatcher is doing what you asked at every round; the design constraint is what's biting.
+When a treatment drops out of a round's pool, the weight mass is implicitly renormalized across the surviving treatments. So a 4:1:1 batch with a too-tight eligibility on `T_moderated` won't deliver 67/17/17 — it'll deliver something more like 0/50/50 conditional on the tight rounds. The dispatcher is doing what you asked at every round; the design constraint is what's biting.
 
 ### A worked example
 
@@ -41,28 +50,31 @@ Suppose you set:
 ```yaml
 dispatcher:
   type: weighted-random
-  weights: [4, 1, 1]
+  weights:
+    T_moderated: 4
+    T_control_A: 1
+    T_control_B: 1
 ```
 
-with three two-player treatments. T0 requires *both* slots to be moderators (`self.prompt.role equals "moderator"`); T1 and T2 have no conditions. Recruitment pulls in 100 participants of whom 20 self-report as moderators (a 20% marginal rate).
+with three two-player treatments. `T_moderated` requires *both* slots to be moderators (`self.prompt.role equals "moderator"`); the two controls have no conditions. Recruitment pulls in 100 participants of whom 20 self-report as moderators (a 20% marginal rate).
 
-Each dispatch tick draws 6 available players. For T0 to be picked *and* fillable, the tick needs at least 2 moderators among its 6 players. Under independent arrival that's a binomial probability — ~**34%** of ticks.[^1] In the other 66%, T0 drops out of the pool, and the dispatcher renormalizes the surviving weights `[1, 1]` over T1 and T2 — so T1 and T2 each absorb half the mass T0 would have taken.
+Each dispatch tick draws 6 available players. For `T_moderated` to be picked *and* fillable, the tick needs at least 2 moderators among its 6 players. Under independent arrival that's a binomial probability — ~**34%** of ticks.[^1] In the other 66%, `T_moderated` drops out of the pool, and the dispatcher renormalizes the surviving weights `[1, 1]` over the two controls — so they each absorb half the mass `T_moderated` would have taken.
 
 Working that out per round:
 
-- **T0 picked & filled**: `0.34 × (4/6) = 23%`
-- **T1 picked**: `0.34 × (1/6) + 0.66 × (1/2) ≈ 39%`
-- **T2 picked**: `0.34 × (1/6) + 0.66 × (1/2) ≈ 39%`
+- **T_moderated picked & filled**: `0.34 × (4/6) = 23%`
+- **T_control_A picked**: `0.34 × (1/6) + 0.66 × (1/2) ≈ 39%`
+- **T_control_B picked**: `0.34 × (1/6) + 0.66 × (1/2) ≈ 39%`
 
 Compared to the target weights:
 
-| | Target (weights/sum) | Realized | Gap |
+| Treatment | Target (weight/sum) | Realized | Gap |
 |---|---|---|---|
-| T0 | 67% | 23% | **−44 pp** |
-| T1 | 17% | 39% | +22 pp |
-| T2 | 17% | 39% | +22 pp |
+| T_moderated | 67% | 23% | **−44 pp** |
+| T_control_A | 17% | 39% | +22 pp |
+| T_control_B | 17% | 39% | +22 pp |
 
-The dispatcher is honoring `weights: [4, 1, 1]` at every feasible round. The 44-percentage-point shortfall on T0 is a study-design issue — you've asked for more moderator-condition assignments than your recruitment can supply.
+The dispatcher is honoring `weights: {T_moderated: 4, T_control_A: 1, T_control_B: 1}` at every feasible round. The 44-percentage-point shortfall on `T_moderated` is a study-design issue — you've asked for more moderator-condition assignments than your recruitment can supply.
 
 [^1]: `P(K ≥ 2 | n=6, p=0.2) = 1 − P(0) − P(1) = 1 − 0.8⁶ − 6·0.2·0.8⁵ ≈ 0.345`. The exact number depends on your tick size and your moderator marginal rate; the qualitative point — that tight eligibility on a high-weight treatment causes its realized rate to fall well below its weight — holds across this whole regime.
 
@@ -85,9 +97,13 @@ Reach for `urn` when you need an **exact count** of each treatment rather than a
 The minimal config:
 
 ```yaml
+treatments: [control, exposure_A, exposure_B]
 dispatcher:
   type: urn
-  counts: [10, 10, 10]
+  counts:
+    control: 10
+    exposure_A: 10
+    exposure_B: 10
 ```
 
 That delivers exactly 10 assignments to each treatment over the batch, then stops.
@@ -100,7 +116,7 @@ This is the central difference from `weighted-random`: that dispatcher hits targ
 
 ### Building `counts`
 
-`counts` is a non-negative integer array with one entry per treatment, in the same order as `treatments` in your batch config. Most studies fall into one of two patterns.
+`counts` is a map from treatment name to non-negative integer. The key set must exactly match the names in your `treatments:` block. Most studies fall into one of two patterns.
 
 **Balanced allocation.** All treatments get the same target N:
 
@@ -108,7 +124,11 @@ This is the central difference from `weighted-random`: that dispatcher hits targ
 treatments: [control, exposure_A, exposure_B]
 dispatcher:
   type: urn
-  counts: [30, 30, 30]   # 90 total assignments, 30 each
+  counts:
+    control: 30
+    exposure_A: 30
+    exposure_B: 30
+  # 90 total assignments, 30 each
 ```
 
 **Asymmetric Ns.** When some conditions need bigger samples than others — e.g., a control plus two main exposures plus two underpowered pilot conditions:
@@ -117,44 +137,65 @@ dispatcher:
 treatments: [control, main_A, main_B, pilot_C, pilot_D]
 dispatcher:
   type: urn
-  counts: [40, 40, 40, 10, 10]
+  counts:
+    control: 40
+    main_A: 40
+    main_B: 40
+    pilot_C: 10
+    pilot_D: 10
 ```
 
 The pilot conditions stop drawing once their 10 balls are gone; the main conditions and control keep filling. If your batch over-recruits past 140 total participants, the extra arrivals can't be assigned to anything — see [Exhaustion](#exhaustion) below.
 
 ### Building `decrements`
 
-`decrements` is an **optional** square matrix that controls how many balls get removed from each bucket after a successful assignment. The shape is `decrements[i][j]` = "how many balls to remove from treatment `j` when treatment `i` is picked." Rows are the *picked* treatment; columns are the *affected* buckets.
+`decrements` is an **optional** labeled matrix that controls how many balls get removed from each bucket after a successful assignment. The shape is `decrements[row][col]` = "how many balls to remove from treatment `col` when treatment `row` is picked." Rows are the *picked* treatment; columns are the *affected* buckets.
 
-When omitted, the default is the **identity matrix** — picking treatment `i` removes exactly one ball from treatment `i` and leaves all others alone. That's what most studies want, and it's why `decrements` is optional.
+The choice to specify `decrements` is binary:
 
-The non-default cases are all about *coupling*: when picking one treatment should also decrement another, because they share something.
+- **`decrements` omitted entirely** → the matrix defaults to the **identity matrix**. Picking treatment `T` removes exactly one ball from `T` and leaves all others alone. That's what most studies want, and it's why `decrements` is optional.
+- **`decrements` present** → the matrix is taken as a **strict literal**. Every treatment must have a row (no implicit identity for omitted rows); within each row, missing column entries default to 0 (no decrement). If you want identity behavior on a particular row, write it explicitly: `T_a: { T_a: 1 }`.
+
+The "matrix on or off" framing keeps the mental model simple and avoids the footgun where a partial row would silently zero out a self-decrement.
+
+The non-default cases — i.e., the reasons to specify `decrements` at all — are about *coupling*: when picking one treatment should also decrement another, because they share something.
+
+> **Heads-up.** If a treatment's row has a zero (or missing) self-decrement entry, the treatment will never deplete from its own picks — it can only deplete via cross-coupled rows, if any. The validator surfaces this as a warning. This is intentional behavior for cross-coupled-only designs, but it's much more often a typo, so it's worth checking the warning when you see it.
 
 #### Pattern 1: Identity (the default)
 
 For three treatments, the implicit matrix is:
 
-```json
-[[1, 0, 0],
- [0, 1, 0],
- [0, 0, 1]]
+```yaml
+decrements:
+  control:    { control: 1 }
+  exposure_A: { exposure_A: 1 }
+  exposure_B: { exposure_B: 1 }
 ```
 
-Each draw consumes exactly one ball from its own bucket. Equivalent to omitting `decrements` entirely; shown here only so the rest of the patterns have a baseline to differ from.
+Each draw consumes exactly one ball from its own bucket. Equivalent to omitting `decrements` entirely — shown here only so the rest of the patterns have a baseline to differ from. In practice you'd never write this out; just omit `decrements` and the dispatcher uses it automatically.
 
 #### Pattern 2: Coupled draws (shared resource)
 
-Suppose `moderated_A` and `moderated_B` both consume the same hard-to-recruit pool — both require participants who self-report as professional moderators, and your overall recruitment ceiling on moderators is 30 people. A naive `counts: [30, 30, 60]` would imply *60* moderator assignments, more than your pipeline can supply. Use off-diagonal decrements to encode the shared resource:
+Suppose `moderated_A` and `moderated_B` both consume the same hard-to-recruit pool — both require participants who self-report as professional moderators, and your overall recruitment ceiling on moderators is 30 people. A naive `counts: {moderated_A: 30, moderated_B: 30, unmoderated: 60}` would imply *60* moderator assignments, more than your pipeline can supply. Use off-diagonal decrements to encode the shared resource:
 
 ```yaml
 treatments: [moderated_A, moderated_B, unmoderated]
 dispatcher:
   type: urn
-  counts: [30, 30, 60]
+  counts:
+    moderated_A: 30
+    moderated_B: 30
+    unmoderated: 60
   decrements:
-    - [1, 1, 0]   # picking moderated_A removes 1 ball from A *and* 1 from B
-    - [1, 1, 0]   # picking moderated_B removes 1 ball from A *and* 1 from B
-    - [0, 0, 1]   # picking unmoderated only removes 1 from its own bucket
+    moderated_A:
+      moderated_A: 1   # self-decrement
+      moderated_B: 1   # cross-decrement: picking A also depletes B's bucket
+    moderated_B:
+      moderated_A: 1   # cross-decrement: picking B also depletes A's bucket
+      moderated_B: 1
+    unmoderated:
+      unmoderated: 1   # explicit identity — required because we specified `decrements`
 ```
 
 Now `moderated_A` and `moderated_B` deplete together: across the two combined, only 30 moderator assignments are made, matching the actual ceiling. Within those 30, the split between A and B is roughly even because both buckets decrement at the same rate.
@@ -168,10 +209,14 @@ If your treatments are arranged in a continuous space — for example, 20 prompt
 A common construction is a Gaussian kernel over a pairwise distance, computed offline:
 
 ```python
+import json
 import numpy as np
 
+# Treatment names, in whatever order matches your treatments: block.
+names = [f"prompt_{i:02d}" for i in range(20)]
+
 # 1D embedding of treatment positions (could equally be 2D, etc.)
-positions = np.linspace(0, 1, 20)
+positions = np.linspace(0, 1, len(names))
 distances = np.abs(positions[:, None] - positions[None, :])
 
 # Gaussian kernel; sigma controls the "neighborhood radius"
@@ -182,7 +227,18 @@ kernel = np.exp(-(distances ** 2) / (2 * sigma ** 2))
 # Tuning target: the diagonal stays 1 (self-decrement); a treatment's
 # immediate neighbors round to 1 (coupled); far treatments round to 0.
 scale = 1.0
-decrements = np.maximum(0, np.round(kernel * scale)).astype(int).tolist()
+matrix = np.maximum(0, np.round(kernel * scale)).astype(int)
+
+# Emit labeled JSON: { row_name: { col_name: value, ... }, ... }.
+# Every treatment needs a row (strict-literal rule); within each row,
+# we omit zero entries to keep the file readable (missing column =>
+# 0 inside a row that's present).
+decrements = {
+    row: {col: int(matrix[i, j]) for j, col in enumerate(names) if matrix[i, j] > 0}
+    for i, row in enumerate(names)
+}
+with open("decrements.json", "w") as f:
+    json.dump(decrements, f, indent=2)
 ```
 
 The resulting matrix is mostly identity-like along the diagonal with small positive off-diagonals between near-neighbors. This is the load-bearing case for studies with hundreds of treatments arranged in a continuous space.
@@ -200,8 +256,8 @@ Both `counts` and `decrements` can be supplied inline (as in the examples above)
 ```yaml
 dispatcher:
   type: urn
-  counts:     { file: "study1/counts.json" }
-  decrements: { file: "study1/decrements.json" }
+  counts:     { from: "study1/counts.json" }
+  decrements: { from: "study1/decrements.json" }
 ```
 
 Reach for file references when:
@@ -210,30 +266,42 @@ Reach for file references when:
 - The matrix is large enough that inlining clutters the batch config (anything past ~5–10 treatments tends to feel that way)
 - You want to version the matrix separately from the batch config
 
-The file shape is just a JSON array (for `counts`) or array-of-arrays (for `decrements`):
+The file shape mirrors the inline form — a labeled JSON object whose keys match treatment names:
 
-**`counts.json`:**
+**`counts.json`** (the asymmetric-N example from earlier):
 
 ```json
-[30, 30, 30, 10, 10]
+{
+  "control": 40,
+  "main_A": 40,
+  "main_B": 40,
+  "pilot_C": 10,
+  "pilot_D": 10
+}
 ```
 
 **`decrements.json`** (the coupled-resource example from Pattern 2):
 
 ```json
-[[1, 1, 0],
- [1, 1, 0],
- [0, 0, 1]]
+{
+  "moderated_A": { "moderated_A": 1, "moderated_B": 1 },
+  "moderated_B": { "moderated_A": 1, "moderated_B": 1 },
+  "unmoderated": { "unmoderated": 1 }
+}
 ```
 
-File references are resolved by the host (deliberation-lab in our deployment), not by stagebook itself — stagebook's algorithm runs on already-resolved arrays. The host enforces these path constraints: must be relative (no leading `/`), must not contain `..` segments, must not begin with a URL scheme (`https:`, `file:`, etc.), and is capped at 512 characters. The path is resolved against the same `assetBaseUrl` your treatment file is served from. The file is fetched at batch creation time and validated; a missing or malformed file fails batch creation rather than a later dispatch tick.
+Every treatment with positive counts needs a row when you specify `decrements` — even rows that are just identity (`{"unmoderated": 1}`). If you wanted identity behavior throughout, you'd just omit `decrements` entirely.
+
+<a id="why-labels"></a>**Why labels?** Earlier versions of stagebook (≤ 0.13) accepted positional arrays here (`[30, 30, 30, 10, 10]`). That form silently mis-mapped if the treatment list got reordered or a treatment was renamed — the dispatcher would happily run with the wrong allocation. The labeled form makes the mapping explicit, so the validator catches drift instead of producing wrong assignments. If you have an old positional file, the validator at batch-creation time will refuse it with an error message pointing at this section; the dispatcher itself has a runtime guard for the same case, so even hand-constructed batches that bypass the validator will fail loudly rather than silently mis-route.
+
+File references are resolved by the host (deliberation-lab in our deployment), not by stagebook itself — stagebook's algorithm runs on already-resolved objects. The host enforces these path constraints: must be relative (no leading `/`), must not contain `..` segments, must not begin with a URL scheme (`https:`, `file:`, etc.), and is capped at 512 characters. The path is resolved against the same `assetBaseUrl` your treatment file is served from. The file is fetched at batch creation time and validated; a missing or malformed file fails batch creation rather than a later dispatch tick.
 
 A typical workflow:
 
 1. Compute the matrix in your analysis repo (offline solver — Python, R, etc.)
-2. Write the result to `counts.json` / `decrements.json`
+2. Write the result to `counts.json` / `decrements.json` in labeled form
 3. Commit them to your assets repo, alongside your treatment YAML
-4. Reference from the batch config via `{ file: "<path>" }`
+4. Reference from the batch config via `{ from: "<path>" }`
 
 This keeps the offline computation auditable and the batch config readable.
 
@@ -243,6 +311,6 @@ Once every bucket in the urn hits zero, no further assignments can be made. New 
 
 ### Realized vs. target Ns under eligibility constraints
 
-The same feasibility caveat applies to `urn` as it does to `weighted-random` (see [above](#realized-vs-target-rates-under-eligibility-constraints)), with one important difference: `urn` *doesn't renormalize away* from a constrained treatment. If treatment T0 has 30 balls and a tight eligibility condition that only 20% of recruits satisfy, the urn keeps T0 in the pool — and draws T0 every time the tick happens to include enough eligible players. The other treatments still fill in parallel, and T0 keeps holding out for qualifying arrivals.
+The same feasibility caveat applies to `urn` as it does to `weighted-random` (see [above](#realized-vs-target-rates-under-eligibility-constraints)), with one important difference: `urn` *doesn't renormalize away* from a constrained treatment. If `T_moderated` has 30 balls and a tight eligibility condition that only 20% of recruits satisfy, the urn keeps `T_moderated` in the pool — and draws it every time the tick happens to include enough eligible players. The other treatments still fill in parallel, and `T_moderated` keeps holding out for qualifying arrivals.
 
-That's the point. The tradeoff is that the batch can't complete until T0's count is drained or no more eligible participants arrive — so either over-recruit by enough margin to satisfy your tightest condition, or accept that the batch may stall on T0 with un-assignable participants accumulating in the lobby.
+That's the point. The tradeoff is that the batch can't complete until `T_moderated`'s count is drained or no more eligible participants arrive — so either over-recruit by enough margin to satisfy your tightest condition, or accept that the batch may stall on `T_moderated` with un-assignable participants accumulating in the lobby.

--- a/packages/stagebook/src/dispatch/contract.test.ts
+++ b/packages/stagebook/src/dispatch/contract.test.ts
@@ -7,6 +7,7 @@ import { buildEligibilityForScenario, runContractSuite } from "./contract.js";
 import { uniformRandom } from "./uniformRandom.js";
 import { weightedRandom } from "./weightedRandom.js";
 import { urnRandomization } from "./urnRandomization.js";
+import type { LabeledMatrix, LabeledScalars } from "./types.js";
 
 runContractSuite("uniform-random", ({ scenario, rng }) => {
   const eligibility = buildEligibilityForScenario(scenario);
@@ -24,17 +25,19 @@ runContractSuite("uniform-random", ({ scenario, rng }) => {
 
 runContractSuite("weighted-random", ({ scenario, rng }) => {
   const eligibility = buildEligibilityForScenario(scenario);
-  // Random per-scenario weights. Mix of distributions:
+  // Random per-scenario weights, keyed by treatment name. Mix of
+  // distributions:
   //   - 25% all-equal (degenerate uniform-random case)
   //   - 25% one zero weight (de-activated treatment)
   //   - 50% random floats in [0.1, 4.0]
-  // Avoids all-zero (which yields no assignments, trivially passing
-  // invariants but not exercising the algorithm).
+  // Avoids all-zero (which yields no assignments — trivially passes
+  // every invariant but doesn't exercise the algorithm).
   const r = rng();
-  const weights = scenario.treatments.map((_, i) => {
-    if (r < 0.25) return 1;
-    if (r < 0.5 && i === 0) return 0;
-    return 0.1 + rng() * 3.9;
+  const weights: LabeledScalars = {};
+  scenario.treatments.forEach((t, i) => {
+    if (r < 0.25) weights[t.name] = 1;
+    else if (r < 0.5 && i === 0) weights[t.name] = 0;
+    else weights[t.name] = 0.1 + rng() * 3.9;
   });
   return {
     params: { weights },
@@ -51,16 +54,26 @@ runContractSuite("weighted-random", ({ scenario, rng }) => {
 
 runContractSuite("urn", ({ scenario, rng }) => {
   const eligibility = buildEligibilityForScenario(scenario);
-  // Random per-scenario counts in [0, 5]. Some zeros so the dispatcher
-  // exercises the "no balls left for this treatment" branch.
-  const counts = scenario.treatments.map(() => Math.floor(rng() * 6));
-  // Random decrement matrix: either identity (50%) or a sparse matrix
-  // with integer entries small enough to avoid validation rejections.
-  let decrements: number[][] | undefined;
+  // Random per-scenario counts in [0, 5], keyed by treatment name.
+  // Some zeros so the dispatcher exercises the "no balls left for
+  // this treatment" branch.
+  const counts: LabeledScalars = {};
+  scenario.treatments.forEach((t) => {
+    counts[t.name] = Math.floor(rng() * 6);
+  });
+  // Random decrement matrix: either identity (50% — use undefined to
+  // exercise the dispatcher's identity-default code path) or a sparse
+  // labeled matrix with integer entries small enough to avoid
+  // validation rejections.
+  let decrements: LabeledMatrix | undefined;
   if (rng() < 0.5) {
-    decrements = undefined; // identity default
+    decrements = undefined;
   } else {
-    decrements = buildSafeDecrementMatrix(counts, rng);
+    decrements = buildSafeDecrementMatrix(
+      counts,
+      scenario.treatments.map((t) => t.name),
+      rng,
+    );
   }
   return {
     params: { counts, decrements },
@@ -76,28 +89,28 @@ runContractSuite("urn", ({ scenario, rng }) => {
   };
 });
 
-/** Build a random decrement matrix where each `decrements[i][j] ≤ counts[j]`
- *  so the dispatcher doesn't immediately clamp to zero on the first use.
- *  Diagonal entries are at least 1 so a treatment's own counter
- *  actually decreases when the treatment is used. */
+/** Build a labeled random decrement matrix where each
+ *  `decrements[row][col] ≤ counts[col]`. Diagonal entries are 1 so a
+ *  treatment's own counter actually decreases when the treatment is
+ *  used (assuming positive count); off-diagonal entries are 0 or 1
+ *  at 25% probability. */
 function buildSafeDecrementMatrix(
-  counts: number[],
+  counts: LabeledScalars,
+  names: string[],
   rng: () => number,
-): number[][] {
-  const n = counts.length;
-  const m: number[][] = [];
-  for (let i = 0; i < n; i += 1) {
-    const row: number[] = [];
-    for (let j = 0; j < n; j += 1) {
-      if (i === j) {
-        // Self-decrement at least 1 (when there's a ball to take).
-        row.push(counts[j] > 0 ? 1 : 0);
-      } else {
-        // Off-diagonal in [0, min(1, counts[j])] — usually 0, sometimes 1.
-        row.push(rng() < 0.25 && counts[j] > 0 ? 1 : 0);
+): LabeledMatrix {
+  const m: LabeledMatrix = {};
+  for (const rowName of names) {
+    const row: Record<string, number> = {};
+    for (const colName of names) {
+      if (rowName === colName) {
+        row[colName] = counts[colName] > 0 ? 1 : 0;
+      } else if (rng() < 0.25 && counts[colName] > 0) {
+        row[colName] = 1;
       }
+      // omitted entries default to 0 at the dispatcher boundary
     }
-    m.push(row);
+    m[rowName] = row;
   }
   return m;
 }

--- a/packages/stagebook/src/dispatch/randomization.test.ts
+++ b/packages/stagebook/src/dispatch/randomization.test.ts
@@ -243,7 +243,9 @@ describe("weightedRandom: randomization properties (α=1e-4)", () => {
     players: { id: string }[],
     seed: number,
     treatments = T_ONE,
-    weights = treatments.map(() => 1),
+    weights: Record<string, number> = Object.fromEntries(
+      treatments.map((t) => [t.name, 1]),
+    ),
   ): DispatchResult {
     const playerIds = players.map((p) => p.id);
     const eligibility = emptyEligibility(playerIds, treatments);
@@ -276,10 +278,10 @@ describe("weightedRandom: randomization properties (α=1e-4)", () => {
       name: `T${i}`,
       playerCount: 2,
     }));
-    const weights = [4, 1, 1];
-    const totalWeight = weights.reduce((s, w) => s + w, 0);
+    const weights: Record<string, number> = { T0: 4, T1: 1, T2: 1 };
+    const totalWeight = Object.values(weights).reduce((s, w) => s + w, 0);
 
-    const useCount = treatments.map(() => 0);
+    const useCount: Record<string, number> = { T0: 0, T1: 0, T2: 0 };
     for (let m = 0; m < M; m += 1) {
       const players = Array.from({ length: playersPerTick }, (_, i) => ({
         id: `p_${m}_${i}`,
@@ -291,15 +293,14 @@ describe("weightedRandom: randomization properties (α=1e-4)", () => {
         weights,
       );
       for (const a of assignments) {
-        const idx = treatments.findIndex((t) => t.name === a.treatment.name);
-        useCount[idx] += 1;
+        useCount[a.treatment.name] += 1;
       }
     }
     // χ² statistic against weighted expectation.
-    const total = useCount.reduce((s, x) => s + x, 0);
-    const chi2 = useCount.reduce((s, observed, i) => {
-      const expected = (total * weights[i]) / totalWeight;
-      return s + (observed - expected) ** 2 / expected;
+    const total = Object.values(useCount).reduce((s, x) => s + x, 0);
+    const chi2 = treatments.reduce((s, t) => {
+      const expected = (total * weights[t.name]) / totalWeight;
+      return s + (useCount[t.name] - expected) ** 2 / expected;
     }, 0);
     expect(chi2).toBeLessThan(CHI2_CRITICAL_ALPHA_1E4[K - 1]);
   });
@@ -442,9 +443,9 @@ describe("urnRandomization: randomization properties (α=1e-4)", () => {
   function runOneUrn(
     players: { id: string }[],
     treatments: Treatment[],
-    counts: number[],
+    counts: Record<string, number>,
     seed: number,
-    decrements?: number[][],
+    decrements?: Record<string, Record<string, number>>,
   ): DispatchResult {
     const playerIds = players.map((p) => p.id);
     const eligibility = emptyEligibility(playerIds, treatments);
@@ -463,9 +464,9 @@ describe("urnRandomization: randomization properties (α=1e-4)", () => {
   test("1. seeded determinism: identical seed + inputs ⇒ identical assignments", () => {
     const makePlayers = () =>
       Array.from({ length: 4 }, (_, i) => ({ id: `p_${i}` }));
-    const a = runOneUrn(makePlayers(), T_ONE, [10], 42);
-    const b = runOneUrn(makePlayers(), T_ONE, [10], 42);
-    const c = runOneUrn(makePlayers(), T_ONE, [10], 43);
+    const a = runOneUrn(makePlayers(), T_ONE, { T: 10 }, 42);
+    const b = runOneUrn(makePlayers(), T_ONE, { T: 10 }, 42);
+    const c = runOneUrn(makePlayers(), T_ONE, { T: 10 }, 43);
     expect(a.assignments).toEqual(b.assignments);
     expect(a.assignments).not.toEqual(c.assignments);
     expect(a.remainingCounts).toEqual(b.remainingCounts);
@@ -474,13 +475,18 @@ describe("urnRandomization: randomization properties (α=1e-4)", () => {
   test("2. marginal target rate: counts are honored exactly across runs", () => {
     // Central claim of urn randomization: over the run, treatment i is
     // used exactly `counts[i]` times.
-    const targetCounts = [25, 25, 25, 25];
-    const K = targetCounts.length;
+    const K = 4;
     const treatments: Treatment[] = Array.from({ length: K }, (_, i) => ({
       name: `T${i}`,
       playerCount: 2,
     }));
-    const totalSlots = targetCounts.reduce((a, b) => a + 2 * b, 0);
+    const targetCounts: Record<string, number> = Object.fromEntries(
+      treatments.map((t) => [t.name, 25]),
+    );
+    const totalSlots = Object.values(targetCounts).reduce(
+      (a, b) => a + 2 * b,
+      0,
+    );
     // Provide enough players to drain the urn. Over-supply is fine —
     // dispatcher stops when no positive-count treatment fits.
     const players = Array.from({ length: totalSlots + 10 }, (_, i) => ({
@@ -492,13 +498,16 @@ describe("urnRandomization: randomization properties (α=1e-4)", () => {
       targetCounts,
       9000,
     );
-    const useCount = treatments.map(() => 0);
+    const useCount: Record<string, number> = Object.fromEntries(
+      treatments.map((t) => [t.name, 0]),
+    );
     for (const a of assignments) {
-      const idx = treatments.findIndex((t) => t.name === a.treatment.name);
-      useCount[idx] += 1;
+      useCount[a.treatment.name] += 1;
     }
     expect(useCount).toEqual(targetCounts);
-    expect(remainingCounts).toEqual([0, 0, 0, 0]);
+    expect(remainingCounts).toEqual(
+      Object.fromEntries(treatments.map((t) => [t.name, 0])),
+    );
   });
 
   test("3. position uniformity: per-player position-0 distribution is uniform (χ²)", () => {
@@ -509,7 +518,7 @@ describe("urnRandomization: randomization properties (α=1e-4)", () => {
 
     for (let m = 0; m < M; m += 1) {
       const players = Array.from({ length: N }, (_, i) => ({ id: `p_${i}` }));
-      const { assignments } = runOneUrn(players, T_ONE, [2], 1000 + m);
+      const { assignments } = runOneUrn(players, T_ONE, { T: 2 }, 1000 + m);
       for (const a of assignments) {
         for (const pa of a.positionAssignments) {
           posCounts[pa.playerId][pa.position as 0 | 1] += 1;
@@ -531,7 +540,7 @@ describe("urnRandomization: randomization properties (α=1e-4)", () => {
       const players = Array.from({ length: N }, (_, i) => ({ id: `p_${i}` }));
       // Counts: 2 means "fill twice", but with only 5 players in T(pc=2)
       // we'll fill exactly twice; one player is leftover each tick.
-      const { assignments } = runOneUrn(players, T_ONE, [2], 2000 + m);
+      const { assignments } = runOneUrn(players, T_ONE, { T: 2 }, 2000 + m);
       const assigned = new Set(
         assignments.flatMap((a) =>
           a.positionAssignments.map((pa) => pa.playerId),
@@ -555,7 +564,12 @@ describe("urnRandomization: randomization properties (α=1e-4)", () => {
       });
       for (let m = 0; m < M; m += 1) {
         const players = playerIds.map((id) => ({ id }));
-        const { assignments } = runOneUrn(players, T_ONE, [10], seedOffset + m);
+        const { assignments } = runOneUrn(
+          players,
+          T_ONE,
+          { T: 10 },
+          seedOffset + m,
+        );
         for (const a of assignments) {
           for (const pa of a.positionAssignments) {
             if (pa.position === 0) counts[pa.playerId] += 1;
@@ -586,7 +600,7 @@ describe("urnRandomization: randomization properties (α=1e-4)", () => {
         { id: "p_4" },
       ];
       const tag = ["A", "A", "A", "B", "B"] as const;
-      const { assignments } = runOneUrn(players, T_ONE, [2], 3000 + m);
+      const { assignments } = runOneUrn(players, T_ONE, { T: 2 }, 3000 + m);
       const assigned = new Set(
         assignments.flatMap((a) =>
           a.positionAssignments.map((pa) => pa.playerId),
@@ -615,7 +629,7 @@ describe("urnRandomization: randomization properties (α=1e-4)", () => {
     }
     for (let m = 0; m < M; m += 1) {
       const players = Array.from({ length: N }, (_, i) => ({ id: `p_${i}` }));
-      const { assignments } = runOneUrn(players, T_ONE, [2], 5000 + m);
+      const { assignments } = runOneUrn(players, T_ONE, { T: 2 }, 5000 + m);
       for (const a of assignments) {
         const ids = a.positionAssignments.map((pa) => pa.playerId);
         for (let i = 0; i < ids.length; i += 1) {
@@ -649,12 +663,21 @@ describe("urnRandomization: randomization properties (α=1e-4)", () => {
         });
       }
     }
-    const counts = treatments.map(() => 20);
-    // Decrement matrix: when L0Vk is used, decrement all L0V* by 1 (same
-    // label coupling) and leave L1V* alone.
-    const decrements = treatments.map((ti) =>
-      treatments.map((tj) => (ti.label === tj.label ? 1 : 0)),
+    const counts: Record<string, number> = Object.fromEntries(
+      treatments.map((t) => [t.name, 20]),
     );
+    // Decrement matrix (labeled): when L_iV_k is used, decrement all
+    // L_iV_* by 1 (same label coupling) and leave L_!iV_* alone. We
+    // write every cross-label entry explicitly as 0 to keep the test
+    // self-documenting; missing entries would default to 0 anyway.
+    const decrements: Record<string, Record<string, number>> = {};
+    for (const ti of treatments) {
+      const row: Record<string, number> = {};
+      for (const tj of treatments) {
+        row[tj.name] = ti.label === tj.label ? 1 : 0;
+      }
+      decrements[ti.name] = row;
+    }
 
     // Two players per tick; enough ticks to drain the urn under same-
     // label coupling.
@@ -662,10 +685,10 @@ describe("urnRandomization: randomization properties (α=1e-4)", () => {
     const useCount: Record<string, number> = {};
     for (const t of treatments) useCount[t.name] = 0;
 
-    let runningCounts = counts.slice();
+    let runningCounts: Record<string, number> = { ...counts };
     let seed = 7000;
     const HARD_CAP = 20_000;
-    while (runningCounts.some((c) => c > 0)) {
+    while (Object.values(runningCounts).some((c) => c > 0)) {
       const players = [{ id: `p_${seed}_0` }, { id: `p_${seed}_1` }];
       const playerIds = players.map((p) => p.id);
       const eligibility = emptyEligibility(playerIds, treatments);
@@ -692,7 +715,7 @@ describe("urnRandomization: randomization properties (α=1e-4)", () => {
         );
       }
     }
-    expect(runningCounts.every((c) => c === 0)).toBe(true);
+    expect(Object.values(runningCounts).every((c) => c === 0)).toBe(true);
     expect(totalUses).toBeGreaterThan(0);
 
     // Per-label variant uniformity: χ² over the 5 variant-counts inside

--- a/packages/stagebook/src/dispatch/types.ts
+++ b/packages/stagebook/src/dispatch/types.ts
@@ -107,20 +107,48 @@ export interface UniformRandomDispatcherConfig {
   type: "uniform-random";
 }
 
+/** Map from treatment name → non-negative real. Used for `urn` counts,
+ *  `weighted-random` weights, and similar 1-D per-treatment parameters.
+ *  Labels are validated against the treatment name set at config-time;
+ *  missing or extra labels are an error. */
+export type LabeledScalars = Record<string, number>;
+
+/** Map from row treatment name → (map from column treatment name → value).
+ *  Used for `urn`'s decrement matrix.
+ *
+ *  Specification is binary: either you omit `decrements` entirely
+ *  (gets the identity matrix as a default) OR you specify it, in
+ *  which case it's a strict literal — every treatment must have a
+ *  row, and missing column entries within a row default to 0. There
+ *  is no "partial matrix layered over identity" mode; if you want
+ *  identity behavior on a particular row, write it (`T_x: {T_x: 1}`).
+ *
+ *  This keeps the mental model simple: matrix off → identity; matrix
+ *  on → literal. And it eliminates the silent-footgun case where an
+ *  author writes a partial row and accidentally zeros out the
+ *  self-decrement of a treatment. */
+export type LabeledMatrix = Record<string, Record<string, number>>;
+
 export interface WeightedRandomDispatcherConfig {
   type: "weighted-random";
-  /** Non-negative reals interpreted up to scale. `[1, 1, 1]`, `[100, 100, 100]`,
-   *  and `[0.33, 0.33, 0.33]` produce identical samplers. Length must match
-   *  the treatment count. A zero weight means "never pick this treatment"
-   *  (useful for de-activating a condition without renumbering). */
-  weights: number[] | FileReference;
+  /** Non-negative reals interpreted up to scale. `{T_a: 1, T_b: 1}`,
+   *  `{T_a: 100, T_b: 100}`, and `{T_a: 0.5, T_b: 0.5}` are identical
+   *  samplers. Label set must equal the treatment name set. A zero
+   *  weight means "never pick this treatment" (useful for deactivating
+   *  a condition without renumbering). */
+  weights: LabeledScalars | FileReference;
 }
 
 export interface UrnDispatcherConfig {
   type: "urn";
-  counts: number[] | FileReference;
-  /** Square matrix; defaults to identity (decrement self by 1) when omitted. */
-  decrements?: number[][] | FileReference;
+  /** Per-treatment target counts, by name. Label set must equal the
+   *  treatment name set. */
+  counts: LabeledScalars | FileReference;
+  /** Optional decrement matrix, by name. When omitted entirely, the
+   *  full matrix defaults to identity. When specified, it's a strict
+   *  literal: every treatment must have a row, and missing column
+   *  entries within a row default to 0. */
+  decrements?: LabeledMatrix | FileReference;
 }
 
 /** Placeholder for the `local-penalization` dispatcher that stays in
@@ -129,8 +157,8 @@ export interface UrnDispatcherConfig {
  *  the call site. */
 export interface LocalPenalizationDispatcherConfig {
   type: "local-penalization";
-  payoffs: number[] | "equal" | FileReference;
-  knockdowns: number | number[] | number[][] | "none" | FileReference;
+  payoffs: LabeledScalars | "equal" | FileReference;
+  knockdowns: number | LabeledScalars | LabeledMatrix | "none" | FileReference;
 }
 
 export type DispatcherConfig =

--- a/packages/stagebook/src/dispatch/urnRandomization.test.ts
+++ b/packages/stagebook/src/dispatch/urnRandomization.test.ts
@@ -1,0 +1,278 @@
+import { describe, test, expect } from "vitest";
+import { urnRandomization } from "./urnRandomization.js";
+import { makeEligibilityTable } from "./makeEligibilityTable.js";
+import { mulberry32 } from "./contract.js";
+import type { Treatment } from "./types.js";
+
+function emptyEligibility(playerIds: string[], treatments: Treatment[]) {
+  return makeEligibilityTable({ playerIds, treatments, playerData: {} });
+}
+
+describe("urnRandomization", () => {
+  const TREATMENTS: Treatment[] = [
+    { name: "t0", playerCount: 2 },
+    { name: "t1", playerCount: 2 },
+    { name: "t2", playerCount: 2 },
+  ];
+
+  test("rejects counts with extra / missing labels", () => {
+    // missing t2
+    expect(() =>
+      urnRandomization({
+        playerIds: ["p0", "p1"],
+        treatments: TREATMENTS,
+        counts: { t0: 1, t1: 1 },
+        eligibility: emptyEligibility(["p0", "p1"], TREATMENTS),
+        rng: mulberry32(0),
+      }),
+    ).toThrow(/labels do not match.*missing.*t2/);
+    // extra tX
+    expect(() =>
+      urnRandomization({
+        playerIds: ["p0", "p1"],
+        treatments: TREATMENTS,
+        counts: { t0: 1, t1: 1, t2: 1, tX: 1 },
+        eligibility: emptyEligibility(["p0", "p1"], TREATMENTS),
+        rng: mulberry32(0),
+      }),
+    ).toThrow(/labels do not match.*extra.*tX/);
+  });
+
+  test("rejects decrements when a row is missing (strict-literal rule)", () => {
+    // No layered-on-identity: if you specify decrements, you specify
+    // every row.
+    expect(() =>
+      urnRandomization({
+        playerIds: ["p0", "p1", "p2", "p3"],
+        treatments: TREATMENTS,
+        counts: { t0: 2, t1: 2, t2: 2 },
+        decrements: {
+          t0: { t0: 1, t1: 1 },
+          // t1 and t2 rows missing
+        },
+        eligibility: emptyEligibility(["p0", "p1", "p2", "p3"], TREATMENTS),
+        rng: mulberry32(0),
+      }),
+    ).toThrow(/labels do not match/);
+  });
+
+  test("rejects decrements with unknown column labels", () => {
+    expect(() =>
+      urnRandomization({
+        playerIds: ["p0", "p1"],
+        treatments: TREATMENTS,
+        counts: { t0: 1, t1: 1, t2: 1 },
+        decrements: {
+          t0: { t0: 1, tX: 1 }, // unknown column
+          t1: { t1: 1 },
+          t2: { t2: 1 },
+        },
+        eligibility: emptyEligibility(["p0", "p1"], TREATMENTS),
+        rng: mulberry32(0),
+      }),
+    ).toThrow(/column label.*tX/);
+  });
+
+  test("omitted decrements equals fully-written identity (behavioral parity)", () => {
+    // Pins the "matrix off = identity" default path. If the default
+    // ever drifts away from identity, this catches it.
+    const players = Array.from({ length: 6 }, (_, i) => ({ id: `p${i}` }));
+    const playerIds = players.map((p) => p.id);
+    const eligibility = emptyEligibility(playerIds, TREATMENTS);
+    const counts = { t0: 1, t1: 1, t2: 1 };
+
+    const omitted = urnRandomization({
+      playerIds,
+      treatments: TREATMENTS,
+      counts,
+      eligibility,
+      rng: mulberry32(42),
+    });
+
+    const explicitIdentity = urnRandomization({
+      playerIds,
+      treatments: TREATMENTS,
+      counts,
+      decrements: {
+        t0: { t0: 1 },
+        t1: { t1: 1 },
+        t2: { t2: 1 },
+      },
+      eligibility,
+      rng: mulberry32(42),
+    });
+
+    expect(omitted.assignments).toEqual(explicitIdentity.assignments);
+    expect(omitted.remainingCounts).toEqual(explicitIdentity.remainingCounts);
+  });
+
+  test("missing column within a present row defaults to 0 (behavioral parity)", () => {
+    // The two forms should produce identical output: a sparse row is
+    // identical to a dense row with explicit zeros.
+    const players = Array.from({ length: 6 }, (_, i) => ({ id: `p${i}` }));
+    const playerIds = players.map((p) => p.id);
+    const eligibility = emptyEligibility(playerIds, TREATMENTS);
+    const counts = { t0: 1, t1: 1, t2: 1 };
+
+    const sparse = urnRandomization({
+      playerIds,
+      treatments: TREATMENTS,
+      counts,
+      decrements: {
+        t0: { t0: 1 }, // t1 and t2 columns omitted → default to 0
+        t1: { t1: 1 },
+        t2: { t2: 1 },
+      },
+      eligibility,
+      rng: mulberry32(42),
+    });
+
+    const explicit = urnRandomization({
+      playerIds,
+      treatments: TREATMENTS,
+      counts,
+      decrements: {
+        t0: { t0: 1, t1: 0, t2: 0 },
+        t1: { t0: 0, t1: 1, t2: 0 },
+        t2: { t0: 0, t1: 0, t2: 1 },
+      },
+      eligibility,
+      rng: mulberry32(42),
+    });
+
+    expect(sparse.assignments).toEqual(explicit.assignments);
+    expect(sparse.remainingCounts).toEqual(explicit.remainingCounts);
+  });
+
+  test("key order in counts is not significant (semantics are by-label)", () => {
+    // counts {t1: 2, t0: 1, t2: 1} should produce identical output to
+    // counts {t0: 1, t1: 2, t2: 1} given the same treatments + seed.
+    // The dispatcher must read counts by label, not by Object.keys()
+    // iteration order.
+    const players = Array.from({ length: 10 }, (_, i) => ({ id: `p${i}` }));
+    const playerIds = players.map((p) => p.id);
+    const eligibility = emptyEligibility(playerIds, TREATMENTS);
+
+    const inOrder = urnRandomization({
+      playerIds,
+      treatments: TREATMENTS,
+      counts: { t0: 1, t1: 2, t2: 1 },
+      eligibility,
+      rng: mulberry32(42),
+    });
+
+    const reordered = urnRandomization({
+      playerIds,
+      treatments: TREATMENTS,
+      counts: { t1: 2, t0: 1, t2: 1 },
+      eligibility,
+      rng: mulberry32(42),
+    });
+
+    expect(inOrder.assignments).toEqual(reordered.assignments);
+    expect(inOrder.remainingCounts).toEqual(reordered.remainingCounts);
+  });
+
+  test("remainingCounts round-trips into a follow-up call", () => {
+    // The host pattern is to persist remainingCounts across ticks and
+    // feed it back into the next call as `counts`. Pin that the label
+    // set survives the round-trip exactly — no string-key drift.
+    const players1 = Array.from({ length: 4 }, (_, i) => ({ id: `p1_${i}` }));
+    const players2 = Array.from({ length: 4 }, (_, i) => ({ id: `p2_${i}` }));
+    const eligibility1 = emptyEligibility(
+      players1.map((p) => p.id),
+      TREATMENTS,
+    );
+    const eligibility2 = emptyEligibility(
+      players2.map((p) => p.id),
+      TREATMENTS,
+    );
+
+    const first = urnRandomization({
+      playerIds: players1.map((p) => p.id),
+      treatments: TREATMENTS,
+      counts: { t0: 3, t1: 3, t2: 3 },
+      eligibility: eligibility1,
+      rng: mulberry32(42),
+    });
+
+    // The label set survives exactly.
+    expect(Object.keys(first.remainingCounts).sort()).toEqual([
+      "t0",
+      "t1",
+      "t2",
+    ]);
+
+    // And feeding it straight back into a subsequent call works (i.e.,
+    // doesn't trip the validateLabelSet defense in depth).
+    expect(() =>
+      urnRandomization({
+        playerIds: players2.map((p) => p.id),
+        treatments: TREATMENTS,
+        counts: first.remainingCounts,
+        eligibility: eligibility2,
+        rng: mulberry32(43),
+      }),
+    ).not.toThrow();
+  });
+
+  test("empty players → empty assignments, counts pass through unchanged", () => {
+    const result = urnRandomization({
+      playerIds: [],
+      treatments: TREATMENTS,
+      counts: { t0: 5, t1: 5, t2: 5 },
+      eligibility: emptyEligibility([], TREATMENTS),
+      rng: mulberry32(0),
+    });
+    expect(result.assignments).toEqual([]);
+    expect(result.remainingCounts).toEqual({ t0: 5, t1: 5, t2: 5 });
+  });
+
+  test("seeded determinism: same seed + inputs → identical output", () => {
+    const players = Array.from({ length: 6 }, (_, i) => ({ id: `p${i}` }));
+    const playerIds = players.map((p) => p.id);
+    const eligibility = emptyEligibility(playerIds, TREATMENTS);
+    const counts = { t0: 2, t1: 2, t2: 2 };
+
+    const a = urnRandomization({
+      playerIds,
+      treatments: TREATMENTS,
+      counts,
+      eligibility,
+      rng: mulberry32(42),
+    });
+    const b = urnRandomization({
+      playerIds,
+      treatments: TREATMENTS,
+      counts,
+      eligibility,
+      rng: mulberry32(42),
+    });
+    const c = urnRandomization({
+      playerIds,
+      treatments: TREATMENTS,
+      counts,
+      eligibility,
+      rng: mulberry32(43),
+    });
+
+    expect(a.assignments).toEqual(b.assignments);
+    expect(a.remainingCounts).toEqual(b.remainingCounts);
+    expect(a.assignments).not.toEqual(c.assignments);
+  });
+
+  test("input `counts` is not mutated", () => {
+    const counts = { t0: 3, t1: 3, t2: 3 };
+    const snapshot = { ...counts };
+    const players = Array.from({ length: 6 }, (_, i) => ({ id: `p${i}` }));
+    const playerIds = players.map((p) => p.id);
+    urnRandomization({
+      playerIds,
+      treatments: TREATMENTS,
+      counts,
+      eligibility: emptyEligibility(playerIds, TREATMENTS),
+      rng: mulberry32(42),
+    });
+    expect(counts).toEqual(snapshot);
+  });
+});

--- a/packages/stagebook/src/dispatch/urnRandomization.test.ts
+++ b/packages/stagebook/src/dispatch/urnRandomization.test.ts
@@ -76,72 +76,83 @@ describe("urnRandomization", () => {
   test("omitted decrements equals fully-written identity (behavioral parity)", () => {
     // Pins the "matrix off = identity" default path. If the default
     // ever drifts away from identity, this catches it.
+    //
+    // Sweep multiple seeds so a parity break that only surfaces for
+    // specific RNG sequences doesn't slip through.
     const players = Array.from({ length: 6 }, (_, i) => ({ id: `p${i}` }));
     const playerIds = players.map((p) => p.id);
     const eligibility = emptyEligibility(playerIds, TREATMENTS);
     const counts = { t0: 1, t1: 1, t2: 1 };
+    const identity = {
+      t0: { t0: 1 },
+      t1: { t1: 1 },
+      t2: { t2: 1 },
+    };
 
-    const omitted = urnRandomization({
-      playerIds,
-      treatments: TREATMENTS,
-      counts,
-      eligibility,
-      rng: mulberry32(42),
-    });
-
-    const explicitIdentity = urnRandomization({
-      playerIds,
-      treatments: TREATMENTS,
-      counts,
-      decrements: {
-        t0: { t0: 1 },
-        t1: { t1: 1 },
-        t2: { t2: 1 },
-      },
-      eligibility,
-      rng: mulberry32(42),
-    });
-
-    expect(omitted.assignments).toEqual(explicitIdentity.assignments);
-    expect(omitted.remainingCounts).toEqual(explicitIdentity.remainingCounts);
+    for (const seed of [42, 100, 7, 0xdeadbeef, 1234567]) {
+      const omitted = urnRandomization({
+        playerIds,
+        treatments: TREATMENTS,
+        counts,
+        eligibility,
+        rng: mulberry32(seed),
+      });
+      const explicit = urnRandomization({
+        playerIds,
+        treatments: TREATMENTS,
+        counts,
+        decrements: identity,
+        eligibility,
+        rng: mulberry32(seed),
+      });
+      expect(omitted.assignments, `seed ${seed}`).toEqual(explicit.assignments);
+      expect(omitted.remainingCounts, `seed ${seed}`).toEqual(
+        explicit.remainingCounts,
+      );
+    }
   });
 
   test("missing column within a present row defaults to 0 (behavioral parity)", () => {
     // The two forms should produce identical output: a sparse row is
-    // identical to a dense row with explicit zeros.
+    // identical to a dense row with explicit zeros. Swept across seeds
+    // to catch parity breaks visible only on specific RNG sequences.
     const players = Array.from({ length: 6 }, (_, i) => ({ id: `p${i}` }));
     const playerIds = players.map((p) => p.id);
     const eligibility = emptyEligibility(playerIds, TREATMENTS);
     const counts = { t0: 1, t1: 1, t2: 1 };
+    const sparseDecrements = {
+      t0: { t0: 1 }, // t1 and t2 columns omitted → default to 0
+      t1: { t1: 1 },
+      t2: { t2: 1 },
+    };
+    const denseDecrements = {
+      t0: { t0: 1, t1: 0, t2: 0 },
+      t1: { t0: 0, t1: 1, t2: 0 },
+      t2: { t0: 0, t1: 0, t2: 1 },
+    };
 
-    const sparse = urnRandomization({
-      playerIds,
-      treatments: TREATMENTS,
-      counts,
-      decrements: {
-        t0: { t0: 1 }, // t1 and t2 columns omitted → default to 0
-        t1: { t1: 1 },
-        t2: { t2: 1 },
-      },
-      eligibility,
-      rng: mulberry32(42),
-    });
-
-    const explicit = urnRandomization({
-      playerIds,
-      treatments: TREATMENTS,
-      counts,
-      decrements: {
-        t0: { t0: 1, t1: 0, t2: 0 },
-        t1: { t0: 0, t1: 1, t2: 0 },
-        t2: { t0: 0, t1: 0, t2: 1 },
-      },
-      eligibility,
-      rng: mulberry32(42),
-    });
-
-    expect(sparse.assignments).toEqual(explicit.assignments);
-    expect(sparse.remainingCounts).toEqual(explicit.remainingCounts);
+    for (const seed of [42, 100, 7, 0xdeadbeef, 1234567]) {
+      const sparse = urnRandomization({
+        playerIds,
+        treatments: TREATMENTS,
+        counts,
+        decrements: sparseDecrements,
+        eligibility,
+        rng: mulberry32(seed),
+      });
+      const dense = urnRandomization({
+        playerIds,
+        treatments: TREATMENTS,
+        counts,
+        decrements: denseDecrements,
+        eligibility,
+        rng: mulberry32(seed),
+      });
+      expect(sparse.assignments, `seed ${seed}`).toEqual(dense.assignments);
+      expect(sparse.remainingCounts, `seed ${seed}`).toEqual(
+        dense.remainingCounts,
+      );
+    }
   });
 
   test("key order in counts is not significant (semantics are by-label)", () => {

--- a/packages/stagebook/src/dispatch/urnRandomization.ts
+++ b/packages/stagebook/src/dispatch/urnRandomization.ts
@@ -1,16 +1,25 @@
-import type { Assignment, EligibilityTable, Treatment } from "./types.js";
+import type {
+  Assignment,
+  EligibilityTable,
+  LabeledMatrix,
+  LabeledScalars,
+  Treatment,
+} from "./types.js";
 import { tryFillTreatment } from "./tryFillTreatment.js";
+import { validateLabelSet } from "./validateLabelSet.js";
 
 export interface UrnRandomizationArgs {
   playerIds: string[];
   treatments: Treatment[];
-  /** Per-treatment remaining-balls. Mutated *by copy* — input is not modified. */
-  counts: number[];
-  /** Optional square N×N matrix of non-negative integer decrements.
-   *  `decrements[i][j]` = how many balls to subtract from treatment j
-   *  when treatment i is used. When omitted, defaults to the identity
-   *  matrix (decrement self by 1, leave others alone). */
-  decrements?: number[][];
+  /** Per-treatment remaining-balls, keyed by treatment name. Mutated
+   *  *by copy* — input is not modified. Label set must equal the set
+   *  of `treatments[i].name`. */
+  counts: LabeledScalars;
+  /** Optional decrement matrix, keyed by treatment name on both axes.
+   *  When omitted entirely, the full matrix defaults to identity.
+   *  When provided, it's a strict literal — every treatment must have
+   *  a row, and missing column entries within a row default to 0. */
+  decrements?: LabeledMatrix;
   eligibility: EligibilityTable;
   rng: () => number;
 }
@@ -18,8 +27,9 @@ export interface UrnRandomizationArgs {
 export interface UrnRandomizationResult {
   assignments: Assignment[];
   /** Persist this across ticks. The host wires it back into the next
-   *  call's `counts`; the dispatcher itself is pure. */
-  remainingCounts: number[];
+   *  call's `counts`; the dispatcher itself is pure. Same label set
+   *  as the input `counts`. */
+  remainingCounts: LabeledScalars;
 }
 
 /**
@@ -30,28 +40,28 @@ export interface UrnRandomizationResult {
  * this is THE central randomization claim for ordinary experimental
  * work.
  *
+ * The label-based input shape protects against silent order drift
+ * between the treatment file and the batch config: if a treatment is
+ * renamed, added, or removed, the validator catches the mismatch at
+ * config-time and the dispatcher refuses to run with an unmatched
+ * label at runtime.
+ *
  * Algorithm (per round, per call):
  *   1. Eligible-treatment pool = treatments where
- *      `counts[i] > 0 ∧ playerCount ≤ available.size ∧ playerCount > 0`.
+ *      `counts[name] > 0 ∧ playerCount ≤ available.size ∧ playerCount > 0`.
  *   2. Sample one treatment from the pool with probability proportional
- *      to `counts[i]` (urn draw — *not* uniform).
+ *      to `counts[name]` (urn draw — *not* uniform).
  *   3. Try to fill its slots via `tryFillTreatment`. On success, emit
  *      the assignment, remove the players, and decrement the urn per
- *      `decrements[i][*]` (clamped to zero on mid-dispatch underflow).
+ *      the picked row of `decrements` (clamped to zero on mid-dispatch
+ *      underflow).
  *   4. On greedy failure, mark this treatment "tried this round" and
  *      sample again from the remaining pool; if every untried
  *      treatment fails, stop.
  *
- * Counts are host-persistent state — call N times across N dispatch
- * ticks; thread `result.remainingCounts` back into each successor's
- * `counts` argument. The dispatcher itself never mutates its inputs.
- *
- * Underflow handling: if a decrement would push `counts[j]` below zero
- * we clamp to zero. The issue's design discussion notes this can
- * legitimately happen mid-dispatch when multiple picks decrement the
- * same off-diagonal entry. We do not emit a warning at the dispatcher
- * level — the host can detect the same condition by comparing input vs.
- * output counts and surface it however its observability stack prefers.
+ * Underflow handling: if a decrement would push a count below zero we
+ * clamp to zero silently. The host can detect the same condition by
+ * comparing input vs. output counts.
  */
 export function urnRandomization({
   playerIds,
@@ -62,25 +72,46 @@ export function urnRandomization({
   rng,
 }: UrnRandomizationArgs): UrnRandomizationResult {
   const n = treatments.length;
-  if (counts.length !== n) {
-    throw new Error(
-      `urnRandomization: counts.length (${counts.length}) must equal treatments.length (${n})`,
-    );
-  }
-  const remainingCounts = counts.slice();
-  const decrementMatrix = decrements ?? identityMatrix(n);
-  if (decrementMatrix.length !== n) {
-    throw new Error(
-      `urnRandomization: decrements is not a square ${n}×${n} matrix (rows=${decrementMatrix.length})`,
-    );
-  }
-  for (let i = 0; i < n; i += 1) {
-    if (decrementMatrix[i].length !== n) {
-      throw new Error(
-        `urnRandomization: decrements row ${i} has length ${decrementMatrix[i].length}, expected ${n}`,
-      );
+  const names = treatments.map((t) => t.name);
+
+  // Validate label set up-front so the failure mode is "loud error at
+  // the top of the function" rather than "silent missing-key default
+  // mid-loop." The validator should have caught these at config-time;
+  // this is defense in depth for callers that bypass validation.
+  validateLabelSet("urnRandomization", "counts", counts, names);
+  if (decrements !== undefined) {
+    // When a matrix is specified, it's a strict literal: every
+    // treatment must have a row (no implicit identity fallback for
+    // omitted rows), and column labels within each row must be known
+    // treatments. This matches the validator's `decrements` rule and
+    // keeps the mental model of "matrix off = identity, matrix on =
+    // literal" intact.
+    validateLabelSet("urnRandomization", "decrements rows", decrements, names);
+    for (const row of names) {
+      for (const col of Object.keys(decrements[row])) {
+        if (!names.includes(col)) {
+          throw new Error(
+            `urnRandomization: decrements column label "${col}" in row "${row}" does not match any treatment name`,
+          );
+        }
+      }
     }
   }
+
+  // Internally we work positionally (cheap arithmetic, dense access)
+  // and convert back to labels only at the boundary. The whole inner
+  // loop is identical to the v0.13 positional implementation.
+  const positionalCounts: number[] = names.map((name) => counts[name]);
+  const positionalDecrements: number[][] =
+    decrements === undefined
+      ? // No matrix → identity (the default-case fast path).
+        names.map((rowName) =>
+          names.map((colName) => (colName === rowName ? 1 : 0)),
+        )
+      : // Matrix specified → strict literal; missing cells default to 0.
+        names.map((rowName) =>
+          names.map((colName) => decrements[rowName][colName] ?? 0),
+        );
 
   const assignments: Assignment[] = [];
   const available = new Set(playerIds);
@@ -89,25 +120,23 @@ export function urnRandomization({
     const tried = new Set<number>();
     let progress = false;
     while (true) {
-      // Build the "positive-count, size-feasible, not-yet-tried" pool.
       const pool: number[] = [];
       let totalWeight = 0;
       for (let i = 0; i < n; i += 1) {
         if (tried.has(i)) continue;
-        if (remainingCounts[i] <= 0) continue;
+        if (positionalCounts[i] <= 0) continue;
         if (treatments[i].playerCount === 0) continue;
         if (treatments[i].playerCount > available.size) continue;
         pool.push(i);
-        totalWeight += remainingCounts[i];
+        totalWeight += positionalCounts[i];
       }
       if (pool.length === 0 || totalWeight === 0) break;
 
-      // Weighted sample by remaining counts.
       const target = rng() * totalWeight;
       let cumulative = 0;
       let treatmentIdx = pool[pool.length - 1];
       for (const i of pool) {
-        cumulative += remainingCounts[i];
+        cumulative += positionalCounts[i];
         if (target < cumulative) {
           treatmentIdx = i;
           break;
@@ -125,28 +154,23 @@ export function urnRandomization({
       if (filled) {
         assignments.push({ treatment, positionAssignments: filled });
         for (const pa of filled) available.delete(pa.playerId);
-        const row = decrementMatrix[treatmentIdx];
+        const row = positionalDecrements[treatmentIdx];
         for (let j = 0; j < n; j += 1) {
-          const next = remainingCounts[j] - row[j];
-          remainingCounts[j] = next < 0 ? 0 : next;
+          const next = positionalCounts[j] - row[j];
+          positionalCounts[j] = next < 0 ? 0 : next;
         }
         progress = true;
-        break; // restart the outer round
+        break;
       }
       tried.add(treatmentIdx);
     }
     if (!progress) break;
   }
 
-  return { assignments, remainingCounts };
-}
+  const remainingCounts: LabeledScalars = {};
+  names.forEach((name, i) => {
+    remainingCounts[name] = positionalCounts[i];
+  });
 
-function identityMatrix(n: number): number[][] {
-  const m: number[][] = [];
-  for (let i = 0; i < n; i += 1) {
-    const row: number[] = [];
-    for (let j = 0; j < n; j += 1) row.push(i === j ? 1 : 0);
-    m.push(row);
-  }
-  return m;
+  return { assignments, remainingCounts };
 }

--- a/packages/stagebook/src/dispatch/validateDispatcherConfig.test.ts
+++ b/packages/stagebook/src/dispatch/validateDispatcherConfig.test.ts
@@ -1,35 +1,38 @@
 import { describe, test, expect } from "vitest";
 import { validateDispatcherConfig } from "./validateDispatcherConfig.js";
 
+const T2 = ["t0", "t1"];
+const T3 = ["t0", "t1", "t2"];
+
 describe("validateDispatcherConfig", () => {
   test("rejects non-object configs", () => {
-    expect(validateDispatcherConfig(null, 2).ok).toBe(false);
-    expect(validateDispatcherConfig("urn", 2).ok).toBe(false);
-    expect(validateDispatcherConfig(42, 2).ok).toBe(false);
+    expect(validateDispatcherConfig(null, T2).ok).toBe(false);
+    expect(validateDispatcherConfig("urn", T2).ok).toBe(false);
+    expect(validateDispatcherConfig(42, T2).ok).toBe(false);
   });
 
   test("rejects missing or non-string `type`", () => {
-    expect(validateDispatcherConfig({}, 2).ok).toBe(false);
-    expect(validateDispatcherConfig({ type: "" }, 2).ok).toBe(false);
+    expect(validateDispatcherConfig({}, T2).ok).toBe(false);
+    expect(validateDispatcherConfig({ type: "" }, T2).ok).toBe(false);
   });
 
   test("rejects unknown `type`", () => {
-    const r = validateDispatcherConfig({ type: "nope" }, 2);
+    const r = validateDispatcherConfig({ type: "nope" }, T2);
     expect(r.ok).toBe(false);
     expect(r.diagnostics[0].path).toBe("type");
   });
 
   describe("uniform-random", () => {
     test("accepts the bare `type` form", () => {
-      const r = validateDispatcherConfig({ type: "uniform-random" }, 3);
+      const r = validateDispatcherConfig({ type: "uniform-random" }, T3);
       expect(r.ok).toBe(true);
       expect(r.diagnostics).toEqual([]);
     });
 
     test("rejects stray fields (would mislead the author)", () => {
       const r = validateDispatcherConfig(
-        { type: "uniform-random", counts: [1, 2, 3] },
-        3,
+        { type: "uniform-random", counts: { t0: 1, t1: 2, t2: 3 } },
+        T3,
       );
       expect(r.ok).toBe(false);
       expect(r.diagnostics[0].path).toBe("counts");
@@ -37,72 +40,93 @@ describe("validateDispatcherConfig", () => {
   });
 
   describe("weighted-random", () => {
-    test("accepts a well-formed weights array", () => {
+    test("accepts a well-formed labeled weights object", () => {
       const r = validateDispatcherConfig(
-        { type: "weighted-random", weights: [4, 1, 1] },
-        3,
+        { type: "weighted-random", weights: { t0: 4, t1: 1, t2: 1 } },
+        T3,
       );
       expect(r.ok).toBe(true);
     });
 
     test("accepts float weights", () => {
       const r = validateDispatcherConfig(
-        { type: "weighted-random", weights: [0.8, 0.1, 0.1] },
-        3,
+        { type: "weighted-random", weights: { t0: 0.8, t1: 0.1, t2: 0.1 } },
+        T3,
       );
       expect(r.ok).toBe(true);
+    });
+
+    test("rejects positional-array form (removed in 0.14)", () => {
+      const r = validateDispatcherConfig(
+        { type: "weighted-random", weights: [4, 1, 1] },
+        T3,
+      );
+      expect(r.ok).toBe(false);
+      const messages = r.diagnostics.map((d) => d.message).join("\n");
+      expect(messages).toMatch(
+        /map keyed by treatment name|removed in stagebook 0\.14/,
+      );
     });
 
     test("rejects unresolved file references on `weights`", () => {
       const r = validateDispatcherConfig(
         { type: "weighted-random", weights: { from: "./weights.json" } },
-        3,
+        T3,
       );
       expect(r.ok).toBe(false);
       expect(r.diagnostics[0].path).toBe("weights");
     });
 
-    test("rejects mismatched weights.length vs treatments", () => {
+    test("flags missing labels", () => {
       const r = validateDispatcherConfig(
-        { type: "weighted-random", weights: [1, 2, 3] },
-        2,
+        { type: "weighted-random", weights: { t0: 4 } },
+        T3,
       );
       expect(r.ok).toBe(false);
-      const messages = r.diagnostics.map((d) => d.message);
-      expect(messages.some((m) => m.includes("weights.length"))).toBe(true);
+      const messages = r.diagnostics.map((d) => d.message).join("\n");
+      expect(messages).toMatch(/missing.*t1.*t2|t1.*t2/);
+    });
+
+    test("flags extra labels", () => {
+      const r = validateDispatcherConfig(
+        {
+          type: "weighted-random",
+          weights: { t0: 1, t1: 1, t2: 1, tX: 1 },
+        },
+        T3,
+      );
+      expect(r.ok).toBe(false);
+      const messages = r.diagnostics.map((d) => d.message).join("\n");
+      expect(messages).toMatch(/unknown.*tX/);
     });
 
     test("rejects negative / NaN / non-finite entries", () => {
       const r = validateDispatcherConfig(
         {
           type: "weighted-random",
-          weights: [1, -1, Number.NaN, Infinity],
+          weights: { t0: 1, t1: -1, t2: Number.NaN, t3: Infinity },
         },
-        4,
+        ["t0", "t1", "t2", "t3"],
       );
       expect(r.ok).toBe(false);
       const paths = r.diagnostics.map((d) => d.path).sort();
-      expect(paths).toContain("weights.1");
-      expect(paths).toContain("weights.2");
-      expect(paths).toContain("weights.3");
+      expect(paths).toContain("weights.t1");
+      expect(paths).toContain("weights.t2");
+      expect(paths).toContain("weights.t3");
     });
 
     test("zero entries are allowed (deactivate a treatment)", () => {
       const r = validateDispatcherConfig(
-        { type: "weighted-random", weights: [4, 0, 1] },
-        3,
+        { type: "weighted-random", weights: { t0: 4, t1: 0, t2: 1 } },
+        T3,
       );
       expect(r.ok).toBe(true);
     });
 
     test("all-zero weights warn but don't fail validation (gated-off batch)", () => {
-      // Per #451, a researcher may legitimately gate a batch off
-      // temporarily by zeroing every weight. We surface a warning so
-      // the empty-batch isn't surprising, but `ok` stays true so the
-      // batch can still be deployed.
       const r = validateDispatcherConfig(
-        { type: "weighted-random", weights: [0, 0, 0] },
-        3,
+        { type: "weighted-random", weights: { t0: 0, t1: 0, t2: 0 } },
+        T3,
       );
       expect(r.ok).toBe(true);
       const warnings = r.diagnostics.filter((d) => d.severity === "warning");
@@ -112,80 +136,207 @@ describe("validateDispatcherConfig", () => {
   });
 
   describe("urn", () => {
-    test("accepts a well-formed counts array", () => {
-      const r = validateDispatcherConfig({ type: "urn", counts: [2, 2, 2] }, 3);
+    test("accepts a well-formed labeled counts object", () => {
+      const r = validateDispatcherConfig(
+        { type: "urn", counts: { t0: 2, t1: 2, t2: 2 } },
+        T3,
+      );
       expect(r.ok).toBe(true);
+    });
+
+    test("rejects positional-array form (removed in 0.14)", () => {
+      const r = validateDispatcherConfig(
+        { type: "urn", counts: [2, 2, 2] },
+        T3,
+      );
+      expect(r.ok).toBe(false);
+      const messages = r.diagnostics.map((d) => d.message).join("\n");
+      expect(messages).toMatch(
+        /map keyed by treatment name|removed in stagebook 0\.14/,
+      );
     });
 
     test("rejects unresolved file references on `counts`", () => {
       const r = validateDispatcherConfig(
         { type: "urn", counts: { from: "./counts.json" } },
-        3,
+        T3,
       );
       expect(r.ok).toBe(false);
       expect(r.diagnostics[0].path).toBe("counts");
     });
 
-    test("rejects mismatched counts.length vs treatments", () => {
-      const r = validateDispatcherConfig({ type: "urn", counts: [1, 2, 3] }, 2);
+    test("flags missing labels", () => {
+      const r = validateDispatcherConfig(
+        { type: "urn", counts: { t0: 1 } },
+        T2,
+      );
       expect(r.ok).toBe(false);
-      const messages = r.diagnostics.map((d) => d.message);
-      expect(messages.some((m) => m.includes("counts.length"))).toBe(true);
+      const messages = r.diagnostics.map((d) => d.message).join("\n");
+      expect(messages).toMatch(/missing.*t1/);
+    });
+
+    test("flags extra labels", () => {
+      const r = validateDispatcherConfig(
+        { type: "urn", counts: { t0: 1, t1: 2, tX: 3 } },
+        T2,
+      );
+      expect(r.ok).toBe(false);
+      const messages = r.diagnostics.map((d) => d.message).join("\n");
+      expect(messages).toMatch(/unknown.*tX/);
     });
 
     test("rejects non-integer / negative count entries", () => {
       const r = validateDispatcherConfig(
-        { type: "urn", counts: [2, -1, 1.5] },
-        3,
+        { type: "urn", counts: { t0: 2, t1: -1, t2: 1.5 } },
+        T3,
       );
       expect(r.ok).toBe(false);
       const paths = r.diagnostics.map((d) => d.path).sort();
-      expect(paths).toContain("counts.1");
-      expect(paths).toContain("counts.2");
+      expect(paths).toContain("counts.t1");
+      expect(paths).toContain("counts.t2");
     });
 
-    test("accepts a well-formed identity-decrement matrix", () => {
+    test("accepts a well-formed labeled identity-decrement matrix", () => {
       const r = validateDispatcherConfig(
         {
           type: "urn",
-          counts: [4, 4, 4],
+          counts: { t0: 4, t1: 4, t2: 4 },
+          decrements: {
+            t0: { t0: 1 },
+            t1: { t1: 1 },
+            t2: { t2: 1 },
+          },
+        },
+        T3,
+      );
+      expect(r.ok).toBe(true);
+    });
+
+    test("requires a row for every treatment when `decrements` is specified", () => {
+      // No layered-on-identity mode — if you specify `decrements`,
+      // you specify it fully. Authors who want identity behavior for
+      // some treatments must write the diagonal explicitly.
+      const r = validateDispatcherConfig(
+        {
+          type: "urn",
+          counts: { t0: 4, t1: 4, t2: 4 },
+          decrements: {
+            t0: { t0: 1, t1: 1 }, // cross-couple t0 → t1
+            // t1 and t2 rows missing → error
+          },
+        },
+        T3,
+      );
+      expect(r.ok).toBe(false);
+      const messages = r.diagnostics.map((d) => d.message).join("\n");
+      expect(messages).toMatch(/missing a row.*t1.*t2|t1.*t2/);
+    });
+
+    test("accepts a fully-specified decrements with cross-coupling and explicit diagonals", () => {
+      const r = validateDispatcherConfig(
+        {
+          type: "urn",
+          counts: { t0: 4, t1: 4, t2: 4 },
+          decrements: {
+            t0: { t0: 1, t1: 1 }, // cross-couple t0 → t1
+            t1: { t1: 1 }, // explicit identity
+            t2: { t2: 1 }, // explicit identity
+          },
+        },
+        T3,
+      );
+      expect(r.ok).toBe(true);
+    });
+
+    test("warns when a treatment with counts > 0 has zero self-decrement", () => {
+      // t1's row exists but has no t1→t1 entry; t1 will never deplete
+      // from its own picks. Surface as a warning (might be intentional
+      // for cross-coupled-only designs, but more often a typo).
+      const r = validateDispatcherConfig(
+        {
+          type: "urn",
+          counts: { t0: 4, t1: 4 },
+          decrements: {
+            t0: { t0: 1, t1: 1 },
+            t1: { t0: 1 }, // missing t1→t1
+          },
+        },
+        T2,
+      );
+      // ok is still true because zero-self-decrement is a warning,
+      // not an error — the user might want this.
+      expect(r.ok).toBe(true);
+      const warnings = r.diagnostics.filter((d) => d.severity === "warning");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toMatch(/t1.*not decremented|never deplete/i);
+    });
+
+    test("rejects positional-matrix form (removed in 0.14)", () => {
+      const r = validateDispatcherConfig(
+        {
+          type: "urn",
+          counts: { t0: 2, t1: 2, t2: 2 },
           decrements: [
             [1, 0, 0],
             [0, 1, 0],
             [0, 0, 1],
           ],
         },
-        3,
+        T3,
       );
-      expect(r.ok).toBe(true);
+      expect(r.ok).toBe(false);
+      const messages = r.diagnostics.map((d) => d.message).join("\n");
+      expect(messages).toMatch(
+        /map keyed by treatment name|removed in stagebook 0\.14/,
+      );
     });
 
-    test("rejects non-square decrement matrix", () => {
+    test("flags unknown row labels in decrements", () => {
       const r = validateDispatcherConfig(
         {
           type: "urn",
-          counts: [2, 2, 2],
-          decrements: [
-            [1, 0],
-            [0, 1],
-          ],
+          counts: { t0: 4, t1: 4 },
+          decrements: {
+            t0: { t0: 1 },
+            t1: { t1: 1 },
+            tX: { tX: 1 }, // unknown row
+          },
         },
-        3,
+        T2,
       );
       expect(r.ok).toBe(false);
+      const messages = r.diagnostics.map((d) => d.message).join("\n");
+      expect(messages).toMatch(/unknown.*tX|tX/);
+    });
+
+    test("flags unknown column labels in decrements", () => {
+      const r = validateDispatcherConfig(
+        {
+          type: "urn",
+          counts: { t0: 4, t1: 4 },
+          decrements: {
+            t0: { t0: 1, tX: 1 }, // unknown column
+            t1: { t1: 1 },
+          },
+        },
+        T2,
+      );
+      expect(r.ok).toBe(false);
+      const messages = r.diagnostics.map((d) => d.message).join("\n");
+      expect(messages).toMatch(/tX.*does not match/);
     });
 
     test("rejects decrement[i][j] > counts[j] (would underflow on first use)", () => {
       const r = validateDispatcherConfig(
         {
           type: "urn",
-          counts: [1, 1],
-          decrements: [
-            [1, 2],
-            [0, 1],
-          ],
+          counts: { t0: 1, t1: 1 },
+          decrements: {
+            t0: { t0: 1, t1: 2 },
+            t1: { t1: 1 },
+          },
         },
-        2,
+        T2,
       );
       expect(r.ok).toBe(false);
       const messages = r.diagnostics.map((d) => d.message).join("\n");
@@ -195,11 +346,9 @@ describe("validateDispatcherConfig", () => {
 
   describe("local-penalization", () => {
     test("is recognized but not deeply validated by stagebook", () => {
-      // Stagebook just confirms the discriminator; deliberation-lab
-      // owns the payoffs/knockdowns shape check.
       const r = validateDispatcherConfig(
         { type: "local-penalization", payoffs: "equal", knockdowns: "none" },
-        2,
+        T2,
       );
       expect(r.ok).toBe(true);
     });

--- a/packages/stagebook/src/dispatch/validateDispatcherConfig.test.ts
+++ b/packages/stagebook/src/dispatch/validateDispatcherConfig.test.ts
@@ -210,6 +210,13 @@ describe("validateDispatcherConfig", () => {
         T3,
       );
       expect(r.ok).toBe(true);
+      // Negative assertion: a correctly-self-decrementing config must
+      // produce zero warnings. Catches spurious-warning regressions in
+      // the zero-self-decrement check (e.g. an off-by-one that fires
+      // on `selfVal === 1`).
+      expect(
+        r.diagnostics.filter((d) => d.severity === "warning"),
+      ).toHaveLength(0);
     });
 
     test("requires a row for every treatment when `decrements` is specified", () => {

--- a/packages/stagebook/src/dispatch/validateDispatcherConfig.ts
+++ b/packages/stagebook/src/dispatch/validateDispatcherConfig.ts
@@ -6,14 +6,14 @@ import type {
 } from "./types.js";
 
 /** One validation diagnostic. `path` points into the config object using
- *  the same dotted convention zod does (`"counts"`, `"decrements.2.1"`)
- *  so callers can surface it the same way they surface zod issues.
+ *  the same dotted convention zod does (e.g. `"counts"`,
+ *  `"decrements.T_a.T_b"`) so callers can surface it the same way they
+ *  surface zod issues.
  *
- *  `severity` defaults to `"error"` when omitted, preserving the v0.12.0
- *  contract where every diagnostic was treated as a hard failure. Some
- *  validations (e.g. `weighted-random` with all-zero weights — the
- *  "batch is temporarily gated off" case) emit `"warning"` instead; those
- *  surface to authors but don't fail `ok`. */
+ *  `severity` defaults to `"error"` when omitted. Most diagnostics are
+ *  errors; a handful (e.g. `weighted-random` with all-zero weights —
+ *  the "batch is temporarily gated off" case) emit `"warning"` instead
+ *  so they surface to authors without failing `ok`. */
 export interface DispatcherConfigDiagnostic {
   path: string;
   message: string;
@@ -21,37 +21,39 @@ export interface DispatcherConfigDiagnostic {
 }
 
 export interface DispatcherConfigValidationResult {
-  /** True iff there are no error-severity diagnostics. Warnings do not
-   *  affect `ok` — callers that want to be strict can scan the
-   *  `diagnostics` array directly. */
+  /** True iff there are no error-severity diagnostics. */
   ok: boolean;
   diagnostics: DispatcherConfigDiagnostic[];
 }
 
 /**
- * Validate the parameter shape of a dispatcher config that the host has
- * already resolved (file-reference `{from: "./counts.json"}` shapes
- * substituted with the concrete arrays). Catches the things the
- * dispatcher itself trusts but the issue body calls out as config-time
- * checks:
+ * Validate a dispatcher config that the host has already resolved
+ * (file-reference `{from: "./counts.json"}` shapes substituted with
+ * concrete labeled objects).
  *
- *   - `urn.counts[i]` non-negative integer
- *   - `urn.decrements` (when present) square N×N of non-negative
- *     integers
- *   - `urn.decrements[i][j] <= counts[j]` — can't subtract more balls
- *     than exist initially
+ * Per-dispatcher rules:
+ *   - `urn.counts` — labeled object `{[treatmentName]: nonNegInt}`.
+ *     Label set must equal the treatment name set.
+ *   - `urn.decrements` (optional) — labeled matrix
+ *     `{[rowName]: {[colName]: nonNegInt}}`. Row labels must be a
+ *     subset of treatment names (missing rows default to identity);
+ *     column labels within a present row must be a subset of treatment
+ *     names (missing columns within a present row default to 0).
+ *     Initial-balance check: `decrements[i][j] <= counts[j]`.
+ *   - `weighted-random.weights` — labeled object
+ *     `{[treatmentName]: nonNegFiniteReal}`. Label set must equal the
+ *     treatment name set. All-zero is a warning, not an error.
+ *   - `uniform-random` — no params; stray fields rejected.
+ *   - `local-penalization` — discriminator recognized; deeper
+ *     validation lives in deliberation-lab.
  *
- * The function is intentionally tolerant of dispatchers it doesn't
- * recognize (returns `ok: true` with a single warning-style diagnostic)
- * so deliberation-lab can register `local-penalization` against the
- * same validator without stagebook needing to know its parameter shape.
- *
- * @param config Resolved dispatcher config (file refs already substituted).
- * @param treatmentCount Number of treatments in the batch (square-matrix check).
+ * Old positional-array forms get a clear migration-hint error (we
+ * shipped them as the API in v0.12-v0.13 but reject them from v0.14
+ * onward to surface batch configs that haven't migrated).
  */
 export function validateDispatcherConfig(
   config: unknown,
-  treatmentCount: number,
+  treatmentNames: string[],
 ): DispatcherConfigValidationResult {
   const diagnostics: DispatcherConfigDiagnostic[] = [];
   const push = (path: string, message: string) =>
@@ -73,10 +75,10 @@ export function validateDispatcherConfig(
     case "weighted-random":
       return validateWeightedRandom(
         config as WeightedRandomDispatcherConfig,
-        treatmentCount,
+        treatmentNames,
       );
     case "urn":
-      return validateUrn(config as UrnDispatcherConfig, treatmentCount);
+      return validateUrn(config as UrnDispatcherConfig, treatmentNames);
     case "local-penalization":
       // Implementation lives in deliberation-lab; stagebook only checks
       // that the discriminator is recognized. The host validator there
@@ -94,9 +96,6 @@ export function validateDispatcherConfig(
 function validateUniformRandom(
   config: UniformRandomDispatcherConfig,
 ): DispatcherConfigValidationResult {
-  // The trivial-case dispatcher carries no params beyond `type`. Extra
-  // keys would silently mislead the author into thinking a counts/
-  // decrements field had an effect, so we reject them here.
   const allowed = new Set(["type"]);
   const diagnostics: DispatcherConfigDiagnostic[] = [];
   for (const k of Object.keys(config)) {
@@ -107,19 +106,22 @@ function validateUniformRandom(
       });
     }
   }
-  return { ok: diagnostics.length === 0, diagnostics };
+  return { ok: isOk(diagnostics), diagnostics };
 }
 
 function validateWeightedRandom(
   config: WeightedRandomDispatcherConfig,
-  treatmentCount: number,
+  treatmentNames: string[],
 ): DispatcherConfigValidationResult {
   const diagnostics: DispatcherConfigDiagnostic[] = [];
   const push = (path: string, message: string) =>
     diagnostics.push({ path, message });
 
   if (!("weights" in config)) {
-    push("weights", "`weighted-random` dispatcher requires a `weights` array");
+    push(
+      "weights",
+      "`weighted-random` dispatcher requires a `weights` map keyed by treatment name",
+    );
     return { ok: false, diagnostics };
   }
   if (isFileReference(config.weights)) {
@@ -129,33 +131,33 @@ function validateWeightedRandom(
     );
     return { ok: false, diagnostics };
   }
-  if (!Array.isArray(config.weights)) {
-    push("weights", "`weights` must be an array of non-negative reals");
-    return { ok: false, diagnostics };
-  }
-  const weights = config.weights as unknown[];
-  if (weights.length !== treatmentCount) {
+  if (Array.isArray(config.weights)) {
     push(
       "weights",
-      `\`weights.length\` (${weights.length}) must equal the number of treatments (${treatmentCount})`,
+      "`weights` must be a map keyed by treatment name, e.g. `{T_a: 4, T_b: 1, T_control: 1}`. The positional array form was removed in stagebook 0.14 — see docs/researcher/dispatchers.md.",
     );
+    return { ok: false, diagnostics };
   }
-  weights.forEach((v, i) => {
-    if (!isNonNegativeFiniteNumber(v)) {
-      push(
-        `weights.${i}`,
-        `weights[${i}] must be a non-negative finite number, got ${formatValue(v)}`,
-      );
-    }
-  });
+  if (typeof config.weights !== "object" || config.weights === null) {
+    push("weights", "`weights` must be an object keyed by treatment name");
+    return { ok: false, diagnostics };
+  }
 
-  // All-zero is allowed (silent no-op — useful for gating a batch off
-  // temporarily without renumbering treatments). Surface as a
-  // *warning* so the author isn't surprised when the batch returns
-  // empty, but don't fail validation — see issue #451 item 3.
+  validateLabeledScalarSet(
+    "weights",
+    config.weights as Record<string, unknown>,
+    treatmentNames,
+    diagnostics,
+    isNonNegativeFiniteNumber,
+    "non-negative finite number",
+  );
+
   const allZero =
-    weights.length > 0 &&
-    weights.every((v) => isNonNegativeFiniteNumber(v) && (v as number) === 0);
+    treatmentNames.length > 0 &&
+    treatmentNames.every((name) => {
+      const v = (config.weights as Record<string, unknown>)[name];
+      return isNonNegativeFiniteNumber(v) && (v as number) === 0;
+    });
   if (allZero) {
     diagnostics.push({
       path: "weights",
@@ -170,14 +172,17 @@ function validateWeightedRandom(
 
 function validateUrn(
   config: UrnDispatcherConfig,
-  treatmentCount: number,
+  treatmentNames: string[],
 ): DispatcherConfigValidationResult {
   const diagnostics: DispatcherConfigDiagnostic[] = [];
   const push = (path: string, message: string) =>
     diagnostics.push({ path, message });
 
   if (!("counts" in config)) {
-    push("counts", "`urn` dispatcher requires a `counts` array");
+    push(
+      "counts",
+      "`urn` dispatcher requires a `counts` map keyed by treatment name",
+    );
     return { ok: false, diagnostics };
   }
   if (isFileReference(config.counts)) {
@@ -187,25 +192,27 @@ function validateUrn(
     );
     return { ok: false, diagnostics };
   }
-  if (!Array.isArray(config.counts)) {
-    push("counts", "`counts` must be an array of non-negative integers");
-    return { ok: false, diagnostics };
-  }
-  const counts = config.counts as unknown[];
-  if (counts.length !== treatmentCount) {
+  if (Array.isArray(config.counts)) {
     push(
       "counts",
-      `\`counts.length\` (${counts.length}) must equal the number of treatments (${treatmentCount})`,
+      "`counts` must be a map keyed by treatment name, e.g. `{T_a: 4, T_b: 4, T_control: 8}`. The positional array form was removed in stagebook 0.14 — see docs/researcher/dispatchers.md.",
     );
+    return { ok: false, diagnostics };
   }
-  counts.forEach((v, i) => {
-    if (!isNonNegativeInteger(v)) {
-      push(
-        `counts.${i}`,
-        `counts[${i}] must be a non-negative integer, got ${formatValue(v)}`,
-      );
-    }
-  });
+  if (typeof config.counts !== "object" || config.counts === null) {
+    push("counts", "`counts` must be an object keyed by treatment name");
+    return { ok: false, diagnostics };
+  }
+
+  const counts = config.counts as Record<string, unknown>;
+  validateLabeledScalarSet(
+    "counts",
+    counts,
+    treatmentNames,
+    diagnostics,
+    isNonNegativeInteger,
+    "non-negative integer",
+  );
 
   if (config.decrements !== undefined) {
     if (isFileReference(config.decrements)) {
@@ -213,69 +220,147 @@ function validateUrn(
         "decrements",
         "`decrements` is still a file reference — the host must resolve `{from: ...}` before calling the validator",
       );
+      return { ok: isOk(diagnostics), diagnostics };
+    }
+    if (Array.isArray(config.decrements)) {
+      push(
+        "decrements",
+        "`decrements` must be a map keyed by treatment name on both axes, e.g. `{T_a: {T_a: 1, T_b: 1}, T_b: {...}}`. The positional matrix form was removed in stagebook 0.14 — see docs/researcher/dispatchers.md.",
+      );
       return { ok: false, diagnostics };
     }
-    if (!Array.isArray(config.decrements)) {
+    if (typeof config.decrements !== "object" || config.decrements === null) {
       push(
         "decrements",
-        "`decrements` must be a square N×N matrix of non-negative integers (or omitted for the identity-matrix default)",
+        "`decrements` must be a labeled object keyed by treatment name on both axes",
       );
-      return { ok: diagnostics.length === 0, diagnostics };
+      return { ok: false, diagnostics };
     }
-    const matrix = config.decrements as unknown[];
-    if (matrix.length !== counts.length) {
+    const decrements = config.decrements as Record<string, unknown>;
+    const nameSet = new Set(treatmentNames);
+    const rowKeys = Object.keys(decrements);
+
+    // Strict literal: every treatment must have a row, and only known
+    // treatment labels are allowed. Mirrors the counts/weights rule;
+    // matches `urnRandomization`'s runtime behavior.
+    const missingRows = treatmentNames.filter((n) => !rowKeys.includes(n));
+    const extraRows = rowKeys.filter((n) => !nameSet.has(n));
+    if (missingRows.length > 0) {
       push(
         "decrements",
-        `\`decrements\` must be a square ${counts.length}×${counts.length} matrix; got ${matrix.length} rows`,
+        `\`decrements\` is missing a row for ${missingRows.length === 1 ? "treatment" : "treatments"}: ${missingRows.join(", ")}. When you specify \`decrements\`, every treatment must have a row (omit \`decrements\` entirely to use the identity-matrix default).`,
       );
     }
-    matrix.forEach((row, i) => {
-      if (!Array.isArray(row)) {
+    if (extraRows.length > 0) {
+      push(
+        "decrements",
+        `\`decrements\` has ${extraRows.length === 1 ? "a row" : "rows"} for unknown ${extraRows.length === 1 ? "treatment" : "treatments"}: ${extraRows.join(", ")}. Expected one of: ${treatmentNames.join(", ")}.`,
+      );
+    }
+
+    for (const [rowName, row] of Object.entries(decrements)) {
+      if (!nameSet.has(rowName)) continue; // already reported as extra
+      if (typeof row !== "object" || row === null || Array.isArray(row)) {
         push(
-          `decrements.${i}`,
-          `decrements row ${i} must be an array of non-negative integers`,
+          `decrements.${rowName}`,
+          `decrements row "${rowName}" must be an object keyed by treatment name`,
         );
-        return;
+        continue;
       }
-      const r = row as unknown[];
-      if (r.length !== counts.length) {
-        push(
-          `decrements.${i}`,
-          `decrements row ${i} has length ${r.length}; expected ${counts.length} (matrix must be square)`,
-        );
-      }
-      r.forEach((v, j) => {
+      const rowObj = row as Record<string, unknown>;
+      for (const [colName, v] of Object.entries(rowObj)) {
+        if (!nameSet.has(colName)) {
+          push(
+            `decrements.${rowName}.${colName}`,
+            `decrements column label "${colName}" in row "${rowName}" does not match any treatment name. Expected one of: ${treatmentNames.join(", ")}.`,
+          );
+          continue;
+        }
         if (!isNonNegativeInteger(v)) {
           push(
-            `decrements.${i}.${j}`,
-            `decrements[${i}][${j}] must be a non-negative integer, got ${formatValue(v)}`,
+            `decrements.${rowName}.${colName}`,
+            `decrements["${rowName}"]["${colName}"] must be a non-negative integer, got ${formatValue(v)}`,
           );
-          return;
+          continue;
         }
-        // Initial-balance check: can't decrement more than the column's
-        // starting balls. Mid-dispatch underflow (after multiple picks)
-        // is clamped at the dispatcher; this check catches obvious
-        // misconfigurations at config-time.
-        const colCount = counts[j];
+        // Initial-balance check: can't decrement more than the column
+        // count's starting balls. Mid-dispatch underflow (after
+        // multiple picks of the same row) is clamped at the dispatcher.
+        const colCount = counts[colName];
         if (
           isNonNegativeInteger(colCount) &&
           (v as number) > (colCount as number)
         ) {
           push(
-            `decrements.${i}.${j}`,
-            `decrements[${i}][${j}] = ${v as number} exceeds counts[${j}] = ${colCount as number} — would underflow on the first use of treatment ${i}`,
+            `decrements.${rowName}.${colName}`,
+            `decrements["${rowName}"]["${colName}"] = ${v as number} exceeds counts["${colName}"] = ${colCount as number} — would underflow on the first use of treatment ${rowName}`,
           );
         }
-      });
-    });
+      }
+      // Zero-self-decrement warning: a treatment with positive counts
+      // whose row doesn't decrement its own column will never deplete
+      // from its own picks. Authors might want this (cross-coupled-only
+      // designs) but it's much more often a typo, so we surface it as
+      // a warning rather than swallow it silently.
+      if (
+        isNonNegativeInteger(counts[rowName]) &&
+        (counts[rowName] as number) > 0
+      ) {
+        const selfVal = rowObj[rowName];
+        if (selfVal === undefined || selfVal === 0) {
+          diagnostics.push({
+            path: `decrements.${rowName}.${rowName}`,
+            message: `decrements["${rowName}"]["${rowName}"] is ${selfVal === undefined ? "absent (defaults to 0)" : "0"} — treatment "${rowName}" has counts > 0 but its own ball is not decremented when it's picked. The treatment will only deplete via cross-coupled rows, if any.`,
+            severity: "warning",
+          });
+        }
+      }
+    }
   }
 
-  return { ok: diagnostics.length === 0, diagnostics };
+  return { ok: isOk(diagnostics), diagnostics };
 }
 
-/** True iff `diagnostics` has no error-severity entries. Diagnostics
- *  without an explicit `severity` are treated as errors (preserving the
- *  v0.12.0 contract). */
+/** Validate that the keys of a labeled scalar object exactly match
+ *  `treatmentNames`, and that each value passes `valueCheck`. Pushes
+ *  one diagnostic per missing / extra label and one per malformed
+ *  value. */
+function validateLabeledScalarSet(
+  field: string,
+  values: Record<string, unknown>,
+  treatmentNames: string[],
+  diagnostics: DispatcherConfigDiagnostic[],
+  valueCheck: (v: unknown) => boolean,
+  valueShape: string,
+): void {
+  const labelKeys = Object.keys(values);
+  const expected = new Set(treatmentNames);
+  const actual = new Set(labelKeys);
+  const missing = treatmentNames.filter((name) => !actual.has(name));
+  const extra = labelKeys.filter((label) => !expected.has(label));
+  if (missing.length > 0) {
+    diagnostics.push({
+      path: field,
+      message: `\`${field}\` is missing an entry for ${missing.length === 1 ? "treatment" : "treatments"}: ${missing.join(", ")}`,
+    });
+  }
+  if (extra.length > 0) {
+    diagnostics.push({
+      path: field,
+      message: `\`${field}\` has ${extra.length === 1 ? "an entry" : "entries"} for unknown ${extra.length === 1 ? "treatment" : "treatments"}: ${extra.join(", ")}. Expected one of: ${treatmentNames.join(", ")}.`,
+    });
+  }
+  for (const [name, v] of Object.entries(values)) {
+    if (!expected.has(name)) continue; // already reported as extra
+    if (!valueCheck(v)) {
+      diagnostics.push({
+        path: `${field}.${name}`,
+        message: `${field}["${name}"] must be a ${valueShape}, got ${formatValue(v)}`,
+      });
+    }
+  }
+}
+
 function isOk(diagnostics: DispatcherConfigDiagnostic[]): boolean {
   return !diagnostics.some((d) => (d.severity ?? "error") === "error");
 }

--- a/packages/stagebook/src/dispatch/validateLabelSet.ts
+++ b/packages/stagebook/src/dispatch/validateLabelSet.ts
@@ -1,0 +1,33 @@
+import type { LabeledScalars } from "./types.js";
+
+/**
+ * Runtime label-set check used by the dispatchers as defense in depth.
+ * The validator (`validateDispatcherConfig`) catches the same mismatches
+ * at config-time; this guard exists so callers that bypass validation
+ * (programmatic batch construction, host adapters that skip the
+ * validator step, tests) still get a clear error instead of silently
+ * working off undefined values.
+ *
+ * Lifted into a shared helper because both `urnRandomization` and
+ * `weightedRandom` need the exact same check — having two copies risked
+ * drift between them as the error format evolved.
+ */
+export function validateLabelSet(
+  dispatcherName: string,
+  field: string,
+  labels: LabeledScalars | Record<string, Record<string, number>>,
+  treatmentNames: string[],
+): void {
+  const labelKeys = Object.keys(labels);
+  const expected = new Set(treatmentNames);
+  const actual = new Set(labelKeys);
+  const missing = treatmentNames.filter((name) => !actual.has(name));
+  const extra = labelKeys.filter((label) => !expected.has(label));
+  if (missing.length === 0 && extra.length === 0) return;
+  const parts: string[] = [];
+  if (missing.length > 0) parts.push(`missing: [${missing.join(", ")}]`);
+  if (extra.length > 0) parts.push(`extra: [${extra.join(", ")}]`);
+  throw new Error(
+    `${dispatcherName}: ${field} labels do not match the treatment name set. ${parts.join("; ")}`,
+  );
+}

--- a/packages/stagebook/src/dispatch/validateLabelSet.ts
+++ b/packages/stagebook/src/dispatch/validateLabelSet.ts
@@ -18,7 +18,23 @@ export function validateLabelSet(
   labels: LabeledScalars | Record<string, Record<string, number>>,
   treatmentNames: string[],
 ): void {
+  // Defensive guard for the most common "obvious mistake" case: the
+  // host forgot to resolve a `{from: "./x.json"}` file reference
+  // before calling the dispatcher. Without this, the generic
+  // missing/extra reporter would say something like "missing: [t0,
+  // t1, t2]; extra: [from]" — true but obscure. The validator catches
+  // this at config-time with a clear message; we mirror its wording
+  // here for callers that bypass the validator.
   const labelKeys = Object.keys(labels);
+  if (
+    labelKeys.length === 1 &&
+    labelKeys[0] === "from" &&
+    typeof (labels as Record<string, unknown>).from === "string"
+  ) {
+    throw new Error(
+      `${dispatcherName}: ${field} is still a file reference ({from: "..."}). The host must resolve file references into labeled objects before calling the dispatcher.`,
+    );
+  }
   const expected = new Set(treatmentNames);
   const actual = new Set(labelKeys);
   const missing = treatmentNames.filter((name) => !actual.has(name));

--- a/packages/stagebook/src/dispatch/weightedRandom.test.ts
+++ b/packages/stagebook/src/dispatch/weightedRandom.test.ts
@@ -9,20 +9,31 @@ function emptyEligibility(playerIds: string[], treatments: Treatment[]) {
 }
 
 describe("weightedRandom", () => {
-  test("rejects mismatched weights/treatments length", () => {
+  test("rejects weights with extra / missing labels", () => {
     const treatments: Treatment[] = [
       { name: "t0", playerCount: 1 },
       { name: "t1", playerCount: 1 },
     ];
+    // Missing t1
     expect(() =>
       weightedRandom({
         playerIds: ["p0"],
         treatments,
-        weights: [1],
+        weights: { t0: 1 },
         eligibility: emptyEligibility(["p0"], treatments),
         rng: mulberry32(0),
       }),
-    ).toThrow(/weights.length/);
+    ).toThrow(/labels do not match.*missing.*t1/);
+    // Extra t2
+    expect(() =>
+      weightedRandom({
+        playerIds: ["p0"],
+        treatments,
+        weights: { t0: 1, t1: 1, t2: 1 },
+        eligibility: emptyEligibility(["p0"], treatments),
+        rng: mulberry32(0),
+      }),
+    ).toThrow(/labels do not match.*extra.*t2/);
   });
 
   test("empty players → empty assignments", () => {
@@ -30,7 +41,7 @@ describe("weightedRandom", () => {
     const result = weightedRandom({
       playerIds: [],
       treatments,
-      weights: [1],
+      weights: { t0: 1 },
       eligibility: emptyEligibility([], treatments),
       rng: mulberry32(0),
     });
@@ -46,7 +57,7 @@ describe("weightedRandom", () => {
     const result = weightedRandom({
       playerIds,
       treatments,
-      weights: [0, 0],
+      weights: { t0: 0, t1: 0 },
       eligibility: emptyEligibility(playerIds, treatments),
       rng: mulberry32(0),
     });
@@ -62,7 +73,7 @@ describe("weightedRandom", () => {
     const result = weightedRandom({
       playerIds,
       treatments,
-      weights: [0, 1],
+      weights: { t0: 0, t1: 1 },
       eligibility: emptyEligibility(playerIds, treatments),
       rng: mulberry32(42),
     });
@@ -77,8 +88,8 @@ describe("weightedRandom", () => {
       name: `t${i}`,
       playerCount: 2,
     }));
-    const weights = [1, 1, 1];
-    const counts = treatments.map(() => 0);
+    const weights = { t0: 1, t1: 1, t2: 1 };
+    const counts: Record<string, number> = { t0: 0, t1: 0, t2: 0 };
     const M = 500;
     for (let m = 0; m < M; m += 1) {
       const playerIds = Array.from({ length: 6 }, (_, i) => `p_${m}_${i}`);
@@ -90,16 +101,12 @@ describe("weightedRandom", () => {
         rng: mulberry32(m + 1),
       });
       for (const a of result.assignments) {
-        const idx = treatments.findIndex((t) => t.name === a.treatment.name);
-        counts[idx] += 1;
+        counts[a.treatment.name] += 1;
       }
     }
-    const total = counts.reduce((s, x) => s + x, 0);
-    // Loose bounds; the statistical-properties suite tightens this to
-    // α=1e-4. Here we just sanity-check the algorithm runs and
-    // produces roughly equal counts.
+    const total = Object.values(counts).reduce((s, x) => s + x, 0);
     expect(total).toBeGreaterThan(0);
-    for (const c of counts) {
+    for (const c of Object.values(counts)) {
       expect(c / total).toBeGreaterThan(0.25);
       expect(c / total).toBeLessThan(0.42);
     }
@@ -110,8 +117,8 @@ describe("weightedRandom", () => {
       { name: "tA", playerCount: 2 },
       { name: "tB", playerCount: 2 },
     ];
-    const weights = [4, 1];
-    const counts = [0, 0];
+    const weights = { tA: 4, tB: 1 };
+    const counts: Record<string, number> = { tA: 0, tB: 0 };
     const M = 2000;
     for (let m = 0; m < M; m += 1) {
       const playerIds = [`p_${m}_0`, `p_${m}_1`];
@@ -123,15 +130,12 @@ describe("weightedRandom", () => {
         rng: mulberry32(m + 1),
       });
       for (const a of result.assignments) {
-        const idx = treatments.findIndex((t) => t.name === a.treatment.name);
-        counts[idx] += 1;
+        counts[a.treatment.name] += 1;
       }
     }
-    const total = counts.reduce((s, x) => s + x, 0);
-    // Target 4/5 = 0.80, 1/5 = 0.20. ±0.05 is well outside the binomial
-    // noise floor at M=2000 (SE ≈ 0.009) but inside any plausible bug.
-    expect(counts[0] / total).toBeGreaterThan(0.75);
-    expect(counts[0] / total).toBeLessThan(0.85);
+    const total = counts.tA + counts.tB;
+    expect(counts.tA / total).toBeGreaterThan(0.75);
+    expect(counts.tA / total).toBeLessThan(0.85);
   });
 
   test("seeded determinism: same seed + inputs → identical assignments", () => {
@@ -140,7 +144,7 @@ describe("weightedRandom", () => {
       { name: "t1", playerCount: 2 },
     ];
     const playerIds = ["p0", "p1", "p2", "p3"];
-    const weights = [3, 1];
+    const weights = { t0: 3, t1: 1 };
     const a = weightedRandom({
       playerIds,
       treatments,
@@ -181,7 +185,7 @@ describe("weightedRandom", () => {
     const nan = weightedRandom({
       playerIds,
       treatments,
-      weights: [Number.NaN, 1],
+      weights: { t0: Number.NaN, t1: 1 },
       eligibility: emptyEligibility(playerIds, treatments),
       rng: mulberry32(42),
     });
@@ -190,7 +194,7 @@ describe("weightedRandom", () => {
     const inf = weightedRandom({
       playerIds,
       treatments,
-      weights: [Number.POSITIVE_INFINITY, 1],
+      weights: { t0: Number.POSITIVE_INFINITY, t1: 1 },
       eligibility: emptyEligibility(playerIds, treatments),
       rng: mulberry32(42),
     });
@@ -199,7 +203,7 @@ describe("weightedRandom", () => {
     const negInf = weightedRandom({
       playerIds,
       treatments,
-      weights: [Number.NEGATIVE_INFINITY, 1],
+      weights: { t0: Number.NEGATIVE_INFINITY, t1: 1 },
       eligibility: emptyEligibility(playerIds, treatments),
       rng: mulberry32(42),
     });
@@ -207,19 +211,17 @@ describe("weightedRandom", () => {
   });
 
   test("renormalization when a treatment drops out of the pool", () => {
-    // Three treatments, weights [1, 1, 5]. T2 needs 6 players; ticks
-    // only supply 4. So every tick's pool is {T0, T1} weighted [1, 1]
-    // (T2 dropped for size-infeasibility); the absorbed mass from T2
-    // is split 50/50 between T0 and T1, *not* allocated to T2 with
-    // the rest of the round failing. Confirms the docstring claim that
-    // renormalization is implicit-proportional over the surviving pool.
+    // Three treatments, weights {t0:1, t1:1, t2:5}. t2 needs 6 players;
+    // ticks only supply 4. So every tick's pool is {t0, t1} weighted
+    // [1, 1] (t2 dropped for size-infeasibility); the absorbed mass
+    // from t2 is split 50/50 between t0 and t1.
     const treatments: Treatment[] = [
       { name: "t0", playerCount: 2 },
       { name: "t1", playerCount: 2 },
       { name: "t2", playerCount: 6 },
     ];
-    const weights = [1, 1, 5];
-    const counts = [0, 0, 0];
+    const weights = { t0: 1, t1: 1, t2: 5 };
+    const counts: Record<string, number> = { t0: 0, t1: 0, t2: 0 };
     const M = 1000;
     for (let m = 0; m < M; m += 1) {
       const playerIds = [`p_${m}_0`, `p_${m}_1`, `p_${m}_2`, `p_${m}_3`];
@@ -231,25 +233,22 @@ describe("weightedRandom", () => {
         rng: mulberry32(m + 1),
       });
       for (const a of result.assignments) {
-        const idx = treatments.findIndex((t) => t.name === a.treatment.name);
-        counts[idx] += 1;
+        counts[a.treatment.name] += 1;
       }
     }
-    const total = counts.reduce((s, x) => s + x, 0);
-    // T2 should never be picked (playerCount > tick size). T0 and T1
-    // should split the runs ~50/50.
-    expect(counts[2]).toBe(0);
+    const total = counts.t0 + counts.t1 + counts.t2;
+    expect(counts.t2).toBe(0);
     expect(total).toBeGreaterThan(0);
-    expect(counts[0] / total).toBeGreaterThan(0.42);
-    expect(counts[0] / total).toBeLessThan(0.58);
+    expect(counts.t0 / total).toBeGreaterThan(0.42);
+    expect(counts.t0 / total).toBeLessThan(0.58);
   });
 
   test("greedy-fill failure on the picked treatment re-samples from the rest", () => {
-    // Set up: two treatments, weights [9, 1]. T0 has a strict role
+    // Two treatments, weights {t0:9, t1:1}. t0 has a strict role
     // condition that NO player satisfies, so greedy-fill always fails
-    // on T0. The dispatcher must mark T0 "tried this round" and pick
-    // T1 from the remaining pool — every successful round must end up
-    // on T1, even though T0 was picked first 90% of the time.
+    // on t0. The dispatcher must mark t0 "tried this round" and pick
+    // t1 from the remaining pool — every successful round must end up
+    // on t1, even though t0 was picked first 90% of the time.
     const treatments: Treatment[] = [
       {
         name: "t0",
@@ -287,7 +286,7 @@ describe("weightedRandom", () => {
       const result = weightedRandom({
         playerIds,
         treatments,
-        weights: [9, 1],
+        weights: { t0: 9, t1: 1 },
         eligibility,
         rng: mulberry32(m + 1),
       });
@@ -296,7 +295,6 @@ describe("weightedRandom", () => {
         if (a.treatment.name === "t1") t1Count += 1;
       }
     }
-    // Every assignment must be on t1 (t0 was never fillable).
     expect(totalAssignments).toBeGreaterThan(0);
     expect(t1Count).toBe(totalAssignments);
   });

--- a/packages/stagebook/src/dispatch/weightedRandom.ts
+++ b/packages/stagebook/src/dispatch/weightedRandom.ts
@@ -2,42 +2,39 @@ import type {
   Assignment,
   DispatchResult,
   EligibilityTable,
+  LabeledScalars,
   Treatment,
 } from "./types.js";
 import { tryFillTreatment } from "./tryFillTreatment.js";
+import { validateLabelSet } from "./validateLabelSet.js";
 
 export interface WeightedRandomArgs {
   playerIds: string[];
   treatments: Treatment[];
-  /** Non-negative reals interpreted up to scale. Length must equal
-   *  `treatments.length`. Zero entries are allowed and mean "never pick
-   *  this treatment." All-zero is allowed and yields no assignments. */
-  weights: number[];
+  /** Non-negative reals interpreted up to scale, keyed by treatment
+   *  name. Label set must equal the set of `treatments[i].name`. Zero
+   *  entries are allowed and mean "never pick this treatment."
+   *  All-zero is allowed and yields no assignments. */
+  weights: LabeledScalars;
   eligibility: EligibilityTable;
   rng: () => number;
 }
 
 /**
  * Stateless categorical sampler (#451): each round draws a treatment
- * iid with probability proportional to `weights[i]`, then attempts a
- * greedy fill. The dispatcher carries no state across rounds — each
- * draw is independent of every prior draw, of the round number, and of
- * any host-persisted bookkeeping. This is the property that
- * distinguishes it from `urn` (where prior draws shift the distribution)
- * and that justifies skipping host state plumbing entirely.
+ * iid with probability proportional to `weights[name]`, then attempts
+ * a greedy fill. The dispatcher carries no state across rounds — each
+ * draw is independent of every prior draw, of the round number, and
+ * of any host-persisted bookkeeping.
  *
- * Relationship to the sibling dispatchers:
- *   - `weighted-random` with all-equal weights is observationally
- *     identical to `uniform-random`. Authors should still prefer
- *     `uniform-random` when they have no balance claim — the
- *     discriminator self-documents the absence of a claim.
- *   - `urn` with very large integer counts and an identity decrement
- *     matrix approximates `weighted-random` (and converges as counts
- *     grow), but pays integer-ball cognitive overhead for a use case
- *     that doesn't need exact-N guarantees.
+ * The label-based input shape protects against silent order drift
+ * between the treatment file and the batch config: if a treatment is
+ * renamed, added, or removed, the validator catches the mismatch at
+ * config-time and the dispatcher refuses to run with an unmatched
+ * label at runtime.
  *
  * Algorithm (per round):
- *   1. Build the per-round pool: treatments with `weights[i] > 0 ∧
+ *   1. Build the per-round pool: treatments with `weights[name] > 0 ∧
  *      playerCount ≤ available.size ∧ playerCount > 0 ∧
  *      not-yet-tried-this-round`.
  *   2. Sample one treatment from the pool with probability proportional
@@ -47,20 +44,10 @@ export interface WeightedRandomArgs {
  *      "tried this round" and re-sample from the remaining weighted
  *      pool; if every untried treatment fails, stop.
  *
- * Realized rate vs. target rate:
- *   The long-run rate matches `weights[i] / sum(weights)` only when
- *   every round is size-feasible for every treatment and every player
- *   is eligible for every position. When eligibility is tight (or the
- *   per-tick player pool is small), the per-round pool gets filtered
- *   for size-feasibility and the marginal rate is implicitly
- *   renormalized over the surviving treatments. Hosts can detect the
- *   divergence by computing realized rates from the returned
- *   `assignments` and comparing against the target weights — see
- *   `docs/researcher/dispatchers.md` for a worked example.
- *
- * Termination: each successful round shrinks `available` by at least
- * 1; each failed round shrinks the "weighted, feasible, untried" set
- * by at least 1. Bounded by `O(treatments² + playerIds)`.
+ * Realized rate vs. target rate: the long-run rate matches
+ * `weights[name] / sum(weights)` only when every round is size-feasible
+ * for every treatment and every player is eligible for every position.
+ * See `docs/researcher/dispatchers.md` for a worked example.
  */
 export function weightedRandom({
   playerIds,
@@ -70,11 +57,14 @@ export function weightedRandom({
   rng,
 }: WeightedRandomArgs): DispatchResult {
   const n = treatments.length;
-  if (weights.length !== n) {
-    throw new Error(
-      `weightedRandom: weights.length (${weights.length}) must equal treatments.length (${n})`,
-    );
-  }
+  const names = treatments.map((t) => t.name);
+
+  validateLabelSet("weightedRandom", "weights", weights, names);
+
+  // Internally we work positionally — same inner loop as the v0.13
+  // positional implementation. The labels are converted at the
+  // boundary so the algorithm itself never juggles strings.
+  const positionalWeights: number[] = names.map((name) => weights[name]);
 
   const assignments: Assignment[] = [];
   const available = new Set(playerIds);
@@ -83,34 +73,29 @@ export function weightedRandom({
     const tried = new Set<number>();
     let progress = false;
     while (true) {
-      // Build the "positive-weight, size-feasible, not-yet-tried" pool.
       const pool: number[] = [];
       let totalWeight = 0;
       for (let i = 0; i < n; i += 1) {
         if (tried.has(i)) continue;
-        // Reject 0, negative, NaN, and ±Infinity. Validation rejects
+        // Reject 0, negative, NaN, ±Infinity. Validation rejects
         // these at config-time but the per-round filter defends in
         // depth — an Infinity that slipped through would make
         // `totalWeight = ∞` and the weighted-sample fallback would
         // always select the last pool entry.
-        if (!Number.isFinite(weights[i]) || weights[i] <= 0) continue;
+        if (!Number.isFinite(positionalWeights[i]) || positionalWeights[i] <= 0)
+          continue;
         if (treatments[i].playerCount === 0) continue;
         if (treatments[i].playerCount > available.size) continue;
         pool.push(i);
-        totalWeight += weights[i];
+        totalWeight += positionalWeights[i];
       }
       if (pool.length === 0 || totalWeight <= 0) break;
 
-      // Weighted sample by weights[i]. The strict `<` on cumulative
-      // means the floating-point edge case `target === totalWeight`
-      // falls through to the last-pool-entry fallback — same pattern
-      // as urnRandomization, kept consistent so readers don't have to
-      // re-verify per dispatcher.
       const target = rng() * totalWeight;
       let cumulative = 0;
       let treatmentIdx = pool[pool.length - 1];
       for (const i of pool) {
-        cumulative += weights[i];
+        cumulative += positionalWeights[i];
         if (target < cumulative) {
           treatmentIdx = i;
           break;
@@ -129,7 +114,7 @@ export function weightedRandom({
         assignments.push({ treatment, positionAssignments: filled });
         for (const pa of filled) available.delete(pa.playerId);
         progress = true;
-        break; // restart the outer round
+        break;
       }
       tried.add(treatmentIdx);
     }


### PR DESCRIPTION
## Summary

Breaking change to the v0.13 dispatcher API. `urn.counts`, `urn.decrements`, `weighted-random.weights`, and urn's returned `remainingCounts` switch from positional arrays to labeled objects keyed by treatment name.

The previous positional form silently mis-mapped when treatments were renamed or reordered — the dispatcher would happily run with the wrong allocation. The labeled form makes the mapping explicit, so the validator catches drift at config-time and the dispatcher refuses to run with an unmatched label at runtime.

Before:

```yaml
dispatcher:
  type: urn
  counts: [10, 10, 10]
  decrements:
    - [1, 0, 0]
    - [0, 1, 0]
    - [0, 0, 1]
```

After:

```yaml
dispatcher:
  type: urn
  counts:
    control: 10
    exposure_A: 10
    exposure_B: 10
  # decrements omitted → identity (the common case)
```

## Decrement-matrix specification is now binary

- **`decrements` omitted** → identity matrix (the common case)
- **`decrements` present** → strict literal. Every treatment must have a row; missing column entries within a row default to 0. If you want identity behavior on a particular row, write it explicitly (`T_a: { T_a: 1 }`).

The asymmetric "missing row defaults to identity, missing column defaults to 0" semantics were rejected because they hid a footgun where a partial row would silently zero out a self-decrement. The validator also surfaces a warning when a row has zero self-decrement while `counts[T] > 0` — the "treatment will never deplete from its own picks" case.

## Validator changes

- `validateDispatcherConfig(config, treatmentNames)` — signature change. Previous arg was `treatmentCount: number`; the new signature gives the validator the names it needs to do label-set checking.
- Rejects old positional-array forms with a migration-hint error pointing at `docs/researcher/dispatchers.md`.
- Adds label-set equality checks for `counts`, `weights`, and `decrements` rows.
- Adds subset checks for `decrements` column labels within each row.
- Adds warning-severity diagnostic for zero-self-decrement rows.

## Runtime defense in depth

Both `urnRandomization` and `weightedRandom` validate the label set up-front (the validator should have caught the same case at config-time, but this guards programmatically-constructed batches that bypass the validator). The runtime check lives in a single shared helper `validateLabelSet.ts` so the two dispatchers can't drift on the error format.

## Test coverage

- **117 dispatch tests pass** (was 107 before this PR; net +10 from new urn unit tests + new validator cases).
- **New `urnRandomization.test.ts`** (10 tests): label-set rejections, default-identity vs. explicit-identity behavioral parity, sparse-row vs. dense-row parity, key-order insensitivity, `remainingCounts` round-trip, input immutability, seeded determinism, empty-players base case.
- **Updated `weightedRandom.test.ts`, `validateDispatcherConfig.test.ts`, `contract.test.ts`, `randomization.test.ts`** for the labeled form.

1362 total stagebook tests pass; lint and build clean.

## Docs (`docs/researcher/dispatchers.md`)

- Top-of-file 0.14 migration callout pointing at the new "Why labels?" section.
- Every YAML and JSON example switched to labeled form (including the Python kernel script that emits a labeled JSON matrix).
- New "Why labels?" subsection with anchor for the migration hint.
- File-reference shape examples corrected (`{ from: ... }` instead of `{ file: ... }` — a pre-existing inconsistency with the `FileReference` type, fixed in this PR since the file is being touched anyway).
- Strict-literal framing for `decrements` with zero-self-decrement warning callout.

## Migration

This is a **clean breaking change** with no compatibility shim, by design (the user wanted to surface any ecosystem callers that haven't migrated):

- Inline YAML / JSON config: rewrite arrays as labeled objects.
- File references (`counts.json` / `decrements.json` / `weights.json`): rewrite the JSON to labeled-object form.
- Programmatic callers (the deliberation-lab manager is the only known external consumer): change `treatments.map(t => count)` to `Object.fromEntries(treatments.map(t => [t.name, count]))` — a 1-line change.

A migration hint pointing at `docs/researcher/dispatchers.md` is part of every rejection error, so consumers won't be left guessing.

## Test plan

- [x] `npm run lint -w stagebook` clean
- [x] `npm test -w stagebook` — 1362/1362 pass (117 dispatch + 1245 existing)
- [x] `npm run build -w stagebook` succeeds
- [x] Contract gauntlet runs against all three dispatchers (10 invariants × 200 scenarios each)
- [x] Statistical-properties suite passes at α=1e-4 for all dispatchers
- [x] New urn unit suite pins missing-row=identity-default, sparse-row=dense-row parity, key-order insensitivity, remainingCounts round-trip, input immutability

🤖 Generated with [Claude Code](https://claude.com/claude-code)