### PR TITLE
feat(viewer): single sectioned part-picker; walk one unit at a time

### DIFF
--- a/apps/viewer/src/components/OverviewPage.tsx
+++ b/apps/viewer/src/components/OverviewPage.tsx
@@ -22,10 +22,11 @@ export function OverviewPage({
   onSelect,
   onBack,
 }: OverviewPageProps) {
-  // `introSequences` is optional in the schema (a treatments-only file is
-  // valid); normalize to [] so the .length/.map below never throw.
+  // Both arrays are optional in the schema (treatments-only and intro-only
+  // files are valid mid-development states); normalize to [] so the
+  // .length/.map below never throw.
   const introSequences = treatmentFile.introSequences ?? [];
-  const { treatments } = treatmentFile;
+  const treatments = treatmentFile.treatments ?? [];
   const multipleIntros = introSequences.length > 1;
   const multipleTreatments = treatments.length > 1;
 

--- a/apps/viewer/src/components/TreatmentPicker.tsx
+++ b/apps/viewer/src/components/TreatmentPicker.tsx
@@ -9,10 +9,11 @@ export function TreatmentPicker({
   treatmentFile,
   onSelect,
 }: TreatmentPickerProps) {
-  // `introSequences` is optional in the schema (a treatments-only file is
-  // valid); normalize to [] so the .length/.map below never throw.
+  // Both arrays are optional in the schema (treatments-only and intro-only
+  // files are valid mid-development states); normalize to [] so the
+  // .length/.map below never throw.
   const introSequences = treatmentFile.introSequences ?? [];
-  const { treatments } = treatmentFile;
+  const treatments = treatmentFile.treatments ?? [];
   const multipleIntros = introSequences.length > 1;
   const multipleTreatments = treatments.length > 1;
 

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -6,11 +6,7 @@ import {
   useCallback,
   useSyncExternalStore,
 } from "react";
-import type {
-  IntroSequenceType,
-  TreatmentFileType,
-  TreatmentType,
-} from "stagebook";
+import type { TreatmentFileType } from "stagebook";
 import {
   StagebookProvider,
   Stage,
@@ -18,7 +14,7 @@ import {
   useScrollAwareness,
   isRTLLocale,
 } from "stagebook/components";
-import { flattenSteps, localeForPhase } from "../lib/steps";
+import { buildUnits, type ViewerUnit } from "../lib/steps";
 import { ViewerStateStore } from "../lib/store";
 import { createViewerContext } from "../lib/context";
 import { StageNav } from "./StageNav";
@@ -61,13 +57,11 @@ export interface ViewerProps {
    */
   onTreatmentIndexChange?: (index: number) => void;
   /**
-   * Optional setter for `selectedIntroIndex`. When provided AND the
-   * treatment file has 2+ intro sequences, the header renders a
-   * dropdown for picking which intro to preview. The schema requires
-   * a non-empty `introSequences` array, so the only suppressed case
-   * is the single-intro-sequence file (the typical shape) — there
-   * the dropdown is omitted entirely (no static label, since the
-   * intro is implicit context for the visible stages).
+   * Accepted for back-compat with the host's landing flow, but no longer
+   * drives a separate dropdown: intro sequences are now selected through the
+   * unified "part to preview" picker alongside treatments. `selectedIntroIndex`
+   * is likewise accepted but ignored (the viewer defaults to the treatment the
+   * landing picked and lets the part picker switch to an intro).
    */
   onIntroIndexChange?: (index: number) => void;
 }
@@ -76,34 +70,25 @@ export function Viewer({
   treatmentFile,
   getTextContent,
   getAssetURL,
-  selectedIntroIndex,
   selectedTreatmentIndex,
   onBack,
   onRefresh,
   contentVersion,
   onTreatmentIndexChange,
-  onIntroIndexChange,
 }: ViewerProps) {
-  const treatment = treatmentFile.treatments[selectedTreatmentIndex];
-  const introSequence = treatmentFile.introSequences?.[selectedIntroIndex];
-
-  // Whether to render the treatment/intro selectors as dropdowns.
-  // When the host doesn't pass setters the viewer is uncontrolled
-  // and falls back to the static-label layout. With only one
-  // treatment the dropdown collapses to a static name label
-  // (researchers still want to see *which* treatment they're
-  // looking at). With only one intro sequence the picker is
-  // omitted entirely — the intro is implicit context, not
-  // foreground UI worth labeling.
-  const showTreatmentPicker =
-    !!onTreatmentIndexChange && treatmentFile.treatments.length > 1;
-  const showIntroPicker =
-    !!onIntroIndexChange && (treatmentFile.introSequences?.length ?? 0) > 1;
-
-  const steps = useMemo(
-    () => flattenSteps(introSequence, treatment),
-    [introSequence, treatment],
+  // The viewer walks ONE selectable unit at a time — an intro sequence OR a
+  // treatment — rather than pairing an intro with a treatment. A single
+  // <optgroup> picker switches between them; each unit declares its own locale
+  // and ends with a transition screen narrating the platform's next phase.
+  const units = useMemo(() => buildUnits(treatmentFile), [treatmentFile]);
+  const introUnits = units.filter((u) => u.kind === "intro");
+  const treatmentUnits = units.filter((u) => u.kind === "treatment");
+  const [selectedUnitKey, setSelectedUnitKey] = useState(
+    `treatment:${selectedTreatmentIndex}`,
   );
+  const unit: ViewerUnit | undefined =
+    units.find((u) => u.key === selectedUnitKey) ?? units[0];
+  const steps = unit?.steps ?? [];
 
   const [stageIndex, setStageIndex] = useState(0);
   // Bumped when the researcher clicks "Reset stage" in the inspector;
@@ -115,6 +100,10 @@ export function Viewer({
   const handleResetStage = useCallback(() => {
     setStageResetVersion((v) => v + 1);
   }, []);
+  // Reset the selected unit when the whole file is swapped (different study).
+  useEffect(() => {
+    setSelectedUnitKey(`treatment:${selectedTreatmentIndex}`);
+  }, [treatmentFile, selectedTreatmentIndex]);
   const [position, setPosition] = useState(0);
   const [store] = useState(() => new ViewerStateStore());
   const stageContainerRef = useRef<HTMLDivElement | null>(null);
@@ -135,6 +124,11 @@ export function Viewer({
     }
   }, [steps.length, stageIndex]);
 
+  // Restart at the first step whenever the selected unit changes.
+  useEffect(() => {
+    setStageIndex(0);
+  }, [selectedUnitKey]);
+
   // Subscribe to store changes so the UI re-renders.
   // The version is included in ctx memo deps below so that
   // StagebookProvider gets a new context value on store changes.
@@ -146,13 +140,9 @@ export function Viewer({
   const currentStep = steps[stageIndex];
   const isSubmitted = store.getSubmitted(stageIndex);
 
-  // Locale follows the PHASE: intro steps render under the intro sequence's
-  // declared locale (intro runs before treatment assignment, so it carries
-  // its own), game + exit stages under the treatment's. Both default to
-  // English. Which locale a real participant sees is the host's assignment
-  // decision; the viewer just renders what each phase declares — and surfaces
-  // it in the header so it's explicit.
-  const locale = localeForPhase(currentStep?.phase, introSequence, treatment);
+  // Each unit declares its own locale (intro sequences run before treatment
+  // assignment, so they carry their own); shown in the header so it's explicit.
+  const locale = unit?.locale ?? "en";
 
   const handleSubmit = useCallback(() => {
     store.setSubmitted(stageIndex, true);
@@ -175,7 +165,7 @@ export function Viewer({
         store,
         position,
         stageIndex,
-        playerCount: treatment.playerCount,
+        playerCount: unit?.playerCount ?? 1,
         locale,
         onSubmit: handleSubmit,
         getTextContent,
@@ -189,7 +179,7 @@ export function Viewer({
       storeVersion,
       position,
       stageIndex,
-      treatment.playerCount,
+      unit?.playerCount,
       locale,
       handleSubmit,
       getTextContent,
@@ -198,7 +188,7 @@ export function Viewer({
     ],
   );
 
-  if (!currentStep) return null;
+  if (!unit || !currentStep) return null;
 
   const stageConfig = {
     name: currentStep.name,
@@ -228,39 +218,42 @@ export function Viewer({
               &#x21bb;
             </button>
           )}
-          {showTreatmentPicker ? (
+          {units.length > 1 ? (
             <select
-              aria-label="Treatment"
-              title="Treatment"
-              value={selectedTreatmentIndex}
-              onChange={(e) => onTreatmentIndexChange?.(Number(e.target.value))}
+              aria-label="Part to preview"
+              title="Part of the study to preview"
+              value={unit.key}
+              onChange={(e) => {
+                const key = e.target.value;
+                setSelectedUnitKey(key);
+                // Keep the host's treatment index in sync for back/refresh.
+                if (key.startsWith("treatment:")) {
+                  onTreatmentIndexChange?.(
+                    Number(key.slice("treatment:".length)),
+                  );
+                }
+              }}
               style={treatmentSelectStyle}
             >
-              {(treatmentFile.treatments as TreatmentType[]).map((t, i) => (
-                <option key={i} value={i}>
-                  {t.name}
-                </option>
-              ))}
+              {introUnits.length > 0 && (
+                <optgroup label="Intro sequences">
+                  {introUnits.map((u) => (
+                    <option key={u.key} value={u.key}>
+                      {u.name}
+                    </option>
+                  ))}
+                </optgroup>
+              )}
+              <optgroup label="Treatments">
+                {treatmentUnits.map((u) => (
+                  <option key={u.key} value={u.key}>
+                    {u.name}
+                  </option>
+                ))}
+              </optgroup>
             </select>
           ) : (
-            <span style={treatmentNameStyle}>{treatment.name}</span>
-          )}
-          {showIntroPicker && (
-            <select
-              aria-label="Intro sequence"
-              title="Intro sequence"
-              value={selectedIntroIndex}
-              onChange={(e) => onIntroIndexChange?.(Number(e.target.value))}
-              style={treatmentSelectStyle}
-            >
-              {(treatmentFile.introSequences as IntroSequenceType[]).map(
-                (seq, i) => (
-                  <option key={i} value={i}>
-                    {seq.name ?? `Intro ${i}`}
-                  </option>
-                ),
-              )}
-            </select>
+            <span style={treatmentNameStyle}>{unit.name}</span>
           )}
           <span style={headerDividerStyle} aria-hidden="true" />
           <StageNav
@@ -279,7 +272,7 @@ export function Viewer({
               (intro sequence vs treatment) — explicit, never overridden. */}
           <span
             data-testid="viewer-locale-badge"
-            title={`Locale declared by the current ${currentStep.phase} phase`}
+            title={`Locale declared by this ${unit.kind === "intro" ? "intro sequence" : "treatment"}`}
             style={localeBadgeStyle}
           >
             {locale}
@@ -293,7 +286,7 @@ export function Viewer({
             onChange={(e) => setPosition(Number(e.target.value))}
             style={positionSelectStyle}
           >
-            {Array.from({ length: treatment.playerCount }, (_, i) => (
+            {Array.from({ length: unit.playerCount }, (_, i) => (
               <option key={i} value={i}>
                 {i}
               </option>
@@ -309,7 +302,7 @@ export function Viewer({
             currentStep={currentStep}
             stageIndex={stageIndex}
             position={position}
-            playerCount={treatment.playerCount}
+            playerCount={unit.playerCount}
             onResetStage={handleResetStage}
           />
         </aside>
@@ -320,7 +313,11 @@ export function Viewer({
           dir={isRTLLocale(locale) ? "rtl" : "ltr"}
           style={mainStyle}
         >
-          {isSubmitted ? (
+          {currentStep.isTransition ? (
+            <div data-testid="viewer-transition" style={transitionPanelStyle}>
+              <p style={transitionTextStyle}>{currentStep.transitionCopy}</p>
+            </div>
+          ) : isSubmitted ? (
             <div style={submittedOverlayStyle}>
               <p style={submittedTextStyle}>
                 Waiting for other participants...
@@ -367,6 +364,26 @@ export function Viewer({
 }
 
 // --- Styles ---
+
+const transitionPanelStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  minHeight: "60vh",
+  padding: "2rem",
+};
+
+const transitionTextStyle: React.CSSProperties = {
+  maxWidth: "32rem",
+  textAlign: "center",
+  fontSize: "0.9375rem",
+  lineHeight: 1.6,
+  color: "#4b5563",
+  background: "#f9fafb",
+  border: "1px dashed #d1d5db",
+  borderRadius: "0.5rem",
+  padding: "1.5rem 1.75rem",
+};
 
 const layoutStyle: React.CSSProperties = {
   display: "flex",

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -188,6 +188,20 @@ export function Viewer({
     ],
   );
 
+  // Nothing to walk: a file with neither intro sequences nor treatments.
+  // That's a valid empty-canvas / just-started state, not an error — so we
+  // show a friendly placeholder rather than a blank screen or a crash.
+  if (units.length === 0) {
+    return (
+      <div style={transitionPanelStyle}>
+        <p data-testid="viewer-empty" style={transitionTextStyle}>
+          Nothing to preview yet. Add an intro sequence or a treatment to this
+          file and the walkthrough will appear here.
+        </p>
+      </div>
+    );
+  }
+
   if (!unit || !currentStep) return null;
 
   const stageConfig = {

--- a/apps/viewer/src/components/Viewer.tsx
+++ b/apps/viewer/src/components/Viewer.tsx
@@ -14,7 +14,7 @@ import {
   useScrollAwareness,
   isRTLLocale,
 } from "stagebook/components";
-import { buildUnits, type ViewerUnit } from "../lib/steps";
+import { buildUnits, initialUnitKey, type ViewerUnit } from "../lib/steps";
 import { ViewerStateStore } from "../lib/store";
 import { createViewerContext } from "../lib/context";
 import { StageNav } from "./StageNav";
@@ -57,11 +57,12 @@ export interface ViewerProps {
    */
   onTreatmentIndexChange?: (index: number) => void;
   /**
-   * Accepted for back-compat with the host's landing flow, but no longer
-   * drives a separate dropdown: intro sequences are now selected through the
-   * unified "part to preview" picker alongside treatments. `selectedIntroIndex`
-   * is likewise accepted but ignored (the viewer defaults to the treatment the
-   * landing picked and lets the part picker switch to an intro).
+   * Setter for the host's intro-sequence index. Intro sequences no longer have
+   * a separate dropdown — they're selected through the unified "part to
+   * preview" picker — but the viewer still calls this when an intro is picked
+   * so the host's persisted selection (and thus the post-refresh restore in the
+   * VS Code preview) tracks the active unit. `selectedIntroIndex` seeds the
+   * initial unit when no treatment is selectable (e.g. an intro-only file).
    */
   onIntroIndexChange?: (index: number) => void;
 }
@@ -70,11 +71,13 @@ export function Viewer({
   treatmentFile,
   getTextContent,
   getAssetURL,
+  selectedIntroIndex,
   selectedTreatmentIndex,
   onBack,
   onRefresh,
   contentVersion,
   onTreatmentIndexChange,
+  onIntroIndexChange,
 }: ViewerProps) {
   // The viewer walks ONE selectable unit at a time — an intro sequence OR a
   // treatment — rather than pairing an intro with a treatment. A single
@@ -83,8 +86,8 @@ export function Viewer({
   const units = useMemo(() => buildUnits(treatmentFile), [treatmentFile]);
   const introUnits = units.filter((u) => u.kind === "intro");
   const treatmentUnits = units.filter((u) => u.kind === "treatment");
-  const [selectedUnitKey, setSelectedUnitKey] = useState(
-    `treatment:${selectedTreatmentIndex}`,
+  const [selectedUnitKey, setSelectedUnitKey] = useState(() =>
+    initialUnitKey(units, selectedIntroIndex, selectedTreatmentIndex),
   );
   const unit: ViewerUnit | undefined =
     units.find((u) => u.key === selectedUnitKey) ?? units[0];
@@ -100,10 +103,18 @@ export function Viewer({
   const handleResetStage = useCallback(() => {
     setStageResetVersion((v) => v + 1);
   }, []);
-  // Reset the selected unit when the whole file is swapped (different study).
+  // When the file changes, keep the current selection if it still exists —
+  // an in-place refresh (VS Code save, same study) must NOT yank the user off
+  // the intro they were previewing back to a treatment (#485 review). Only when
+  // the selected unit is gone (study swapped, or the researcher deleted it) do
+  // we fall back to the host's landing selection.
   useEffect(() => {
-    setSelectedUnitKey(`treatment:${selectedTreatmentIndex}`);
-  }, [treatmentFile, selectedTreatmentIndex]);
+    setSelectedUnitKey((prev) =>
+      units.some((u) => u.key === prev)
+        ? prev
+        : initialUnitKey(units, selectedIntroIndex, selectedTreatmentIndex),
+    );
+  }, [treatmentFile, units, selectedIntroIndex, selectedTreatmentIndex]);
   const [position, setPosition] = useState(0);
   const [store] = useState(() => new ViewerStateStore());
   const stageContainerRef = useRef<HTMLDivElement | null>(null);
@@ -124,10 +135,18 @@ export function Viewer({
     }
   }, [steps.length, stageIndex]);
 
-  // Restart at the first step whenever the selected unit changes.
+  // Restart at the first step whenever the selected unit changes, and give the
+  // new unit a clean slate: submitted flags + elapsed time are keyed by numeric
+  // stageIndex, so without clearing them an intro's submitted[0] would make the
+  // treatment's first stage read as already-submitted (waiting overlay), and a
+  // stale participant `position` could exceed the new unit's playerCount
+  // (#485 review). The store wipe only fires on an actual unit switch — an
+  // in-place refresh keeps the same key, so saved responses persist as before.
   useEffect(() => {
     setStageIndex(0);
-  }, [selectedUnitKey]);
+    setPosition(0);
+    store.clearAll();
+  }, [selectedUnitKey, store]);
 
   // Subscribe to store changes so the UI re-renders.
   // The version is included in ctx memo deps below so that
@@ -143,6 +162,14 @@ export function Viewer({
   // Each unit declares its own locale (intro sequences run before treatment
   // assignment, so they carry their own); shown in the header so it's explicit.
   const locale = unit?.locale ?? "en";
+
+  // Switching to a smaller unit (an intro is always 1 player; a treatment may
+  // have fewer) can leave `position` past the new range for the render before
+  // the unit-switch effect resets it. Clamp here so the position <select> never
+  // shows a value with no matching option and the context never reports an
+  // impossible participant index (#485 review).
+  const playerCount = unit?.playerCount ?? 1;
+  const clampedPosition = Math.min(position, Math.max(0, playerCount - 1));
 
   const handleSubmit = useCallback(() => {
     store.setSubmitted(stageIndex, true);
@@ -163,9 +190,9 @@ export function Viewer({
     () =>
       createViewerContext({
         store,
-        position,
+        position: clampedPosition,
         stageIndex,
-        playerCount: unit?.playerCount ?? 1,
+        playerCount,
         locale,
         onSubmit: handleSubmit,
         getTextContent,
@@ -177,9 +204,9 @@ export function Viewer({
     [
       store,
       storeVersion,
-      position,
+      clampedPosition,
       stageIndex,
-      unit?.playerCount,
+      playerCount,
       locale,
       handleSubmit,
       getTextContent,
@@ -188,16 +215,46 @@ export function Viewer({
     ],
   );
 
+  // Host-owned navigation affordances (back to landing, refresh the preview).
+  // Shared between the normal header and the empty-state header so neither
+  // strands the user without a way back / a refresh after adding content.
+  const hostControls = (
+    <>
+      {onBack && (
+        <button aria-label="Back" onClick={onBack} style={backButtonStyle}>
+          &larr;
+        </button>
+      )}
+      {onRefresh && (
+        <button
+          aria-label="Refresh preview"
+          title="Refresh preview"
+          onClick={onRefresh}
+          style={refreshButtonStyle}
+        >
+          &#x21bb;
+        </button>
+      )}
+    </>
+  );
+
   // Nothing to walk: a file with neither intro sequences nor treatments.
   // That's a valid empty-canvas / just-started state, not an error — so we
-  // show a friendly placeholder rather than a blank screen or a crash.
+  // show a friendly placeholder rather than a blank screen or a crash. Keep
+  // the header so back/refresh stay available — in VS Code you refresh here
+  // after adding the first intro sequence or treatment (#485 review).
   if (units.length === 0) {
     return (
-      <div style={transitionPanelStyle}>
-        <p data-testid="viewer-empty" style={transitionTextStyle}>
-          Nothing to preview yet. Add an intro sequence or a treatment to this
-          file and the walkthrough will appear here.
-        </p>
+      <div style={layoutStyle}>
+        <header style={headerStyle}>
+          <div style={headerLeftStyle}>{hostControls}</div>
+        </header>
+        <div style={transitionPanelStyle}>
+          <p data-testid="viewer-empty" style={transitionTextStyle}>
+            Nothing to preview yet. Add an intro sequence or a treatment to this
+            file and the walkthrough will appear here.
+          </p>
+        </div>
       </div>
     );
   }
@@ -217,21 +274,7 @@ export function Viewer({
       {/* Header */}
       <header style={headerStyle}>
         <div style={headerLeftStyle}>
-          {onBack && (
-            <button aria-label="Back" onClick={onBack} style={backButtonStyle}>
-              &larr;
-            </button>
-          )}
-          {onRefresh && (
-            <button
-              aria-label="Refresh preview"
-              title="Refresh preview"
-              onClick={onRefresh}
-              style={refreshButtonStyle}
-            >
-              &#x21bb;
-            </button>
-          )}
+          {hostControls}
           {units.length > 1 ? (
             <select
               aria-label="Part to preview"
@@ -240,11 +283,15 @@ export function Viewer({
               onChange={(e) => {
                 const key = e.target.value;
                 setSelectedUnitKey(key);
-                // Keep the host's treatment index in sync for back/refresh.
+                // Keep the host's persisted selection in sync so the VS Code
+                // preview restores this unit (not the previous treatment) after
+                // a refresh (#485 review).
                 if (key.startsWith("treatment:")) {
                   onTreatmentIndexChange?.(
                     Number(key.slice("treatment:".length)),
                   );
+                } else if (key.startsWith("intro:")) {
+                  onIntroIndexChange?.(Number(key.slice("intro:".length)));
                 }
               }}
               style={treatmentSelectStyle}
@@ -296,11 +343,11 @@ export function Viewer({
           </label>
           <select
             id="position-select"
-            value={position}
+            value={clampedPosition}
             onChange={(e) => setPosition(Number(e.target.value))}
             style={positionSelectStyle}
           >
-            {Array.from({ length: unit.playerCount }, (_, i) => (
+            {Array.from({ length: playerCount }, (_, i) => (
               <option key={i} value={i}>
                 {i}
               </option>
@@ -315,8 +362,8 @@ export function Viewer({
             store={store}
             currentStep={currentStep}
             stageIndex={stageIndex}
-            position={position}
-            playerCount={unit.playerCount}
+            position={clampedPosition}
+            playerCount={playerCount}
             onResetStage={handleResetStage}
           />
         </aside>

--- a/apps/viewer/src/components/introSequencesOptional.test.tsx
+++ b/apps/viewer/src/components/introSequencesOptional.test.tsx
@@ -138,8 +138,8 @@ describe("treatments-only file renders (no introSequences)", () => {
   });
 });
 
-describe("viewer per-phase locale", () => {
-  it("badge follows the phase: intro sequence's locale, then the treatment's", () => {
+describe("viewer unit selection (one unit at a time)", () => {
+  it("the locale badge follows the SELECTED unit (intro vs treatment)", () => {
     const { container, unmount } = render(
       <Viewer
         treatmentFile={introHeTreatmentEnFile()}
@@ -152,20 +152,53 @@ describe("viewer per-phase locale", () => {
     const badge = () =>
       container.querySelector('[data-testid="viewer-locale-badge"]')
         ?.textContent;
-    // stageIndex 0 = the intro step → intro sequence locale (he).
-    expect(badge()).toBe("he");
-
-    // Navigate to the game stage via the StageNav <select>; the catalog must
-    // re-resolve (the `locale` useMemo dep) so the badge flips to en.
-    const select = container.querySelector(
-      "select",
-    ) as HTMLSelectElement | null;
-    expect(select).not.toBeNull();
-    act(() => {
-      select!.value = "1";
-      select!.dispatchEvent(new Event("change", { bubbles: true }));
-    });
+    // Starts on the treatment unit (en).
     expect(badge()).toBe("en");
+
+    // Switch to the intro-sequence unit via the part picker → badge flips to he
+    // (each unit declares its own locale; the catalog re-resolves).
+    const picker = container.querySelector(
+      'select[aria-label="Part to preview"]',
+    ) as HTMLSelectElement | null;
+    expect(picker).not.toBeNull();
+    act(() => {
+      picker!.value = "intro:0";
+      picker!.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(badge()).toBe("he");
+    unmount();
+  });
+
+  it("ends a unit with a transition screen, not a stage", () => {
+    const { container, unmount } = render(
+      <Viewer
+        treatmentFile={introHeTreatmentEnFile()}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+      />,
+    );
+    // The treatment unit here is one stage + a transition. Navigate to the
+    // last step (the transition) via StageNav's stage <select>.
+    const stageSelect = container.querySelector(
+      'select[aria-label="Stage"], select[title="Stage"]',
+    ) as HTMLSelectElement | null;
+    // Fallback: the stage selector is the one whose options are stage indices.
+    const selects = Array.from(container.querySelectorAll("select"));
+    const nav =
+      stageSelect ??
+      (selects.find((sel) =>
+        Array.from(sel.options).some((o) => o.value === "1"),
+      ) as HTMLSelectElement | undefined);
+    expect(nav).toBeTruthy();
+    act(() => {
+      nav!.value = "1";
+      nav!.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(
+      container.querySelector('[data-testid="viewer-transition"]'),
+    ).not.toBeNull();
     unmount();
   });
 });

--- a/apps/viewer/src/components/introSequencesOptional.test.tsx
+++ b/apps/viewer/src/components/introSequencesOptional.test.tsx
@@ -74,6 +74,25 @@ function treatmentsOnlyFile(locale?: string): TreatmentFileType {
   } as unknown as TreatmentFileType;
 }
 
+/** A valid intro-only file: no `treatments:` key at all. The structure you
+ *  preview while still building the intro, before any treatment exists. */
+function introOnlyFile(): TreatmentFileType {
+  return {
+    introSequences: [
+      {
+        name: "intro1",
+        locale: "en",
+        introSteps: [{ name: "welcome", elements: [{ type: "submitButton" }] }],
+      },
+    ],
+  } as unknown as TreatmentFileType;
+}
+
+/** An empty file: neither intro sequences nor treatments. */
+function emptyFile(): TreatmentFileType {
+  return {} as unknown as TreatmentFileType;
+}
+
 /** he intro sequence + en treatment, to exercise per-phase locale. */
 function introHeTreatmentEnFile(): TreatmentFileType {
   return {
@@ -134,6 +153,68 @@ describe("treatments-only file renders (no introSequences)", () => {
       '[data-testid="viewer-locale-badge"]',
     );
     expect(badge?.textContent).toBe("he");
+    unmount();
+  });
+});
+
+describe("intro-only file renders (no treatments)", () => {
+  // Symmetric to the treatments-only case: `treatments` is also optional in
+  // the schema, so previewing while you've only built the intro must not
+  // crash. See #476 (the secondary note).
+  it("OverviewPage does not crash", () => {
+    const { container, unmount } = render(
+      <OverviewPage
+        treatmentFile={introOnlyFile()}
+        readmeContent={null}
+        onSelect={noop}
+      />,
+    );
+    expect(container.textContent).toBeTruthy();
+    unmount();
+  });
+
+  it("TreatmentPicker does not crash", () => {
+    const { container, unmount } = render(
+      <TreatmentPicker treatmentFile={introOnlyFile()} onSelect={noop} />,
+    );
+    expect(container.textContent).toBeTruthy();
+    unmount();
+  });
+
+  it("Viewer starts at the intro unit", () => {
+    const { container, unmount } = render(
+      <Viewer
+        treatmentFile={introOnlyFile()}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+      />,
+    );
+    // No treatment unit exists, so the viewer falls back to the only unit
+    // (the intro) rather than blanking. Locale badge shows its locale.
+    const badge = container.querySelector(
+      '[data-testid="viewer-locale-badge"]',
+    );
+    expect(badge?.textContent).toBe("en");
+    unmount();
+  });
+});
+
+describe("empty file renders a placeholder (no intro, no treatment)", () => {
+  it("Viewer shows the empty-state, not a blank screen or crash", () => {
+    const { container, unmount } = render(
+      <Viewer
+        treatmentFile={emptyFile()}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+      />,
+    );
+    expect(
+      container.querySelector('[data-testid="viewer-empty"]'),
+    ).not.toBeNull();
     unmount();
   });
 });

--- a/apps/viewer/src/components/introSequencesOptional.test.tsx
+++ b/apps/viewer/src/components/introSequencesOptional.test.tsx
@@ -35,6 +35,7 @@ beforeAll(() => {
 
 function render(node: ReactNode): {
   container: HTMLElement;
+  rerender: (next: ReactNode) => void;
   unmount: () => void;
 } {
   const container = document.createElement("div");
@@ -46,12 +47,28 @@ function render(node: ReactNode): {
   });
   return {
     container,
+    rerender: (next: ReactNode) =>
+      act(() => {
+        root.render(next);
+      }),
     unmount: () =>
       act(() => {
         root.unmount();
         container.remove();
       }),
   };
+}
+
+/** Switch the "part to preview" picker to the given unit key. */
+function selectUnit(container: HTMLElement, key: string): void {
+  const picker = container.querySelector(
+    'select[aria-label="Part to preview"]',
+  ) as HTMLSelectElement | null;
+  if (!picker) throw new Error("part picker not found");
+  act(() => {
+    picker.value = key;
+    picker.dispatchEvent(new Event("change", { bubbles: true }));
+  });
 }
 
 const noop = () => {};
@@ -91,6 +108,30 @@ function introOnlyFile(): TreatmentFileType {
 /** An empty file: neither intro sequences nor treatments. */
 function emptyFile(): TreatmentFileType {
   return {} as unknown as TreatmentFileType;
+}
+
+/** An intro (with a submit button) plus a treatment of `playerCount` players,
+ *  to exercise unit-switch state hygiene (submitted flags, position). */
+function introPlusTreatmentFile(playerCount = 3): TreatmentFileType {
+  return {
+    introSequences: [
+      {
+        name: "intro1",
+        locale: "en",
+        introSteps: [{ name: "consent", elements: [{ type: "submitButton" }] }],
+      },
+    ],
+    treatments: [
+      {
+        name: "study1",
+        locale: "en",
+        playerCount,
+        gameStages: [
+          { name: "s1", duration: 60, elements: [{ type: "submitButton" }] },
+        ],
+      },
+    ],
+  } as unknown as TreatmentFileType;
 }
 
 /** he intro sequence + en treatment, to exercise per-phase locale. */
@@ -215,6 +256,124 @@ describe("empty file renders a placeholder (no intro, no treatment)", () => {
     expect(
       container.querySelector('[data-testid="viewer-empty"]'),
     ).not.toBeNull();
+    unmount();
+  });
+
+  it("keeps the back + refresh controls so the user isn't stranded", () => {
+    // In VS Code you refresh the empty preview after adding the first part;
+    // in the standalone app you need a way back to the landing page.
+    const { container, unmount } = render(
+      <Viewer
+        treatmentFile={emptyFile()}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+        onBack={noop}
+        onRefresh={noop}
+      />,
+    );
+    expect(container.querySelector('[aria-label="Back"]')).not.toBeNull();
+    expect(
+      container.querySelector('[aria-label="Refresh preview"]'),
+    ).not.toBeNull();
+    unmount();
+  });
+});
+
+describe("unit-switch state hygiene", () => {
+  it("does not carry a submitted intro step into the treatment's first stage", () => {
+    const { container, unmount } = render(
+      <Viewer
+        treatmentFile={introPlusTreatmentFile()}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+      />,
+    );
+    const main = () => container.querySelector("main")!;
+
+    // Switch to the intro unit and submit its only step → waiting overlay.
+    selectUnit(container, "intro:0");
+    const submit = main().querySelector(
+      '[data-testid="submitButton"]',
+    ) as HTMLButtonElement | null;
+    expect(submit).not.toBeNull();
+    act(() => {
+      submit!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(main().textContent).toContain("Waiting for other participants");
+
+    // Switch to the treatment: its first stage must render fresh, NOT inherit
+    // the intro's submitted[0] (which would show the waiting overlay).
+    selectUnit(container, "treatment:0");
+    expect(main().textContent).not.toContain("Waiting for other participants");
+    expect(main().querySelector('[data-testid="submitButton"]')).not.toBeNull();
+    unmount();
+  });
+
+  it("clamps the participant position when switching to a 1-player unit", () => {
+    const { container, unmount } = render(
+      <Viewer
+        treatmentFile={introPlusTreatmentFile(3)}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+      />,
+    );
+    const positionSelect = () =>
+      container.querySelector("#position-select") as HTMLSelectElement;
+
+    // On the 3-player treatment, pick participant 2.
+    expect(positionSelect().options).toHaveLength(3);
+    act(() => {
+      positionSelect().value = "2";
+      positionSelect().dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(positionSelect().value).toBe("2");
+
+    // Switch to the intro (always 1 player): the select must collapse to a
+    // single in-range option, not keep an impossible index.
+    selectUnit(container, "intro:0");
+    expect(positionSelect().options).toHaveLength(1);
+    expect(positionSelect().value).toBe("0");
+    unmount();
+  });
+});
+
+describe("selection survives an in-place refresh", () => {
+  it("stays on the chosen intro when the file is re-supplied (VS Code save)", () => {
+    const { container, rerender, unmount } = render(
+      <Viewer
+        treatmentFile={introHeTreatmentEnFile()}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+      />,
+    );
+    const badge = () =>
+      container.querySelector('[data-testid="viewer-locale-badge"]')
+        ?.textContent;
+
+    // Choose the intro unit (he).
+    selectUnit(container, "intro:0");
+    expect(badge()).toBe("he");
+
+    // A refresh hands us a fresh-but-equal treatmentFile object. The viewer
+    // must keep the intro the user was on, not snap back to the treatment.
+    rerender(
+      <Viewer
+        treatmentFile={introHeTreatmentEnFile()}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+      />,
+    );
+    expect(badge()).toBe("he");
     unmount();
   });
 });

--- a/apps/viewer/src/lib/selection.test.ts
+++ b/apps/viewer/src/lib/selection.test.ts
@@ -2,10 +2,11 @@ import { describe, it, expect } from "vitest";
 import { needsOverviewPicker } from "./selection";
 import type { TreatmentFileType } from "stagebook";
 
-// `introSequences` is `any`-typed in the built .d.ts (altTemplateContext), so
-// tsc can't catch a `.length`-on-undefined regression here — these tests are
-// the guard. A treatments-only file (no `introSequences:`) is valid and must
-// not throw. (This computation crashed on such files; see #479.)
+// Both arrays are `any`-typed in the built .d.ts (altTemplateContext), so tsc
+// can't catch a `.length`-on-undefined regression here — these tests are the
+// guard. A treatments-only file (no `introSequences:`) AND an intro-only file
+// (no `treatments:`) are both valid mid-development states and must not throw.
+// (This computation crashed on treatments-only files; see #476/#479.)
 
 function file(parts: Partial<TreatmentFileType>): TreatmentFileType {
   return parts as TreatmentFileType;
@@ -30,6 +31,25 @@ describe("needsOverviewPicker", () => {
         file({ treatments: [{ name: "a" }, { name: "b" }] as never }),
       ),
     ).toBe(true);
+  });
+
+  it("does not throw on an intro-only file (no treatments)", () => {
+    // The structure you preview while still building the intro, before any
+    // treatment exists. Valid; symmetric to the treatments-only case.
+    expect(() =>
+      needsOverviewPicker(file({ introSequences: [{ name: "i1" }] as never })),
+    ).not.toThrow();
+  });
+
+  it("is false for a single intro and no treatments", () => {
+    expect(
+      needsOverviewPicker(file({ introSequences: [{ name: "i1" }] as never })),
+    ).toBe(false);
+  });
+
+  it("does not throw on an empty file (no intros, no treatments)", () => {
+    expect(() => needsOverviewPicker(file({}))).not.toThrow();
+    expect(needsOverviewPicker(file({}))).toBe(false);
   });
 
   it("is true with 2+ intro sequences", () => {

--- a/apps/viewer/src/lib/selection.ts
+++ b/apps/viewer/src/lib/selection.ts
@@ -5,16 +5,21 @@ import type { TreatmentFileType } from "stagebook";
  *
  * True when there's a choice to make: 2+ intro sequences or 2+ treatments.
  *
- * `introSequences` is optional in the schema (a treatments-only file is
- * valid), and — critically — `altTemplateContext` types it as `any` in the
- * built `.d.ts`, so tsc will NOT flag a bare `.length` here. The `?? 0`
- * guard is load-bearing: a treatments-only file previously crashed this exact
+ * Both `introSequences` and `treatments` are optional in the schema — a
+ * treatments-only file (no intro yet) and an intro-only file (the structure
+ * you preview while still building the intro, before any treatment exists)
+ * are both valid mid-development states, not errors. Neither completeness
+ * check belongs in static validation: "is there a treatment to assign people
+ * to?" is a launch-time concern the host enforces, not an authoring error.
+ * Critically, `altTemplateContext` types both fields as `any` in the built
+ * `.d.ts`, so tsc will NOT flag a bare `.length` here. The `?? 0` guards are
+ * load-bearing: a treatments-only file previously crashed this exact
  * computation. Kept as a pure, tested function so a regression can't slip past
  * the type checker (it can't see the optionality) AND the test suite.
  */
 export function needsOverviewPicker(treatmentFile: TreatmentFileType): boolean {
   return (
     (treatmentFile.introSequences?.length ?? 0) > 1 ||
-    treatmentFile.treatments.length > 1
+    (treatmentFile.treatments?.length ?? 0) > 1
   );
 }

--- a/apps/viewer/src/lib/steps.test.ts
+++ b/apps/viewer/src/lib/steps.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { flattenSteps, localeForPhase } from "./steps";
+import { flattenSteps, localeForPhase, buildUnits } from "./steps";
 
 describe("flattenSteps", () => {
   const introSequence = {
@@ -200,5 +200,86 @@ describe("localeForPhase", () => {
     expect(localeForPhase("intro", {}, {})).toBe("en");
     expect(localeForPhase("game", undefined, {})).toBe("en");
     expect(localeForPhase(undefined, undefined, {})).toBe("en");
+  });
+});
+
+describe("buildUnits", () => {
+  const treatment = {
+    name: "treatment1",
+    playerCount: 2,
+    gameStages: [
+      { name: "round1", duration: 60, elements: [] },
+      { name: "round2", duration: 120, elements: [] },
+    ],
+    exitSequence: [{ name: "debrief", elements: [] }],
+  };
+
+  it("yields one unit per intro sequence and treatment, in picker order", () => {
+    const file = {
+      introSequences: [
+        {
+          name: "consent",
+          locale: "he",
+          introSteps: [{ name: "c1", elements: [] }],
+        },
+      ],
+      treatments: [treatment, { ...treatment, name: "treatment2" }],
+    };
+    const units = buildUnits(file);
+    expect(units.map((u) => u.key)).toEqual([
+      "intro:0",
+      "treatment:0",
+      "treatment:1",
+    ]);
+    expect(units.map((u) => u.kind)).toEqual([
+      "intro",
+      "treatment",
+      "treatment",
+    ]);
+  });
+
+  it("each unit carries its own locale + playerCount", () => {
+    const units = buildUnits({
+      introSequences: [
+        { name: "i", locale: "he", introSteps: [{ name: "s", elements: [] }] },
+      ],
+      treatments: [{ ...treatment, locale: "en", playerCount: 3 }],
+    });
+    expect(units[0]).toMatchObject({
+      kind: "intro",
+      locale: "he",
+      playerCount: 1,
+    });
+    expect(units[1]).toMatchObject({
+      kind: "treatment",
+      locale: "en",
+      playerCount: 3,
+    });
+  });
+
+  it("appends a transition step to each unit", () => {
+    const units = buildUnits({ treatments: [treatment] });
+    const last = units[0].steps[units[0].steps.length - 1];
+    expect(last.isTransition).toBe(true);
+    expect(last.transitionCopy).toContain(treatment.name);
+    // The real stages still precede it.
+    expect(
+      units[0].steps.filter((s) => !s.isTransition).map((s) => s.name),
+    ).toEqual(["round1", "round2", "debrief"]);
+  });
+
+  it("handles a treatments-only file (no introSequences)", () => {
+    const units = buildUnits({ treatments: [treatment] });
+    expect(units.every((u) => u.kind === "treatment")).toBe(true);
+  });
+
+  it("handles an intro-only file (no treatments)", () => {
+    const units = buildUnits({
+      introSequences: [
+        { name: "i", introSteps: [{ name: "s", elements: [] }] },
+      ],
+    });
+    expect(units).toHaveLength(1);
+    expect(units[0].kind).toBe("intro");
   });
 });

--- a/apps/viewer/src/lib/steps.test.ts
+++ b/apps/viewer/src/lib/steps.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { flattenSteps, localeForPhase, buildUnits } from "./steps";
+import {
+  flattenSteps,
+  localeForPhase,
+  buildUnits,
+  initialUnitKey,
+} from "./steps";
 
 describe("flattenSteps", () => {
   const introSequence = {
@@ -281,5 +286,80 @@ describe("buildUnits", () => {
     });
     expect(units).toHaveLength(1);
     expect(units[0].kind).toBe("intro");
+  });
+
+  it("transition copy only points at the picker when 2+ units exist", () => {
+    // Single treatment → no picker, so no 'picker above' instruction.
+    const solo = buildUnits({ treatments: [treatment] });
+    const soloCopy = solo[0].steps.at(-1)!.transitionCopy!;
+    expect(soloCopy).toContain(treatment.name);
+    expect(soloCopy).not.toMatch(/picker above/i);
+
+    // Two treatments → picker exists, so the treatment transition points to it.
+    const multi = buildUnits({
+      treatments: [treatment, { ...treatment, name: "treatment2" }],
+    });
+    expect(multi[0].steps.at(-1)!.transitionCopy).toMatch(
+      /picker above to preview another part/i,
+    );
+  });
+
+  it("intro transition mentions previewing a treatment only when one exists", () => {
+    // Intro + treatment → intro transition invites previewing the treatment.
+    const withT = buildUnits({
+      introSequences: [
+        { name: "i", introSteps: [{ name: "s", elements: [] }] },
+      ],
+      treatments: [treatment],
+    });
+    expect(withT[0].steps.at(-1)!.transitionCopy).toMatch(
+      /picker above to preview a treatment/i,
+    );
+
+    // Intro-only (single) → no picker, no treatment to point at.
+    const introOnly = buildUnits({
+      introSequences: [
+        { name: "i", introSteps: [{ name: "s", elements: [] }] },
+      ],
+    });
+    const copy = introOnly[0].steps.at(-1)!.transitionCopy!;
+    expect(copy).not.toMatch(/picker above/i);
+    expect(copy).not.toMatch(/preview a treatment/i);
+  });
+});
+
+describe("initialUnitKey", () => {
+  const treatment = {
+    name: "treatment1",
+    playerCount: 2,
+    gameStages: [{ name: "round1", duration: 60, elements: [] }],
+  };
+  const file = {
+    introSequences: [
+      { name: "i0", introSteps: [{ name: "s", elements: [] }] },
+      { name: "i1", introSteps: [{ name: "s", elements: [] }] },
+    ],
+    treatments: [treatment, { ...treatment, name: "t1" }],
+  };
+
+  it("prefers the selected treatment when it exists", () => {
+    const units = buildUnits(file);
+    expect(initialUnitKey(units, 1, 1)).toBe("treatment:1");
+  });
+
+  it("falls back to the selected intro when no treatment matches (intro-only)", () => {
+    const units = buildUnits({ introSequences: file.introSequences });
+    // No treatment unit, so the chosen intro (#1) is honored rather than
+    // silently opening the first intro.
+    expect(initialUnitKey(units, 1, 0)).toBe("intro:1");
+  });
+
+  it("falls back to the first unit when neither index matches", () => {
+    const units = buildUnits({ treatments: [treatment] });
+    expect(initialUnitKey(units, 5, 9)).toBe("treatment:0");
+  });
+
+  it("returns a treatment key as last resort when there are no units", () => {
+    expect(initialUnitKey([], 0, 3)).toBe("treatment:3");
   });
 });

--- a/apps/viewer/src/lib/steps.ts
+++ b/apps/viewer/src/lib/steps.ts
@@ -13,6 +13,32 @@ export interface ViewerStep {
   notes?: string;
   /** Stage-level conditions (#183). Evaluated by StageConditionGate. */
   conditions?: ConditionType[];
+  /** When true, this is a synthetic end-of-unit interstitial (not a real
+   *  stage): the viewer renders `transitionCopy` instead of a `<Stage>`. It
+   *  narrates the platform behavior between phases (assignment, lobby, etc.)
+   *  that the preview can't simulate. */
+  isTransition?: boolean;
+  transitionCopy?: string;
+}
+
+/**
+ * A separately-selectable unit of a study: one intro sequence OR one
+ * treatment. The viewer walks **one unit at a time** (rather than pairing an
+ * intro with a treatment), which matches how researchers author each phase
+ * independently — and removes any which-intro-goes-with-which-treatment
+ * pairing logic. Each unit carries its own locale (intro sequences run before
+ * treatment assignment, so they declare their own).
+ */
+export interface ViewerUnit {
+  /** Stable key, e.g. `intro:0` / `treatment:1`. */
+  key: string;
+  kind: "intro" | "treatment";
+  name: string;
+  locale: string;
+  /** Participant count for the inspector; 1 for intro (pre-assignment). */
+  playerCount: number;
+  /** The unit's own stages, plus a trailing synthetic transition step. */
+  steps: ViewerStep[];
 }
 
 interface IntroSequence {
@@ -115,4 +141,75 @@ export function flattenSteps(
   }
 
   return steps;
+}
+
+interface TreatmentFileShape {
+  introSequences?: IntroSequence[];
+  treatments?: Treatment[];
+}
+
+function transitionStep(
+  index: number,
+  kind: "intro" | "treatment",
+  name: string,
+): ViewerStep {
+  // Narrate the platform's between-phase behavior the preview can't simulate.
+  const copy =
+    kind === "intro"
+      ? `End of the intro sequence “${name}”. In a real study, participants are now assigned to a condition and matched into a group. Use the picker above to preview a treatment.`
+      : `End of “${name}”. In a real study, participants would now finish the session (and complete any debrief). Use the picker above to preview another part.`;
+  return {
+    index,
+    phase: kind === "intro" ? "intro" : "exit",
+    name: "→ transition",
+    elements: [],
+    isTransition: true,
+    transitionCopy: copy,
+  };
+}
+
+/**
+ * Build the flat list of separately-selectable units (each intro sequence and
+ * each treatment), in picker order. Each unit's steps are its own stages plus
+ * a trailing transition interstitial. A treatment-only file yields only
+ * treatment units; an intro-only file only intro units.
+ */
+export function buildUnits(treatmentFile: TreatmentFileShape): ViewerUnit[] {
+  const units: ViewerUnit[] = [];
+
+  (treatmentFile.introSequences ?? []).forEach((seq, i) => {
+    let index = 0;
+    const steps: ViewerStep[] = (seq.introSteps ?? []).map((step) => ({
+      index: index++,
+      phase: "intro" as const,
+      name: step.name,
+      elements: step.elements,
+      notes: step.notes,
+      conditions: step.conditions,
+    }));
+    steps.push(transitionStep(index, "intro", seq.name));
+    units.push({
+      key: `intro:${i}`,
+      kind: "intro",
+      name: seq.name,
+      locale: seq.locale ?? "en",
+      playerCount: 1,
+      steps,
+    });
+  });
+
+  (treatmentFile.treatments ?? []).forEach((t, i) => {
+    const steps = flattenSteps(undefined, t);
+    steps.push(transitionStep(steps.length, "treatment", t.name));
+    units.push({
+      key: `treatment:${i}`,
+      kind: "treatment",
+      name: t.name,
+      locale: t.locale ?? "en",
+      playerCount: t.playerCount,
+      steps,
+    });
+  });
+
+  return units;
 }

--- a/apps/viewer/src/lib/steps.ts
+++ b/apps/viewer/src/lib/steps.ts
@@ -152,19 +152,29 @@ function transitionStep(
   index: number,
   kind: "intro" | "treatment",
   name: string,
+  opts: { hasPicker: boolean; hasTreatmentToPreview: boolean },
 ): ViewerStep {
   // Narrate the platform's between-phase behavior the preview can't simulate.
-  const copy =
+  // Only point at "the picker above" when one actually exists (2+ units) and,
+  // for an intro, only mention previewing a treatment when one exists — a
+  // single-unit or intro-only preview has no such control/target (#485 review).
+  const base =
     kind === "intro"
-      ? `End of the intro sequence “${name}”. In a real study, participants are now assigned to a condition and matched into a group. Use the picker above to preview a treatment.`
-      : `End of “${name}”. In a real study, participants would now finish the session (and complete any debrief). Use the picker above to preview another part.`;
+      ? `End of the intro sequence “${name}”. In a real study, participants are now assigned to a condition and matched into a group.`
+      : `End of “${name}”. In a real study, participants would now finish the session (and complete any debrief).`;
+  let hint = "";
+  if (kind === "intro" && opts.hasPicker && opts.hasTreatmentToPreview) {
+    hint = " Use the picker above to preview a treatment.";
+  } else if (kind === "treatment" && opts.hasPicker) {
+    hint = " Use the picker above to preview another part.";
+  }
   return {
     index,
     phase: kind === "intro" ? "intro" : "exit",
     name: "→ transition",
     elements: [],
     isTransition: true,
-    transitionCopy: copy,
+    transitionCopy: base + hint,
   };
 }
 
@@ -176,8 +186,13 @@ function transitionStep(
  */
 export function buildUnits(treatmentFile: TreatmentFileShape): ViewerUnit[] {
   const units: ViewerUnit[] = [];
+  const introSequences = treatmentFile.introSequences ?? [];
+  const treatments = treatmentFile.treatments ?? [];
+  // A picker only renders when there's more than one unit to switch between.
+  const hasPicker = introSequences.length + treatments.length > 1;
+  const hasTreatmentToPreview = treatments.length > 0;
 
-  (treatmentFile.introSequences ?? []).forEach((seq, i) => {
+  introSequences.forEach((seq, i) => {
     let index = 0;
     const steps: ViewerStep[] = (seq.introSteps ?? []).map((step) => ({
       index: index++,
@@ -187,7 +202,12 @@ export function buildUnits(treatmentFile: TreatmentFileShape): ViewerUnit[] {
       notes: step.notes,
       conditions: step.conditions,
     }));
-    steps.push(transitionStep(index, "intro", seq.name));
+    steps.push(
+      transitionStep(index, "intro", seq.name, {
+        hasPicker,
+        hasTreatmentToPreview,
+      }),
+    );
     units.push({
       key: `intro:${i}`,
       kind: "intro",
@@ -198,9 +218,14 @@ export function buildUnits(treatmentFile: TreatmentFileShape): ViewerUnit[] {
     });
   });
 
-  (treatmentFile.treatments ?? []).forEach((t, i) => {
+  treatments.forEach((t, i) => {
     const steps = flattenSteps(undefined, t);
-    steps.push(transitionStep(steps.length, "treatment", t.name));
+    steps.push(
+      transitionStep(steps.length, "treatment", t.name, {
+        hasPicker,
+        hasTreatmentToPreview,
+      }),
+    );
     units.push({
       key: `treatment:${i}`,
       kind: "treatment",
@@ -212,4 +237,23 @@ export function buildUnits(treatmentFile: TreatmentFileShape): ViewerUnit[] {
   });
 
   return units;
+}
+
+/**
+ * The unit the viewer should open on, given the host's landing selection.
+ * Prefers the selected treatment (the walk-one-unit default — intros are
+ * reachable via the picker); falls back to the selected intro when no matching
+ * treatment exists (e.g. an intro-only file, or a multi-intro file where the
+ * overview picked the second intro — #485 review); finally to the first unit.
+ */
+export function initialUnitKey(
+  units: ViewerUnit[],
+  introIndex: number,
+  treatmentIndex: number,
+): string {
+  const wantTreatment = `treatment:${treatmentIndex}`;
+  if (units.some((u) => u.key === wantTreatment)) return wantTreatment;
+  const wantIntro = `intro:${introIndex}`;
+  if (units.some((u) => u.key === wantIntro)) return wantIntro;
+  return units[0]?.key ?? wantTreatment;
 }

--- a/apps/vscode/src/webview/index.tsx
+++ b/apps/vscode/src/webview/index.tsx
@@ -108,7 +108,13 @@ function App() {
           const desired = isFirstLoad
             ? ((msg.treatmentIndex as number | undefined) ?? prev)
             : prev;
-          return Math.min(desired, Math.max(0, incoming.treatments.length - 1));
+          // `treatments` is optional in the schema (an intro-only file is a
+          // valid mid-development state) — guard the bound so a refresh of
+          // such a file doesn't crash (#476).
+          return Math.min(
+            desired,
+            Math.max(0, (incoming.treatments?.length ?? 1) - 1),
+          );
         });
         setIntroIndex((prev) => {
           const desired = isFirstLoad


### PR DESCRIPTION
Reworks the viewer's preview model from "pick an intro **and** a treatment, walk them flattened together" to **"pick one part, walk it"** — with a single sectioned picker.

## What changes
- **One `<optgroup>` "part to preview" picker** replaces the two header dropdowns (treatment + intro sequence): an *Intro sequences* group and a *Treatments* group. Generalizes to a future **Consent** section by adding another optgroup.
- **Walk one unit at a time.** `buildUnits()` produces one `ViewerUnit` per intro sequence and per treatment (each with its own steps, locale, player count). The viewer renders the selected unit's stages only — no more flattening an intro into a treatment, and **no which-intro-pairs-with-which-treatment logic**.
- **Transition screen** at the end of each unit narrates the platform's between-phase behavior the preview can't simulate — *"participants are now assigned a condition; pick a treatment to preview."* Makes the host-owned boundary (assignment, lobby, matching) explicit rather than papering over it with a seamless walk.
- **Simplifies the i18n locale wiring** from #482: each unit declares its own locale, so the header badge is just `unit.locale` (no per-phase derivation across a flattened walk).

## Why
Matches how researchers actually author each phase — independently. The combined walk implied a canonical intro+treatment pairing that doesn't exist; the sectioned picker + transition screens are both simpler and more honest.

## Notes
- `selectedIntroIndex` / `onIntroIndexChange` are accepted for back-compat with the host landing flow but no longer drive a separate dropdown (the viewer manages unit selection internally). A follow-up can retire them from `App`/`PreviewHost`.
- Consent stays a future section (just a named intro sequence today); this PR establishes the generalizable pattern.

## Testing
- `buildUnits` unit tests (one unit per intro/treatment, own locale + playerCount, trailing transition, intro-only / treatments-only files).
- Viewer render tests: treatments-only no-crash, **locale badge follows the selected unit** (switch intro↔treatment flips he↔en), transition screen renders at end-of-unit.
- viewer suite **141** green; gallery validates clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)