### PR TITLE
fix(prompts): make the colon the numeric-mode signal for multipleChoice (#289)

### DIFF
--- a/docs/researcher/prompts.md
+++ b/docs/researcher/prompts.md
@@ -102,6 +102,32 @@ Each option on its own line, prefixed with `- `:
 - Option C
 ```
 
+The saved value is the chosen option's text.
+
+**Numeric scales (#282).** To attach numeric scale points (averaged downstream), label every option in the explicit `- <number>: <label>` form. The colon is what turns the prompt numeric — it's an opt-in:
+
+```markdown
+- 1: Strongly disagree
+- 2: Disagree
+- 3: Neutral
+- 4: Agree
+- 5: Strongly agree
+```
+
+Each numeric value must be unique, and numeric mode is single-select only.
+
+A **bare** option that happens to look like a number (`- 2`, no colon) is **text**, with the number as its label — never a scale point (#289). So a comprehension check or quiz whose options are small integers plus a non-numeric foil stays in text mode, and `value:` conditions match the bare label:
+
+```markdown
+- 1
+- 2
+- 3
+- 4
+- It Varies
+```
+
+Mixing explicit `- <number>: <label>` options with bare/text options in the same prompt is a preflight error — make every option numeric (add a trailing colon to label-less points, e.g. `- 2:`) or none.
+
 ### Open Response
 
 Placeholder text prefixed with `> `:

--- a/packages/stagebook/src/schemas/promptFile.test.ts
+++ b/packages/stagebook/src/schemas/promptFile.test.ts
@@ -722,7 +722,10 @@ How much do you agree?
       }
     });
 
-    test("bare numbers are accepted; label defaults to stringified number", () => {
+    test("bare numbers are text mode; numeric mode requires an explicit colon (#289)", () => {
+      // The colon is the numeric-mode signal. A bare `- 1` is shorthand for
+      // `- 1: 1` (text label "1"), never a numeric scale point. Authors who
+      // want numeric semantics (responsePoints) must write `- 1: <label>`.
       const markdown = `---
 name: scale
 type: multipleChoice
@@ -737,8 +740,67 @@ Rate it
       const result = promptFileSchema.safeParse(markdown);
       expect(result.success).toBe(true);
       if (result.success) {
-        expect(result.data.responsePoints).toEqual([1, 2, 3, 4, 5]);
+        expect(result.data.responsePoints).toEqual([]);
         expect(result.data.responseItems).toEqual(["1", "2", "3", "4", "5"]);
+      }
+    });
+
+    test("comprehension check: numeric-looking labels with a text foil are text mode, not a mixing error (#289)", () => {
+      // Real research pattern: an MCQ gate on a discrete fact whose options
+      // happen to be small integers plus a non-numeric foil. These are
+      // identifiers, not scale points, so the whole prompt is text mode and
+      // `value: "2"` conditions keep working against the bare labels.
+      const markdown = `---
+name: num_speakers
+type: multipleChoice
+---
+How many different people will tell you a story?
+---
+- 1
+- 2
+- 3
+- 4
+- It Varies`;
+      const result = promptFileSchema.safeParse(markdown);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.responsePoints).toEqual([]);
+        expect(result.data.responseItems).toEqual([
+          "1",
+          "2",
+          "3",
+          "4",
+          "It Varies",
+        ]);
+      }
+    });
+
+    test("endpoints-only Likert opts into numeric mode with trailing colons (#289)", () => {
+      // The migration path for a numeric scale that only labels its endpoints:
+      // give every middle point a trailing colon so it reads as `<number>:`
+      // (empty label falls back to the stringified number).
+      const markdown = `---
+name: agreement
+type: multipleChoice
+---
+How much do you agree?
+---
+- 1: Strongly disagree
+- 2:
+- 3:
+- 4:
+- 5: Strongly agree`;
+      const result = promptFileSchema.safeParse(markdown);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.responsePoints).toEqual([1, 2, 3, 4, 5]);
+        expect(result.data.responseItems).toEqual([
+          "Strongly disagree",
+          "2",
+          "3",
+          "4",
+          "Strongly agree",
+        ]);
       }
     });
 
@@ -799,6 +861,81 @@ Pick one
             i.message.includes("mixes numeric and text"),
           ),
         ).toBe(true);
+      }
+    });
+
+    test("a text label that contains a colon stays text, not numeric (#289)", () => {
+      // The colon-as-numeric-signal rule must not trip on text labels that
+      // happen to contain a colon — only a *number* before the first colon
+      // counts. "Maybe" isn't finite, so this is plain text mode and the
+      // label is preserved verbatim, colon and all.
+      const markdown = `---
+name: certainty
+type: multipleChoice
+---
+Pick one
+---
+- Maybe: not sure
+- Yes
+- No`;
+      const result = promptFileSchema.safeParse(markdown);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.responsePoints).toEqual([]);
+        expect(result.data.responseItems).toEqual([
+          "Maybe: not sure",
+          "Yes",
+          "No",
+        ]);
+      }
+    });
+
+    test("a single bare numeric option is text mode (#289)", () => {
+      const markdown = `---
+name: lone
+type: multipleChoice
+---
+Pick one
+---
+- 1`;
+      const result = promptFileSchema.safeParse(markdown);
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.responsePoints).toEqual([]);
+        expect(result.data.responseItems).toEqual(["1"]);
+      }
+    });
+
+    test("explicit-numeric mixed with a bare number is an error, both orderings (#289)", () => {
+      // The mixing rule is order-independent: a bare number (now text) next
+      // to an explicit `- <number>: <label>` option errors regardless of
+      // which comes first.
+      const numericFirst = `---
+name: mix_a
+type: multipleChoice
+---
+Pick one
+---
+- 1: One
+- 2`;
+      const bareFirst = `---
+name: mix_b
+type: multipleChoice
+---
+Pick one
+---
+- 1
+- 2: Two`;
+      for (const markdown of [numericFirst, bareFirst]) {
+        const result = promptFileSchema.safeParse(markdown);
+        expect(result.success).toBe(false);
+        if (!result.success) {
+          expect(
+            result.error.issues.some((i) =>
+              i.message.includes("mixes numeric and text"),
+            ),
+          ).toBe(true);
+        }
       }
     });
 

--- a/packages/stagebook/src/schemas/promptFile.ts
+++ b/packages/stagebook/src/schemas/promptFile.ts
@@ -241,15 +241,22 @@ function parseNumericResponseLine(
 
 /**
  * Inspect a response-line content (already stripped of `- ` prefix) to see
- * if it begins with a finite number followed by EOL, colon, or whitespace.
- * Used by multipleChoice mode detection — if every option starts with a
- * number, the prompt is in numeric mode (#282).
+ * if it is an explicit numeric option: `<number>: <label>` with a finite
+ * number before the first colon.
+ *
+ * The colon is the numeric-mode signal (#289). A bare `- 1` is NOT numeric —
+ * it's shorthand for `- 1: 1` (text label "1"). This keeps comprehension
+ * checks / quizzes whose labels happen to be small integers (`1 / 2 / 3 /
+ * It Varies`) in text mode instead of false-positiving into a numeric scale.
+ * To get numeric semantics (responsePoints) an author must opt in by labeling
+ * every option `<number>: <label>` — used by multipleChoice mode detection:
+ * if every option is an explicit numeric option, the prompt is numeric (#282).
  */
 function isNumericResponseLine(raw: string): boolean {
   const trimmed = raw.trim();
-  if (trimmed.length === 0) return false;
   const colonIdx = trimmed.indexOf(":");
-  const pointStr = colonIdx < 0 ? trimmed : trimmed.slice(0, colonIdx).trim();
+  if (colonIdx < 0) return false;
+  const pointStr = trimmed.slice(0, colonIdx).trim();
   if (pointStr.length === 0) return false;
   return Number.isFinite(Number(pointStr));
 }
@@ -284,8 +291,9 @@ export interface ParsedPromptFile {
   /**
    * Numeric per-option values, parsed from the body section. Populated for:
    *   - slider — every line is numeric
-   *   - multipleChoice in numeric mode (#282) — every option has a numeric
-   *     prefix (`- 1: Strongly disagree`, or bare `- 1`)
+   *   - multipleChoice in numeric mode (#282) — every option uses the
+   *     explicit `- <number>: <label>` colon form (#289). A bare `- 1` is
+   *     text, not a scale point, so it does NOT populate this array.
    * Empty for text-only multipleChoice, listSorter, openResponse, noResponse.
    * `responsePoints[i]` corresponds to `responseItems[i]`.
    */
@@ -518,10 +526,14 @@ export const promptFileSchema: z.ZodType<
       responsePoints = points;
       responseItems = labels;
     } else if (parsedMetadata.type === "multipleChoice") {
-      // #282: multipleChoice options can be all-numeric (`- 1: Strongly disagree`)
-      // or all-text (`- Strongly disagree`). Mixed = validation error.
-      // Numeric mode is restricted to single-select (radio); multi-select
-      // numeric mode has no clean averaging semantics and is out of scope for v1.
+      // #282/#289: multipleChoice options are all-numeric or all-text. The
+      // explicit `<number>: <label>` colon form is the numeric signal — a
+      // bare `- 1` is text (label "1"), so `1 / 2 / 3 / It Varies`
+      // comprehension checks stay text instead of erroring. All explicit
+      // numeric → numeric mode; mixing explicit-numeric with anything else =
+      // validation error. Numeric mode is restricted to single-select (radio);
+      // multi-select numeric mode has no clean averaging semantics and is out
+      // of scope for v1.
       const stripped: string[] = [];
       for (const line of responseLines) {
         if (!(line.startsWith("- ") || line === "-")) continue;


### PR DESCRIPTION
Fixes #289.

## Problem

`multipleChoice` numeric mode (#282) inferred "this is a numeric scale" from the **surface form** of the labels: any option beginning with a number counted as numeric. A comprehension check / quiz whose options are small integers plus a non-numeric foil — e.g.

```
- 1
- 2
- 3
- 4
- It Varies
```

therefore tripped the *mixes numeric and text* preflight error, even though the labels are identifiers used to gate on a discrete fact (`prompt.<name> == "2"`), not scale points. The only workaround was to make every label non-parseable (`1 person`, `2 people`, …) and rewire any `value:` conditions — viral and cosmetic.

## Change

Make the explicit `- <number>: <label>` **colon form** the numeric signal (the design the issue author proposed — no new frontmatter knob). A bare `- 1` is now text (label `"1"`), shorthand for `- 1: 1`, never a scale point:

- **all** options explicit-numeric → numeric mode (`responsePoints` populated)
- **any** bare/text option mixed with explicit-numeric → mixing error (unchanged)
- otherwise (including all-bare) → text mode

So comprehension checks stay text and `value: "2"` conditions keep matching the bare label. To opt a scale into numeric semantics, label every option with a colon — give label-less middle points a trailing colon (`- 2:`), which falls back to the stringified number. The endpoints-only Likert pattern migrates cleanly:

```
- 1: Strongly disagree
- 2:
- 3:
- 4:
- 5: Strongly agree
```

## ⚠️ Breaking behavior change

A `multipleChoice` that used **bare** numbers (`- 1` / `- 2` / `- 3`) to get numeric mode is now **text** mode (`responsePoints` empty; labels `"1".."3"`). The saved value is still the bare label, so `value:` conditions are unaffected — only the numeric `responsePoints` (averaging semantics) are dropped for the bare form.

No example or test in the tree relied on bare-number numeric mode, and numeric mode (#282) is recent, so blast radius is minimal. **Recommend cutting as a minor bump (0.19.0)** with this note rather than a patch.

## Tests (red/green TDD)

- Flipped the old `bare numbers → numeric` test in place to assert text mode (regression lock).
- Added: comprehension check (`1/2/3/4/It Varies` → text, not error); endpoints-only Likert via trailing colons → numeric; colon-bearing **text** label stays text (`- Maybe: not sure`); single bare numeric → text; explicit-numeric mixed with a bare number errors in **both** orderings.

## Reviews

Ran correctness / coverage / security subagent reviews against the diff before opening:
- **Correctness**: change is correct; sliders unaffected (they call `parseNumericResponseLine` directly); fixed one stale `responsePoints` JSDoc that still said "or bare `- 1`".
- **Coverage**: added the colon-in-text-label and both mixing-order tests it flagged.
- **Security**: no vuln / no ReDoS (only `indexOf`/`slice`/`Number`); the only finding is the data-semantics migration concern captured in the breaking-change note above.

Docs: added a "Numeric scales" subsection to `docs/researcher/prompts.md` documenting the colon opt-in.

Full local vitest (1570 lib + viewer + vscode) green; Playwright CT green (one known unrelated webkit `CheckboxGroup` focus-ring flake, passed on re-run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)