### PR TITLE
Bump stagebook to 0.17.0

### DIFF
--- a/docs/researcher/dispatchers.md
+++ b/docs/researcher/dispatchers.md
@@ -16,6 +16,8 @@ The first three are stateless or carry only a small piece of state (urn's remain
 > **Stagebook 0.15 breaking change.** The `local-penalization` dispatcher (config-shape placeholder; implementation lived in deliberation-lab) was replaced by a simpler in-stagebook implementation with explicit state-in/state-out and softmax-based exploration. Batch configs using `type: "local-penalization"` need to be migrated; see [`softmax-knockdown` in detail](#softmax-knockdown-in-detail) below for the new shape.
 >
 > **Stagebook 0.16 breaking change.** The dispatcher introduced in 0.15 was renamed from `weighted-knockdown` to `softmax-knockdown`. The original name was ambiguous — it could be read as "weighted-random with knockdowns" when the actual selection rule is softmax. The new name names the selection mechanism explicitly. Algorithm and config shape are unchanged; the only migration needed is `type: "weighted-knockdown"` → `type: "softmax-knockdown"`. Exported symbols follow the same rename: `weightedKnockdown` → `softmaxKnockdown`, `WeightedKnockdownDispatcherConfig` → `SoftmaxKnockdownDispatcherConfig`.
+>
+> **Stagebook 0.17 breaking change.** The file-reference key was renamed from `{ from: "..." }` to `{ file: "..." }` to match the manager + deliberation-lab convention. New shape: `counts: { file: "study1/counts.json" }`. The runtime check accepts both shapes during a one-release deprecation window; `{ from }` is removed in 0.18. (#466)
 
 ## `weighted-random` in detail
 
@@ -260,8 +262,8 @@ Both `counts` and `decrements` can be supplied inline (as in the examples above)
 ```yaml
 dispatcher:
   type: urn
-  counts: { from: "study1/counts.json" }
-  decrements: { from: "study1/decrements.json" }
+  counts: { file: "study1/counts.json" }
+  decrements: { file: "study1/decrements.json" }
 ```
 
 Reach for file references when:
@@ -305,7 +307,7 @@ A typical workflow:
 1. Compute the matrix in your analysis repo (offline solver — Python, R, etc.)
 2. Write the result to `counts.json` / `decrements.json` in labeled form
 3. Commit them to your assets repo, alongside your treatment YAML
-4. Reference from the batch config via `{ from: "<path>" }`
+4. Reference from the batch config via `{ file: "<path>" }`
 
 This keeps the offline computation auditable and the batch config readable.
 
@@ -394,8 +396,8 @@ For studies with many treatments arranged in a continuous space, generate the ma
 ```yaml
 dispatcher:
   type: softmax-knockdown
-  payoffs: { from: "study1/payoffs.json" }
-  knockdowns: { from: "study1/knockdowns.json" }
+  payoffs: { file: "study1/payoffs.json" }
+  knockdowns: { file: "study1/knockdowns.json" }
   temperature: 0.5
 ```
 

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/stagebook/src/dispatch/types.ts
+++ b/packages/stagebook/src/dispatch/types.ts
@@ -98,9 +98,15 @@ export type PlayerDataSnapshot = Record<string, Record<string, unknown>>;
  *  The host resolves the reference and substitutes the literal value at
  *  config-load time; the dispatcher itself only ever sees the resolved
  *  numbers. The type lives here so `validateDispatcherConfig` can accept
- *  either form at the boundary. */
+ *  either form at the boundary.
+ *
+ *  Key renamed from `from` to `file` in stagebook 0.17 to match the
+ *  manager + deliberation-lab convention that had already converged on
+ *  `{ file }` (deliberation-lab#273, manager#305). The runtime check
+ *  in `validateDispatcherConfig` accepts both shapes for one release
+ *  as a compat shim; `{ from }` will be removed in 0.18. (#466) */
 export interface FileReference {
-  from: string;
+  file: string;
 }
 
 export interface UniformRandomDispatcherConfig {

--- a/packages/stagebook/src/dispatch/validateDispatcherConfig.test.ts
+++ b/packages/stagebook/src/dispatch/validateDispatcherConfig.test.ts
@@ -70,7 +70,7 @@ describe("validateDispatcherConfig", () => {
 
     test("rejects unresolved file references on `weights`", () => {
       const r = validateDispatcherConfig(
-        { type: "weighted-random", weights: { from: "./weights.json" } },
+        { type: "weighted-random", weights: { file: "./weights.json" } },
         T3,
       );
       expect(r.ok).toBe(false);
@@ -158,11 +158,28 @@ describe("validateDispatcherConfig", () => {
 
     test("rejects unresolved file references on `counts`", () => {
       const r = validateDispatcherConfig(
-        { type: "urn", counts: { from: "./counts.json" } },
+        { type: "urn", counts: { file: "./counts.json" } },
         T3,
       );
       expect(r.ok).toBe(false);
       expect(r.diagnostics[0].path).toBe("counts");
+    });
+
+    test("also recognizes the deprecated `{ from }` file-ref shape (0.17 compat shim)", () => {
+      // The key renamed from `from` to `file` in 0.17 to match the
+      // manager + deliberation-lab convention (#466). The runtime
+      // accepts both shapes for one release so existing configs keep
+      // working; `{ from }` is removed in 0.18.
+      const r = validateDispatcherConfig(
+        { type: "urn", counts: { from: "./counts.json" } },
+        T3,
+      );
+      // Still rejected (file refs must be resolved by the host), but
+      // the rejection reason is "file reference not resolved", not
+      // "missing labels for treatments t0/t1/t2".
+      expect(r.ok).toBe(false);
+      expect(r.diagnostics[0].path).toBe("counts");
+      expect(r.diagnostics[0].message).toMatch(/file reference/);
     });
 
     test("flags missing labels", () => {
@@ -435,7 +452,7 @@ describe("validateDispatcherConfig", () => {
       const a = validateDispatcherConfig(
         {
           type: "softmax-knockdown",
-          payoffs: { from: "./p.json" },
+          payoffs: { file: "./p.json" },
           knockdowns: "none",
         },
         T3,
@@ -445,7 +462,7 @@ describe("validateDispatcherConfig", () => {
         {
           type: "softmax-knockdown",
           payoffs: "equal",
-          knockdowns: { from: "./k.json" },
+          knockdowns: { file: "./k.json" },
         },
         T3,
       );

--- a/packages/stagebook/src/dispatch/validateDispatcherConfig.ts
+++ b/packages/stagebook/src/dispatch/validateDispatcherConfig.ts
@@ -29,7 +29,7 @@ export interface DispatcherConfigValidationResult {
 
 /**
  * Validate a dispatcher config that the host has already resolved
- * (file-reference `{from: "./counts.json"}` shapes substituted with
+ * (file-reference `{file: "./counts.json"}` shapes substituted with
  * concrete labeled objects).
  *
  * Per-dispatcher rules:
@@ -132,7 +132,7 @@ function validateWeightedRandom(
   if (isFileReference(config.weights)) {
     push(
       "weights",
-      "`weights` is still a file reference — the host must resolve `{from: ...}` before calling the validator",
+      "`weights` is still a file reference — the host must resolve `{file: ...}` before calling the validator",
     );
     return { ok: false, diagnostics };
   }
@@ -193,7 +193,7 @@ function validateUrn(
   if (isFileReference(config.counts)) {
     push(
       "counts",
-      "`counts` is still a file reference — the host must resolve `{from: ...}` before calling the validator",
+      "`counts` is still a file reference — the host must resolve `{file: ...}` before calling the validator",
     );
     return { ok: false, diagnostics };
   }
@@ -223,7 +223,7 @@ function validateUrn(
     if (isFileReference(config.decrements)) {
       push(
         "decrements",
-        "`decrements` is still a file reference — the host must resolve `{from: ...}` before calling the validator",
+        "`decrements` is still a file reference — the host must resolve `{file: ...}` before calling the validator",
       );
       return { ok: isOk(diagnostics), diagnostics };
     }
@@ -386,7 +386,7 @@ function validateSoftmaxKnockdown(
   if (isFileReference(config.payoffs)) {
     push(
       "payoffs",
-      "`payoffs` is still a file reference — the host must resolve `{from: ...}` before calling the validator",
+      "`payoffs` is still a file reference — the host must resolve `{file: ...}` before calling the validator",
     );
     return { ok: false, diagnostics };
   }
@@ -426,7 +426,7 @@ function validateSoftmaxKnockdown(
   if (isFileReference(config.knockdowns)) {
     push(
       "knockdowns",
-      "`knockdowns` is still a file reference — the host must resolve `{from: ...}` before calling the validator",
+      "`knockdowns` is still a file reference — the host must resolve `{file: ...}` before calling the validator",
     );
     return { ok: false, diagnostics };
   }
@@ -574,13 +574,16 @@ function isNonNegativeFiniteNumber(v: unknown): boolean {
   return typeof v === "number" && Number.isFinite(v) && v >= 0;
 }
 
-function isFileReference(v: unknown): v is { from: string } {
-  return (
-    typeof v === "object" &&
-    v !== null &&
-    "from" in v &&
-    typeof (v as { from: unknown }).from === "string"
-  );
+/** Detect a host-side file reference that hasn't been resolved yet.
+ *  Accepts both `{ file: "..." }` (the canonical 0.17 shape, matches
+ *  manager + deliberation-lab) and `{ from: "..." }` (the deprecated
+ *  shape, removed in 0.18). The validator's job is just to recognize
+ *  the shape so it can emit a clear "host must resolve before calling"
+ *  error rather than mis-parsing the object as inline data. (#466) */
+function isFileReference(v: unknown): v is { file: string } | { from: string } {
+  if (typeof v !== "object" || v === null) return false;
+  const obj = v as Record<string, unknown>;
+  return typeof obj.file === "string" || typeof obj.from === "string";
 }
 
 function formatValue(v: unknown): string {

--- a/packages/stagebook/src/dispatch/validateLabelSet.ts
+++ b/packages/stagebook/src/dispatch/validateLabelSet.ts
@@ -19,20 +19,22 @@ export function validateLabelSet(
   treatmentNames: string[],
 ): void {
   // Defensive guard for the most common "obvious mistake" case: the
-  // host forgot to resolve a `{from: "./x.json"}` file reference
-  // before calling the dispatcher. Without this, the generic
-  // missing/extra reporter would say something like "missing: [t0,
-  // t1, t2]; extra: [from]" — true but obscure. The validator catches
-  // this at config-time with a clear message; we mirror its wording
-  // here for callers that bypass the validator.
+  // host forgot to resolve a `{file: "./x.json"}` (or the deprecated
+  // `{from: "..."}`) file reference before calling the dispatcher.
+  // Without this, the generic missing/extra reporter would say
+  // something like "missing: [t0, t1, t2]; extra: [file]" — true but
+  // obscure. The validator catches this at config-time with a clear
+  // message; we mirror its wording here for callers that bypass the
+  // validator. Accepts both shapes during the 0.17 → 0.18 transition.
   const labelKeys = Object.keys(labels);
-  if (
+  const labelsRec = labels as Record<string, unknown>;
+  const isUnresolvedFileRef =
     labelKeys.length === 1 &&
-    labelKeys[0] === "from" &&
-    typeof (labels as Record<string, unknown>).from === "string"
-  ) {
+    (labelKeys[0] === "file" || labelKeys[0] === "from") &&
+    typeof labelsRec[labelKeys[0]] === "string";
+  if (isUnresolvedFileRef) {
     throw new Error(
-      `${dispatcherName}: ${field} is still a file reference ({from: "..."}). The host must resolve file references into labeled objects before calling the dispatcher.`,
+      `${dispatcherName}: ${field} is still a file reference ({file: "..."}). The host must resolve file references into labeled objects before calling the dispatcher.`,
     );
   }
   const expected = new Set(treatmentNames);


### PR DESCRIPTION
Closes #466. Renames `FileReference` from `{ from: "..." }` to `{ file: "..." }` to match the convention the manager and deliberation-lab already use.

## Why

Manager and deliberation-lab both shipped `{ file }` (deliberation-lab#273, manager#305). Stagebook was the outlier still using `{ from }`. The divergence was hidden by a manager-side `crossCheckDispatcher` short-circuit that prevented `{ file }` from ever reaching stagebook's validator. A future caller without that short-circuit (a CLI tool, a researcher's editor, a different host) passing `{ file: "..." }` would see a misleading "missing labels" error instead of a clear "file reference not resolved" error.

## What changes

- **Type**: `FileReference = { from: string }` → `{ file: string }`
- **Runtime check**: `isFileReference` accepts both `{ file }` and `{ from }` during the 0.17 → 0.18 deprecation window. `{ from }` is removed in 0.18.
- **Error messages**: All "host must resolve `{from: ...}`" hints now say `{file: ...}`.
- **Tests**: All `{ from }` usages updated. Added one explicit compat-shim test confirming `{ from }` still produces the correct "file reference not resolved" rejection rather than a misleading "missing labels" error.
- **Docs**: All `{ from }` examples updated; new 0.17 breaking-change callout added.

## Migration

- **Host code calling `validateDispatcherConfig`**: existing `{ from }` configs keep working in 0.17, but new configs should use `{ file }`. In 0.18 `{ from }` is removed.
- **Deliberation-lab and manager**: no change needed — they already use `{ file }`. Manager's `crossCheckDispatcher` short-circuit can be dropped once both packages bump to ≥ 0.17.

## Test plan

- [x] `npm run lint -w stagebook` clean
- [x] `npm test -w stagebook` — 1421 tests pass (added 1 compat shim test; all `{ from }` test occurrences updated to `{ file }`)
- [x] `npm run build -w stagebook` succeeds
- [x] Sharded CT was reliable on the last few PRs (#462, #463, #464, #465)

🤖 Generated with [Claude Code](https://claude.com/claude-code)