### PR TITLE
fix(media): hoist hooks above the unsafe-URL guard (#484)

### DIFF
--- a/packages/stagebook/src/components/elements/MediaPlayer.hooks.test.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.hooks.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MediaPlayer } from "./MediaPlayer.js";
+
+// A rules-of-hooks violation is reported by React's dev build through
+// console.error (and can leave the fiber corrupted), not as a thrown error
+// that re-render() would surface. So we detect it by watching console.error.
+const HOOK_VIOLATION = /order of Hooks|Rendered (more|fewer) hooks/i;
+
+// Regression for #484: MediaPlayer must call the same hooks on every render
+// so a single instance can transition between an invalid/unsafe URL and a
+// valid one in place (e.g. editing/refreshing a treatment in the viewer
+// preview) without tripping React's rules-of-hooks invariant.
+//
+// This runs under jsdom, which uses React's development build — unlike the
+// Playwright CT bundle (production React), the dev build actually *throws*
+// "Rendered more/fewer hooks than during the previous render" when the hook
+// count changes between renders. That makes this the test that goes red on
+// the pre-fix code, where the unsafe-URL early return sits ahead of the
+// useRef/useState/useEffect calls.
+
+const UNSAFE_URL = "javascript:alert(1)";
+const SAFE_URL = "https://example.com/clip.mp4";
+
+const noopProps = {
+  name: "test",
+  save: () => {},
+  getElapsedTime: () => 0,
+};
+
+function render(root: Root, url: string) {
+  act(() => {
+    root.render(<MediaPlayer {...noopProps} url={url} />);
+  });
+}
+
+describe("MediaPlayer hook stability across URL validity changes (#484)", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (root) act(() => root!.unmount());
+    container?.remove();
+    root = null;
+    container = null;
+    vi.restoreAllMocks();
+  });
+
+  function hookViolations() {
+    return errorSpy.mock.calls.filter((args) =>
+      args.some((a) => typeof a === "string" && HOOK_VIOLATION.test(a)),
+    );
+  }
+
+  function mount(initialUrl: string) {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    render(root, initialUrl);
+    return { container, root };
+  }
+
+  // NOTE: a single test owns the rules-of-hooks assertion on purpose. React's
+  // dev build dedupes the "change in the order of Hooks" warning to once per
+  // component type per process (didWarnAboutMismatchedHooksForComponent), so a
+  // second test re-running the same transition would see no console.error and
+  // silently pass even on broken code. Keep the load-bearing checks here; don't
+  // add a sibling test that re-asserts hookViolations() for MediaPlayer.
+  it("re-renders in place across repeated unsafe↔valid URL toggles without a rules-of-hooks violation", () => {
+    const { container, root } = mount(UNSAFE_URL);
+    // Unsafe URL renders the invalid-URL alert (no <video>).
+    expect(
+      container
+        .querySelector('[data-testid="mediaPlayer"]')
+        ?.getAttribute("role"),
+    ).toBe("alert");
+    expect(container.querySelector("video")).toBeNull();
+
+    // Toggle the URL in place several times, modelling the viewer's
+    // edit/refresh loop. Mounting on the unsafe URL set a clean 2-hook
+    // baseline, so the first valid render is the "more hooks than the previous
+    // render" path — the direction React's dev build flags — which makes this
+    // load-bearing: it fails on the pre-fix code where the guard sat ahead of
+    // the hooks. (The valid→unsafe steps are the "fewer hooks" unwind, which
+    // React 19 tolerates silently; they're here for realism.)
+    for (const url of [SAFE_URL, UNSAFE_URL, SAFE_URL]) {
+      render(root, url);
+    }
+    expect(hookViolations()).toEqual([]);
+
+    // Ends on a valid URL — back to a working player.
+    expect(
+      container
+        .querySelector('[data-testid="mediaPlayer"]')
+        ?.getAttribute("role"),
+    ).toBe("region");
+    expect(container.querySelector("video")).not.toBeNull();
+  });
+});

--- a/packages/stagebook/src/components/elements/MediaPlayer.hooks.test.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.hooks.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
-import React, { act } from "react";
+import React, { act, useState, type ReactNode } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { MediaPlayer } from "./MediaPlayer.js";
+import { MediaPlayer, type MediaPlayerProps } from "./MediaPlayer.js";
+import { PlaybackProvider, usePlayback } from "../playback/PlaybackProvider.js";
 
 // A rules-of-hooks violation is reported by React's dev build through
 // console.error (and can leave the fiber corrupted), not as a thrown error
@@ -102,5 +103,127 @@ describe("MediaPlayer hook stability across URL validity changes (#484)", () => 
         ?.getAttribute("role"),
     ).toBe("region");
     expect(container.querySelector("video")).not.toBeNull();
+  });
+});
+
+// The guard moved below the effects (#484), so each URL-touching effect now
+// has to gate itself on the unsafe URL — and recover when the URL becomes
+// valid. These cover the side-effects Codex flagged on PR #487.
+describe("MediaPlayer effects are gated on URL validity (#487)", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  afterEach(() => {
+    if (root) act(() => root!.unmount());
+    container?.remove();
+    root = null;
+    container = null;
+    vi.restoreAllMocks();
+  });
+
+  function mount(node: ReactNode) {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root!.render(node));
+    return container;
+  }
+
+  // Holds the URL in state and exposes a setter, so the same MediaPlayer
+  // instance re-renders in place when the URL changes.
+  let setUrlExternally: ((url: string) => void) | null = null;
+  function Harness(
+    props: Omit<MediaPlayerProps, "url"> & { initialUrl: string },
+  ) {
+    const { initialUrl, ...rest } = props;
+    const [url, setUrl] = useState(initialUrl);
+    setUrlExternally = setUrl;
+    return <MediaPlayer {...rest} url={url} />;
+  }
+
+  it("does not fetch captions while the media URL is unsafe, then fetches on recovery (P3)", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("WEBVTT\n\n00:00.000 --> 00:01.000\nhi\n", {
+        status: 200,
+      }),
+    );
+    const captionsURL = "https://example.com/captions.vtt";
+    const fetchedCaptions = () =>
+      fetchSpy.mock.calls.some((c) => c[0] === captionsURL);
+
+    mount(
+      <Harness
+        name="t"
+        save={() => {}}
+        getElapsedTime={() => 0}
+        initialUrl={UNSAFE_URL}
+        captionsURL={captionsURL}
+      />,
+    );
+    // Rejected media → no caption fetch.
+    expect(fetchedCaptions()).toBe(false);
+
+    // Recover to a valid media URL → captions load.
+    act(() => setUrlExternally!(SAFE_URL));
+    expect(fetchedCaptions()).toBe(true);
+  });
+
+  it("registers no playback handle while unsafe, then registers on recovery (P2)", () => {
+    const seen: string[] = [];
+    function Probe() {
+      seen.push(usePlayback("vid") ? "found" : "not-found");
+      return null;
+    }
+    mount(
+      <PlaybackProvider>
+        <Harness
+          name="vid"
+          save={() => {}}
+          getElapsedTime={() => 0}
+          initialUrl={UNSAFE_URL}
+        />
+        <Probe />
+      </PlaybackProvider>,
+    );
+    // No <video> is mounted for an unsafe URL, so nothing is registered.
+    expect(seen.at(-1)).toBe("not-found");
+
+    act(() => setUrlExternally!(SAFE_URL));
+    // The recovered player registers its handle (undefined→handle), which is
+    // the transition a sibling Timeline keys its waveform retry on.
+    expect(seen.at(-1)).toBe("found");
+  });
+
+  it("reapplies startAt to the <video> that mounts on recovery (P2)", () => {
+    // Intercept currentTime assignments at the prototype level — robust to
+    // jsdom not persisting media element state.
+    const sets: number[] = [];
+    const proto = window.HTMLMediaElement.prototype;
+    const original = Object.getOwnPropertyDescriptor(proto, "currentTime");
+    Object.defineProperty(proto, "currentTime", {
+      configurable: true,
+      get: () => sets.at(-1) ?? 0,
+      set: (v: number) => sets.push(v),
+    });
+
+    try {
+      mount(
+        <Harness
+          name="t"
+          save={() => {}}
+          getElapsedTime={() => 0}
+          initialUrl={UNSAFE_URL}
+          startAt={12}
+        />,
+      );
+      // No video while unsafe → no seek applied.
+      expect(sets).toEqual([]);
+
+      act(() => setUrlExternally!(SAFE_URL));
+      // The recovered <video> is seeked to startAt rather than left at 0.
+      expect(sets).toContain(12);
+    } finally {
+      if (original) Object.defineProperty(proto, "currentTime", original);
+    }
   });
 });

--- a/packages/stagebook/src/components/elements/MediaPlayer.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.tsx
@@ -482,8 +482,12 @@ export function MediaPlayer({
     }),
     [channelCount, startWaveformCapture], // re-create when channelCount changes so consumers see the update
   );
-  // Use the YouTube handle when available, fall back to the HTML5 handle
-  useRegisterPlayback(name, ytHandle ?? handle);
+  // Use the YouTube handle when available, fall back to the HTML5 handle.
+  // Register nothing while the URL is unsafe: no <video> is mounted, so the
+  // handle would be inert (null videoRef), and registering it would let a
+  // sibling Timeline latch onto a dead handle whose identity never changes —
+  // so it would never retry waveform capture once the URL recovers (#487).
+  useRegisterPlayback(name, urlIsUnsafe ? null : (ytHandle ?? handle));
 
   // Hold-to-scrub state
   const arrowRepeatCountRef = useRef(0);
@@ -493,6 +497,10 @@ export function MediaPlayer({
   // Fetch and parse captions when captionsURL changes
   useEffect(() => {
     if (!captionsURL) return;
+    // Don't fetch captions for media we're rejecting — the component only
+    // renders the invalid-URL alert. Re-runs when urlIsUnsafe flips false so
+    // captions still load once the media URL recovers (#487).
+    if (urlIsUnsafe) return;
     if (!isSafeURL(captionsURL)) {
       console.warn(
         `[MediaPlayer] Rejected unsafe captions URL: ${captionsURL}`,
@@ -511,9 +519,13 @@ export function MediaPlayer({
     return () => {
       cancelled = true;
     };
-  }, [captionsURL]);
+  }, [captionsURL, urlIsUnsafe]);
 
-  // Seek to startAt on mount (or to elapsedTime+startAt when syncToStageTime)
+  // Seek to startAt on mount (or to elapsedTime+startAt when syncToStageTime).
+  // Re-runs when urlIsUnsafe flips false so the offset is (re)applied to the
+  // <video> that first mounts on an invalid→valid recovery — on the initial
+  // unsafe render videoRef is null, the effect no-ops, and without this dep it
+  // would never run again, leaving the recovered clip at time 0 (#487).
   useEffect(() => {
     if (!videoRef.current) return;
     if (syncToStageTime) {
@@ -522,7 +534,9 @@ export function MediaPlayer({
     } else if (startAt !== undefined) {
       videoRef.current.currentTime = startAt;
     }
-  }, []); // mount-only: reads initial values of getElapsedTime/startAt
+    // reads current startAt/getElapsedTime when it (re)runs; deliberately not
+    // re-applied on every startAt change — only on first mount and recovery.
+  }, [urlIsUnsafe]);
 
   // Autoplay for "once" mode: attempt .play() once metadata is loaded.
   // If the browser blocks it (no prior user interaction), show a fallback button.

--- a/packages/stagebook/src/components/elements/MediaPlayer.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.tsx
@@ -130,13 +130,13 @@ export function MediaPlayer({
   // Defense-in-depth: reject dangerous URL protocols. Element.tsx already
   // resolves relative paths via getAssetURL(), so this guards against
   // javascript:, data:, and other non-HTTP schemes reaching a <video> src.
-  if (!youtubeVideoId && !isSafeURL(url)) {
-    return (
-      <div data-testid="mediaPlayer" role="alert">
-        {messages.mediaInvalidUrl}
-      </div>
-    );
-  }
+  // The actual early return for this is deferred until *after* all hooks
+  // (just above the render branches) so the hook count stays constant when a
+  // single instance transitions unsafe→safe in place — otherwise React's
+  // rules of hooks are violated and the component throws (#484). The
+  // URL-fetching effects below already guard on isSafeURL, so deferring the
+  // return never lets an unsafe URL be fetched.
+  const urlIsUnsafe = !youtubeVideoId && !isSafeURL(url);
 
   const eventsRef = useRef<VideoEvent[]>([]);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -1072,6 +1072,18 @@ export function MediaPlayer({
     onScrubMove,
     onScrubEnd,
   };
+
+  // ---------------------------------------------------------------------------
+  // Unsafe-URL guard (deferred past all hooks — see urlIsUnsafe above, #484)
+  // ---------------------------------------------------------------------------
+
+  if (urlIsUnsafe) {
+    return (
+      <div data-testid="mediaPlayer" role="alert">
+        {messages.mediaInvalidUrl}
+      </div>
+    );
+  }
 
   // ---------------------------------------------------------------------------
   // YouTube branch

--- a/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
+++ b/packages/stagebook/src/components/elements/mediaPlayer/MediaPlayer.ct.tsx
@@ -1,5 +1,8 @@
 import { test, expect } from "@playwright/experimental-ct-react";
-import { MockMediaPlayer } from "../../testing/MockMediaPlayer.js";
+import {
+  MockMediaPlayer,
+  UrlTransitionMediaPlayer,
+} from "../../testing/MockMediaPlayer.js";
 
 // -- Rendering structure --
 
@@ -2426,4 +2429,100 @@ test("focus is left alone when activeElement is somewhere else entirely", async 
 
   // Focus should stay on the other input, not get stolen.
   await expect(other).toBeFocused();
+});
+
+// -- Unsafe / invalid URL handling (#484) --
+
+test("renders an invalid-URL alert for a dangerous protocol", async ({
+  mount,
+}) => {
+  // Defense-in-depth: a javascript:/data:/etc. scheme must never reach a
+  // <video src>. Instead we render an accessible alert.
+  const component = await mount(
+    <MockMediaPlayer url="javascript:alert(1)" name="test" />,
+  );
+  const player = component.locator('[data-testid="mediaPlayer"]');
+  await expect(player).toHaveAttribute("role", "alert");
+  await expect(player).toContainText("Invalid media URL");
+  // No <video> element is rendered for an unsafe URL.
+  await expect(
+    component.locator('[data-testid="mediaPlayer-video"]'),
+  ).not.toBeAttached();
+});
+
+test("survives an invalid→valid URL transition in place (#484)", async ({
+  mount,
+  page,
+}) => {
+  // A single mounted instance editing its URL from unsafe to safe (e.g.
+  // refreshing a treatment in the viewer preview) must keep working through
+  // an in-place re-render. The hook-count invariant itself is enforced by
+  // MediaPlayer.hooks.test.tsx under jsdom (dev React throws there); this CT
+  // bundle is production React, so here we assert the real-browser outcome —
+  // the player recovers to a working <video> — plus a defensive guard that
+  // no rules-of-hooks error ever reached window.onerror.
+  const pageErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(err.message));
+
+  const component = await mount(
+    <UrlTransitionMediaPlayer
+      initialUrl="javascript:alert(1)"
+      nextUrl="/sample-video.mp4"
+      name="test"
+    />,
+  );
+  await expect(
+    component.locator('[data-testid="mediaPlayer"]'),
+  ).toHaveAttribute("role", "alert");
+
+  // Flip the URL on the same MediaPlayer instance (in-place re-render).
+  await component.locator('[data-testid="swap-url"]').click();
+
+  // The player now renders normally — a <video> appears and the role flips
+  // back to "region".
+  await expect(
+    component.locator('[data-testid="mediaPlayer-video"]'),
+  ).toBeAttached();
+  await expect(
+    component.locator('[data-testid="mediaPlayer"]'),
+  ).toHaveAttribute("role", "region");
+
+  // And no rules-of-hooks crash reached window.onerror.
+  expect(
+    pageErrors.filter((m) =>
+      /Rendered more hooks|Rendered fewer hooks/.test(m),
+    ),
+  ).toEqual([]);
+});
+
+test("survives a valid→invalid URL transition in place (#484)", async ({
+  mount,
+  page,
+}) => {
+  // The reverse direction (more hooks → fewer) trips a different React
+  // invariant ("Rendered fewer hooks than expected"); guard against it too.
+  const pageErrors: string[] = [];
+  page.on("pageerror", (err) => pageErrors.push(err.message));
+
+  const component = await mount(
+    <UrlTransitionMediaPlayer
+      initialUrl="/sample-video.mp4"
+      nextUrl="javascript:alert(1)"
+      name="test"
+    />,
+  );
+  await expect(
+    component.locator('[data-testid="mediaPlayer-video"]'),
+  ).toBeAttached();
+
+  await component.locator('[data-testid="swap-url"]').click();
+
+  await expect(
+    component.locator('[data-testid="mediaPlayer"]'),
+  ).toHaveAttribute("role", "alert");
+  expect(
+    pageErrors.filter((m) =>
+      /Rendered more hooks|Rendered fewer hooks/.test(m),
+    ),
+  ).toEqual([]);
 });

--- a/packages/stagebook/src/components/playback/PlaybackProvider.test.tsx
+++ b/packages/stagebook/src/components/playback/PlaybackProvider.test.tsx
@@ -121,3 +121,51 @@ describe("PlaybackProvider register/unregister render loop (#103)", () => {
     act(() => root.unmount());
   });
 });
+
+describe("useRegisterPlayback null handle (#487)", () => {
+  test("a null handle registers nothing; switching null→handle registers it", () => {
+    const container = document.createElement("div");
+    let root: Root;
+    const seen: string[] = [];
+
+    function Registrar({ live }: { live: boolean }): ReactNode {
+      // A would-be handle, only registered once `live`. Mirrors MediaPlayer
+      // passing null while the URL is unsafe, then the real handle on recovery.
+      const handle = useMemo(() => makeHandle({ getCurrentTime: () => 7 }), []);
+      useRegisterPlayback("vid", live ? handle : null);
+      return null;
+    }
+
+    function Consumer(): ReactNode {
+      const handle = usePlayback("vid");
+      seen.push(handle ? "found" : "not-found");
+      return null;
+    }
+
+    act(() => {
+      root = createRoot(container);
+      root.render(
+        <PlaybackProvider>
+          <Registrar live={false} />
+          <Consumer />
+        </PlaybackProvider>,
+      );
+    });
+    // No handle registered while null.
+    expect(seen.at(-1)).toBe("not-found");
+
+    // Flip to a real handle — the consumer now sees it (undefined→handle),
+    // which is exactly the transition a Timeline keys its waveform retry on.
+    act(() => {
+      root.render(
+        <PlaybackProvider>
+          <Registrar live={true} />
+          <Consumer />
+        </PlaybackProvider>,
+      );
+    });
+    expect(seen.at(-1)).toBe("found");
+
+    act(() => root.unmount());
+  });
+});

--- a/packages/stagebook/src/components/playback/PlaybackProvider.tsx
+++ b/packages/stagebook/src/components/playback/PlaybackProvider.tsx
@@ -64,10 +64,16 @@ export function PlaybackProvider({ children }: { children: React.ReactNode }) {
 /**
  * Register a PlaybackHandle under `name` for the duration of the component's
  * life. Safe to call without a PlaybackProvider — silently no-ops.
+ *
+ * Pass `null` to register nothing (e.g. while a media URL is invalid). When
+ * the handle later becomes non-null, the dependency change re-runs the effect
+ * and registers it — and because `usePlayback` then transitions from
+ * `undefined` to a handle, sibling consumers (Timeline waveform capture) that
+ * key off handle identity re-run their own effects (#487 / #484 recovery).
  */
 export function useRegisterPlayback(
   name: string,
-  handle: PlaybackHandle,
+  handle: PlaybackHandle | null,
 ): void {
   const ctx = useContext(PlaybackContext);
   // Extract the stable callbacks so the effect depends on them directly
@@ -78,7 +84,7 @@ export function useRegisterPlayback(
   const unregister = ctx?.unregister;
 
   useEffect(() => {
-    if (!register || !unregister) return; // no PlaybackProvider — no-op
+    if (!register || !unregister || !handle) return; // no provider / no handle
     register(name, handle);
     return () => unregister(name);
   }, [name, handle, register, unregister]);

--- a/packages/stagebook/src/components/testing/MockMediaPlayer.tsx
+++ b/packages/stagebook/src/components/testing/MockMediaPlayer.tsx
@@ -38,3 +38,36 @@ export function MockMediaPlayer({
     </div>
   );
 }
+
+/**
+ * Harness for the invalid→valid URL transition (#484). Holds the URL in
+ * component state and swaps it on button click, so the underlying
+ * MediaPlayer instance re-renders *in place* (rather than remounting). This
+ * is what surfaces a rules-of-hooks violation if the unsafe-URL guard sits
+ * ahead of the hooks.
+ */
+export interface UrlTransitionMediaPlayerProps {
+  initialUrl: string;
+  nextUrl: string;
+  name: string;
+}
+
+export function UrlTransitionMediaPlayer({
+  initialUrl,
+  nextUrl,
+  name,
+}: UrlTransitionMediaPlayerProps) {
+  const [url, setUrl] = useState(initialUrl);
+  return (
+    <div>
+      <button
+        type="button"
+        data-testid="swap-url"
+        onClick={() => setUrl(nextUrl)}
+      >
+        swap
+      </button>
+      <MockMediaPlayer url={url} name={name} />
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes #484.

## Problem

`MediaPlayer` had a conditional early `return` for invalid/unsafe URLs sitting **ahead** of its `useRef`/`useState`/`useEffect` calls. A single mounted instance that transitioned invalid→valid URL in place (e.g. editing/refreshing a treatment in the viewer preview) changed the number of hooks React saw between renders → rules-of-hooks violation → throw. Flagged by Codex on #482; pre-existing, not introduced by the i18n PR.

## Fix

- Replace the early return with a derived `const urlIsUnsafe = …` computed up top.
- Let every hook run unconditionally.
- Re-introduce the invalid-URL alert `return` just before the YouTube/HTML5 render branches — after the last hook.

The URL-fetching effects already self-guard on `isSafeURL` (the HEAD-probe effect and the captions effect), so deferring the rejection past the hooks never lets an unsafe URL get fetched or reach a `<video src>`. The playback handle registered on the unsafe path is inert against a null `videoRef`.

## Tests

- **`MediaPlayer.hooks.test.tsx` (new)** — the regression guard. It runs under jsdom, which uses React's **dev** build; the Playwright CT bundle is **production** React and never throws on a hook-order change, so the invariant can only be exercised here. Verified **red on the pre-fix code, green on the fix**, and covers repeated in-place toggling. A single test owns the assertion on purpose: React dedupes the hook-order warning once per component type per process, so a second warning-based test would silently pass even on broken code.
- **`MediaPlayer.ct.tsx` + `MockMediaPlayer.tsx`** — invalid-URL alert coverage (previously untested) and a real-browser check that the player recovers to a working `<video>` across the transition.

## Verification

- vitest: full package suite green (incl. the new test)
- Playwright CT: full `MediaPlayer.ct.tsx` suite green (chromium)
- lint: 0 warnings; prettier clean

## Review

Pre-PR three-subagent review (correctness / coverage / security) run against the branch; findings folded in (the coverage pass caught a tautological test, since fixed). Security pass confirmed no unsafe URL is ever fetched or placed in a DOM sink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)