### PR TITLE
feat(compare): membership conditions on multi-select (array-LHS) values

### DIFF
--- a/examples/component-gallery/component-gallery.stagebook.yaml
+++ b/examples/component-gallery/component-gallery.stagebook.yaml
@@ -85,6 +85,17 @@ treatments:
           - type: prompt
             name: checkbox_demo
             file: prompts/checkbox_demo.prompt.md
+          - type: prompt
+            file: prompts/checkbox_conditional_demo.prompt.md
+            notes: |
+              Conditional gate on a multi-select (#470). `includes` does
+              element membership when the referenced value is the array
+              of checked labels, so this block renders only while
+              "Sliders" is checked above.
+            conditions:
+              - reference: self.prompt.checkbox_demo
+                comparator: includes
+                value: Sliders
           - type: submitButton
 
       - name: checkbox_group_horizontal

--- a/examples/component-gallery/prompts/checkbox_conditional_demo.prompt.md
+++ b/examples/component-gallery/prompts/checkbox_conditional_demo.prompt.md
@@ -1,0 +1,18 @@
+---
+type: noResponse
+---
+
+## You checked "Sliders" ✅
+
+This block is gated on the checkbox above with:
+
+```yaml
+conditions:
+  - reference: self.prompt.checkbox_demo
+    comparator: includes
+    value: Sliders
+```
+
+`includes` does **element membership** when the referenced value is a
+multi-select array — so it renders only when "Sliders" is among the
+checked options. Uncheck it and this section disappears.

--- a/packages/stagebook/src/utils/compare.test.ts
+++ b/packages/stagebook/src/utils/compare.test.ts
@@ -198,6 +198,76 @@ describe("array comparisons", () => {
   });
 });
 
+// ----------- Multi-select (array LHS) membership ------------
+//
+// A `select: multiple` checkbox prompt saves its value as a string[]
+// (the selected option labels). When that lands on the LHS of a
+// condition, `includes`/`doesNotInclude` do element membership and the
+// length comparators measure how many options were checked. The
+// condition `value` stays a scalar label — no schema change. (#470)
+
+describe("multi-select (array LHS) membership", () => {
+  test("includes is element membership, not substring", () => {
+    expect(compare(["Likert scales", "Sliders"], "includes", "Sliders")).toBe(
+      true,
+    );
+    expect(compare(["Likert scales", "Sliders"], "includes", "Drag")).toBe(
+      false,
+    );
+    // Substring of a member must NOT match — membership is exact.
+    expect(compare(["Sliders"], "includes", "Slide")).toBe(false);
+  });
+
+  test("includes on an empty selection is false", () => {
+    expect(compare([], "includes", "Sliders")).toBe(false);
+  });
+
+  test("doesNotInclude is the symmetric negation on arrays", () => {
+    expect(compare(["Likert scales"], "doesNotInclude", "Sliders")).toBe(true);
+    expect(compare(["Likert scales"], "doesNotInclude", "Likert scales")).toBe(
+      false,
+    );
+    // Emptied selection includes nothing, so it does-not-include anything.
+    expect(compare([], "doesNotInclude", "Sliders")).toBe(true);
+  });
+
+  test("hasLengthAtLeast counts selected options", () => {
+    expect(compare(["a", "b"], "hasLengthAtLeast", 2)).toBe(true);
+    expect(compare(["a"], "hasLengthAtLeast", 2)).toBe(false);
+    expect(compare([], "hasLengthAtLeast", 1)).toBe(false);
+  });
+
+  test("hasLengthAtMost counts selected options", () => {
+    expect(compare(["a"], "hasLengthAtMost", 2)).toBe(true);
+    expect(compare(["a", "b", "c"], "hasLengthAtMost", 2)).toBe(false);
+    expect(compare([], "hasLengthAtMost", 0)).toBe(true);
+  });
+
+  test("numeric labels compare as strings (no coercion)", () => {
+    // Multi-select labels are always strings; membership is strict.
+    expect(compare(["5", "7"], "includes", "5")).toBe(true);
+    expect(compare(["5", "7"], "includes", 5 as unknown as string)).toBe(false);
+  });
+
+  test("comparators with no array semantics are undecidable on an array", () => {
+    // No accidental array-vs-array equality or numeric coercion: these
+    // return undefined so the leaf collapses to false / propagates unknown.
+    expect(compare(["a"], "equals", "a")).toBeUndefined();
+    expect(compare(["a"], "doesNotEqual", "a")).toBeUndefined();
+    expect(compare(["1"], "isAbove", 0)).toBeUndefined();
+    expect(compare(["a"], "isOneOf", ["a", "b"])).toBeUndefined();
+    expect(compare(["a"], "matches", "a")).toBeUndefined();
+  });
+
+  test("exists/doesNotExist still answer presence for arrays", () => {
+    // Handled by the top-of-function presence probe — an emptied
+    // selection is still a value that exists.
+    expect(compare([], "exists")).toBe(true);
+    expect(compare(["a"], "exists")).toBe(true);
+    expect(compare([], "doesNotExist")).toBe(false);
+  });
+});
+
 // ----------- Invalid comparator ------------
 
 describe("invalid comparator", () => {

--- a/packages/stagebook/src/utils/compare.test.ts
+++ b/packages/stagebook/src/utils/compare.test.ts
@@ -246,7 +246,7 @@ describe("multi-select (array LHS) membership", () => {
   test("numeric labels compare as strings (no coercion)", () => {
     // Multi-select labels are always strings; membership is strict.
     expect(compare(["5", "7"], "includes", "5")).toBe(true);
-    expect(compare(["5", "7"], "includes", 5 as unknown as string)).toBe(false);
+    expect(compare(["5", "7"], "includes", 5)).toBe(false);
   });
 
   test("comparators with no array semantics are undecidable on an array", () => {

--- a/packages/stagebook/src/utils/compare.ts
+++ b/packages/stagebook/src/utils/compare.ts
@@ -67,6 +67,33 @@ export function compare(
     return undefined;
   }
 
+  // Multi-select (array LHS) membership (#470). A `select: multiple`
+  // checkbox prompt saves its value as a string[] of the selected
+  // labels; when that array reaches a condition, `includes` /
+  // `doesNotInclude` do exact element membership (mirroring how JS
+  // overloads String vs Array `.includes`), and the length comparators
+  // count how many options were checked. The `value` stays a scalar
+  // label, so no schema change is needed. Handled here — before the
+  // numeric/string/boolean branches — so an array never falls through
+  // to e.g. the `isOneOf` rhs-array branch with the whole selection as
+  // the LHS. Comparators with no sensible array semantics fall to the
+  // `undefined` return below (undecidable → leaf collapses to false /
+  // propagates unknown); `exists` / `doesNotExist` are already answered
+  // by the presence probe at the top of the function.
+  if (Array.isArray(lhs)) {
+    switch (comparator) {
+      case "includes":
+        return lhs.includes(rhs);
+      case "doesNotInclude":
+        return !lhs.includes(rhs);
+      case "hasLengthAtLeast":
+        return lhs.length >= parseFloat(rhs as string);
+      case "hasLengthAtMost":
+        return lhs.length <= parseFloat(rhs as string);
+    }
+    return undefined;
+  }
+
   if (isNumberOrParsableNumber(lhs) && isNumberOrParsableNumber(rhs)) {
     const numLhs = parseFloat(lhs as string);
     const numRhs = parseFloat(rhs as string);

--- a/packages/stagebook/src/utils/evaluateConditions.test.ts
+++ b/packages/stagebook/src/utils/evaluateConditions.test.ts
@@ -167,6 +167,91 @@ describe("evaluateCondition", () => {
         ),
       ).toBe(true);
     });
+
+    // Multi-select membership (#470). The host resolves a `select:
+    // multiple` prompt to a single value that is itself the selected-
+    // labels array, so the leaf sees `[["Likert scales","Sliders"]]` —
+    // one element, which is the array. `includes` then does element
+    // membership.
+    test("includes matches a checked option in a multi-select", () => {
+      expect(
+        evaluateCondition(
+          {
+            reference: "self.prompt.tools_used",
+            comparator: "includes",
+            value: "Sliders",
+          },
+          [["Likert scales", "Sliders"]],
+        ),
+      ).toBe(true);
+    });
+
+    test("includes fails when the option was not checked", () => {
+      expect(
+        evaluateCondition(
+          {
+            reference: "self.prompt.tools_used",
+            comparator: "includes",
+            value: "Drag-to-rank",
+          },
+          [["Likert scales", "Sliders"]],
+        ),
+      ).toBe(false);
+    });
+
+    test("includes against an emptied selection is false", () => {
+      expect(
+        evaluateCondition(
+          {
+            reference: "self.prompt.tools_used",
+            comparator: "includes",
+            value: "Sliders",
+          },
+          [[]],
+        ),
+      ).toBe(false);
+    });
+
+    test("hasLengthAtLeast gates on number of checked options", () => {
+      expect(
+        evaluateCondition(
+          {
+            reference: "self.prompt.tools_used",
+            comparator: "hasLengthAtLeast",
+            value: 2,
+          },
+          [["Likert scales", "Sliders"]],
+        ),
+      ).toBe(true);
+    });
+
+    test("cross-player: every player's selection must include the option", () => {
+      // `all.prompt.x` resolves to one array-value per player; the leaf
+      // AND-loop requires each to include the option.
+      expect(
+        evaluateCondition(
+          {
+            reference: "all.prompt.tools_used",
+            comparator: "includes",
+            value: "Sliders",
+          },
+          [
+            ["Likert scales", "Sliders"],
+            ["Sliders", "Discussion"],
+          ],
+        ),
+      ).toBe(true);
+      expect(
+        evaluateCondition(
+          {
+            reference: "all.prompt.tools_used",
+            comparator: "includes",
+            value: "Sliders",
+          },
+          [["Likert scales", "Sliders"], ["Discussion"]],
+        ),
+      ).toBe(false);
+    });
   });
 });
 
@@ -983,5 +1068,191 @@ describe("evaluateConditions — negative comparators vs unset reference (#348)"
         emptyResolve,
       ),
     ).toBe(false);
+  });
+});
+
+// --------------- Multi-select membership through the tree (#470) ---------------
+//
+// The leaf-level tests above (evaluateCondition) pin the array branch of
+// `compare`. These exercise the same array values through the field-level
+// `evaluateConditions` entrypoint and the boolean tree — the only logic
+// not otherwise reached is how a definite array leaf composes inside
+// `none:` (the tri-state-critical operator) and the contrast between a
+// present-but-not-selected array and an absent reference.
+
+describe("evaluateConditions — multi-select membership (#470)", () => {
+  const makeResolve =
+    (data: Record<string, unknown[]>) =>
+    (reference: string): unknown[] =>
+      data[reference] ?? [];
+
+  test("includes through the tree gates on a checked option", () => {
+    const resolve = makeResolve({
+      "self.prompt.tools": [["Likert scales", "Sliders"]],
+    });
+    expect(
+      evaluateConditions(
+        [
+          {
+            reference: "self.prompt.tools",
+            comparator: "includes",
+            value: "Sliders",
+          },
+        ],
+        resolve,
+      ),
+    ).toBe(true);
+    expect(
+      evaluateConditions(
+        [
+          {
+            reference: "self.prompt.tools",
+            comparator: "includes",
+            value: "Discussion / chat",
+          },
+        ],
+        resolve,
+      ),
+    ).toBe(false);
+  });
+
+  test("hasLengthAtMost through the tree gates on number of checked options", () => {
+    const resolve = makeResolve({
+      "self.prompt.tools": [["Likert scales", "Sliders"]],
+    });
+    expect(
+      evaluateConditions(
+        [
+          {
+            reference: "self.prompt.tools",
+            comparator: "hasLengthAtMost",
+            value: 2,
+          },
+        ],
+        resolve,
+      ),
+    ).toBe(true);
+    expect(
+      evaluateConditions(
+        [
+          {
+            reference: "self.prompt.tools",
+            comparator: "hasLengthAtMost",
+            value: 1,
+          },
+        ],
+        resolve,
+      ),
+    ).toBe(false);
+  });
+
+  describe("doesNotInclude: present-but-not-selected vs absent reference", () => {
+    test("present non-empty array, option not selected → true (array branch)", () => {
+      const resolve = makeResolve({
+        "self.prompt.tools": [["Likert scales"]],
+      });
+      expect(
+        evaluateConditions(
+          {
+            reference: "self.prompt.tools",
+            comparator: "doesNotInclude",
+            value: "Sliders",
+          },
+          resolve,
+        ),
+      ).toBe(true);
+    });
+
+    test("present non-empty array, option selected → false (array branch)", () => {
+      const resolve = makeResolve({
+        "self.prompt.tools": [["Likert scales", "Sliders"]],
+      });
+      expect(
+        evaluateConditions(
+          {
+            reference: "self.prompt.tools",
+            comparator: "doesNotInclude",
+            value: "Sliders",
+          },
+          resolve,
+        ),
+      ).toBe(false);
+    });
+
+    test("absent reference → true via the #348 absence policy, not the array branch", () => {
+      // No resolved value: the leaf short-circuits through
+      // compare(undefined, "doesNotInclude", …), which is satisfied by
+      // absence — a different code path that lands on the same answer as
+      // the present-but-not-selected case above.
+      expect(
+        evaluateConditions(
+          {
+            reference: "self.prompt.tools",
+            comparator: "doesNotInclude",
+            value: "Sliders",
+          },
+          makeResolve({}),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("none: over a multi-select includes leaf (tri-state composition)", () => {
+    test("option selected → includes true → none → false", () => {
+      const resolve = makeResolve({ "self.prompt.tools": [["Sliders"]] });
+      expect(
+        evaluateConditions(
+          {
+            none: [
+              {
+                reference: "self.prompt.tools",
+                comparator: "includes",
+                value: "Sliders",
+              },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(false);
+    });
+
+    test("option not selected (present array) → includes false → none → true", () => {
+      const resolve = makeResolve({
+        "self.prompt.tools": [["Likert scales"]],
+      });
+      expect(
+        evaluateConditions(
+          {
+            none: [
+              {
+                reference: "self.prompt.tools",
+                comparator: "includes",
+                value: "Sliders",
+              },
+            ],
+          },
+          resolve,
+        ),
+      ).toBe(true);
+    });
+
+    test("absent reference → includes undefined → none → false at boundary (gate stays closed)", () => {
+      // The tri-state guard: an unanswered multi-select must not open a
+      // `none:`-gated fallback before any data exists.
+      expect(
+        evaluateConditions(
+          {
+            none: [
+              {
+                reference: "self.prompt.tools",
+                comparator: "includes",
+                value: "Sliders",
+              },
+            ],
+          },
+          makeResolve({}),
+        ),
+      ).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## What & why

Authors couldn't gate content on a multi-select checkbox selection. A `select: multiple` prompt saves its value as a `string[]` of the selected labels; when that array reached a `conditions:` leaf, [`compare()`](packages/stagebook/src/utils/compare.ts) had no array-LHS branch, so `includes` / `isOneOf` / `equals` all silently failed. There was no way to express "render this when option X is checked."

Fixes #470.

## Approach

Extend `compare()` with an `Array.isArray(lhs)` branch — chosen over a new comparator because the operation is semantically the same one JS already overloads (`String` vs `Array` `.includes`), so it needs no new author vocabulary and **no treatment-schema change** (the condition `value` stays a scalar label):

- `includes` / `doesNotInclude` → exact element membership
- `hasLengthAtLeast` / `hasLengthAtMost` → number of checked options
- every other comparator on an array LHS → `undefined` (undecidable → fails closed)

```yaml
conditions:
  - reference: self.prompt.tools_used
    comparator: includes
    value: Sliders          # renders only if "Sliders" was checked
```

The branch sits before the numeric/string branches so a selection array can't fall through to the `isOneOf` rhs-array path with the whole array as LHS. As a side benefit it removes the emptied-selection footgun: `[].includes("X")` is a clean `false`, unlike `exists` which returns `true` on an emptied `[]`.

## Tests

TDD (red → green). Coverage at two levels:
- **Leaf** (`compare.test.ts`): membership-vs-substring, empty selection, symmetric `doesNotInclude`, length counting, no numeric-label coercion, the undecidable set (pins the `isOneOf`-on-array behavior change), presence probe.
- **Tree** (`evaluateConditions.test.ts`): `includes` / `hasLengthAtMost` through `evaluateConditions`, `none:` composition over a multi-select (tri-state), and the present-empty vs absent-reference contrast for `doesNotInclude`.

Plus an author-facing demo in the component-gallery checkbox stage.

## Behavior change to note

`isOneOf` / `isNotOneOf` with an array LHS previously hit the rhs-array branch and returned a reference compare (`["a"].includes-as-element` → effectively always `false`); they now return `undefined`. No condition in the repo relied on the old broken behavior (searched examples/fixtures/tests).

## Verification

- `npm test` (1387 unit) + `npm run test:ct:all` (1704 CT) green
- `npm run lint -w stagebook` clean
- `stagebook validate` clean on the edited gallery + new prompt
- Pre-existing, unrelated: `apps/vscode` vitest config fails to load (`ERR_REQUIRE_ESM` on `std-env`) on `main` too — not touched here

## Review

Folded in pre-PR subagent review (correctness / test-coverage / security): no blockers, no security issues (the change fails closed and tightens prior coercion); added the three boolean-tree tests the coverage pass flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
