### PR TITLE
Bump stagebook to 0.18.0

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Minor release standardizing the participant-attributes surface.

## What's in

- **#473 / #477** — Consolidate the three host-supplied reference sources (`connectionInfo`, `browserInfo`, `participantInfo`) into one flat `attributes` source; standardize identifiers (`stableParticipantId`, `sampleId`), fix the internal-`playerId` leak into Qualtrics URLs, and add the `attributesSchema` / `hasStableParticipantId` host contract. **Breaking.**
- **#471** — `compare()` now supports membership conditions on multi-select (array-LHS) values.
- **#475** — Viewer surfaces post-fill validation errors on the field form.
- **#468 / #469** — Docs cleanup of stale `local-penalization` references.

## Compatibility

- **Breaking:** reference sources `connectionInfo` / `browserInfo` / `participantInfo` are removed — references migrate to `attributes.*` (old names now produce a parse error). Hosts must supply a single `attributes` bag including `stableParticipantId`. The Qualtrics URL param `deliberationId` is renamed to `stableParticipantId` — existing Qualtrics surveys must update their embedded-data field.
- `attributes.sampleId` is game-phase-only; referencing it pre-game is a validation error.
- Consumer adaptation: deliberation-lab/deliberation-lab#294, deliberation-lab/annotator#214.
