### PR TITLE
Bump stagebook to 0.14.0

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Breaking-change release: dispatcher parameters are now labeled objects keyed by treatment name.

## What's in

- **#458** — `urn.counts`, `urn.decrements`, `weighted-random.weights`, and urn's returned `remainingCounts` switch from positional arrays to labeled objects keyed by treatment name. Old positional configs are rejected with a migration hint pointing at `docs/researcher/dispatchers.md`. Decrement-matrix specification is now binary: omitted → identity, present → strict literal (every treatment must have a row). Validator gains an optional severity field on diagnostics (`"warning"` vs default `"error"`); all-zero weights and zero-self-decrement rows surface as warnings. New shared runtime `validateLabelSet` helper and a dedicated `urnRandomization.test.ts` suite.

## Compatibility

- **Breaking.** Inline `counts: [10, 10, 10]` / `decrements: [[1,0,0],...]` YAML forms are rejected at validation time. JSON file-reference shapes (`counts.json`, `decrements.json`, `weights.json`) must be labeled objects keyed by treatment name. The validator's error message points at the migration section in `docs/researcher/dispatchers.md`.
- `validateDispatcherConfig` signature changed: was `(config, treatmentCount: number)`, now `(config, treatmentNames: string[])`. Hosts that already had the treatment list can pass `treatments.map(t => t.name)`.

## Heads-up on CI

Recurring webkit Component-Test flake (#457) — Timeline / MediaPlayer test-body errors on webkit only, unrelated to this PR's diff. May require admin-merge if it hits.