### PR TITLE
test(mediaPlayer): fix sync-read race on completion state

### DIFF
--- a/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
+++ b/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
@@ -633,10 +633,18 @@ test("onComplete called when submitOnComplete is true and video ends", async ({
     .locator('[data-testid="mediaPlayer-video"]')
     .evaluate((el) => el.dispatchEvent(new Event("ended")));
 
-  const completed = await component
-    .locator('[data-testid="completed"]')
-    .textContent();
-  expect(completed).toBe("true");
+  // Poll the textContent rather than reading once: the synthetic
+  // `ended` event triggers a React handler that updates state, but
+  // the state hasn't necessarily flushed to the DOM by the time the
+  // textContent read returns. Other tests in this file dodge this
+  // by reading state that's already "false" (the initial value);
+  // this test asserts state changed to "true", so we need to wait.
+  // Same shape as the createRangeViaDrag race fix from #457. (#457)
+  await expect
+    .poll(async () =>
+      component.locator('[data-testid="completed"]').textContent(),
+    )
+    .toBe("true");
 });
 
 // -- startAt / stopAt scrub bounds --
@@ -744,10 +752,12 @@ test("onComplete called when submitOnComplete is true and stopAt is reached", as
       el.dispatchEvent(new Event("timeupdate"));
     });
 
-  const completed = await component
-    .locator('[data-testid="completed"]')
-    .textContent();
-  expect(completed).toBe("true");
+  // Poll-after-dispatch — same race pattern as the "ended" test above.
+  await expect
+    .poll(async () =>
+      component.locator('[data-testid="completed"]').textContent(),
+    )
+    .toBe("true");
 });
 
 // -- captions overlay --


### PR DESCRIPTION
## Summary

Fixes a residual webkit-CT flake on `MediaPlayer.ct.tsx:621` and `:733`. Same shape of race as the `createRangeViaDrag` race fixed in the v0.15 release (#463).

## What was happening

Both tests dispatch a synthetic video event (`ended` or `timeupdate`) on the video element, then *immediately* read `data-testid=\"completed\"`'s textContent and assert it equals `\"true\"`:

```ts
await component.locator(/* video */).evaluate(el => el.dispatchEvent(new Event(\"ended\")));
const completed = await component.locator(/* completed */).textContent();
expect(completed).toBe(\"true\");
```

The synthetic event triggers a React handler that updates state to `\"true\"`, but the textContent read happens before React has flushed the update to the DOM — so on a slow-enough webkit run (the sharded `--workers=1` Linux runner especially), the read returns the old `\"false\"` value and the test times out.

This was actually the third instance of the same pattern in the file — the first one reads `\"false\"`, which is the initial state, so it doesn't race. The other two only fail intermittently because the race outcome depends on Playwright's task scheduling vs. webkit's pointer-event microtask delivery.

## Fix

Replace the synchronous `textContent + expect.toBe` with `expect.poll(textContent).toBe(expected)`. Polls until the value settles, default Playwright 5s timeout. Same surgical pattern as the createRangeViaDrag race fix from v0.15.

## Test plan

- [x] Verified locally on Mac webkit with `--workers=1`: both tests pass (5.0s)
- [x] Lint clean (no source code touched, just test wiring)

Refs #457 — closes the last known sync-read race in CT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)