### PR TITLE
feat(validate): run prompt locale-consistency in editor + viewer (#483)

### DIFF
--- a/apps/viewer/src/lib/loader.test.ts
+++ b/apps/viewer/src/lib/loader.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { loadTreatmentFromUrl } from "./loader";
+import { TreatmentValidationError } from "./treatment";
 
 const MINIMAL_YAML = `
 introSequences:
@@ -185,6 +186,224 @@ introSequences:
     ).rejects.toThrow(
       /Failed to fetch imported file 'modules\/missing\.stagebook\.yaml'.*HTTP 404.*same repo/s,
     );
+  });
+
+  // -- #483: prompt locale-consistency on load --
+
+  it("rejects when a he treatment references an untagged (en) prompt (#483)", async () => {
+    const rootYaml = `
+treatments:
+  - name: t
+    playerCount: 1
+    locale: he
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: prompt
+            name: q
+            file: prompts/q.prompt.md
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+`;
+    const fetch = routedFetch([
+      ["treatment.yaml", rootYaml],
+      ["prompts/q.prompt.md", "---\ntype: noResponse\n---\nhello\n"],
+    ]);
+
+    await expect(
+      loadTreatmentFromUrl(
+        "https://github.com/org/repo/blob/main/treatment.yaml",
+        fetch,
+      ),
+    ).rejects.toThrow(/authored in locale "en".*declares locale "he"/s);
+  });
+
+  it("loads cleanly when the prompt is tagged with the treatment's locale (#483)", async () => {
+    const rootYaml = `
+treatments:
+  - name: t
+    playerCount: 1
+    locale: he
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: prompt
+            name: q
+            file: prompts/q.prompt.md
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+`;
+    const fetch = routedFetch([
+      ["treatment.yaml", rootYaml],
+      [
+        "prompts/q.prompt.md",
+        "---\ntype: noResponse\nlocale: he\n---\nhello\n",
+      ],
+    ]);
+
+    const result = await loadTreatmentFromUrl(
+      "https://github.com/org/repo/blob/main/treatment.yaml",
+      fetch,
+    );
+    expect(result.treatmentFile.treatments[0].name).toBe("t");
+  });
+
+  it("does not reject on locale grounds when the prompt can't be fetched (#483)", async () => {
+    // A missing prompt 404s; the locale rule skips it rather than emitting a
+    // spurious mismatch. (Runtime rendering surfaces the missing file.)
+    const rootYaml = `
+treatments:
+  - name: t
+    playerCount: 1
+    locale: he
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: prompt
+            name: q
+            file: prompts/q.prompt.md
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+`;
+    const fetch = routedFetch([
+      ["treatment.yaml", rootYaml],
+      // prompts/q.prompt.md not routed → 404
+    ]);
+
+    const result = await loadTreatmentFromUrl(
+      "https://github.com/org/repo/blob/main/treatment.yaml",
+      fetch,
+    );
+    expect(result.treatmentFile.treatments[0].name).toBe("t");
+  });
+
+  it("never fetches a schema-rejected prompt path for the locale check (#483)", async () => {
+    // The live-fetch surface must never turn a gated path (absolute,
+    // traversal) into a network request. An absolute prompt path is rejected
+    // by the treatment schema; the locale rule must not fetch it or emit a
+    // second (locale) diagnostic for it.
+    const rootYaml = `
+treatments:
+  - name: t
+    playerCount: 1
+    locale: he
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: prompt
+            name: q
+            file: /etc/hosts.prompt.md
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+`;
+    const fetch = routedFetch([["treatment.yaml", rootYaml]]);
+
+    const err = await loadTreatmentFromUrl(
+      "https://github.com/org/repo/blob/main/treatment.yaml",
+      fetch,
+    ).catch((e: unknown) => e);
+
+    // Rejected on schema grounds (relative-path rule), not locale grounds.
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/relative path/);
+    expect((err as Error).message).not.toMatch(/authored in locale/);
+    // And the gated path was never fetched.
+    const fetchedUrls = (fetch.mock.calls as unknown[][]).map(
+      (args) => args[0] as string,
+    );
+    expect(fetchedUrls.some((u) => u.includes("hosts.prompt.md"))).toBe(false);
+  });
+
+  it("checks intro-step prompts against the intro sequence's own locale (#483)", async () => {
+    const rootYaml = `
+introSequences:
+  - name: i
+    locale: he
+    introSteps:
+      - name: consent
+        elements:
+          - type: prompt
+            name: c
+            file: prompts/consent.prompt.md
+          - type: submitButton
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+    const fetch = routedFetch([
+      ["treatment.yaml", rootYaml],
+      ["prompts/consent.prompt.md", "---\ntype: noResponse\n---\nhello\n"],
+    ]);
+
+    await expect(
+      loadTreatmentFromUrl(
+        "https://github.com/org/repo/blob/main/treatment.yaml",
+        fetch,
+      ),
+    ).rejects.toThrow(/intro sequence "i".*declares locale "he"/s);
+  });
+
+  it("surfaces every mismatching prompt, not just the first (#483)", async () => {
+    const rootYaml = `
+treatments:
+  - name: t
+    playerCount: 1
+    locale: he
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: prompt
+            name: a
+            file: prompts/a.prompt.md
+          - type: prompt
+            name: b
+            file: prompts/b.prompt.md
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+`;
+    const fetch = routedFetch([
+      ["treatment.yaml", rootYaml],
+      ["prompts/a.prompt.md", "---\ntype: noResponse\n---\na\n"],
+      ["prompts/b.prompt.md", "---\ntype: noResponse\n---\nb\n"],
+    ]);
+
+    const err = await loadTreatmentFromUrl(
+      "https://github.com/org/repo/blob/main/treatment.yaml",
+      fetch,
+    ).catch((e: unknown) => e);
+
+    expect(err).toBeInstanceOf(TreatmentValidationError);
+    expect((err as TreatmentValidationError).issues).toHaveLength(2);
   });
 
   it("supports transitive imports (A imports B imports C) (#312)", async () => {

--- a/apps/viewer/src/lib/loader.ts
+++ b/apps/viewer/src/lib/loader.ts
@@ -2,7 +2,10 @@ import { parseGitHubUrl } from "./github";
 import { expandTreatmentFile } from "./expandTreatmentFile";
 import { TreatmentValidationError } from "./treatment";
 import { safeParseTreatmentFile, type TreatmentFileType } from "stagebook";
-import { loadAndMergeImports } from "stagebook/validate";
+import {
+  loadAndMergeImports,
+  checkPromptLocaleConsistencyWithLoader,
+} from "stagebook/validate";
 
 export interface LoadResult {
   treatmentFile: TreatmentFileType;
@@ -78,6 +81,32 @@ export async function loadTreatmentFromUrl(
   }
 
   const { result, unresolvedFields } = expandTreatmentFile(parsed.data);
+
+  // Post-hydration locale-consistency rule (ADR 2026-06-localization #6):
+  // every referenced prompt's frontmatter `locale` must match its container's
+  // `locale` (both default `en`). Runs on the hydrated tree, fetching each
+  // prompt's frontmatter from the same repo + branch as the entry-point file.
+  // Surfaced through the same `TreatmentValidationError` path as schema errors
+  // so it shows up in the preview's validation UI. Unreadable / unparseable
+  // prompts return null and are skipped — those failures surface elsewhere.
+  const loadPrompt = async (relPath: string): Promise<string | null> => {
+    const promptResponse = await fetchFn(
+      `${rawBaseUrl}${relPath}?t=${Date.now()}`,
+    );
+    return promptResponse.ok ? promptResponse.text() : null;
+  };
+  const localeMismatches = await checkPromptLocaleConsistencyWithLoader({
+    fileObj: result,
+    loadPrompt,
+  });
+  if (localeMismatches.length > 0) {
+    throw new TreatmentValidationError(
+      localeMismatches.map((mismatch) => ({
+        path: mismatch.promptFile,
+        message: mismatch.message,
+      })),
+    );
+  }
 
   return { treatmentFile: result, unresolvedFields, rawBaseUrl };
 }

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -1042,12 +1042,24 @@ export function activate(context: vscode.ExtensionContext): void {
   // common-case win (skipping redundant tab-focus revalidations of the
   // unchanged active doc) while ensuring import edits cause the root to
   // re-validate on its next trigger.
+  //
+  // A treatment's validation result ALSO depends on its referenced
+  // prompts' frontmatter `locale` (the locale-consistency rule). Editing
+  // a `.prompt.md` — e.g. fixing or removing a `locale:` tag — must
+  // likewise invalidate the treatment caches so the stale locale-mismatch
+  // diagnostic clears on the treatment's next trigger. Prompt docs aren't
+  // themselves cache-keyed here (only treatments are), so clear every
+  // entry.
   context.subscriptions.push(
     vscode.workspace.onDidChangeTextDocument((event) => {
       if (isStagebookYaml(event.document)) {
         const changedKey = event.document.uri.toString();
         for (const k of lastValidatedSource.keys()) {
           if (k !== changedKey) lastValidatedSource.delete(k);
+        }
+      } else if (isStagebookPrompt(event.document)) {
+        for (const k of lastValidatedSource.keys()) {
+          lastValidatedSource.delete(k);
         }
       }
       validateDocumentDebounced(event.document);

--- a/packages/stagebook/src/cli/validate.ts
+++ b/packages/stagebook/src/cli/validate.ts
@@ -9,14 +9,9 @@ import {
   validateTreatmentSource,
   validatePromptSource,
   expandAndValidateWithImports,
+  checkPromptLocaleConsistencyWithLoader,
 } from "../validate/index.js";
 import { load as loadYaml } from "js-yaml";
-import {
-  fileSchema,
-  promptFileSchema,
-  collectReferencedPromptFiles,
-  checkPromptLocaleConsistency,
-} from "../index.js";
 
 export type Format = "text" | "json";
 export type FileType = "treatment" | "prompt";
@@ -280,10 +275,12 @@ function detectFileType(path: string): FileType | null {
 }
 
 /**
- * Build the prompt→locale map by reading each referenced prompt file from
- * disk, then run `checkPromptLocaleConsistency`. Unreadable or unparseable
- * prompts are skipped — missing files and invalid prompt syntax are different
- * error classes, reported when those files are validated directly.
+ * Run the locale-consistency rule over the expanded treatment, reading each
+ * referenced prompt file from disk via the shared
+ * `checkPromptLocaleConsistencyWithLoader` wiring (same loop the extension and
+ * viewer use). Unreadable or unparseable prompts are skipped — missing files
+ * and invalid prompt syntax are different error classes, reported when those
+ * files are validated directly.
  */
 async function checkLocaleConsistencyDiagnostics(
   fullYaml: string,
@@ -296,31 +293,22 @@ async function checkLocaleConsistencyDiagnostics(
     return []; // YAML errors are already reported by the schema pass
   }
 
-  const promptLocales = new Map<string, string | undefined>();
-  for (const relPath of collectReferencedPromptFiles(fileObj)) {
-    // Gate before the read (ADR security acceptance condition): never read a
-    // path the schema rejects (absolute, backslash, interior `..`). Those
-    // paths already carry their own error diagnostics from the schema pass —
-    // this just ensures the locale rule can't be used to read them anyway.
-    if (!fileSchema.safeParse(relPath).success) continue;
-    let promptSource: string;
-    try {
-      promptSource = await readFile(resolvePath(dir, relPath), "utf8");
-    } catch {
-      continue;
-    }
-    const parsed = promptFileSchema.safeParse(promptSource);
-    if (!parsed.success) continue;
-    promptLocales.set(relPath, parsed.data.metadata.locale);
-  }
+  const mismatches = await checkPromptLocaleConsistencyWithLoader({
+    fileObj,
+    loadPrompt: async (relPath) => {
+      try {
+        return await readFile(resolvePath(dir, relPath), "utf8");
+      } catch {
+        return null;
+      }
+    },
+  });
 
-  return checkPromptLocaleConsistency(fileObj, promptLocales).map(
-    (mismatch) => ({
-      severity: "error" as const,
-      message: mismatch.message,
-      range: null,
-    }),
-  );
+  return mismatches.map((mismatch) => ({
+    severity: "error" as const,
+    message: mismatch.message,
+    range: null,
+  }));
 }
 
 function hasGlobChars(s: string): boolean {

--- a/packages/stagebook/src/validate/index.ts
+++ b/packages/stagebook/src/validate/index.ts
@@ -8,6 +8,7 @@ export * from "./yamlPositionMap.js";
 export * from "./offsetToLineCol.js";
 export * from "./unrecognizedKeyMessage.js";
 export * from "./loadAndMergeImports.js";
+export * from "./localeConsistency.js";
 export * from "./parseTreatmentSource.js";
 export * from "./validateTreatment.js";
 export * from "./validatePrompt.js";

--- a/packages/stagebook/src/validate/localeConsistency.test.ts
+++ b/packages/stagebook/src/validate/localeConsistency.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from "vitest";
+import { checkPromptLocaleConsistencyWithLoader } from "./localeConsistency.js";
+
+/**
+ * Host-side wiring for the locale-consistency rule. The pure rule has its
+ * own exhaustive suite (`schemas/localeConsistency.test.ts`); this verifies
+ * the I/O layer that feeds it: which paths get loaded, how unreadable /
+ * unparseable / schema-rejected prompts are handled, and that the loaded
+ * frontmatter locale reaches the rule.
+ */
+
+const treatment = (locale: string | undefined, file: string) => ({
+  treatments: [
+    {
+      name: "t",
+      ...(locale === undefined ? {} : { locale }),
+      gameStages: [{ name: "g", elements: [{ type: "prompt", file }] }],
+    },
+  ],
+});
+
+const promptWithLocale = (locale: string | undefined) =>
+  `---\ntype: noResponse\n${locale === undefined ? "" : `locale: ${locale}\n`}---\nbody\n`;
+
+describe("checkPromptLocaleConsistencyWithLoader", () => {
+  it("flags an untagged prompt referenced by a non-English treatment", async () => {
+    const loadPrompt = vi.fn(async () => promptWithLocale(undefined));
+    const mismatches = await checkPromptLocaleConsistencyWithLoader({
+      fileObj: treatment("he", "intro.prompt.md"),
+      loadPrompt,
+    });
+    expect(loadPrompt).toHaveBeenCalledWith("intro.prompt.md");
+    expect(mismatches).toHaveLength(1);
+    expect(mismatches[0]).toMatchObject({
+      containerLocale: "he",
+      promptLocale: "en",
+      promptFile: "intro.prompt.md",
+    });
+  });
+
+  it("passes when prompt locale matches the treatment", async () => {
+    const mismatches = await checkPromptLocaleConsistencyWithLoader({
+      fileObj: treatment("he", "intro.prompt.md"),
+      loadPrompt: async () => promptWithLocale("he"),
+    });
+    expect(mismatches).toEqual([]);
+  });
+
+  it("skips prompts the loader can't read (returns null)", async () => {
+    const mismatches = await checkPromptLocaleConsistencyWithLoader({
+      fileObj: treatment("he", "missing.prompt.md"),
+      loadPrompt: async () => null,
+    });
+    expect(mismatches).toEqual([]);
+  });
+
+  it("skips prompts whose loader throws", async () => {
+    const mismatches = await checkPromptLocaleConsistencyWithLoader({
+      fileObj: treatment("he", "boom.prompt.md"),
+      loadPrompt: async () => {
+        throw new Error("network");
+      },
+    });
+    expect(mismatches).toEqual([]);
+  });
+
+  it("skips prompts that don't parse as prompt files", async () => {
+    const mismatches = await checkPromptLocaleConsistencyWithLoader({
+      fileObj: treatment("he", "junk.prompt.md"),
+      loadPrompt: async () => "this is not a valid prompt file",
+    });
+    expect(mismatches).toEqual([]);
+  });
+
+  it("never loads a schema-rejected path (absolute / traversal)", async () => {
+    const loadPrompt = vi.fn(async () => promptWithLocale(undefined));
+    await checkPromptLocaleConsistencyWithLoader({
+      fileObj: treatment("he", "/etc/passwd"),
+      loadPrompt,
+    });
+    expect(loadPrompt).not.toHaveBeenCalled();
+  });
+
+  it("loads each unique referenced prompt once", async () => {
+    const loadPrompt = vi.fn(async () => promptWithLocale("en"));
+    await checkPromptLocaleConsistencyWithLoader({
+      fileObj: {
+        treatments: [
+          {
+            name: "t",
+            locale: "en",
+            gameStages: [
+              {
+                name: "a",
+                elements: [{ type: "prompt", file: "p.prompt.md" }],
+              },
+              {
+                name: "b",
+                elements: [{ type: "prompt", file: "p.prompt.md" }],
+              },
+            ],
+          },
+        ],
+      },
+      loadPrompt,
+    });
+    expect(loadPrompt).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/stagebook/src/validate/localeConsistency.ts
+++ b/packages/stagebook/src/validate/localeConsistency.ts
@@ -1,0 +1,58 @@
+import {
+  fileSchema,
+  promptFileSchema,
+  collectReferencedPromptFiles,
+  checkPromptLocaleConsistency,
+  type PromptLocaleMismatch,
+} from "../index.js";
+
+/**
+ * Host-side wiring for the locale-consistency rule (ADR
+ * docs/decisions/2026-06-localization.md, decision #6).
+ *
+ * The pure rule (`checkPromptLocaleConsistency`) compares already-loaded
+ * locales; the file I/O it needs is host-specific (Node `fs` in the CLI,
+ * `vscode.workspace.fs` in the extension, `fetch` in the viewer). This
+ * function is that shared wiring so the three surfaces don't each reimplement
+ * the same load-gate-parse loop:
+ *
+ *   1. collect the referenced prompt files (scheme-bearing paths excluded —
+ *      the host can't read those locally),
+ *   2. gate each path through `fileSchema` — never read a path the schema
+ *      rejects (absolute, backslash, interior `..`); those carry their own
+ *      error diagnostics elsewhere, and this keeps the locale rule from being
+ *      used to read them anyway (ADR security acceptance condition),
+ *   3. load + parse frontmatter via the host's `loadPrompt` callback,
+ *   4. run the rule.
+ *
+ * `loadPrompt` returns the prompt source, or `null` when it can't be read.
+ * A throwing loader is also treated as unreadable: missing-file and
+ * invalid-prompt problems are different error classes with their own
+ * reporting, so they're skipped here rather than reported twice.
+ *
+ * @param fileObj hydrated (post-fillTemplates) treatment file object — the
+ *   same shape the pure rule walks.
+ */
+export async function checkPromptLocaleConsistencyWithLoader({
+  fileObj,
+  loadPrompt,
+}: {
+  fileObj: unknown;
+  loadPrompt: (relPath: string) => Promise<string | null>;
+}): Promise<PromptLocaleMismatch[]> {
+  const promptLocales = new Map<string, string | undefined>();
+  for (const relPath of collectReferencedPromptFiles(fileObj)) {
+    if (!fileSchema.safeParse(relPath).success) continue;
+    let source: string | null;
+    try {
+      source = await loadPrompt(relPath);
+    } catch {
+      continue;
+    }
+    if (source === null) continue;
+    const parsed = promptFileSchema.safeParse(source);
+    if (!parsed.success) continue;
+    promptLocales.set(relPath, parsed.data.metadata.locale);
+  }
+  return checkPromptLocaleConsistency(fileObj, promptLocales);
+}

--- a/packages/stagebook/src/validate/validateTreatmentDiff.test.ts
+++ b/packages/stagebook/src/validate/validateTreatmentDiff.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { validateTreatmentWithDiff } from "./validateTreatmentDiff.js";
 
 /**
@@ -304,6 +304,124 @@ treatments:
       // should match the position of 's' in 'surveryName'.
       const colInLine = lines[keyLine].indexOf("surveryName");
       expect(unrecognized!.range?.startCol).toBe(colInLine);
+    });
+  });
+
+  describe("prompt locale consistency (ADR 2026-06-localization #6)", () => {
+    const heTreatment = `treatments:
+  - name: t
+    playerCount: 1
+    locale: he
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: prompt
+            file: intro.prompt.md
+`;
+
+    it("flags an untagged (en) prompt referenced by a he treatment", async () => {
+      const result = await validateTreatmentWithDiff({
+        source: heTreatment,
+        loadImport: loaderFromMap({
+          "intro.prompt.md": "---\ntype: noResponse\n---\nhello\n",
+        }),
+      });
+      const localeError = result.diagnostics.find((d) =>
+        d.message.includes("authored in locale"),
+      );
+      expect(localeError).toBeDefined();
+      expect(localeError!.severity).toBe("error");
+    });
+
+    it("passes when the prompt is tagged with the treatment's locale", async () => {
+      const result = await validateTreatmentWithDiff({
+        source: heTreatment,
+        loadImport: loaderFromMap({
+          "intro.prompt.md": "---\ntype: noResponse\nlocale: he\n---\nhello\n",
+        }),
+      });
+      const localeError = result.diagnostics.find((d) =>
+        d.message.includes("authored in locale"),
+      );
+      expect(localeError).toBeUndefined();
+    });
+
+    it("stays silent when the prompt file can't be loaded", async () => {
+      // Missing prompts are the file-existence checker's job, not the
+      // locale rule's — no spurious locale diagnostic here.
+      const result = await validateTreatmentWithDiff({
+        source: heTreatment,
+        loadImport: noImports,
+      });
+      const localeError = result.diagnostics.find((d) =>
+        d.message.includes("authored in locale"),
+      );
+      expect(localeError).toBeUndefined();
+    });
+
+    it("checks intro-step prompts against the intro sequence's locale", async () => {
+      const source = `introSequences:
+  - name: i
+    locale: he
+    introSteps:
+      - name: consent
+        elements:
+          - type: prompt
+            file: consent.prompt.md
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+      const result = await validateTreatmentWithDiff({
+        source,
+        loadImport: loaderFromMap({
+          "consent.prompt.md": "---\ntype: noResponse\n---\nhello\n",
+        }),
+      });
+      const localeError = result.diagnostics.find((d) =>
+        d.message.includes("authored in locale"),
+      );
+      expect(localeError).toBeDefined();
+      expect(localeError!.message).toContain('intro sequence "i"');
+    });
+
+    it("never reads a schema-rejected prompt path for the locale check", async () => {
+      // An absolute prompt path is flagged by the schema; the locale rule
+      // must gate before the read — no loadImport call, no second
+      // (locale) diagnostic for it.
+      const source = `treatments:
+  - name: t
+    playerCount: 1
+    locale: he
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: prompt
+            file: /etc/hosts.prompt.md
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+`;
+      const loadImport = vi.fn(loaderFromMap({}));
+      const result = await validateTreatmentWithDiff({ source, loadImport });
+      const localeError = result.diagnostics.find((d) =>
+        d.message.includes("authored in locale"),
+      );
+      expect(localeError).toBeUndefined();
+      const readAbsPath = loadImport.mock.calls.some((args) =>
+        String(args[0]).includes("hosts.prompt.md"),
+      );
+      expect(readAbsPath).toBe(false);
     });
   });
 

--- a/packages/stagebook/src/validate/validateTreatmentDiff.ts
+++ b/packages/stagebook/src/validate/validateTreatmentDiff.ts
@@ -7,6 +7,7 @@ import {
 } from "../index.js";
 import type { ZodIssue } from "zod";
 import { loadAndMergeImports } from "./loadAndMergeImports.js";
+import { checkPromptLocaleConsistencyWithLoader } from "./localeConsistency.js";
 import { createPositionMapper, extractYamlErrors } from "./yamlPositionMap.js";
 import type { Diagnostic } from "./types.js";
 
@@ -216,6 +217,26 @@ export async function validateTreatmentWithDiff({
         message: `${issue.message} (${formatPath(issue.path)})`,
         severity: "error",
         range: resolveOrWalkUp(mapper, issue.path),
+      });
+    }
+
+    // Post-hydration locale-consistency rule (ADR 2026-06-localization #6):
+    // every referenced prompt's frontmatter `locale` must match its
+    // container's `locale` (both default `en`). Cross-file by nature — it
+    // loads each prompt's frontmatter via the same `loadImport` bridge the
+    // editor uses for `imports:`. Unreadable/unparseable prompts are skipped
+    // (a missing prompt is reported by the file-existence checker instead).
+    // Top-of-file range (null): the rule reports per (container, prompt file),
+    // not a single source token, and the message names both.
+    const localeMismatches = await checkPromptLocaleConsistencyWithLoader({
+      fileObj: diff.hydrated,
+      loadPrompt: loadImport,
+    });
+    for (const mismatch of localeMismatches) {
+      diagnostics.push({
+        message: mismatch.message,
+        severity: "error",
+        range: null,
       });
     }
   }


### PR DESCRIPTION
Fixes #483.

## Problem

`checkPromptLocaleConsistency` — a prompt's frontmatter `locale` must match its container's locale, both defaulting to `en` (ADR `docs/decisions/2026-06-localization.md`, decision #6) — was only run by the CLI (`stagebook validate`). The VS Code extension's live validation (`validateTreatmentWithDiff`) and the viewer's load path (`loadTreatmentFromUrl`) didn't invoke it, so on those surfaces a `locale: he` treatment could reference an untagged English prompt with **no diagnostic**.

The rule needs file I/O (it loads each referenced prompt's frontmatter), so it can't live in the pure schema validators — each host must wire it.

## Approach

Rather than duplicate the CLI's collect → gate → load → parse → run loop across three hosts, this adds one shared host-side wiring helper and points every surface at it:

- **`checkPromptLocaleConsistencyWithLoader`** (new, `stagebook/validate`) — takes the hydrated treatment object plus a `loadPrompt(relPath) => Promise<string | null>` callback. Collects referenced prompt files, gates each path through `fileSchema` **before** any load, parses frontmatter, and runs the pure rule. A `null`-returning or throwing loader is treated as "unreadable → skip" (missing/invalid prompts are different error classes, reported elsewhere).

Wired into each host:

- **VS Code extension** — runs inside `validateTreatmentWithDiff` on the hydrated tree (`diff.hydrated`), reusing the editor's existing `loadImport` bridge. Mismatches surface as error diagnostics. No extension-side code change needed.
- **Viewer** — runs in `loadTreatmentFromUrl` on the expanded treatment, fetching prompt frontmatter from the same repo + branch as the entry-point file (same resolution the runtime uses in `contentFns`). Mismatches surface through the existing `TreatmentValidationError` → preview validation UI.
- **CLI** — refactored to drop its duplicated loop and call the shared helper (behavior unchanged).

## Security

The path gate (never read a path `fileSchema` rejects — absolute, backslash, interior `..` traversal) runs **before** any load at every surface, preserving the rule's existing invariant. Scheme-bearing paths (`http(s)://`, `asset://`) are already excluded by `collectReferencedPromptFiles`, so the viewer can't be coerced into fetching an attacker-supplied absolute URL. The extension keeps its `isWithinWorkspace` workspace-boundary guard as defense in depth.

## Tests

- New unit tests for the shared helper (gate, null/throw/unparseable skip, dedup).
- New wiring tests in `validateTreatmentDiff.test.ts` and viewer `loader.test.ts`: treatment + intro-sequence mismatch, match passes, unreadable-prompt skip, security gate (gated path never loaded/fetched), multiple mismatches surfaced together.
- Existing CLI locale-consistency coverage still pins the refactored path.

Full vitest suite (1590 + 164 + 88) and Playwright CT green locally; lint clean.

Reviewed before opening with three parallel subagents (correctness / coverage / security) — no correctness or security findings; coverage gaps were folded in as the tests above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)