### PR TITLE
feat(attributes): consolidate host metadata into a flat `attributes` source; standardize identifiers (#473)

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ getReferenceKeyAndPath("self.prompt.myQuestion");
 
 Un-prefixed strings (`"survey.bigFive.result.score"`) throw at parse time with an error suggesting the migration.
 
-Supported namespaces: `survey`, `submitButton`, `qualtrics`, `prompt`, `trackedLink`, `timeline`, `discussion`, `entryUrl`, `connectionInfo`, `browserInfo`, `participantInfo`. (`urlParams` was renamed to `entryUrl` in #246.) `entryUrl` references must use the `params` subpath, e.g. `getReferenceKeyAndPath("self.entryUrl.params.foo")`.
+Supported namespaces: `survey`, `submitButton`, `qualtrics`, `prompt`, `trackedLink`, `timeline`, `discussion`, `entryUrl`, `attributes`. (`urlParams` was renamed to `entryUrl` in #246; `connectionInfo` / `browserInfo` / `participantInfo` were merged into a single flat `attributes` source in #473.) `entryUrl` references must use the `params` subpath, e.g. `getReferenceKeyAndPath("self.entryUrl.params.foo")`.
 
 ### Expanding templates
 

--- a/apps/viewer/src/lib/context.test.ts
+++ b/apps/viewer/src/lib/context.test.ts
@@ -134,4 +134,40 @@ describe("createViewerContext", () => {
       expect(ctx.getElapsedTime()).toBe(30);
     });
   });
+
+  // The provider reports a contract violation without
+  // `attributes.stableParticipantId` (#473). The viewer synthesizes a
+  // per-position default so previews stay clean.
+  describe("attributes default (#473)", () => {
+    it("synthesizes a per-position stableParticipantId when nothing is stored", () => {
+      const { ctx } = makeContext({ position: 2 });
+      expect(ctx.get("attributes", "player")).toEqual([
+        { stableParticipantId: "viewer-p2" },
+      ]);
+    });
+
+    it("lets a seeded non-empty stableParticipantId override the default", () => {
+      const { store, ctx } = makeContext({ position: 0 });
+      store.set(0, "attributes", { stableParticipantId: "seeded-id" }, 0);
+      expect(ctx.get("attributes", "player")).toEqual([
+        { stableParticipantId: "seeded-id" },
+      ]);
+    });
+
+    it("merges the default id under other seeded attribute fields", () => {
+      const { store, ctx } = makeContext({ position: 0 });
+      store.set(0, "attributes", { country: "US" }, 0);
+      expect(ctx.get("attributes", "player")).toEqual([
+        { country: "US", stableParticipantId: "viewer-p0" },
+      ]);
+    });
+
+    it("does NOT let a stored empty-string id clobber the default (would trigger a contract violation)", () => {
+      const { store, ctx } = makeContext({ position: 1 });
+      store.set(1, "attributes", { stableParticipantId: "" }, 0);
+      expect(ctx.get("attributes", "player")).toEqual([
+        { stableParticipantId: "viewer-p1" },
+      ]);
+    });
+  });
 });

--- a/apps/viewer/src/lib/context.ts
+++ b/apps/viewer/src/lib/context.ts
@@ -49,12 +49,21 @@ export function createViewerContext(
       // trackedLink/qualtrics urlParams), and stagebook normalizes
       // `display.position: "any"` to `"all"` before reaching this
       // callback so we only need to handle one aggregator scope.
-      if (typeof mapped === "number" || mapped === "shared") {
-        return store.lookup(key, mapped);
+      const raw =
+        typeof mapped === "number" || mapped === "shared"
+          ? store.lookup(key, mapped)
+          : // `"all"` (or any unrecognized scope, defensively) reads
+            // every participant's value for this key.
+            store.lookup(key);
+      // Synthesize a per-position default `stableParticipantId` (#473) so
+      // previews work out of the box and a qualtrics element doesn't report a
+      // (preview-only) contract violation; any value seeded via the
+      // StateInspector overrides it.
+      if (key === "attributes") {
+        const posForId = typeof mapped === "number" ? mapped : position;
+        return withDefaultAttributes(raw, posForId);
       }
-      // `"all"` (or any unrecognized scope, defensively) reads
-      // every participant's value for this key.
-      return store.lookup(key);
+      return raw;
     },
 
     save(key: string, value: unknown, scope?: "player" | "shared"): void {
@@ -96,6 +105,33 @@ export function createViewerContext(
 
     ...renderers,
   };
+}
+
+/**
+ * Ensure every `attributes` value carries a non-empty `stableParticipantId`
+ * (#473). A seeded/inspector value wins only when it's a non-empty string;
+ * otherwise the synthesized `viewer-p<n>` default fills the gap so a
+ * freshly-loaded study previews without the host having to seed identity.
+ * (A stored empty-string id must NOT clobber the default — that would make
+ * the provider report a contract violation during preview.)
+ */
+function withDefaultAttributes(
+  values: unknown[],
+  positionForId: number,
+): unknown[] {
+  const fallbackId = `viewer-p${String(positionForId)}`;
+  if (values.length === 0) return [{ stableParticipantId: fallbackId }];
+  return values.map((v) => {
+    const bag: Record<string, unknown> =
+      v !== null && typeof v === "object" && !Array.isArray(v)
+        ? { ...(v as Record<string, unknown>) }
+        : {};
+    const id = bag.stableParticipantId;
+    if (typeof id !== "string" || id.trim().length === 0) {
+      bag.stableParticipantId = fallbackId;
+    }
+    return bag;
+  });
 }
 
 function mapPosition(

--- a/docs/engineer/api-reference.md
+++ b/docs/engineer/api-reference.md
@@ -6,30 +6,30 @@ All schemas are [Zod](https://zod.dev/) objects. Use `.safeParse(data)` for vali
 
 ### Treatment File
 
-| Export | Description |
-|--------|-------------|
-| `treatmentFileSchema` | Top-level schema for `.stagebook.yaml` files |
-| `treatmentSchema` | Single treatment (name, playerCount, gameStages, exitSequence) |
-| `stageSchema` | Game stage (name, duration, elements, discussion) |
-| `elementSchema` | Any element type (discriminated union on `type`) |
-| `promptSchema` | Prompt element specifically |
-| `discussionSchema` | Discussion configuration |
-| `conditionSchema` | Single condition (reference, comparator, value, position) |
-| `conditionsSchema` | Array of conditions |
-| `referenceSchema` | Reference string validator (parses and validates `type.name.path`) |
-| `introSequenceSchema` | Intro sequence with named steps |
-| `introExitStepSchema` | Single intro or exit step |
-| `templateSchema` | Template definition (name, contentType, content) |
-| `templateContextSchema` | Template usage (template, fields, broadcast) |
+| Export                  | Description                                                        |
+| ----------------------- | ------------------------------------------------------------------ |
+| `treatmentFileSchema`   | Top-level schema for `.stagebook.yaml` files                       |
+| `treatmentSchema`       | Single treatment (name, playerCount, gameStages, exitSequence)     |
+| `stageSchema`           | Game stage (name, duration, elements, discussion)                  |
+| `elementSchema`         | Any element type (discriminated union on `type`)                   |
+| `promptSchema`          | Prompt element specifically                                        |
+| `discussionSchema`      | Discussion configuration                                           |
+| `conditionSchema`       | Single condition (reference, comparator, value, position)          |
+| `conditionsSchema`      | Array of conditions                                                |
+| `referenceSchema`       | Reference string validator (parses and validates `type.name.path`) |
+| `introSequenceSchema`   | Intro sequence with named steps                                    |
+| `introExitStepSchema`   | Single intro or exit step                                          |
+| `templateSchema`        | Template definition (name, contentType, content)                   |
+| `templateContextSchema` | Template usage (template, fields, broadcast)                       |
 
 ### Prompt File
 
-| Export | Description |
-|--------|-------------|
-| `promptFileSchema` | Parses raw markdown → `{ metadata, body, responseItems, sliderPoints }` with full validation |
-| `promptMetadataSchema` | Discriminated-union schema for the YAML frontmatter (one strict branch per `type:`) |
-| `metadataTypeSchema` / `metadataRefineSchema` / `metadataLogicalSchema` | Back-compat aliases for `promptMetadataSchema` (#243 — the parallel pre-refine pair was unified into one schema) |
-| `validateSliderLabels(metadata, items)` | No-op shim retained for back-compat — slider points and labels share the same body lines after #243, so this check is structurally impossible to fail |
+| Export                                                                  | Description                                                                                                                                           |
+| ----------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `promptFileSchema`                                                      | Parses raw markdown → `{ metadata, body, responseItems, sliderPoints }` with full validation                                                          |
+| `promptMetadataSchema`                                                  | Discriminated-union schema for the YAML frontmatter (one strict branch per `type:`)                                                                   |
+| `metadataTypeSchema` / `metadataRefineSchema` / `metadataLogicalSchema` | Back-compat aliases for `promptMetadataSchema` (#243 — the parallel pre-refine pair was unified into one schema)                                      |
+| `validateSliderLabels(metadata, items)`                                 | No-op shim retained for back-compat — slider points and labels share the same body lines after #243, so this check is structurally impossible to fail |
 
 ### Types
 
@@ -57,10 +57,10 @@ Evaluate a condition comparator.
 ```typescript
 import { compare, type Comparator } from "stagebook";
 
-compare(5, "isAbove", 3);              // true
+compare(5, "isAbove", 3); // true
 compare(undefined, "doesNotEqual", "x"); // true (undefined != anything)
-compare(undefined, "equals", "x");      // undefined (can't determine yet)
-compare("hello", "matches", "\\d+");    // false
+compare(undefined, "equals", "x"); // undefined (can't determine yet)
+compare("hello", "matches", "\\d+"); // false
 ```
 
 **Returns:** `true`, `false`, or `undefined` (when comparison can't be made yet, e.g., undefined lhs).
@@ -89,7 +89,7 @@ getReferenceKeyAndPath("self.entryUrl.params.condition");
 // { referenceKey: "entryUrl", path: ["params", "condition"] }
 ```
 
-Supported namespaces: `survey`, `submitButton`, `qualtrics`, `prompt`, `trackedLink`, `timeline`, `discussion`, `entryUrl`, `connectionInfo`, `browserInfo`, `participantInfo`. (`urlParams` was renamed to `entryUrl` in #246.) `entryUrl` references must use the `params` subpath, e.g. `self.entryUrl.params.condition` — bare `entryUrl.<key>` is rejected.
+Supported namespaces: `survey`, `submitButton`, `qualtrics`, `prompt`, `trackedLink`, `timeline`, `discussion`, `entryUrl`, `attributes`. (`urlParams` was renamed to `entryUrl` in #246; the `connectionInfo` / `browserInfo` / `participantInfo` bags were merged into a single flat `attributes` source in #473.) `entryUrl` references must use the `params` subpath, e.g. `self.entryUrl.params.condition` — bare `entryUrl.<key>` is rejected.
 
 ### `getNestedValueByPath(obj, path?)`
 
@@ -99,8 +99,8 @@ Traverse a nested object by path array.
 import { getNestedValueByPath } from "stagebook";
 
 getNestedValueByPath({ a: { b: { c: 42 } } }, ["a", "b", "c"]); // 42
-getNestedValueByPath({ a: 1 }, ["x"]);                           // undefined
-getNestedValueByPath({ a: 1 });                                   // { a: 1 }
+getNestedValueByPath({ a: 1 }, ["x"]); // undefined
+getNestedValueByPath({ a: 1 }); // { a: 1 }
 ```
 
 ### `fillTemplates({ obj, templates })`
@@ -127,31 +127,25 @@ Also exported: `expandTemplate`, `substituteFields`, `recursivelyFillTemplates` 
 ```tsx
 import { StagebookProvider, type StagebookContext } from "stagebook/components";
 
-<StagebookProvider value={context}>
-  {children}
-</StagebookProvider>
+<StagebookProvider value={context}>{children}</StagebookProvider>;
 ```
 
 ### Hooks
 
-| Hook | Returns | Requires Provider |
-|------|---------|-------------------|
-| `useStagebookContext()` | Full `StagebookContext` object | yes |
-| `useResolve(reference, position?)` | `unknown[]` | yes |
-| `useSave()` | `save` function | yes |
-| `useElapsedTime()` | `number` (seconds) | yes |
-| `useTextContent(path)` | `{ data, isLoading, error }` | yes |
+| Hook                               | Returns                        | Requires Provider |
+| ---------------------------------- | ------------------------------ | ----------------- |
+| `useStagebookContext()`            | Full `StagebookContext` object | yes               |
+| `useResolve(reference, position?)` | `unknown[]`                    | yes               |
+| `useSave()`                        | `save` function                | yes               |
+| `useElapsedTime()`                 | `number` (seconds)             | yes               |
+| `useTextContent(path)`             | `{ data, isLoading, error }`   | yes               |
 
 ### Stage
 
 ```tsx
 import { Stage, type StageConfig } from "stagebook/components";
 
-<Stage
-  stage={stageConfig}
-  onSubmit={handleSubmit}
-  scrollMode="host"
-/>
+<Stage stage={stageConfig} onSubmit={handleSubmit} scrollMode="host" />;
 ```
 
 Requires StagebookProvider. Renders a complete stage: lays out elements with conditional rendering (time, position, conditions), handles two-column layout when a discussion is present, and shows a waiting message after submission. **This is the primary rendering API** — prefer `Stage` over manually rendering `Element` components.
@@ -163,10 +157,7 @@ Requires StagebookProvider. Renders a complete stage: lays out elements with con
 ### Scroll Awareness
 
 ```tsx
-import {
-  useScrollAwareness,
-  ScrollIndicator,
-} from "stagebook/components";
+import { useScrollAwareness, ScrollIndicator } from "stagebook/components";
 
 const scrollRef = useRef<HTMLElement>(null);
 const { showIndicator, dismissIndicator } = useScrollAwareness(scrollRef);
@@ -190,52 +181,52 @@ These are the primitives Stage's `internal` mode uses internally; in `host` mode
 ```tsx
 import { Element, type ElementConfig } from "stagebook/components";
 
-<Element element={elementConfig} onSubmit={handleSubmit} stageDuration={300} />
+<Element element={elementConfig} onSubmit={handleSubmit} stageDuration={300} />;
 ```
 
 Requires StagebookProvider. Dispatches to the appropriate element component based on `element.type`. Use this for lower-level control when `Stage` doesn't fit your needs.
 
 ### Form Components (standalone)
 
-| Component | Key Props |
-|-----------|-----------|
-| `Button` | `onClick`, `children`, `primary?`, `disabled?` |
-| `Separator` | `style?` (`"thin"`, `"regular"`, `"thick"`) |
-| `RadioGroup` | `options`, `value`, `onChange`, `label?` |
-| `CheckboxGroup` | `options`, `value`, `onChange`, `label?` |
-| `Select` | `options`, `value`, `onChange`, `label?`, `placeholder?` |
-| `TextArea` | `value`, `onChange`, `rows?`, `minLength?`, `maxLength?`, `showCharacterCount?`, `onDebugMessage?` |
-| `Slider` | `min`, `max`, `interval`, `value?`, `onChange`, `labelPts?` (parallel to `labels?`, sourced from `promptFileSchema.parse(...).sliderPoints` after #243), `labels?` |
-| `ListSorter` | `items`, `onChange` |
-| `Markdown` | `text`, `resolveURL?` |
+| Component       | Key Props                                                                                                                                                          |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `Button`        | `onClick`, `children`, `primary?`, `disabled?`                                                                                                                     |
+| `Separator`     | `style?` (`"thin"`, `"regular"`, `"thick"`)                                                                                                                        |
+| `RadioGroup`    | `options`, `value`, `onChange`, `label?`                                                                                                                           |
+| `CheckboxGroup` | `options`, `value`, `onChange`, `label?`                                                                                                                           |
+| `Select`        | `options`, `value`, `onChange`, `label?`, `placeholder?`                                                                                                           |
+| `TextArea`      | `value`, `onChange`, `rows?`, `minLength?`, `maxLength?`, `showCharacterCount?`, `onDebugMessage?`                                                                 |
+| `Slider`        | `min`, `max`, `interval`, `value?`, `onChange`, `labelPts?` (parallel to `labels?`, sourced from `promptFileSchema.parse(...).sliderPoints` after #243), `labels?` |
+| `ListSorter`    | `items`, `onChange`                                                                                                                                                |
+| `Markdown`      | `text`, `resolveURL?`                                                                                                                                              |
 
 ### Element Components (pure props)
 
-| Component | Key Props |
-|-----------|-----------|
-| `Prompt` | `metadata`, `body`, `responseItems`, `name`, `save`, `getElapsedTime`, `value`, `progressLabel` |
-| `Display` | `reference`, `values`, `position?` |
-| `SubmitButton` | `onSubmit`, `name`, `save`, `getElapsedTime`, `buttonText?` |
-| `AudioElement` | `src` |
-| `ImageElement` | `src`, `width?` |
-| `KitchenTimer` | `startTime`, `endTime`, `getElapsedTime`, `warnTimeRemaining?` |
-| `TrackedLink` | `name`, `url`, `displayText`, `save`, `getElapsedTime`, `progressLabel`, `resolvedParams?` |
-| `TrainingVideo` | `url`, `getElapsedTime`, `onComplete` |
-| `Qualtrics` | `url`, `resolvedParams?`, `participantId?`, `groupId?`, `progressLabel`, `save`, `onComplete` |
+| Component       | Key Props                                                                                       |
+| --------------- | ----------------------------------------------------------------------------------------------- |
+| `Prompt`        | `metadata`, `body`, `responseItems`, `name`, `save`, `getElapsedTime`, `value`, `progressLabel` |
+| `Display`       | `reference`, `values`, `position?`                                                              |
+| `SubmitButton`  | `onSubmit`, `name`, `save`, `getElapsedTime`, `buttonText?`                                     |
+| `AudioElement`  | `src`                                                                                           |
+| `ImageElement`  | `src`, `width?`                                                                                 |
+| `KitchenTimer`  | `startTime`, `endTime`, `getElapsedTime`, `warnTimeRemaining?`                                  |
+| `TrackedLink`   | `name`, `url`, `displayText`, `save`, `getElapsedTime`, `progressLabel`, `resolvedParams?`      |
+| `TrainingVideo` | `url`, `getElapsedTime`, `onComplete`                                                           |
+| `Qualtrics`     | `url`, `resolvedParams?`, `participantId?`, `groupId?`, `progressLabel`, `save`, `onComplete`   |
 
 ### Render Slots (platform-provided)
 
-| Slot | Config | When Used |
-|------|--------|-----------|
-| `renderSurvey` | `{ surveyName, onComplete }` | `type: "survey"` element (deprecated — pending removal once a module-reuse pattern lands) |
-| `renderDiscussion` | Full `DiscussionType` config | Stage with `discussion` block |
-| `renderSharedNotepad` | `{ padName }` | `shared: true` open-response prompt |
+| Slot                  | Config                       | When Used                                                                                 |
+| --------------------- | ---------------------------- | ----------------------------------------------------------------------------------------- |
+| `renderSurvey`        | `{ surveyName, onComplete }` | `type: "survey"` element (deprecated — pending removal once a module-reuse pattern lands) |
+| `renderDiscussion`    | Full `DiscussionType` config | Stage with `discussion` block                                                             |
+| `renderSharedNotepad` | `{ padName }`                | `shared: true` open-response prompt                                                       |
 
 ### Conditional Components
 
-| Component | Key Props |
-|-----------|-----------|
-| `TimeConditionalRender` | `displayTime?`, `hideTime?`, `getElapsedTime`, `children` |
-| `PositionConditionalRender` | `showToPositions?`, `hideFromPositions?`, `position`, `children` |
-| `ConditionsConditionalRender` | `conditions`, `resolve`, `children`, `fallback?` |
-| `SubmissionConditionalRender` | `isSubmitted`, `playerCount`, `children` |
+| Component                     | Key Props                                                        |
+| ----------------------------- | ---------------------------------------------------------------- |
+| `TimeConditionalRender`       | `displayTime?`, `hideTime?`, `getElapsedTime`, `children`        |
+| `PositionConditionalRender`   | `showToPositions?`, `hideFromPositions?`, `position`, `children` |
+| `ConditionsConditionalRender` | `conditions`, `resolve`, `children`, `fallback?`                 |
+| `SubmissionConditionalRender` | `isSubmitted`, `playerCount`, `children`                         |

--- a/docs/engineer/api-reference.md
+++ b/docs/engineer/api-reference.md
@@ -202,17 +202,17 @@ Requires StagebookProvider. Dispatches to the appropriate element component base
 
 ### Element Components (pure props)
 
-| Component       | Key Props                                                                                       |
-| --------------- | ----------------------------------------------------------------------------------------------- |
-| `Prompt`        | `metadata`, `body`, `responseItems`, `name`, `save`, `getElapsedTime`, `value`, `progressLabel` |
-| `Display`       | `reference`, `values`, `position?`                                                              |
-| `SubmitButton`  | `onSubmit`, `name`, `save`, `getElapsedTime`, `buttonText?`                                     |
-| `AudioElement`  | `src`                                                                                           |
-| `ImageElement`  | `src`, `width?`                                                                                 |
-| `KitchenTimer`  | `startTime`, `endTime`, `getElapsedTime`, `warnTimeRemaining?`                                  |
-| `TrackedLink`   | `name`, `url`, `displayText`, `save`, `getElapsedTime`, `progressLabel`, `resolvedParams?`      |
-| `TrainingVideo` | `url`, `getElapsedTime`, `onComplete`                                                           |
-| `Qualtrics`     | `url`, `resolvedParams?`, `participantId?`, `groupId?`, `progressLabel`, `save`, `onComplete`   |
+| Component       | Key Props                                                                                                   |
+| --------------- | ----------------------------------------------------------------------------------------------------------- |
+| `Prompt`        | `metadata`, `body`, `responseItems`, `name`, `save`, `getElapsedTime`, `value`, `progressLabel`             |
+| `Display`       | `reference`, `values`, `position?`                                                                          |
+| `SubmitButton`  | `onSubmit`, `name`, `save`, `getElapsedTime`, `buttonText?`                                                 |
+| `AudioElement`  | `src`                                                                                                       |
+| `ImageElement`  | `src`, `width?`                                                                                             |
+| `KitchenTimer`  | `startTime`, `endTime`, `getElapsedTime`, `warnTimeRemaining?`                                              |
+| `TrackedLink`   | `name`, `url`, `displayText`, `save`, `getElapsedTime`, `progressLabel`, `resolvedParams?`                  |
+| `TrainingVideo` | `url`, `getElapsedTime`, `onComplete`                                                                       |
+| `Qualtrics`     | `url`, `resolvedParams?`, `stableParticipantId?`, `sampleId?`, `onContractViolation?`, `save`, `onComplete` |
 
 ### Render Slots (platform-provided)
 

--- a/docs/engineer/platform-requirements.md
+++ b/docs/engineer/platform-requirements.md
@@ -66,30 +66,30 @@ State must survive page refreshes. If a participant disconnects and reconnects, 
 
 Some reference namespaces require the platform to collect and store data that Stagebook components don't produce. If your treatment files use conditions or displays referencing these namespaces, the platform must populate them in player state during onboarding:
 
-**`connectionInfo.*`** — Network metadata collected during consent/onboarding:
+**`attributes.*`** — everything the participant arrives with, stored under a single key `attributes` as one flat nested object (#473). The platform populates it during consent/onboarding and keeps it current (values may change mid-study, e.g. screen width on resize). Internally, Stagebook's `resolve("self.attributes.country")` calls `get("attributes")` and traverses `.country`.
 
-- `connectionInfo.country` — ISO country code (e.g., from IP geolocation)
-- `connectionInfo.timezone` — IP-based timezone
-- `connectionInfo.isKnownVpn` — whether the IP is on a known VPN list
+This single bag replaces the former `connectionInfo`, `browserInfo`, and `participantInfo` keys. References to those legacy sources are now rejected by validation — migrate them to `attributes.*`.
 
-The platform stores this under the key `connectionInfo` in player state. Internally, Stagebook's `resolve("connectionInfo.country")` calls `get("connectionInfo")` and traverses `.country`.
+Identity fields (special):
 
-**`browserInfo.*`** — Client-side browser information:
+- **`attributes.stableParticipantId`** — anonymized, stable across sessions, the release-safe id used to link the participant's exported data. **Required for studies that use it.** Stagebook never blocks on it and does not check it eagerly at mount (most studies never touch it). It's checked lazily at the one place stagebook consumes it — the Qualtrics `stableParticipantId` URL-param injection (the survey's participant-linkage field; replaces the legacy `deliberationId` param) — where a missing id would silently orphan the survey response; there it surfaces the violation loudly (`console.error` + the optional `onContractViolation` callback) and renders anyway. Enforce presence upstream: a host CI integration test (assert `hasStableParticipantId(get("attributes","player")[0])`), a batch-start preflight, and a readiness gate that doesn't mount Stagebook until identity is available. (Do **not** put the recruitment-platform id here — keeping recruitment PII out of the referenceable surface is the privacy guarantee.)
+- `attributes.sampleId` — the per-assignment data-row id. Optional; it does not exist until the game phase (assigned at game-stage start), so it's absent during intro/groupComposition, and validation flags pre-game reads.
 
-- `browserInfo.screenWidth`, `browserInfo.screenHeight` — screen resolution
-- `browserInfo.language` — browser language (e.g., `en-US`)
-- `browserInfo.userAgent` — raw user-agent string
+Onboarding / connection / browser fields (all optional):
 
-The platform stores this under the key `browserInfo` in player state.
+- `attributes.name` — nickname entered during onboarding
+- `attributes.country` — ISO country code (e.g., from IP geolocation)
+- `attributes.timezone` — IP-based timezone
+- `attributes.isKnownVpn` — whether the IP is on a known VPN list
+- `attributes.screenWidth`, `attributes.screenHeight` — screen resolution
+- `attributes.language` — browser language (e.g., `en-US`)
+- `attributes.userAgent` — raw user-agent string
 
-**`participantInfo.*`** — Participant attributes:
+Example stored object: `{ stableParticipantId: "d3f1…", name: "alice", country: "US", screenWidth: 1280 }`. The bag is open — the platform may add further fields a treatment references; the exported `attributesSchema` (zod) is the authoritative shape.
 
-- `participantInfo.name` — nickname entered during onboarding
-- `participantInfo.sampleId` — identifier from recruiting platform
+If a field is not populated, references to it resolve to `undefined` and conditions return "can't determine yet" (not a hard failure) — this is true for every `attributes` field, including `stableParticipantId` when a study doesn't use it. The only loud signal is at the Qualtrics use site described above.
 
-The platform stores this under the key `participantInfo` in player state as a nested object (e.g., `{ name: "alice", sampleId: "P123" }`). Internally, Stagebook's `resolve("participantInfo.name")` calls `get("participantInfo")` and traverses `.name`.
-
-If these namespaces are not populated, conditions referencing them will evaluate to `undefined`, which causes the condition to return "can't determine yet" (not a hard failure).
+**Privacy boundary — `entryUrl.params`.** Keeping recruitment PII out of the referenceable surface is the reason `attributes` deliberately omits the recruitment-platform id. That guarantee covers `attributes` only — `entryUrl.params.<key>` still exposes whatever the host put in the participant's landing URL (e.g. a Prolific PID), and a treatment can route any such value into an outgoing Qualtrics/`trackedLink` `urlParams`. So a host that wants the guarantee to hold end-to-end must not place participant PII in the entry URL (and reviewers should watch for treatments that forward `entryUrl.params.*` PII into external links). Stagebook can't enforce this — it's a host responsibility.
 
 ### Browser Compatibility
 

--- a/docs/researcher/conditions.md
+++ b/docs/researcher/conditions.md
@@ -107,12 +107,12 @@ For OR logic on a single reference (across positions, comparators, etc.), `any:`
 References point to data collected earlier in the experiment. The dotted form is always `<position>.<source>.<...>`, where the position selector (`self`, `shared`, `all`, or a numeric slot index — see the note at the top) is required as the first segment and the rest depends on the source:
 
 - **Named sources** (`prompt`, `survey`, `submitButton`, `qualtrics`, `timeline`, `trackedLink`, `discussion`): `<position>.<source>.<name>(.<path>...)` — `name` is required, `path` is optional.
-- **External sources** (`entryUrl`, `connectionInfo`, `browserInfo`, `participantInfo`): `<position>.<source>.<path>...` — no `name`, `path` is required. `entryUrl` references must currently use the `params` subpath (see [URL Parameters](#url-parameters) below).
+- **External sources** (`entryUrl`, `attributes`): `<position>.<source>.<path>...` — no `name`, `path` is required. `entryUrl` references must currently use the `params` subpath (see [URL Parameters](#url-parameters) below).
 
 ```yaml
-- reference: self.prompt.familiarity         # named: position.source.name
-- reference: self.survey.TIPI.responses.q1   # named: position.source.name.path...
-- reference: self.entryUrl.params.condition  # external: position.source.path...
+- reference: self.prompt.familiarity # named: position.source.name
+- reference: self.survey.TIPI.responses.q1 # named: position.source.name.path...
+- reference: self.entryUrl.params.condition # external: position.source.path...
 ```
 
 After #240, references can also be written in **structured form** — preferred in new code, especially when you need to override the implicit defaults the dotted form bakes in (e.g. addressing the `debugMessages` field on a prompt's saved record instead of the default `value`):
@@ -121,12 +121,12 @@ After #240, references can also be written in **structured form** — preferred 
 - reference:
     source: prompt
     name: familiarity
-    path: [value]                 # explicit; same as the dotted `prompt.familiarity`
+    path: [value] # explicit; same as the dotted `prompt.familiarity`
 
 - reference:
     source: prompt
     name: familiarity
-    path: [debugMessages]         # newly possible — addresses other saved fields
+    path: [debugMessages] # newly possible — addresses other saved fields
 
 - reference:
     source: entryUrl
@@ -173,34 +173,31 @@ Returns elapsed seconds when the button was clicked.
 
 Query parameters from the participant's landing URL (e.g., `?role=confederate`). The `params` subpath is required — the `entryUrl.*` namespace is reserved so future additions like `entryUrl.path`, `entryUrl.host`, `entryUrl.href` can land non-breakingly.
 
-Renamed from the legacy `urlParams.<key>` source in #246 to disambiguate from the unrelated `urlParams:` element field on `trackedLink` / `qualtrics`, which sets *outgoing* query parameters (i.e. params appended to the element's own URL). The element field is unchanged.
+Renamed from the legacy `urlParams.<key>` source in #246 to disambiguate from the unrelated `urlParams:` element field on `trackedLink` / `qualtrics`, which sets _outgoing_ query parameters (i.e. params appended to the element's own URL). The element field is unchanged.
 
-### Connection Info
+### Attributes
 
-```
-connectionInfo.country
-connectionInfo.isKnownVpn
-connectionInfo.timezone
-```
-
-Network metadata captured during consent.
-
-### Browser Info
+Everything the participant arrives with — identity, onboarding, connection,
+and browser metadata — in one flat host-supplied bag (#473). Replaces the
+former `connectionInfo` / `browserInfo` / `participantInfo` sources, which are
+no longer valid.
 
 ```
-browserInfo.screenWidth
-browserInfo.language
-browserInfo.userAgent
+<position>.attributes.stableParticipantId  # anonymized id; links exported data (always available)
+<position>.attributes.sampleId             # per-assignment data-row id (game phase onward only)
+<position>.attributes.name                 # nickname entered during onboarding
+<position>.attributes.country              # ISO country code
+<position>.attributes.timezone             # IP-based timezone
+<position>.attributes.isKnownVpn           # known-VPN flag
+<position>.attributes.screenWidth          # screen resolution
+<position>.attributes.screenHeight
+<position>.attributes.language             # browser language
+<position>.attributes.userAgent
 ```
 
-Client-side browser information from onboarding.
-
-### Participant Info
-
-```
-<position>.participantInfo.name           # nickname
-<position>.participantInfo.sampleId       # recruiting platform ID
-```
+The recruitment-platform id is intentionally not exposed here (privacy). Note
+`sampleId` is assigned at game-stage start, so reads from intro /
+groupComposition are rejected by validation.
 
 ### Timeline Selections
 
@@ -471,7 +468,7 @@ A reference must point at data produced by an earlier or the current stage in th
 introSteps → gameStages → exitSequence
 ```
 
-Referencing a stage that hasn't run yet is rejected. External references (`entryUrl.params.*`, `participantInfo.*`, `connectionInfo.*`, `browserInfo.*`) are always valid — they come from the platform, not a stage.
+Referencing a stage that hasn't run yet is rejected. External references (`entryUrl.params.*`, `attributes.*`) are always valid — they come from the platform, not a stage. The one exception is `attributes.sampleId`, which is assigned at game-stage start: reading it during intro / groupComposition is rejected like a forward reference.
 
 `groupComposition` is stricter: it runs before the game starts, so its conditions can only reference intro-phase or external data. Referencing game or exit data from `groupComposition` is rejected.
 

--- a/docs/researcher/elements.md
+++ b/docs/researcher/elements.md
@@ -6,11 +6,11 @@ Elements are the building blocks of every stage. The `elements` array is rendere
 
 A few element types look superficially redundant but encode distinct intents — they answer different authoring questions, so they stay distinct.
 
-| Type          | Intent                                                                                              |
-| ------------- | --------------------------------------------------------------------------------------------------- |
+| Type          | Intent                                                                                                                                            |
+| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `audio`       | Non-interactive audio (chimes, alerts, ambient sound). One-shot; no participant controls expected. `audio` ≠ `mediaPlayer with playVideo: false`. |
-| `image`       | Non-interactive image display. Static picture; conceptually parallel to `audio`, not `display`. `image` ≠ `display`. |
-| `mediaPlayer` | Interactive audio/video with playback controls (play, pause, scrub, speed). Participant interacts with the clip. |
+| `image`       | Non-interactive image display. Static picture; conceptually parallel to `audio`, not `display`. `image` ≠ `display`.                              |
+| `mediaPlayer` | Interactive audio/video with playback controls (play, pause, scrub, speed). Participant interacts with the clip.                                  |
 | `display`     | Shows a value looked up by reference from elsewhere in the study (e.g., `prompt.foo`'s response). Reactive to stored data, not a static resource. |
 
 Use `audio` for a chime, `mediaPlayer` for a video, `image` for a picture, `display` to show a stored value. The four types are intentionally separate — a sequence of `if (playVideo) ... else ...` configuration on a single type would conflate "fire-and-forget asset" with "controllable surface" and "live data view."
@@ -488,7 +488,7 @@ An instrumented external link that records click/blur/focus events and time spen
   displayText: Complete the bonus signup form
   urlParams:
     - key: participant
-      reference: self.participantInfo.sampleId
+      reference: self.attributes.stableParticipantId
     - key: source
       value: deliberation_lab
 ```
@@ -530,7 +530,6 @@ Where `prompts/group_notes.prompt.md` is a minimal openResponse file:
 ---
 type: openResponse
 ---
-
 # Group notes
 
 (Optional framing for the notepad goes in the body.)

--- a/docs/researcher/syntax-reference.md
+++ b/docs/researcher/syntax-reference.md
@@ -49,33 +49,34 @@ Un-prefixed references like `prompt.topicVote` are rejected at parse time. The e
 
 **String shorthand (the common form):**
 
-| Pattern                                | Example                                |
-| -------------------------------------- | -------------------------------------- |
-| `<position>.prompt.<name>`             | `self.prompt.topicVote`                |
-| `<position>.survey.<name>.<path...>`   | `self.survey.TIPI.responses.q1`        |
-| `<position>.submitButton.<name>.<path>`| `self.submitButton.confirm.time`       |
-| `<position>.qualtrics.<name>.<path>`   | `self.qualtrics.exit.sessionId`        |
-| `<position>.trackedLink.<name>.<path>` | `self.trackedLink.signup.events`       |
-| `<position>.timeline.<name>(.<path>)`  | `self.timeline.story.0.start`          |
-| `<position>.discussion.<name>(.<path>)`| `shared.discussion.lobby.messageCount` |
-| `<position>.entryUrl.params.<key>`     | `self.entryUrl.params.PROLIFIC_PID`    |
-| `<position>.connectionInfo.<key>`      | `self.connectionInfo.country`          |
-| `<position>.browserInfo.<key>`         | `self.browserInfo.language`            |
-| `<position>.participantInfo.<field>`   | `self.participantInfo.name`            |
+| Pattern                                 | Example                                |
+| --------------------------------------- | -------------------------------------- |
+| `<position>.prompt.<name>`              | `self.prompt.topicVote`                |
+| `<position>.survey.<name>.<path...>`    | `self.survey.TIPI.responses.q1`        |
+| `<position>.submitButton.<name>.<path>` | `self.submitButton.confirm.time`       |
+| `<position>.qualtrics.<name>.<path>`    | `self.qualtrics.exit.sessionId`        |
+| `<position>.trackedLink.<name>.<path>`  | `self.trackedLink.signup.events`       |
+| `<position>.timeline.<name>(.<path>)`   | `self.timeline.story.0.start`          |
+| `<position>.discussion.<name>(.<path>)` | `shared.discussion.lobby.messageCount` |
+| `<position>.entryUrl.params.<key>`      | `self.entryUrl.params.PROLIFIC_PID`    |
+| `<position>.attributes.<field>`         | `self.attributes.stableParticipantId`  |
 
 **Structured form** (#240 — preferred in new code):
 
 ```yaml
 reference:
-  source: prompt | survey | submitButton | qualtrics | timeline | trackedLink | discussion |
-          entryUrl | connectionInfo | browserInfo | participantInfo
-  name: <element name>      # required for named sources, forbidden for external sources
-  path: [<segments>...]     # optional for named sources, required for external sources
+  source:
+    prompt | survey | submitButton | qualtrics | timeline | trackedLink | discussion |
+    entryUrl | attributes
+  name: <element name> # required for named sources, forbidden for external sources
+  path: [<segments>...] # optional for named sources, required for external sources
 ```
 
 For named sources, `prompt` references default to `path: [value]` when omitted (the participant's saved answer). Other named sources read the whole stored record by default. The structured form lets you override the implicit default — e.g. `path: [debugMessages]` to address other fields on a prompt's saved record.
 
 For external sources, `path` is required. Additionally, `entryUrl` references must currently start the path with `params` (e.g. `path: [params, condition]` — equivalent to the dotted `entryUrl.params.condition`). The `entryUrl.*` namespace is reserved so future additions like `entryUrl.path` / `entryUrl.host` / `entryUrl.href` can land non-breakingly.
+
+`attributes.*` is the host-supplied bag of participant metadata (#473), replacing the former `connectionInfo` / `browserInfo` / `participantInfo` sources — references to those are now rejected. Common fields: `stableParticipantId` (the anonymized id used to link exported data — always available), `sampleId` (the per-assignment data-row id — only from the game phase onward), `name`, `country`, `timezone`, `language`, `screenWidth`. The recruitment-platform id is intentionally not exposed here.
 
 ## 5. Conditions
 
@@ -95,20 +96,20 @@ conditions:
 
 All elements accept: `name?`, `notes?`, `displayTime?`, `hideTime?`, `showToPositions?`, `hideFromPositions?`, `conditions?`, `tags?`. (`file?` is per-type — only `prompt`, `audio`, `image`, `mediaPlayer` accept it; see #249.)
 
-| Type            | Key Fields                                                                                                                                                                                                                                     |
-| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `prompt`        | `file` (required), `shared?`                                                                                                                                                                                                                   |
-| `display`       | `reference` (required), `position?` (default: `player`)                                                                                                                                                                                        |
-| `submitButton`  | `buttonText?` (default: "Next")                                                                                                                                                                                                                |
-| `timer`         | `startTime?`, `endTime?`, `warnTimeRemaining?`                                                                                                                                                                                                 |
-| `separator`     | `style?` (`thin`, `regular`, `thick`)                                                                                                                                                                                                          |
-| `audio`         | `file` (required)                                                                                                                                                                                                                              |
-| `image`         | `file` (required), `width?`                                                                                                                                                                                                                    |
-| `mediaPlayer`   | `file` (required), `name`, `controls?`, `syncToStageTime?`, `submitOnComplete?`, `startAt?`, `stopAt?`, `stepDuration?`, `playVideo?`, `playAudio?`, `captionsFile?`, `allowScrubOutsideBounds?`                                              |
-| `timeline`      | `source` (required, name of a sibling `mediaPlayer`), `name` (required), `selectionType` (required, `range` or `point`), `selectionScope?` (default `all`), `multiSelect?` (default `false`), `showWaveform?` (default `true`), `trackLabels?` |
-| `survey`        | `surveyName` (required) — _deprecated; pending removal once a module-reuse pattern lands. Prefer prompt-based patterns._                                                                                                                       |
-| `qualtrics`     | `url` (required), `urlParams?`                                                                                                                                                                                                                 |
-| `trackedLink`   | `name` (required), `url` (required), `displayText` (required), `helperText?`, `urlParams?`                                                                                                                                                     |
+| Type           | Key Fields                                                                                                                                                                                                                                     |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `prompt`       | `file` (required), `shared?`                                                                                                                                                                                                                   |
+| `display`      | `reference` (required), `position?` (default: `player`)                                                                                                                                                                                        |
+| `submitButton` | `buttonText?` (default: "Next")                                                                                                                                                                                                                |
+| `timer`        | `startTime?`, `endTime?`, `warnTimeRemaining?`                                                                                                                                                                                                 |
+| `separator`    | `style?` (`thin`, `regular`, `thick`)                                                                                                                                                                                                          |
+| `audio`        | `file` (required)                                                                                                                                                                                                                              |
+| `image`        | `file` (required), `width?`                                                                                                                                                                                                                    |
+| `mediaPlayer`  | `file` (required), `name`, `controls?`, `syncToStageTime?`, `submitOnComplete?`, `startAt?`, `stopAt?`, `stepDuration?`, `playVideo?`, `playAudio?`, `captionsFile?`, `allowScrubOutsideBounds?`                                               |
+| `timeline`     | `source` (required, name of a sibling `mediaPlayer`), `name` (required), `selectionType` (required, `range` or `point`), `selectionScope?` (default `all`), `multiSelect?` (default `false`), `showWaveform?` (default `true`), `trackLabels?` |
+| `survey`       | `surveyName` (required) — _deprecated; pending removal once a module-reuse pattern lands. Prefer prompt-based patterns._                                                                                                                       |
+| `qualtrics`    | `url` (required), `urlParams?`                                                                                                                                                                                                                 |
+| `trackedLink`  | `name` (required), `url` (required), `displayText` (required), `helperText?`, `urlParams?`                                                                                                                                                     |
 
 ### Media hosting requirements
 

--- a/packages/stagebook/src/components/Element.contract.test.tsx
+++ b/packages/stagebook/src/components/Element.contract.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { describe, test, expect, vi } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  StagebookProvider,
+  type StagebookContext,
+} from "./StagebookProvider.js";
+import { Element } from "./Element.js";
+
+// End-to-end wiring (#473): a `qualtrics` element rendered through `Element`
+// must source its identifiers from `self.attributes.*` and thread the
+// `onContractViolation` hook from context to the leaf Qualtrics component.
+// The leaf behavior is unit-tested in Qualtrics.contract.test.tsx; this guards
+// the resolve → Element → Qualtrics path the leaf tests bypass.
+
+function makeContext(overrides?: Partial<StagebookContext>): StagebookContext {
+  return {
+    get: vi.fn(() => []),
+    save: vi.fn(),
+    getElapsedTime: vi.fn(() => 0),
+    submit: vi.fn(),
+    getAssetURL: vi.fn((p: string) => `https://cdn.test/${p}`),
+    getTextContent: vi.fn(() => Promise.resolve("mock")),
+    progressLabel: "game_0_survey",
+    playerId: "internal-player-1",
+    position: 0,
+    playerCount: 2,
+    isSubmitted: false,
+    ...overrides,
+  };
+}
+
+function renderQualtricsElement(ctx: StagebookContext): HTMLElement {
+  const container = document.createElement("div");
+  act(() => {
+    createRoot(container).render(
+      <StagebookProvider value={ctx}>
+        <Element
+          element={{
+            type: "qualtrics",
+            url: "https://upenn.qualtrics.com/jfe/form/SV_x",
+          }}
+          onSubmit={() => {}}
+        />
+      </StagebookProvider>,
+    );
+  });
+  return container;
+}
+
+describe("Element → Qualtrics attributes wiring (#473)", () => {
+  test("resolves stableParticipantId + sampleId from attributes into the survey URL (not playerId)", () => {
+    const ctx = makeContext({
+      get: vi.fn((key: string) =>
+        key === "attributes"
+          ? [{ stableParticipantId: "stable-1", sampleId: "row-9" }]
+          : [],
+      ),
+    });
+    const container = renderQualtricsElement(ctx);
+    const src = container.querySelector("iframe")?.getAttribute("src") ?? "";
+    expect(src).toContain("stableParticipantId=stable-1");
+    expect(src).toContain("sampleId=row-9");
+    // The internal playerId must never reach the URL.
+    expect(src).not.toContain("internal-player-1");
+  });
+
+  test("threads onContractViolation through Element when stableParticipantId is empty", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const onContractViolation = vi.fn();
+    // Host provides no attributes → resolve yields "" for the id.
+    const ctx = makeContext({ get: vi.fn(() => []), onContractViolation });
+
+    const container = renderQualtricsElement(ctx);
+
+    expect(onContractViolation).toHaveBeenCalledTimes(1);
+    expect(onContractViolation).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "missingStableParticipantId" }),
+    );
+    // ...and the empty id is omitted from the URL rather than sent blank.
+    const src = container.querySelector("iframe")?.getAttribute("src") ?? "";
+    expect(src).not.toContain("stableParticipantId=");
+    consoleError.mockRestore();
+  });
+});

--- a/packages/stagebook/src/components/Element.ct.tsx
+++ b/packages/stagebook/src/components/Element.ct.tsx
@@ -197,6 +197,52 @@ test.describe("Element router dispatch", () => {
     expect(src).toContain("answer=yes");
   });
 
+  // Regression guard (#473): Element must source the standard Qualtrics
+  // identifiers from the current participant's `attributes` — the anonymized
+  // `stableParticipantId` and `sampleId` URL params — NOT the internal
+  // `playerId`. Like the urlParams guard above, this exercises the Element
+  // wrapper, not the leaf Qualtrics component.
+  test("type: qualtrics sources stableParticipantId + sampleId from attributes", async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <MockStageRenderer
+        stage={singleElementStage({
+          type: "qualtrics",
+          url: "https://upenn.qualtrics.com/jfe/form/SV_test",
+        })}
+        stateValues={{
+          "self.attributes.stableParticipantId": "stable-xyz",
+          "self.attributes.sampleId": "row-9",
+        }}
+      />,
+    );
+    const src = await component.locator("iframe").getAttribute("src");
+    expect(src).toContain("stableParticipantId=stable-xyz");
+    expect(src).toContain("sampleId=row-9");
+    // The internal playerId ("test-player-1") must never leak into the URL.
+    expect(src).not.toContain("test-player-1");
+  });
+
+  test("type: qualtrics omits sampleId param when sampleId is unset (pre-game)", async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <MockStageRenderer
+        stage={singleElementStage({
+          type: "qualtrics",
+          url: "https://upenn.qualtrics.com/jfe/form/SV_test",
+        })}
+        stateValues={{
+          "self.attributes.stableParticipantId": "stable-xyz",
+        }}
+      />,
+    );
+    const src = await component.locator("iframe").getAttribute("src");
+    expect(src).toContain("stableParticipantId=stable-xyz");
+    expect(src).not.toContain("sampleId=");
+  });
+
   test("type: mediaPlayer renders a video element", async ({ mount }) => {
     const component = await mount(
       <MockStageRenderer

--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -111,8 +111,8 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
     renderSharedNotepad,
     renderDiscussion,
     renderSurvey,
-    playerId,
     setAllowIdle,
+    onContractViolation,
   } = ctx;
 
   // Wrap save to add consistent metadata to every element's saved data
@@ -396,11 +396,23 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
 
     case "qualtrics": {
       const qualtricsParams = resolveParams(element.urlParams, resolve);
+      // Source the standard Qualtrics identifiers from the current
+      // participant's attributes (#473) — the anonymized, release-safe
+      // `stableParticipantId` (NOT the internal `playerId`) and, once the
+      // game phase has assigned it, the per-row `sampleId`. `resolve`
+      // returns one value per matched position; for `self.*` that's a
+      // single value (or none, when sampleId isn't assigned yet).
+      const asString = (ref: string): string => {
+        const picked = resolve(ref).find((v) => v !== undefined);
+        return picked == null ? "" : String(picked as string | number);
+      };
       return (
         <Qualtrics
           url={element.url ?? ""}
           resolvedParams={qualtricsParams}
-          participantId={playerId}
+          stableParticipantId={asString("self.attributes.stableParticipantId")}
+          sampleId={asString("self.attributes.sampleId")}
+          onContractViolation={onContractViolation}
           save={wrappedSave}
           onComplete={onSubmit}
         />

--- a/packages/stagebook/src/components/StagebookProvider.test.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.test.tsx
@@ -17,6 +17,9 @@ import {
 function createMockContext(
   overrides?: Partial<StagebookContext>,
 ): StagebookContext {
+  // No attributes shim needed: the provider does not check
+  // `stableParticipantId` at mount (#473) — that's a use-site check in the
+  // Qualtrics element — so a missing attributes bag here is harmless.
   return {
     get: vi.fn(() => []),
     save: vi.fn(),

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -143,6 +143,25 @@ export interface StagebookContext {
     error: Error;
     errorInfo: React.ErrorInfo;
   }) => void;
+
+  /**
+   * Optional telemetry hook for host-contract violations (#473) — currently
+   * the one case is a missing `attributes.stableParticipantId` at the point
+   * stagebook needs it: the Qualtrics `stableParticipantId` URL-param
+   * injection, where an empty id silently orphans the survey response. It is
+   * **not** checked
+   * eagerly at mount (most studies never use the id). This is a notification
+   * only — Stagebook still renders (`console.error` fires regardless). Real
+   * violations are meant to be caught earlier — in the host's CI integration
+   * test (against `hasStableParticipantId`/`attributesSchema`) and at batch
+   * start — and the connect/sync race by the host's readiness gate. Use this
+   * to surface a slipped-through violation to telemetry (e.g. Sentry). The
+   * payload never includes participant values.
+   */
+  onContractViolation?: (info: {
+    kind: "missingStableParticipantId";
+    message: string;
+  }) => void;
 }
 
 // --------------- Internal context ---------------
@@ -208,6 +227,16 @@ export function StagebookProvider({
     () => ({ ...value, resolve }),
     [value, resolve],
   );
+
+  // Note (#473): the required `attributes.stableParticipantId` is NOT checked
+  // here. Most studies never use it (no Qualtrics, no explicit reference, and
+  // the export linkage is joined host-side), so an eager mount check would
+  // complain about a value that's never touched. Instead the contract is
+  // checked lazily at the one place stagebook itself consumes the id — the
+  // Qualtrics `stableParticipantId` URL-param injection (see `Qualtrics`) — and enforced
+  // upstream by the host (CI integration test against `hasStableParticipantId`,
+  // batch-start preflight, readiness gate). The `onContractViolation` hook is
+  // fired from that use site, not from here.
 
   return (
     <StagebookReactContext.Provider value={internal}>

--- a/packages/stagebook/src/components/elements/Qualtrics.contract.test.tsx
+++ b/packages/stagebook/src/components/elements/Qualtrics.contract.test.tsx
@@ -42,6 +42,26 @@ describe("Qualtrics stableParticipantId contract check (#473)", () => {
     consoleError.mockRestore();
   });
 
+  test("reports a violation for a whitespace-only stableParticipantId (treated as absent)", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const onContractViolation = vi.fn();
+
+    render(
+      <Qualtrics
+        url="https://upenn.qualtrics.com/jfe/form/SV_x"
+        stableParticipantId="   "
+        onContractViolation={onContractViolation}
+        save={() => {}}
+        onComplete={() => {}}
+      />,
+    );
+
+    expect(onContractViolation).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
+  });
+
   test("does not report a violation when stableParticipantId is present", () => {
     const consoleError = vi
       .spyOn(console, "error")

--- a/packages/stagebook/src/components/elements/Qualtrics.contract.test.tsx
+++ b/packages/stagebook/src/components/elements/Qualtrics.contract.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, test, expect, vi } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { Qualtrics } from "./Qualtrics.js";
+
+// The `stableParticipantId` contract is checked at the use site (#473): a
+// Qualtrics survey always wants `stableParticipantId` linkage, so a missing id
+// is real (silent) data loss and is surfaced loudly. Studies without Qualtrics
+// never reach this check.
+
+function render(el: React.ReactElement): void {
+  const container = document.createElement("div");
+  act(() => {
+    createRoot(container).render(el);
+  });
+}
+
+describe("Qualtrics stableParticipantId contract check (#473)", () => {
+  test("reports a violation (console.error + onContractViolation) when stableParticipantId is empty", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const onContractViolation = vi.fn();
+
+    render(
+      <Qualtrics
+        url="https://upenn.qualtrics.com/jfe/form/SV_x"
+        onContractViolation={onContractViolation}
+        save={() => {}}
+        onComplete={() => {}}
+      />,
+    );
+
+    expect(onContractViolation).toHaveBeenCalledTimes(1);
+    expect(onContractViolation).toHaveBeenCalledWith(
+      expect.objectContaining({ kind: "missingStableParticipantId" }),
+    );
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining("without a stableParticipantId"),
+    );
+    consoleError.mockRestore();
+  });
+
+  test("does not report a violation when stableParticipantId is present", () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const onContractViolation = vi.fn();
+
+    render(
+      <Qualtrics
+        url="https://upenn.qualtrics.com/jfe/form/SV_x"
+        stableParticipantId="stable-1"
+        onContractViolation={onContractViolation}
+        save={() => {}}
+        onComplete={() => {}}
+      />,
+    );
+
+    expect(onContractViolation).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalledWith(
+      expect.stringContaining("without a stableParticipantId"),
+    );
+    consoleError.mockRestore();
+  });
+});

--- a/packages/stagebook/src/components/elements/Qualtrics.ct.tsx
+++ b/packages/stagebook/src/components/elements/Qualtrics.ct.tsx
@@ -8,7 +8,6 @@ test.describe("Qualtrics", () => {
       const component = await mount(
         <Qualtrics
           url="https://upenn.qualtrics.com/jfe/form/SV_test123"
-          progressLabel="game_0_survey"
           save={() => {}}
           onComplete={() => {}}
         />,
@@ -27,7 +26,6 @@ test.describe("Qualtrics", () => {
             { key: "condition", value: "topicA" },
             { key: "prolificId", value: "P123" },
           ]}
-          progressLabel="game_0_survey"
           save={() => {}}
           onComplete={() => {}}
         />,
@@ -37,32 +35,32 @@ test.describe("Qualtrics", () => {
       expect(src).toContain("prolificId=P123");
     });
 
-    test("appends participantId as deliberationId", async ({ mount }) => {
+    test("appends stableParticipantId as a URL param (#473)", async ({
+      mount,
+    }) => {
       const component = await mount(
         <Qualtrics
           url="https://upenn.qualtrics.com/jfe/form/SV_test123"
-          participantId="player-abc"
-          progressLabel="game_0_survey"
+          stableParticipantId="stable-abc"
           save={() => {}}
           onComplete={() => {}}
         />,
       );
       const src = await component.locator("iframe").getAttribute("src");
-      expect(src).toContain("deliberationId=player-abc");
+      expect(src).toContain("stableParticipantId=stable-abc");
     });
 
-    test("appends groupId as sampleId", async ({ mount }) => {
+    test("appends sampleId (#473)", async ({ mount }) => {
       const component = await mount(
         <Qualtrics
           url="https://upenn.qualtrics.com/jfe/form/SV_test123"
-          groupId="game-xyz"
-          progressLabel="game_0_survey"
+          sampleId="row-xyz"
           save={() => {}}
           onComplete={() => {}}
         />,
       );
       const src = await component.locator("iframe").getAttribute("src");
-      expect(src).toContain("sampleId=game-xyz");
+      expect(src).toContain("sampleId=row-xyz");
     });
   });
 

--- a/packages/stagebook/src/components/elements/Qualtrics.tsx
+++ b/packages/stagebook/src/components/elements/Qualtrics.tsx
@@ -8,8 +8,31 @@ export interface ResolvedParam {
 export interface QualtricsProps {
   url: string;
   resolvedParams?: ResolvedParam[];
-  participantId?: string;
-  groupId?: string;
+  /**
+   * The anonymized, release-safe participant id (#473). Appended to the
+   * survey URL as `stableParticipantId` so Qualtrics responses can be linked
+   * back to the participant's exported data. Sourced from
+   * `attributes.stableParticipantId` — NOT the internal `playerId`. (Replaces
+   * the legacy `deliberationId` URL param; Qualtrics surveys must read the
+   * embedded data field `stableParticipantId`.)
+   */
+  stableParticipantId?: string;
+  /**
+   * The per-assignment data-row id (#473), appended as `sampleId`. Absent
+   * until the game phase, so it may be empty.
+   */
+  sampleId?: string;
+  /**
+   * Telemetry hook (#473) fired when `stableParticipantId` is empty — i.e.
+   * this survey would launch without participant linkage, silently
+   * orphaning the response. This is the one place stagebook consumes the id,
+   * so it's the one place the missing-id contract is checked (lazily, at use,
+   * not eagerly at mount). Notification only — the survey still renders.
+   */
+  onContractViolation?: (info: {
+    kind: "missingStableParticipantId";
+    message: string;
+  }) => void;
   save: (key: string, value: unknown) => void;
   onComplete: () => void;
 }
@@ -17,11 +40,27 @@ export interface QualtricsProps {
 export function Qualtrics({
   url,
   resolvedParams = [],
-  participantId = "",
-  groupId = "",
+  stableParticipantId = "",
+  sampleId = "",
+  onContractViolation,
   save,
   onComplete,
 }: QualtricsProps) {
+  // The contract check for `stableParticipantId` lives here, not at provider
+  // mount: a Qualtrics survey always wants the `stableParticipantId` URL param
+  // to link its response back to the participant, so an empty id is a real
+  // (silent) data loss. Surface it loudly. Studies without Qualtrics never hit
+  // this.
+  useEffect(() => {
+    if (stableParticipantId) return;
+    const message =
+      "Stagebook: a Qualtrics survey is rendering without a " +
+      "stableParticipantId, so its response will not carry the " +
+      "stableParticipantId link back to the participant. The host must populate " +
+      "`attributes.stableParticipantId` before reaching a Qualtrics stage.";
+    console.error(message);
+    onContractViolation?.({ kind: "missingStableParticipantId", message });
+  }, [stableParticipantId, onContractViolation]);
   // Ref unstable callbacks so the listener-registration effect below
   // doesn't tear down and re-add on every parent re-render (#105).
   const saveRef = useRef(save);
@@ -66,14 +105,14 @@ export function Qualtrics({
     resolvedParams.forEach(({ key, value }) =>
       urlObj.searchParams.append(key, value),
     );
-    if (participantId) {
-      urlObj.searchParams.append("deliberationId", participantId);
+    if (stableParticipantId) {
+      urlObj.searchParams.append("stableParticipantId", stableParticipantId);
     }
-    if (groupId) {
-      urlObj.searchParams.append("sampleId", groupId);
+    if (sampleId) {
+      urlObj.searchParams.append("sampleId", sampleId);
     }
     return urlObj.toString();
-  }, [url, resolvedParams, participantId, groupId]);
+  }, [url, resolvedParams, stableParticipantId, sampleId]);
 
   return (
     <div

--- a/packages/stagebook/src/components/elements/Qualtrics.tsx
+++ b/packages/stagebook/src/components/elements/Qualtrics.tsx
@@ -46,13 +46,20 @@ export function Qualtrics({
   save,
   onComplete,
 }: QualtricsProps) {
+  // Trim before any presence test so behavior matches `hasStableParticipantId`
+  // (a whitespace-only id counts as absent). The trimmed values are what we
+  // both check and append, so the contract warning and the outbound URL stay
+  // consistent.
+  const trimmedStableId = stableParticipantId.trim();
+  const trimmedSampleId = sampleId.trim();
+
   // The contract check for `stableParticipantId` lives here, not at provider
   // mount: a Qualtrics survey always wants the `stableParticipantId` URL param
   // to link its response back to the participant, so an empty id is a real
   // (silent) data loss. Surface it loudly. Studies without Qualtrics never hit
   // this.
   useEffect(() => {
-    if (stableParticipantId) return;
+    if (trimmedStableId) return;
     const message =
       "Stagebook: a Qualtrics survey is rendering without a " +
       "stableParticipantId, so its response will not carry the " +
@@ -60,7 +67,7 @@ export function Qualtrics({
       "`attributes.stableParticipantId` before reaching a Qualtrics stage.";
     console.error(message);
     onContractViolation?.({ kind: "missingStableParticipantId", message });
-  }, [stableParticipantId, onContractViolation]);
+  }, [trimmedStableId, onContractViolation]);
   // Ref unstable callbacks so the listener-registration effect below
   // doesn't tear down and re-add on every parent re-render (#105).
   const saveRef = useRef(save);
@@ -105,14 +112,14 @@ export function Qualtrics({
     resolvedParams.forEach(({ key, value }) =>
       urlObj.searchParams.append(key, value),
     );
-    if (stableParticipantId) {
-      urlObj.searchParams.append("stableParticipantId", stableParticipantId);
+    if (trimmedStableId) {
+      urlObj.searchParams.append("stableParticipantId", trimmedStableId);
     }
-    if (sampleId) {
-      urlObj.searchParams.append("sampleId", sampleId);
+    if (trimmedSampleId) {
+      urlObj.searchParams.append("sampleId", trimmedSampleId);
     }
     return urlObj.toString();
-  }, [url, resolvedParams, stableParticipantId, sampleId]);
+  }, [url, resolvedParams, trimmedStableId, trimmedSampleId]);
 
   return (
     <div

--- a/packages/stagebook/src/components/elements/TrackedLink.ct.tsx
+++ b/packages/stagebook/src/components/elements/TrackedLink.ct.tsx
@@ -250,11 +250,11 @@ test("urlParam with empty value is rendered as `&key=` (not dropped)", async ({
   );
 });
 
-test("participantInfo-style values are URL-encoded into the href", async ({
+test("attributes-style values are URL-encoded into the href", async ({
   mount,
 }) => {
   // Cypress 01 line 800 asserted href contains a URL-encoded
-  // `participantInfo.name` value. The ref is resolved by the host before
+  // `attributes.name` value. The ref is resolved by the host before
   // it ever reaches TrackedLink — the contract here is that whatever
   // string the host hands us gets encoded correctly into the href.
   const nicknameRaw = "nickname_user with space&danger=1";

--- a/packages/stagebook/src/components/testing/MockQualtrics.tsx
+++ b/packages/stagebook/src/components/testing/MockQualtrics.tsx
@@ -8,15 +8,15 @@ import { Qualtrics } from "../elements/Qualtrics.js";
 export interface MockQualtricsProps {
   url: string;
   resolvedParams?: Array<{ key: string; value: string }>;
-  participantId?: string;
-  groupId?: string;
+  stableParticipantId?: string;
+  sampleId?: string;
 }
 
 export function MockQualtrics({
   url,
   resolvedParams = [],
-  participantId,
-  groupId,
+  stableParticipantId,
+  sampleId,
 }: MockQualtricsProps) {
   const [savedData, setSavedData] = useState<{
     key: string;
@@ -56,9 +56,8 @@ export function MockQualtrics({
       <Qualtrics
         url={url}
         resolvedParams={resolvedParams}
-        participantId={participantId}
-        groupId={groupId}
-        progressLabel="game_0_qualtrics"
+        stableParticipantId={stableParticipantId}
+        sampleId={sampleId}
         save={(key, value) => setSavedData({ key, value })}
         onComplete={() => setCompleted(true)}
       />

--- a/packages/stagebook/src/components/testing/MockStageRenderer.tsx
+++ b/packages/stagebook/src/components/testing/MockStageRenderer.tsx
@@ -104,11 +104,7 @@ export function MockStageRenderer({
       // override the id explicitly).
       if (key === "attributes") {
         const base = { stableParticipantId: "test-stable-1" };
-        return [
-          val !== null && typeof val === "object"
-            ? { ...base, ...(val as Record<string, unknown>) }
-            : base,
-        ];
+        return [isPlainObject(val) ? { ...base, ...val } : base];
       }
       return val !== undefined ? [val] : [];
     },

--- a/packages/stagebook/src/components/testing/MockStageRenderer.tsx
+++ b/packages/stagebook/src/components/testing/MockStageRenderer.tsx
@@ -53,6 +53,10 @@ function wrapAtPath(value: unknown, path: string[]): unknown {
   return result;
 }
 
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === "object" && !Array.isArray(v);
+}
+
 /** Convert DSL-reference-keyed stateValues to flat-key → raw-record map. */
 function buildFlatValues(
   stateValues: Record<string, unknown>,
@@ -60,7 +64,18 @@ function buildFlatValues(
   const flat = new Map<string, unknown>();
   for (const [ref, val] of Object.entries(stateValues)) {
     const { referenceKey, path } = getReferenceKeyAndPath(ref);
-    flat.set(referenceKey, wrapAtPath(val, path));
+    const wrapped = wrapAtPath(val, path);
+    const existing = flat.get(referenceKey);
+    // Merge multiple references that share a storage key (e.g. several
+    // `attributes.*` fields) into one record instead of overwriting, so a
+    // test can seed `self.attributes.stableParticipantId` AND
+    // `self.attributes.sampleId` together.
+    flat.set(
+      referenceKey,
+      isPlainObject(existing) && isPlainObject(wrapped)
+        ? { ...existing, ...wrapped }
+        : wrapped,
+    );
   }
   return flat;
 }
@@ -81,6 +96,20 @@ export function MockStageRenderer({
   const mockContext: StagebookContext = {
     get: (key: string) => {
       const val = flatValues.get(key);
+      // A Qualtrics element reports a contract violation (console.error +
+      // onContractViolation) when `attributes.stableParticipantId` is missing
+      // at its use site (#473). Seed a default so CT harnesses that mount a
+      // qualtrics element without setting identity render without that noise;
+      // merge it under any attributes fields a test did seed (a test can still
+      // override the id explicitly).
+      if (key === "attributes") {
+        const base = { stableParticipantId: "test-stable-1" };
+        return [
+          val !== null && typeof val === "object"
+            ? { ...base, ...(val as Record<string, unknown>) }
+            : base,
+        ];
+      }
       return val !== undefined ? [val] : [];
     },
     save: () => {},

--- a/packages/stagebook/src/schemas/attributes.test.ts
+++ b/packages/stagebook/src/schemas/attributes.test.ts
@@ -1,0 +1,65 @@
+import { describe, test, expect } from "vitest";
+import { attributesSchema, hasStableParticipantId } from "./attributes.js";
+
+describe("attributesSchema", () => {
+  test("accepts a minimal bag with only stableParticipantId", () => {
+    expect(
+      attributesSchema.safeParse({ stableParticipantId: "abc" }).success,
+    ).toBe(true);
+  });
+
+  test("rejects a missing or empty stableParticipantId", () => {
+    expect(attributesSchema.safeParse({}).success).toBe(false);
+    expect(
+      attributesSchema.safeParse({ stableParticipantId: "" }).success,
+    ).toBe(false);
+  });
+
+  test("sampleId is optional (absent pre-assignment)", () => {
+    expect(
+      attributesSchema.safeParse({ stableParticipantId: "abc" }).success,
+    ).toBe(true);
+    expect(
+      attributesSchema.safeParse({
+        stableParticipantId: "abc",
+        sampleId: "row-1",
+      }).success,
+    ).toBe(true);
+  });
+
+  test("passes through host-added fields without a schema change", () => {
+    const parsed = attributesSchema.parse({
+      stableParticipantId: "abc",
+      country: "US",
+      screenWidth: 1280,
+      customCohort: "panel-a",
+    });
+    expect(parsed.customCohort).toBe("panel-a");
+    expect(parsed.country).toBe("US");
+  });
+});
+
+describe("hasStableParticipantId", () => {
+  test("true only for a non-empty, non-whitespace string id", () => {
+    expect(hasStableParticipantId({ stableParticipantId: "abc" })).toBe(true);
+    expect(hasStableParticipantId({ stableParticipantId: "" })).toBe(false);
+    expect(hasStableParticipantId({ stableParticipantId: "   " })).toBe(false);
+    expect(hasStableParticipantId({})).toBe(false);
+    expect(hasStableParticipantId(undefined)).toBe(false);
+    expect(hasStableParticipantId(null)).toBe(false);
+    expect(hasStableParticipantId([{ stableParticipantId: "abc" }])).toBe(
+      false,
+    );
+  });
+
+  test("tolerates loosely-typed soft fields (only the id matters)", () => {
+    // A host that typed screenWidth as a string still passes the gate —
+    // the mount check enforces presence of the export id, not full shape.
+    expect(
+      hasStableParticipantId({
+        stableParticipantId: "abc",
+        screenWidth: "1280",
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/stagebook/src/schemas/attributes.ts
+++ b/packages/stagebook/src/schemas/attributes.ts
@@ -1,0 +1,72 @@
+/**
+ * Host-supplied participant attributes (#473).
+ *
+ * `attributes` is the single flat bag of everything the participant arrives
+ * at the study with — identity, onboarding, connection, and browser
+ * metadata — addressed via the `attributes` reference source
+ * (`self.attributes.<field>`). It replaces the three legacy host bags
+ * `connectionInfo`, `browserInfo`, and `participantInfo`, which were merged
+ * on the premise that they're all "host-maintained attributes of the current
+ * participant" with no meaningful split. Values may change mid-study (e.g.
+ * screen width on resize); the host is responsible for keeping them current.
+ *
+ * Two identity fields are special:
+ *   - `stableParticipantId` — anonymized, stable across sessions, the
+ *     release-safe id used to link exported data. **Required for studies that
+ *     use it.** Not checked eagerly at mount (most studies never touch it);
+ *     checked lazily at the one place stagebook consumes it — the Qualtrics
+ *     `stableParticipantId` URL-param injection — where a missing id is loud
+ *     (`console.error` + the optional `onContractViolation` callback) but
+ *     never blocks. Presence is enforced upstream via a host CI integration
+ *     test (this helper) + a batch-start preflight, and the connect race by a
+ *     host readiness gate.
+ *   - `sampleId` — the per-assignment data-row id, minted at game-stage
+ *     start. **Optional** and absent during intro / groupComposition;
+ *     `validateReferences` flags pre-game reads.
+ *
+ * The recruitment-platform id is deliberately **not** modeled here. Keeping
+ * recruitment PII out of stagebook's referenceable surface is the privacy
+ * guarantee; released data is linkable via `stableParticipantId`.
+ *
+ * The bag is open (`.passthrough()`) so a host can add further fields it
+ * references in treatments without a schema change. This schema is the host
+ * contract, a test-fixture factory, and the documentation source of truth.
+ */
+
+import { z } from "zod";
+
+export const attributesSchema = z
+  .object({
+    // Identity (see module doc).
+    stableParticipantId: z.string().min(1),
+    sampleId: z.string().min(1).optional(),
+    // Onboarding.
+    name: z.string().optional(),
+    // Connection / geo metadata.
+    country: z.string().optional(),
+    timezone: z.string().optional(),
+    isKnownVpn: z.boolean().optional(),
+    // Browser / client metadata.
+    screenWidth: z.number().optional(),
+    screenHeight: z.number().optional(),
+    language: z.string().optional(),
+    userAgent: z.string().optional(),
+  })
+  .passthrough();
+
+export type AttributesType = z.infer<typeof attributesSchema>;
+
+/**
+ * The one hard requirement on the `attributes` bag: a non-empty
+ * `stableParticipantId`. Isolated from the full schema so the provider's
+ * contract check (and host integration tests / batch-start preflight) can
+ * assert *presence of the export id* without rejecting a participant over a
+ * soft/optional field a host typed loosely (e.g. a stringified `screenWidth`).
+ */
+export function hasStableParticipantId(attributes: unknown): boolean {
+  if (typeof attributes !== "object" || attributes === null) return false;
+  const id = (attributes as Record<string, unknown>).stableParticipantId;
+  // Non-empty after trimming — a whitespace-only id is treated as absent so a
+  // degenerate host value can't silently ship as the export id.
+  return typeof id === "string" && id.trim().length > 0;
+}

--- a/packages/stagebook/src/schemas/index.ts
+++ b/packages/stagebook/src/schemas/index.ts
@@ -95,6 +95,12 @@ export {
 } from "./treatment.js";
 
 export {
+  attributesSchema,
+  hasStableParticipantId,
+  type AttributesType,
+} from "./attributes.js";
+
+export {
   safeParseTreatmentFile,
   type UnrecognizedKeyIssueParams,
 } from "./safeParseTreatmentFile.js";

--- a/packages/stagebook/src/schemas/reference.ts
+++ b/packages/stagebook/src/schemas/reference.ts
@@ -4,7 +4,7 @@
  * A reference identifies a value somewhere in the study state. There are two
  * kinds: **named** sources (`prompt`, `survey`, …) whose data is keyed by
  * a researcher-chosen `name`, and **external** sources (`entryUrl`,
- * `participantInfo`, …) supplied by the host as a singleton.
+ * `attributes`) supplied by the host as a singleton.
  *
  * Per #298, every reference begins with an explicit **position selector** —
  * `<integer>`, `self`, `shared`, or `all`. The position selector is part of
@@ -49,9 +49,17 @@ export const externalSourceEnum = z.enum([
   // so it doesn't collide with the unrelated `urlParams:` element field
   // (outgoing params on trackedLink / qualtrics).
   "entryUrl",
-  "connectionInfo",
-  "browserInfo",
-  "participantInfo",
+  // `attributes.<field>` is the single host-supplied bag of everything
+  // the participant arrives with — identity, onboarding, connection,
+  // and browser metadata, addressed flat (#473). It replaces the three
+  // legacy bags `connectionInfo` / `browserInfo` / `participantInfo`,
+  // which were merged on the premise that they're all "host-maintained
+  // attributes of the current participant" with no meaningful split.
+  // Two identity fields are special: `stableParticipantId` (anonymized,
+  // stable across sessions, the release-safe id — required) and
+  // `sampleId` (per-assignment data-row id — available only from the
+  // game phase onward).
+  "attributes",
 ]);
 export type ExternalSource = z.infer<typeof externalSourceEnum>;
 

--- a/packages/stagebook/src/schemas/validateReferences.test.ts
+++ b/packages/stagebook/src/schemas/validateReferences.test.ts
@@ -504,7 +504,7 @@ describe("Rule 1 — no forward references", () => {
     expect(hit).toBeDefined();
   });
 
-  test("external references (entryUrl.params.x, participantInfo.x) accepted at every site", () => {
+  test("external references (entryUrl.params.x, attributes.x) accepted at every site", () => {
     const file = baseFile({
       gameStages: [
         {
@@ -520,7 +520,7 @@ describe("Rule 1 — no forward references", () => {
           elements: [
             {
               type: "display",
-              reference: "self.participantInfo.playerId",
+              reference: "self.attributes.stableParticipantId",
             },
             { type: "submitButton" },
           ],
@@ -529,6 +529,99 @@ describe("Rule 1 — no forward references", () => {
     });
     const issues = validateTreatmentFileReferences(file);
     expect(issues.length).toBe(0);
+  });
+
+  const hasSampleIdIssue = (issues: { message: string }[]): boolean =>
+    issues.some((i) => /attributes\.sampleId/.test(i.message));
+
+  test("attributes.sampleId is rejected in an intro step (#473)", () => {
+    // In an intro step it's empty at runtime (assigned at game start).
+    const introFile = baseFile({
+      introSteps: [
+        {
+          name: "i1",
+          elements: [
+            { type: "display", reference: "self.attributes.sampleId" },
+          ],
+        },
+      ],
+    });
+    expect(hasSampleIdIssue(validateTreatmentFileReferences(introFile))).toBe(
+      true,
+    );
+  });
+
+  test("attributes.sampleId is rejected in groupComposition (#473)", () => {
+    // groupComposition runs before any stage — sampleId doesn't exist yet.
+    const gcFile = baseFile({
+      groupComposition: [
+        {
+          position: 0,
+          conditions: [
+            { reference: "self.attributes.sampleId", comparator: "exists" },
+          ],
+        },
+      ],
+    });
+    expect(hasSampleIdIssue(validateTreatmentFileReferences(gcFile))).toBe(
+      true,
+    );
+  });
+
+  test("attributes.sampleId is accepted in a game stage (#473)", () => {
+    const gameFile = baseFile({
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          elements: [
+            { type: "display", reference: "self.attributes.sampleId" },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    expect(hasSampleIdIssue(validateTreatmentFileReferences(gameFile))).toBe(
+      false,
+    );
+  });
+
+  test("attributes.sampleId is accepted in an exit step (#473)", () => {
+    // Exit runs after the game — sampleId has been assigned.
+    const exitFile = baseFile({
+      exitSequence: [
+        {
+          name: "e1",
+          elements: [
+            { type: "display", reference: "self.attributes.sampleId" },
+            { type: "submitButton" },
+          ],
+        },
+      ],
+    });
+    expect(hasSampleIdIssue(validateTreatmentFileReferences(exitFile))).toBe(
+      false,
+    );
+  });
+
+  test("non-sampleId attributes fields are NOT gated pre-game (#473)", () => {
+    // Only the sampleId subpath is phase-restricted; other attributes come
+    // from connect and are valid anywhere, including intro.
+    const introFile = baseFile({
+      introSteps: [
+        {
+          name: "i1",
+          elements: [
+            { type: "display", reference: "self.attributes.country" },
+            {
+              type: "display",
+              reference: "self.attributes.stableParticipantId",
+            },
+          ],
+        },
+      ],
+    });
+    expect(validateTreatmentFileReferences(introFile).length).toBe(0);
   });
 
   test("earlier-stage reference accepted", () => {

--- a/packages/stagebook/src/schemas/validateReferences.ts
+++ b/packages/stagebook/src/schemas/validateReferences.ts
@@ -4,7 +4,7 @@
  * Two rules:
  * 1. **No forward references** — applies to every reference site. A reference
  *    whose target storage key is produced by a *later* stage in the flow is
- *    rejected. External references (entryUrl, participantInfo, …) are
+ *    rejected. External references (entryUrl, attributes, …) are
  *    always valid.
  * 2. **No always-skip-at-load** — stage-level conditions only. A stage-level
  *    condition whose reference points at the *current* stage's data and
@@ -73,7 +73,7 @@ const RANK_INTRO = 0;
 const RANK_GAME_BASE = 1;
 
 /** The types of reference whose target keys are **produced by a stage**. A
- *  reference of any other type (entryUrl, participantInfo, …) is external
+ *  reference of any other type (entryUrl, attributes, …) is external
  *  and always valid regardless of position.
  *
  *  Note: `discussion` references aren't in this set because stagebook
@@ -531,6 +531,32 @@ function applyRules({
   // Determine the source. External sources always validate; stage-produced
   // sources go through the producer check.
   const refType = site.reference.source;
+
+  // `attributes.sampleId` (#473) is the per-assignment data-row id, minted
+  // at game-stage start — it does not exist during groupComposition or
+  // intro. Like a forward reference, a pre-game read is always empty at
+  // runtime, so flag it. The rest of `attributes.*` is host-maintained and
+  // available from connect, so only the `sampleId` subpath is gated. Phase
+  // is read from `phaseLabel`/`allowedProducerRanks` rather than the numeric
+  // rank, because the intro walker reuses `enclosingRank` as a within-
+  // sequence step index, not a phase rank. Exit steps run after the game,
+  // so sampleId is available there.
+  const isPreGame =
+    phaseLabel === "intro step" || allowedProducerRanks !== undefined;
+  if (
+    refType === "attributes" &&
+    "path" in site.reference &&
+    site.reference.path[0] === "sampleId" &&
+    isPreGame
+  ) {
+    const phase = phaseLabel ?? "groupComposition";
+    issues.push({
+      path: site.path,
+      message: `Reference "${refStr}" reads attributes.sampleId, which is assigned at game-stage start and is empty during ${phase}. Move the reference to a game or exit stage.`,
+    });
+    return;
+  }
+
   if (!STAGE_PRODUCED_REF_TYPES.has(refType)) return;
 
   // Look up the producer rank. If the key isn't produced anywhere in the
@@ -606,7 +632,7 @@ function applyRules({
     if (!allowedProducerRanks.has(producerRank)) {
       issues.push({
         path: site.path,
-        message: `groupComposition condition references "${refStr}", which is produced by a game or exit stage. groupComposition is evaluated before any stage runs — it can only reference intro-phase data or external values (entryUrl.params.*, participantInfo.*, …).`,
+        message: `groupComposition condition references "${refStr}", which is produced by a game or exit stage. groupComposition is evaluated before any stage runs — it can only reference intro-phase data or external values (entryUrl.params.*, attributes.*, …).`,
       });
     }
     return;

--- a/packages/stagebook/src/utils/reference.test.ts
+++ b/packages/stagebook/src/utils/reference.test.ts
@@ -48,31 +48,34 @@ describe("getReferenceKeyAndPath", () => {
     );
   });
 
-  test("connectionInfo reference", () => {
-    const result = getReferenceKeyAndPath("self.connectionInfo.country");
-    expect(result.referenceKey).toBe("connectionInfo");
+  test("attributes reference (connectionInfo+browserInfo+participantInfo merged flat in #473)", () => {
+    // The three legacy host-supplied bags are unified under one flat
+    // `attributes` source; the field is addressed via the nested path.
+    const result = getReferenceKeyAndPath("self.attributes.country");
+    expect(result.referenceKey).toBe("attributes");
     expect(result.path).toEqual(["country"]);
   });
 
-  test("browserInfo reference", () => {
-    const result = getReferenceKeyAndPath("self.browserInfo.name");
-    expect(result.referenceKey).toBe("browserInfo");
-    expect(result.path).toEqual(["name"]);
+  test("attributes identity reference: stableParticipantId", () => {
+    const result = getReferenceKeyAndPath(
+      "self.attributes.stableParticipantId",
+    );
+    expect(result.referenceKey).toBe("attributes");
+    expect(result.path).toEqual(["stableParticipantId"]);
   });
 
-  test("participantInfo reference", () => {
-    // participantInfo uses the same flat-namespace pattern as connectionInfo
-    // and browserInfo — stored under a single `participantInfo` key with
-    // the field addressed via the nested path.
-    const result = getReferenceKeyAndPath("self.participantInfo.name");
-    expect(result.referenceKey).toBe("participantInfo");
-    expect(result.path).toEqual(["name"]);
-  });
-
-  test("participantInfo reference with deep path", () => {
-    const result = getReferenceKeyAndPath("self.participantInfo.sampleId.raw");
-    expect(result.referenceKey).toBe("participantInfo");
+  test("attributes reference with deep path", () => {
+    const result = getReferenceKeyAndPath("self.attributes.sampleId.raw");
+    expect(result.referenceKey).toBe("attributes");
     expect(result.path).toEqual(["sampleId", "raw"]);
+  });
+
+  test("legacy bag sources are rejected after the #473 consolidation", () => {
+    for (const legacy of ["connectionInfo", "browserInfo", "participantInfo"]) {
+      expect(() => getReferenceKeyAndPath(`self.${legacy}.country`)).toThrow(
+        /Invalid reference source/,
+      );
+    }
   });
 
   test("timeline reference", () => {
@@ -99,13 +102,7 @@ describe("getReferenceKeyAndPath", () => {
 
   test("throws on missing path segment for external sources", () => {
     // External-source references require at least one path segment.
-    expect(() => getReferenceKeyAndPath("self.participantInfo")).toThrow(
-      "A path must be provided",
-    );
-    expect(() => getReferenceKeyAndPath("self.connectionInfo")).toThrow(
-      "A path must be provided",
-    );
-    expect(() => getReferenceKeyAndPath("self.browserInfo")).toThrow(
+    expect(() => getReferenceKeyAndPath("self.attributes")).toThrow(
       "A path must be provided",
     );
     expect(() => getReferenceKeyAndPath("self.entryUrl")).toThrow(


### PR DESCRIPTION
## Summary

Consolidates the three host-supplied reference sources (`connectionInfo`, `browserInfo`, `participantInfo`) into a single flat external source **`attributes`** (`self.attributes.<field>`), and standardizes the participant identifiers that flow through it. Closes #473.

This is a coordinated breaking change to the reference grammar and the host-storage contract — consumer adaptation is tracked in deliberation-lab/deliberation-lab#294 and deliberation-lab/annotator#214.

## What changed

- **Grammar** — `externalSourceEnum` drops the three legacy bags and adds `attributes`; the old source names are now rejected by validation.
- **Contract** — new `attributesSchema` (zod) + `hasStableParticipantId` helper, exported as the host contract / fixture factory / docs source of truth.
- **`attributes.stableParticipantId`** — the anonymized, release-safe id used to link exported data. Checked **lazily at the one place stagebook consumes it** (the Qualtrics URL-param injection) via a non-blocking `console.error` + optional `onContractViolation` telemetry hook. It is **not** checked eagerly at mount and never blocks the study — presence is enforced upstream (host CI integration test, batch-start preflight, readiness gate; see #294).
- **`attributes.sampleId`** — the per-assignment data-row id, available only from the game phase. Referencing it in intro/groupComposition is a validation error (it's empty there at runtime).
- **Identifier-leak fix** — the Qualtrics element no longer emits the internal `playerId`. It sources `stableParticipantId` + `sampleId` from `attributes` and emits them as URL params named `stableParticipantId` (renamed from `deliberationId`) and `sampleId`. ⚠️ The param rename is an external contract with deployed Qualtrics surveys — see the note on #294.
- **Viewer** — synthesizes a per-position default `stableParticipantId` so previews work without host identity wiring.
- **Docs** — migrated to `attributes.*`; added a privacy-boundary note on `entryUrl.params`.

The recruitment-platform id is deliberately **not** modeled — keeping recruitment PII out of the referenceable surface is the privacy guarantee. `playerId` stays internal and is not referenceable.

## Review

Three subagent reviews (correctness, test coverage, security) were run against the branch before opening; findings folded in:
- **Correctness** — fixed a blocking lint error in the contract test.
- **Coverage** — added an Element-level wiring test (`Element.contract.test.tsx`) verifying `attributes` → Qualtrics URL params and the `onContractViolation` threading end-to-end.
- **Security — safe to merge.** Leak fully closed (`playerId` non-referenceable, only the anonymized id outgoing), telemetry payload value-free, multi-tenant isolation preserved. Added a follow-up doc note on the pre-existing `entryUrl.params` PII passthrough.

## Verification

- vitest: **1561 passing**
- Playwright CT: affected suites green (Element, Qualtrics, Stage)
- lint clean (zero-warning), Prettier clean, build incl. type declarations succeeds, viewer typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
