### PR TITLE
Bump stagebook to 0.19.0

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Minor release: additive features and new exports, no breaking changes.

## What's in

- **#412** — self-host Inter instead of fetching from rsms.me. Font bundled in the package (OFL-1.1) + new `stagebook/assets/InterVariable.woff2` subpath export, so participants get the same font regardless of network/CSP/CDN. Bundler-processed `stagebook/styles` imports need no action.
- **#482** — internationalization: chrome message catalog, locale schema, RTL support, viewer locale switching.
- **#485** — viewer: single sectioned part-picker; walk one unit at a time.
- **#289** — prompts: the colon is the numeric-mode signal for `multipleChoice`.
- **#487** — media: gate URL-touching effects on validity after deferring the guard.
- **#484** — media: hoist hooks above the unsafe-URL guard.
- i18n: derive `REGISTERED_LOCALES` from `defaultMessages`; locale runbook + docs.
- **#472** — docs: hosts must reset idle countdown on allow-idle release.

## Compatibility

- No API changes to existing exports; i18n and the font subpath export are additive.
- The Inter `@font-face` now resolves to a bundled asset instead of rsms.me — a bundler-processed `stagebook/styles` import handles it automatically; plain esbuild consumers must add a `.woff2` loader (`--loader:.woff2=file`).