### PR TITLE
ci: raise per-test timeout for webkit CT project to 30s (#457)

### DIFF
--- a/packages/stagebook/playwright-ct.config.ts
+++ b/packages/stagebook/playwright-ct.config.ts
@@ -21,6 +21,15 @@ export default defineConfig({
     {
       name: "webkit",
       use: { ...devices["Desktop Safari"] },
+      // webkit's `browserContext.newPage()` is intermittently slow on
+      // CI runners — see #457. Failures consistently shape as
+      // `Test timeout of 10000ms exceeded while setting up "page"`,
+      // not as test-body errors. Bumping the per-test timeout for
+      // this project only (chromium and firefox stay at the 10s
+      // default) masks the symptom while a real bootstrap-latency
+      // investigation happens. If webkit suddenly gets healthy on
+      // CI, this can drop back to the default.
+      timeout: 30_000,
     },
     {
       name: "firefox",


### PR DESCRIPTION
## Summary

Masking fix for the recurring webkit Component-Test flake that's been failing CI on unrelated PRs (see #457). The failures consistently shape as:

```
Test timeout of 10000ms exceeded while setting up "page"
Error: browserContext.newPage: Test timeout of 10000ms exceeded.
```

Chromium and Firefox on the same commits pass. The downstream test-body errors (`Cannot read properties of undefined`, `toBe` mismatches in Timeline / MediaPlayer / PositionConditionalRender) cascade from the failed page setup, not from anything the tests themselves do.

Cumulative pattern over the last 24 hours: **7 failures across 4 PRs / main commits**, all webkit-only, all in the same Timeline / MediaPlayer / PositionConditionalRender cluster. PR #456 (a 1-line release-bump) required toggling `enforce_admins` to admin-merge. PR #458 (labeled-dispatcher-params, no UI changes) has now failed twice with the same pattern.

## Change

Per-project timeout on the webkit project only:

```ts
{
  name: "webkit",
  use: { ...devices["Desktop Safari"] },
  timeout: 30_000,  // was the 10s global default
}
```

Chromium and Firefox stay at the 10s default. Once webkit's bootstrap latency on CI runners is investigated and fixed at the root, this can drop back down.

## Why not a root-cause fix

The page-setup timeout points at webkit's `browserContext.newPage()` being intermittently slow on the GitHub Actions Ubuntu runners. That's a real infrastructure issue worth investigating (split the heavy Timeline tests into a separate Playwright project? bump the runner spec? pin a known-good webkit version?) — but it doesn't need to gate every unrelated PR while we figure it out. This change stops the bleeding so #458 and future PRs can merge.

## Test plan

- [x] Lint clean (no source code touched)
- [x] All existing tests still pass locally (no test surface affected)
- [ ] CI passes — this PR is itself an attempt to make CI pass; if webkit flakes on this PR too, that's an even stronger signal the symptom-masking is justified

Closes #457.

🤖 Generated with [Claude Code](https://claude.com/claude-code)