### PR TITLE
docs: clean up stale references to local-penalization (#468)

### DIFF
--- a/docs/researcher/dispatchers.md
+++ b/docs/researcher/dispatchers.md
@@ -352,7 +352,7 @@ Each round, the dispatcher samples a treatment by softmax over the running payof
 
 At `T=0`, ties at the argmax are broken uniformly at random — so a batch with all-equal payoffs and no knockdowns gives a uniform random sampler. As `T` increases, the softmax flattens; in the limit, you get the same uniform behavior.
 
-> **Exhausted treatments are filtered out at every `T`.** Treatments whose payoff has dropped to zero (or below) are excluded from the feasible pool — they can't be argmax-picked at `T=0` and aren't softmax-sampled at `T>0` either, regardless of how large `T` is. This matches the local-penalization convention: payoff `= 0` is the "fully decayed" sentinel, not "low probability." If you want a treatment to remain at a nonzero baseline probability across the batch, keep its payoff strictly above 0; the knockdowns shouldn't drive it to 0 unless you intend for it to drop out of the pool.
+> **Exhausted treatments are filtered out at every `T`.** Treatments whose payoff has dropped to zero (or below) are excluded from the feasible pool — they can't be argmax-picked at `T=0` and aren't softmax-sampled at `T>0` either, regardless of how large `T` is. Payoff `= 0` is the "fully decayed" sentinel, not "low probability." If you want a treatment to remain at a nonzero baseline probability across the batch, keep its payoff strictly above 0; the knockdowns shouldn't drive it to 0 unless you intend for it to drop out of the pool.
 
 ### Picking the knockdown rule
 

--- a/packages/stagebook/src/dispatch/contract.ts
+++ b/packages/stagebook/src/dispatch/contract.ts
@@ -2,12 +2,12 @@
 
 // Generic dispatcher contract harness (#448).
 //
-// Every dispatcher implementation — current and future, stagebook's
-// own (`uniform-random`, `urn`) and external (`local-penalization` in
-// deliberation-lab) — MUST satisfy the structural invariants pinned
-// here. The harness is parameterized over a *factory* so registering a
-// new algorithm is a matter of supplying its scenario-to-dispatcher
-// adapter and re-running the gauntlet.
+// Every dispatcher implementation — `uniform-random`, `weighted-random`,
+// `urn`, `softmax-knockdown`, and any future additions — MUST satisfy
+// the structural invariants pinned here. The harness is parameterized
+// over a *factory* so registering a new algorithm is a matter of
+// supplying its scenario-to-dispatcher adapter and re-running the
+// gauntlet.
 //
 // Scope: structural invariants only. Algorithm-specific statistical
 // claims (marginal target rate, irrelevant-attribute independence, …)
@@ -15,11 +15,12 @@
 // different randomization claim worth a paper-defensible receipt.
 //
 // History: this harness is the generalization of
-// `dispatch.contract.test.js` in deliberation-lab (was tightly coupled
-// to payoffs+knockdowns shape). The scenario was shrunk to just
-// `{ players, treatments }`; algorithm-specific params come from the
-// registered factory (which can also generate them from the seeded
-// rng so the gauntlet's full input space remains deterministic).
+// `dispatch.contract.test.js` from deliberation-lab, which was tightly
+// coupled to a single algorithm's parameter shape. The scenario was
+// shrunk to just `{ players, treatments }`; algorithm-specific params
+// come from the registered factory (which can also generate them from
+// the seeded rng so the gauntlet's full input space remains
+// deterministic).
 
 import { describe, test, expect } from "vitest";
 import type { DispatchResult, Treatment } from "./types.js";

--- a/packages/stagebook/src/dispatch/softmaxKnockdown.ts
+++ b/packages/stagebook/src/dispatch/softmaxKnockdown.ts
@@ -34,12 +34,11 @@ export interface SoftmaxKnockdownResult {
 }
 
 /**
- * Softmax-sampled, payoff-with-knockdown dispatcher (#452). Replaces
- * the v0.14 `local-penalization` placeholder. The algorithm in one
- * line: each round, pick a size-feasible treatment by softmax over
- * the current payoffs (or argmax + random tiebreak at `T=0`), try to
- * fill it, and on success multiply the payoffs by the configured
- * knockdowns before the next round.
+ * Softmax-sampled, payoff-with-knockdown dispatcher (#452). The
+ * algorithm in one line: each round, pick a size-feasible treatment
+ * by softmax over the current payoffs (or argmax + random tiebreak
+ * at `T=0`), try to fill it, and on success multiply the payoffs by
+ * the configured knockdowns before the next round.
  *
  * State-in / state-out: callers thread `newState.payoffs` into the
  * next call's `payoffs`. The dispatcher itself is pure — no closure

--- a/packages/stagebook/src/dispatch/types.ts
+++ b/packages/stagebook/src/dispatch/types.ts
@@ -157,11 +157,10 @@ export interface UrnDispatcherConfig {
   decrements?: LabeledMatrix | FileReference;
 }
 
-/** Softmax-sampled, payoff-with-knockdown dispatcher (#452). Replaces
- *  the v0.14 `local-penalization` placeholder with an in-stagebook
- *  implementation that simplifies the deliberation-lab original (no
- *  recursive DFS, no closure-mutated state, explicit softmax over the
- *  payoff vector instead of pure greedy).
+/** Softmax-sampled, payoff-with-knockdown dispatcher (#452). The
+ *  algorithm simplifies the original batched-BO implementation that
+ *  inspired it: no recursive DFS, no closure-mutated state, explicit
+ *  softmax over the payoff vector instead of pure greedy.
  *
  *  Stateful in the same sense `urn` is: callers thread
  *  `newState.payoffs` back into the next call's `payoffs` to carry the


### PR DESCRIPTION
Closes #468 — the audit subagent's punch list.

## What

5 surgical fixes to docstrings/prose that still referenced the pre-v0.15 `local-penalization` name as if it were current:

- `contract.ts:6-7` — invariant-list framing dropped the "external dispatcher in deliberation-lab" clause; the dispatcher set is now `uniform-random`, `weighted-random`, `urn`, `softmax-knockdown`, and any future additions.
- `contract.ts:17-19` — history note about the harness's origin rephrased to be accurate.
- `softmaxKnockdown.ts:38` and `types.ts:160-164` — dropped the "replaces v0.14 local-penalization placeholder" lines; surrounding paragraphs already explain the design.
- `dispatchers.md:355` — dropped the "matches the local-penalization convention" framing; the rule (payoff = 0 is the exhausted sentinel) stands on its own.

## Why no release

Comments-only changes. No API surface, no runtime behavior, no test expectations. Consumers (deliberation-lab, manager) don't need to upgrade for doc comment fixes.

## Test plan

- [x] `npm run lint -w stagebook` clean
- [x] `npx vitest run src/dispatch` — 176/176 dispatch tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)