### PR TITLE
feat(vscode): Validate Workspace command (#442)

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -28,6 +28,10 @@
       {
         "command": "stagebook.previewStage",
         "title": "Stagebook: Preview Treatment"
+      },
+      {
+        "command": "stagebook.validateWorkspace",
+        "title": "Stagebook: Validate Workspace"
       }
     ],
     "menus": {

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -416,24 +416,28 @@ async function validateWorkspace(
 
       await runPool(tasks, WORKSPACE_VALIDATION_CONCURRENCY);
 
-      updateWorkspaceStatusBar(statusBar, treatments.length + prompts.length);
+      updateWorkspaceStatusBar(statusBar, [...treatments, ...prompts]);
     },
   );
 }
 
 /**
- * Aggregate all Stagebook diagnostics currently in the diagnostic collection
- * and render the status-bar summary. Counts every `source === "stagebook"`
- * diagnostic across the workspace (not only this run's files), which is the
- * accurate current picture after a sweep.
+ * Render the status-bar summary for a completed sweep. Counts only the
+ * `source === "stagebook"` diagnostics on the files this run actually scanned
+ * (`scannedUris`) — NOT every Stagebook diagnostic in the collection. The
+ * latter would fold in files outside the glob (e.g. a `node_modules` file the
+ * user happens to have open and edited), so the "across N files" headline and
+ * the "of N scanned" tooltip would attribute errors to a scan that never
+ * touched the offending file.
  */
 function updateWorkspaceStatusBar(
   statusBar: vscode.StatusBarItem,
-  filesValidated: number,
+  scannedUris: vscode.Uri[],
 ): void {
   const perFile: DiagnosticSeverityLabel[][] = [];
-  for (const [, diags] of vscode.languages.getDiagnostics()) {
-    const labels = diags
+  for (const uri of scannedUris) {
+    const labels = vscode.languages
+      .getDiagnostics(uri)
       .filter((d) => d.source === "stagebook")
       .map<DiagnosticSeverityLabel>((d) =>
         d.severity === vscode.DiagnosticSeverity.Error ? "error" : "warning",
@@ -442,7 +446,10 @@ function updateWorkspaceStatusBar(
   }
 
   const summary = summarizeDiagnostics(perFile);
-  const { text, tooltip } = formatValidationStatusBar(summary, filesValidated);
+  const { text, tooltip } = formatValidationStatusBar(
+    summary,
+    scannedUris.length,
+  );
   statusBar.text = text;
   statusBar.tooltip = tooltip;
   statusBar.command = OPEN_PROBLEMS_COMMAND;

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -17,6 +17,7 @@ import { findClosestMatch } from "./lib/levenshtein";
 import { UnrecognizedKeyQuickFixProvider } from "./lib/unrecognizedKeyQuickFix";
 import { isWithinWorkspace, relativizePath } from "./lib/filePaths";
 import { runPool } from "./lib/runPool";
+import { buildFindExcludeGlob } from "./lib/findExclude";
 import {
   summarizeDiagnostics,
   formatValidationStatusBar,
@@ -358,6 +359,22 @@ const WORKSPACE_VALIDATION_CONCURRENCY = 4;
 const OPEN_PROBLEMS_COMMAND = "workbench.actions.view.problems";
 
 /**
+ * Set a single top-of-file error diagnostic when a swept file can't be read.
+ * Uses `source: "stagebook"` so `updateWorkspaceStatusBar` counts it — a read
+ * failure must not be reported as a clean scan.
+ */
+function setReadErrorDiagnostic(uri: vscode.Uri, err: unknown): void {
+  const message = err instanceof Error ? err.message : String(err);
+  const diag = new vscode.Diagnostic(
+    new vscode.Range(0, 0, 0, 1),
+    `Stagebook could not read this file: ${message}`,
+    vscode.DiagnosticSeverity.Error,
+  );
+  diag.source = "stagebook";
+  diagnosticCollection.set(uri, [diag]);
+}
+
+/**
  * Validate every Stagebook file in the workspace, not just the ones the user
  * has opened this session (issue #442). Globs `**\/*.stagebook.yaml` and
  * `**\/*.prompt.md` (honoring `files.exclude` / `search.exclude` via
@@ -381,9 +398,22 @@ async function validateWorkspace(
       title: "Stagebook: validating workspace…",
     },
     async () => {
+      // Honor the user's configured excludes. `findFiles` drops both
+      // `files.exclude` and `search.exclude` as soon as a concrete exclude
+      // glob is passed, so merge them (plus node_modules) ourselves.
+      const excludeGlob = buildFindExcludeGlob(
+        vscode.workspace
+          .getConfiguration("files")
+          .get<Record<string, unknown>>("exclude") ?? {},
+        vscode.workspace
+          .getConfiguration("search")
+          .get<Record<string, unknown>>("exclude") ?? {},
+        ["**/node_modules/**"],
+      );
+
       const [treatments, prompts] = await Promise.all([
-        vscode.workspace.findFiles("**/*.stagebook.yaml", "**/node_modules/**"),
-        vscode.workspace.findFiles("**/*.prompt.md", "**/node_modules/**"),
+        vscode.workspace.findFiles("**/*.stagebook.yaml", excludeGlob),
+        vscode.workspace.findFiles("**/*.prompt.md", excludeGlob),
       ]);
 
       // Prefer the live editor buffer when a file is open so workspace results
@@ -407,14 +437,45 @@ async function validateWorkspace(
           // The user explicitly asked to re-validate, so bypass the
           // source-equality short-circuit for this run.
           lastValidatedSource.delete(uri.toString());
-          await validateTreatmentSourceAt(uri, await readSource(uri));
+          let source: string;
+          try {
+            source = await readSource(uri);
+          } catch (e) {
+            // A matched file can become unreadable between findFiles and the
+            // read (deleted, permissions). runPool swallows task rejections,
+            // so surface it as a diagnostic rather than letting the URI count
+            // as a clean scan.
+            setReadErrorDiagnostic(uri, e);
+            return;
+          }
+          await validateTreatmentSourceAt(uri, source);
         }),
         ...prompts.map((uri) => async () => {
-          validatePromptSourceAt(uri, await readSource(uri));
+          let source: string;
+          try {
+            source = await readSource(uri);
+          } catch (e) {
+            setReadErrorDiagnostic(uri, e);
+            return;
+          }
+          validatePromptSourceAt(uri, source);
         }),
       ];
 
       await runPool(tasks, WORKSPACE_VALIDATION_CONCURRENCY);
+
+      // Drop the source-equality cache for scanned files that aren't currently
+      // open. Those files get no `onDidCloseTextDocument` to clear the stamp,
+      // so leaving it set would let a later open hit the shortcut and keep
+      // stale cross-file diagnostics after an import/prompt/asset changes on
+      // disk. Open files keep their stamp (live editing manages it).
+      const openKeys = new Set(
+        vscode.workspace.textDocuments.map((d) => d.uri.toString()),
+      );
+      for (const uri of treatments) {
+        const key = uri.toString();
+        if (!openKeys.has(key)) lastValidatedSource.delete(key);
+      }
 
       updateWorkspaceStatusBar(statusBar, [...treatments, ...prompts]);
     },

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -16,6 +16,12 @@ import {
 import { findClosestMatch } from "./lib/levenshtein";
 import { UnrecognizedKeyQuickFixProvider } from "./lib/unrecognizedKeyQuickFix";
 import { isWithinWorkspace, relativizePath } from "./lib/filePaths";
+import { runPool } from "./lib/runPool";
+import {
+  summarizeDiagnostics,
+  formatValidationStatusBar,
+  type DiagnosticSeverityLabel,
+} from "./lib/diagnosticSummary";
 import {
   ASSET_GLOB,
   buildCompletionGlob,
@@ -117,11 +123,23 @@ function toVscodeRange(range: Diagnostic["range"]): vscode.Range {
   );
 }
 
-async function validateTreatmentFile(
-  document: vscode.TextDocument,
+function validateTreatmentFile(document: vscode.TextDocument): Promise<void> {
+  return validateTreatmentSourceAt(document.uri, document.getText());
+}
+
+/**
+ * Validate a treatment from `(uri, source)` without requiring a live
+ * `vscode.TextDocument`. Used both for open editors (via
+ * `validateTreatmentFile`) and for on-disk files swept by the
+ * "Validate Workspace" command. Results land in the shared
+ * `diagnosticCollection` keyed by `uri`, so a later live edit cleanly
+ * overwrites a workspace-run entry for the same file.
+ */
+async function validateTreatmentSourceAt(
+  uri: vscode.Uri,
+  source: string,
 ): Promise<void> {
-  const uriKey = document.uri.toString();
-  const source = document.getText();
+  const uriKey = uri.toString();
 
   // Skip when re-validating an identical source — e.g. tab-focus or
   // doc-open events that fire after the user looked at another file
@@ -132,9 +150,9 @@ async function validateTreatmentFile(
 
   const version = (validationVersions.get(uriKey) ?? 0) + 1;
   validationVersions.set(uriKey, version);
-  const rootDir = vscode.Uri.joinPath(document.uri, "..");
+  const rootDir = vscode.Uri.joinPath(uri, "..");
   const workspaceFolder =
-    vscode.workspace.getWorkspaceFolder(document.uri) ??
+    vscode.workspace.getWorkspaceFolder(uri) ??
     vscode.workspace.workspaceFolders?.[0];
   const decoder = new TextDecoder();
 
@@ -174,7 +192,7 @@ async function validateTreatmentFile(
       vscode.DiagnosticSeverity.Error,
     );
     fallback.source = "stagebook";
-    diagnosticCollection.set(document.uri, [fallback]);
+    diagnosticCollection.set(uri, [fallback]);
     return;
   }
 
@@ -192,7 +210,7 @@ async function validateTreatmentFile(
     return diag;
   });
 
-  diagnosticCollection.set(document.uri, vscodeDiagnostics);
+  diagnosticCollection.set(uri, vscodeDiagnostics);
   // Stamp the cache after the schema/diff pass succeeds. We deliberately
   // stamp BEFORE the async `checkFileReferences` call below — file-existence
   // checks update the diagnostic set in place and don't need to re-trigger
@@ -205,8 +223,8 @@ async function validateTreatmentFile(
     typeof result.parsedObj === "object" &&
     vscode.workspace.workspaceFolders?.length
   ) {
-    checkFileReferences(
-      document,
+    await checkFileReferences(
+      uri,
       result.parsedObj,
       source,
       vscodeDiagnostics,
@@ -221,47 +239,51 @@ async function validateTreatmentFile(
  * type allowlist of file-like fields (prompt.file, image.file, audio.file,
  * mediaPlayer.file, mediaPlayer.captionsFile) and filters out template
  * placeholders and full URLs; we still apply a path-traversal guard here.
+ *
+ * Awaits every `fs.stat` and applies the resulting diagnostics in a single
+ * batched `set`. Callers (`validateTreatmentSourceAt`) await it, so the
+ * "Validate Workspace" summary counts file-existence errors accurately rather
+ * than racing the stats; the live debounced path is fire-and-forget either way.
  */
-function checkFileReferences(
-  document: vscode.TextDocument,
+async function checkFileReferences(
+  uri: vscode.Uri,
   obj: unknown,
   source: string,
   diagnostics: vscode.Diagnostic[],
   version: number,
-): void {
+): Promise<void> {
   const assets = getReferencedAssets(obj);
   if (assets.length === 0) return;
 
-  const treatmentDir = vscode.Uri.joinPath(document.uri, "..");
+  const treatmentDir = vscode.Uri.joinPath(uri, "..");
   const workspaceFolder =
-    vscode.workspace.getWorkspaceFolder(document.uri) ??
+    vscode.workspace.getWorkspaceFolder(uri) ??
     vscode.workspace.workspaceFolders![0];
-  const uriKey = document.uri.toString();
+  const uriKey = uri.toString();
 
-  for (const asset of assets) {
-    const fileUri = vscode.Uri.joinPath(treatmentDir, asset.path);
+  let changed = false;
+  await Promise.all(
+    assets.map(async (asset) => {
+      const fileUri = vscode.Uri.joinPath(treatmentDir, asset.path);
 
-    if (!isWithinWorkspace(fileUri.fsPath, workspaceFolder.uri.fsPath)) {
-      diagnostics.push(
-        makeFileDiagnostic(
-          source,
-          asset.pathInTree,
-          `File path escapes workspace: ${asset.path}`,
-          vscode.DiagnosticSeverity.Error,
-        ),
-      );
-      diagnosticCollection.set(document.uri, diagnostics);
-      continue;
-    }
+      if (!isWithinWorkspace(fileUri.fsPath, workspaceFolder.uri.fsPath)) {
+        diagnostics.push(
+          makeFileDiagnostic(
+            source,
+            asset.pathInTree,
+            `File path escapes workspace: ${asset.path}`,
+            vscode.DiagnosticSeverity.Error,
+          ),
+        );
+        changed = true;
+        return;
+      }
 
-    vscode.workspace.fs.stat(fileUri).then(
-      () => {
+      try {
+        await vscode.workspace.fs.stat(fileUri);
         // File exists — extension validity (e.g. .prompt.md for prompts) is
         // enforced by schema (promptFilePathSchema), so no redundant check.
-      },
-      () => {
-        if (validationVersions.get(uriKey) !== version) return;
-
+      } catch {
         diagnostics.push(
           makeFileDiagnostic(
             source,
@@ -270,10 +292,15 @@ function checkFileReferences(
             vscode.DiagnosticSeverity.Error,
           ),
         );
-        diagnosticCollection.set(document.uri, diagnostics);
-      },
-    );
-  }
+        changed = true;
+      }
+    }),
+  );
+
+  // Stale-version guard: a newer edit may have fired while we awaited the
+  // stats. Discard rather than clobber the newer result.
+  if (validationVersions.get(uriKey) !== version) return;
+  if (changed) diagnosticCollection.set(uri, diagnostics);
 }
 
 function makeFileDiagnostic(
@@ -298,7 +325,15 @@ function makeFileDiagnostic(
 }
 
 function validatePromptFile(document: vscode.TextDocument): void {
-  const source = document.getText();
+  validatePromptSourceAt(document.uri, document.getText());
+}
+
+/**
+ * Validate a prompt from `(uri, source)` without requiring a live
+ * `vscode.TextDocument`. Used both for open editors and for on-disk files
+ * swept by the "Validate Workspace" command.
+ */
+function validatePromptSourceAt(uri: vscode.Uri, source: string): void {
   const result = validatePromptSource(source);
 
   const vscodeDiagnostics = result.diagnostics.map((d) => {
@@ -311,7 +346,107 @@ function validatePromptFile(document: vscode.TextDocument): void {
     return diag;
   });
 
-  diagnosticCollection.set(document.uri, vscodeDiagnostics);
+  diagnosticCollection.set(uri, vscodeDiagnostics);
+}
+
+// --- Validate Workspace command ---
+
+/** Max treatment/prompt validations in flight during a workspace sweep. */
+const WORKSPACE_VALIDATION_CONCURRENCY = 4;
+
+/** Command id for opening the Problems panel (status-bar click-through). */
+const OPEN_PROBLEMS_COMMAND = "workbench.actions.view.problems";
+
+/**
+ * Validate every Stagebook file in the workspace, not just the ones the user
+ * has opened this session (issue #442). Globs `**\/*.stagebook.yaml` and
+ * `**\/*.prompt.md` (honoring `files.exclude` / `search.exclude` via
+ * `findFiles`; `.gitignore` is intentionally NOT applied — see PR), runs the
+ * same validators the live editor flow uses so diagnostics are identical, and
+ * surfaces an aggregate count in the status bar.
+ */
+async function validateWorkspace(
+  statusBar: vscode.StatusBarItem,
+): Promise<void> {
+  if (!vscode.workspace.workspaceFolders?.length) {
+    void vscode.window.showWarningMessage(
+      "Stagebook: open a folder to validate its treatment and prompt files.",
+    );
+    return;
+  }
+
+  await vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Window,
+      title: "Stagebook: validating workspace…",
+    },
+    async () => {
+      const [treatments, prompts] = await Promise.all([
+        vscode.workspace.findFiles("**/*.stagebook.yaml", "**/node_modules/**"),
+        vscode.workspace.findFiles("**/*.prompt.md", "**/node_modules/**"),
+      ]);
+
+      // Prefer the live editor buffer when a file is open so workspace results
+      // match exactly what live validation shows (including unsaved edits);
+      // otherwise read committed bytes from disk. Reading bytes — rather than
+      // `openTextDocument` — is deliberate: documents opened-but-never-shown
+      // can be disposed by VS Code, firing `onDidCloseTextDocument`, which
+      // would wipe the diagnostics we just set.
+      const openByUri = new Map(
+        vscode.workspace.textDocuments.map((d) => [d.uri.toString(), d]),
+      );
+      const decoder = new TextDecoder();
+      const readSource = async (uri: vscode.Uri): Promise<string> => {
+        const open = openByUri.get(uri.toString());
+        if (open) return open.getText();
+        return decoder.decode(await vscode.workspace.fs.readFile(uri));
+      };
+
+      const tasks: Array<() => Promise<void>> = [
+        ...treatments.map((uri) => async () => {
+          // The user explicitly asked to re-validate, so bypass the
+          // source-equality short-circuit for this run.
+          lastValidatedSource.delete(uri.toString());
+          await validateTreatmentSourceAt(uri, await readSource(uri));
+        }),
+        ...prompts.map((uri) => async () => {
+          validatePromptSourceAt(uri, await readSource(uri));
+        }),
+      ];
+
+      await runPool(tasks, WORKSPACE_VALIDATION_CONCURRENCY);
+
+      updateWorkspaceStatusBar(statusBar, treatments.length + prompts.length);
+    },
+  );
+}
+
+/**
+ * Aggregate all Stagebook diagnostics currently in the diagnostic collection
+ * and render the status-bar summary. Counts every `source === "stagebook"`
+ * diagnostic across the workspace (not only this run's files), which is the
+ * accurate current picture after a sweep.
+ */
+function updateWorkspaceStatusBar(
+  statusBar: vscode.StatusBarItem,
+  filesValidated: number,
+): void {
+  const perFile: DiagnosticSeverityLabel[][] = [];
+  for (const [, diags] of vscode.languages.getDiagnostics()) {
+    const labels = diags
+      .filter((d) => d.source === "stagebook")
+      .map<DiagnosticSeverityLabel>((d) =>
+        d.severity === vscode.DiagnosticSeverity.Error ? "error" : "warning",
+      );
+    if (labels.length > 0) perFile.push(labels);
+  }
+
+  const summary = summarizeDiagnostics(perFile);
+  const { text, tooltip } = formatValidationStatusBar(summary, filesValidated);
+  statusBar.text = text;
+  statusBar.tooltip = tooltip;
+  statusBar.command = OPEN_PROBLEMS_COMMAND;
+  statusBar.show();
 }
 
 // Standard VS Code semantic token types — every theme colors these
@@ -725,6 +860,19 @@ async function parseTreatmentForPreview(
 
 export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(diagnosticCollection);
+
+  // Status bar item for the "Validate Workspace" summary. Hidden until the
+  // command runs (created here so it can be disposed on deactivate).
+  const workspaceStatusBar = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Right,
+    100,
+  );
+  context.subscriptions.push(workspaceStatusBar);
+  context.subscriptions.push(
+    vscode.commands.registerCommand("stagebook.validateWorkspace", () =>
+      validateWorkspace(workspaceStatusBar),
+    ),
+  );
 
   // Register semantic token provider for treatment files
   context.subscriptions.push(

--- a/apps/vscode/src/lib/diagnosticSummary.test.ts
+++ b/apps/vscode/src/lib/diagnosticSummary.test.ts
@@ -59,12 +59,25 @@ describe("formatValidationStatusBar", () => {
     expect(text).toBe("$(warning) Stagebook: 1 error, 1 warning across 1 file");
   });
 
-  it("tooltip mentions the affected-file count and the click action", () => {
+  it("mixes singular and plural nouns within one string", () => {
+    const { text } = formatValidationStatusBar(
+      { errors: 1, warnings: 2, filesWithDiagnostics: 2 },
+      3,
+    );
+    expect(text).toBe(
+      "$(warning) Stagebook: 1 error, 2 warnings across 3 files",
+    );
+  });
+
+  it("tooltip distinguishes affected files from scanned files", () => {
+    // 2 files have diagnostics out of 5 scanned — the tooltip must keep those
+    // two counts distinct (the whole reason filesWithDiagnostics exists).
     const { tooltip } = formatValidationStatusBar(
-      { errors: 1, warnings: 0, filesWithDiagnostics: 1 },
+      { errors: 3, warnings: 0, filesWithDiagnostics: 2 },
       5,
     );
-    expect(tooltip).toContain("1 file");
+    expect(tooltip).toContain("in 2 files");
+    expect(tooltip).toContain("of 5 files scanned");
     expect(tooltip.toLowerCase()).toContain("problems");
   });
 });

--- a/apps/vscode/src/lib/diagnosticSummary.test.ts
+++ b/apps/vscode/src/lib/diagnosticSummary.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  summarizeDiagnostics,
+  formatValidationStatusBar,
+} from "./diagnosticSummary";
+
+describe("summarizeDiagnostics", () => {
+  it("returns zeros for no files", () => {
+    expect(summarizeDiagnostics([])).toEqual({
+      errors: 0,
+      warnings: 0,
+      filesWithDiagnostics: 0,
+    });
+  });
+
+  it("counts errors and warnings across files", () => {
+    expect(
+      summarizeDiagnostics([
+        ["error", "warning"],
+        ["error"],
+        ["warning", "warning"],
+      ]),
+    ).toEqual({ errors: 2, warnings: 3, filesWithDiagnostics: 3 });
+  });
+
+  it("ignores files with no diagnostics when counting affected files", () => {
+    expect(summarizeDiagnostics([["error"], [], [], ["warning"]])).toEqual({
+      errors: 1,
+      warnings: 1,
+      filesWithDiagnostics: 2,
+    });
+  });
+});
+
+describe("formatValidationStatusBar", () => {
+  it("reports a clean run with no issues", () => {
+    const { text } = formatValidationStatusBar(
+      { errors: 0, warnings: 0, filesWithDiagnostics: 0 },
+      12,
+    );
+    expect(text).toBe("$(check) Stagebook: no issues in 12 files");
+  });
+
+  it("pluralizes errors and warnings", () => {
+    const { text } = formatValidationStatusBar(
+      { errors: 2, warnings: 3, filesWithDiagnostics: 4 },
+      30,
+    );
+    expect(text).toBe(
+      "$(warning) Stagebook: 2 errors, 3 warnings across 30 files",
+    );
+  });
+
+  it("uses singular forms for a single error/warning/file", () => {
+    const { text } = formatValidationStatusBar(
+      { errors: 1, warnings: 1, filesWithDiagnostics: 1 },
+      1,
+    );
+    expect(text).toBe("$(warning) Stagebook: 1 error, 1 warning across 1 file");
+  });
+
+  it("tooltip mentions the affected-file count and the click action", () => {
+    const { tooltip } = formatValidationStatusBar(
+      { errors: 1, warnings: 0, filesWithDiagnostics: 1 },
+      5,
+    );
+    expect(tooltip).toContain("1 file");
+    expect(tooltip.toLowerCase()).toContain("problems");
+  });
+});

--- a/apps/vscode/src/lib/diagnosticSummary.ts
+++ b/apps/vscode/src/lib/diagnosticSummary.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure aggregation + formatting for the "Validate Workspace" status-bar
+ * summary. Kept free of the `vscode` API so it can be unit-tested; the
+ * extension maps `vscode.Diagnostic.severity` to these string labels and
+ * groups by file before calling in.
+ */
+
+export type DiagnosticSeverityLabel = "error" | "warning";
+
+export interface ValidationSummary {
+  errors: number;
+  warnings: number;
+  /** Number of files that have at least one Stagebook diagnostic. */
+  filesWithDiagnostics: number;
+}
+
+/**
+ * Aggregate per-file diagnostic severities into totals. `perFile[i]` is the
+ * list of Stagebook diagnostic severities for one file (already filtered to
+ * `source === "stagebook"` by the caller).
+ */
+export function summarizeDiagnostics(
+  perFile: DiagnosticSeverityLabel[][],
+): ValidationSummary {
+  let errors = 0;
+  let warnings = 0;
+  let filesWithDiagnostics = 0;
+
+  for (const file of perFile) {
+    if (file.length === 0) continue;
+    filesWithDiagnostics += 1;
+    for (const severity of file) {
+      if (severity === "error") errors += 1;
+      else warnings += 1;
+    }
+  }
+
+  return { errors, warnings, filesWithDiagnostics };
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * Build the status-bar `text` and `tooltip` for a completed workspace
+ * validation. `filesValidated` is the total number of Stagebook files scanned
+ * (not just those with diagnostics).
+ */
+export function formatValidationStatusBar(
+  summary: ValidationSummary,
+  filesValidated: number,
+): { text: string; tooltip: string } {
+  const filesScanned = plural(filesValidated, "file");
+
+  if (summary.errors === 0 && summary.warnings === 0) {
+    return {
+      text: `$(check) Stagebook: no issues in ${filesScanned}`,
+      tooltip: `Validated ${filesScanned}, no issues found — click to open the Problems panel.`,
+    };
+  }
+
+  const text =
+    `$(warning) Stagebook: ${plural(summary.errors, "error")}, ` +
+    `${plural(summary.warnings, "warning")} across ${filesScanned}`;
+
+  const affected = plural(summary.filesWithDiagnostics, "file");
+  const tooltip =
+    `${plural(summary.errors, "error")}, ${plural(summary.warnings, "warning")} ` +
+    `in ${affected} (of ${filesScanned} scanned) — click to open the Problems panel.`;
+
+  return { text, tooltip };
+}

--- a/apps/vscode/src/lib/findExclude.test.ts
+++ b/apps/vscode/src/lib/findExclude.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { buildFindExcludeGlob } from "./findExclude";
+
+describe("buildFindExcludeGlob", () => {
+  it("returns undefined when there is nothing to exclude", () => {
+    expect(buildFindExcludeGlob({}, {}, [])).toBeUndefined();
+  });
+
+  it("returns a bare pattern (no braces) for a single exclude", () => {
+    expect(buildFindExcludeGlob({}, {}, ["**/node_modules/**"])).toBe(
+      "**/node_modules/**",
+    );
+  });
+
+  it("brace-joins multiple patterns", () => {
+    expect(
+      buildFindExcludeGlob({ "**/dist/**": true }, {}, ["**/node_modules/**"]),
+    ).toBe("{**/dist/**,**/node_modules/**}");
+  });
+
+  it("merges files.exclude and search.exclude", () => {
+    expect(
+      buildFindExcludeGlob({ "**/.git": true }, { "**/coverage/**": true }, []),
+    ).toBe("{**/.git,**/coverage/**}");
+  });
+
+  it("skips patterns explicitly disabled with false", () => {
+    expect(
+      buildFindExcludeGlob({ "**/.git": true, "**/keepme/**": false }, {}, []),
+    ).toBe("**/.git");
+  });
+
+  it("treats an object value (e.g. a when-clause) as enabled", () => {
+    expect(
+      buildFindExcludeGlob({ "**/*.js": { when: "$(basename).ts" } }, {}, []),
+    ).toBe("**/*.js");
+  });
+
+  it("de-duplicates patterns across all three sources", () => {
+    expect(
+      buildFindExcludeGlob(
+        { "**/node_modules/**": true },
+        { "**/node_modules/**": true },
+        ["**/node_modules/**"],
+      ),
+    ).toBe("**/node_modules/**");
+  });
+});

--- a/apps/vscode/src/lib/findExclude.ts
+++ b/apps/vscode/src/lib/findExclude.ts
@@ -1,0 +1,43 @@
+/**
+ * Build a single `findFiles` exclude glob that honors the user's configured
+ * excludes.
+ *
+ * `vscode.workspace.findFiles(include, exclude)` applies the default
+ * `files.exclude` only when `exclude` is `undefined`, and never applies
+ * `search.exclude`. Passing any concrete glob (as the workspace-validation
+ * command must, to skip `node_modules`) therefore silently discards BOTH
+ * user settings. To keep honoring them we merge `files.exclude` +
+ * `search.exclude` (plus any `extra` patterns) into one brace glob and pass
+ * that explicitly.
+ *
+ * A setting entry counts as enabled unless its value is exactly `false`
+ * (VS Code allows `true` or a `{ when: ... }` object; we treat any non-`false`
+ * value as on, ignoring the `when` predicate — a conservative over-exclude is
+ * safer here than surfacing diagnostics for a file the user hid).
+ */
+export function buildFindExcludeGlob(
+  filesExclude: Record<string, unknown>,
+  searchExclude: Record<string, unknown>,
+  extra: string[],
+): string | undefined {
+  const patterns: string[] = [];
+  const add = (glob: string, enabled: boolean): void => {
+    if (enabled && !patterns.includes(glob)) patterns.push(glob);
+  };
+
+  for (const [glob, value] of Object.entries(filesExclude)) {
+    add(glob, value !== false);
+  }
+  for (const [glob, value] of Object.entries(searchExclude)) {
+    add(glob, value !== false);
+  }
+  for (const glob of extra) {
+    add(glob, true);
+  }
+
+  if (patterns.length === 0) return undefined;
+  // A single-element brace list (`{a}`) is not expanded by VS Code's glob
+  // engine, so emit the bare pattern in that case.
+  if (patterns.length === 1) return patterns[0];
+  return `{${patterns.join(",")}}`;
+}

--- a/apps/vscode/src/lib/runPool.test.ts
+++ b/apps/vscode/src/lib/runPool.test.ts
@@ -70,6 +70,35 @@ describe("runPool", () => {
     await expect(runPool([], 4)).resolves.toBeUndefined();
   });
 
+  it("runs all tasks when the limit exceeds the task count", async () => {
+    // The production config (limit 4) routinely exceeds the file count in a
+    // small repo, exercising the worker-cap branch (workerCount = min).
+    const seen: number[] = [];
+    const tasks = [1, 2].map((n) => () => {
+      seen.push(n);
+      return Promise.resolve();
+    });
+
+    await runPool(tasks, 4);
+    expect(seen.sort((a, b) => a - b)).toEqual([1, 2]);
+  });
+
+  it("isolates a thunk that throws synchronously before returning a promise", async () => {
+    const completed: number[] = [];
+    const tasks: Array<() => Promise<void>> = [
+      () => {
+        throw new Error("sync boom");
+      },
+      () => {
+        completed.push(2);
+        return Promise.resolve();
+      },
+    ];
+
+    await expect(runPool(tasks, 2)).resolves.toBeUndefined();
+    expect(completed).toEqual([2]);
+  });
+
   it("treats a concurrency limit below 1 as 1", async () => {
     let inFlight = 0;
     let maxInFlight = 0;

--- a/apps/vscode/src/lib/runPool.test.ts
+++ b/apps/vscode/src/lib/runPool.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { runPool } from "./runPool";
+
+/** Resolve after a microtask-ish delay without real timers. */
+function tick(): Promise<void> {
+  return Promise.resolve();
+}
+
+describe("runPool", () => {
+  it("runs every task", async () => {
+    const seen: number[] = [];
+    const tasks = [1, 2, 3, 4, 5].map((n) => () => {
+      seen.push(n);
+      return Promise.resolve(n);
+    });
+
+    await runPool(tasks, 2);
+
+    expect(seen.sort((a, b) => a - b)).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("never exceeds the concurrency limit of in-flight tasks", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const releasers: Array<() => void> = [];
+
+    const tasks = Array.from({ length: 6 }, () => () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      return new Promise<void>((resolve) => {
+        releasers.push(() => {
+          inFlight -= 1;
+          resolve();
+        });
+      });
+    });
+
+    const done = runPool(tasks, 2);
+
+    // Let the pool start its first batch.
+    await tick();
+    expect(maxInFlight).toBeLessThanOrEqual(2);
+
+    // Drain: release tasks one at a time, allowing the pool to refill.
+    while (releasers.length > 0) {
+      const release = releasers.shift()!;
+      release();
+      await tick();
+      await tick();
+    }
+
+    await done;
+    expect(maxInFlight).toBe(2);
+  });
+
+  it("isolates failures so a rejecting task does not abort the others", async () => {
+    const completed: number[] = [];
+    const tasks = [0, 1, 2, 3].map((n) => () => {
+      if (n === 1) return Promise.reject(new Error("boom"));
+      completed.push(n);
+      return Promise.resolve();
+    });
+
+    // Should not throw even though one task rejects.
+    await expect(runPool(tasks, 2)).resolves.toBeUndefined();
+    expect(completed.sort((a, b) => a - b)).toEqual([0, 2, 3]);
+  });
+
+  it("handles an empty task list", async () => {
+    await expect(runPool([], 4)).resolves.toBeUndefined();
+  });
+
+  it("treats a concurrency limit below 1 as 1", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const tasks = Array.from({ length: 3 }, () => async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await tick();
+      inFlight -= 1;
+    });
+
+    await runPool(tasks, 0);
+    expect(maxInFlight).toBe(1);
+  });
+});

--- a/apps/vscode/src/lib/runPool.ts
+++ b/apps/vscode/src/lib/runPool.ts
@@ -1,0 +1,38 @@
+/**
+ * Run `tasks` with at most `limit` in flight at once, waiting for all to
+ * settle. Each task is a thunk returning a promise.
+ *
+ * Failure isolation: a task that rejects does NOT abort the pool or the
+ * returned promise — its rejection is swallowed so the remaining tasks still
+ * run to completion. Callers that need per-task outcomes should capture them
+ * inside the thunk (e.g. set diagnostics as a side effect) rather than relying
+ * on a return value.
+ *
+ * This bound matters in the extension host: validating a treatment file is
+ * several seconds of synchronous Zod recursion, so firing every workspace file
+ * at once would jank the UI. A small pool keeps the host responsive while still
+ * overlapping the async import reads.
+ */
+export async function runPool(
+  tasks: Array<() => Promise<unknown>>,
+  limit: number,
+): Promise<void> {
+  const max = Math.max(1, Math.floor(limit));
+  let next = 0;
+
+  async function worker(): Promise<void> {
+    while (next < tasks.length) {
+      const index = next;
+      next += 1;
+      try {
+        await tasks[index]();
+      } catch {
+        // Failure isolation — see doc comment. The task itself is responsible
+        // for surfacing its own errors.
+      }
+    }
+  }
+
+  const workerCount = Math.min(max, tasks.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+}


### PR DESCRIPTION
Fixes #442.

## What

Adds a command palette entry **"Stagebook: Validate Workspace"** (`stagebook.validateWorkspace`) that globs every `.stagebook.yaml` and `.prompt.md` file in the workspace, validates them, and populates the Problems panel — not just the files opened this session. A status-bar summary reports aggregate counts with click-through to the Problems panel.

Depends on the now-merged #439 (validators live in `stagebook/validate`).

## How

- **Refactor live validators into URI+source cores** (`validateTreatmentSourceAt` / `validatePromptSourceAt`). On-disk files and open editor buffers share one code path, so workspace-sweep diagnostics are **identical** to live validation (same `validateTreatmentWithDiff` + `checkFileReferences` for treatments, `validatePromptSource` for prompts — including the locale-consistency rule).
- **`checkFileReferences` is now awaitable + batched** (was fire-and-forget per-`stat`). The sweep awaits it, so the status-bar summary counts file-existence errors accurately instead of racing the stats. The stale-version guard is now applied once before the final `set` (strictly stronger than before — the old path-escape branch had no version guard).
- **Reads on-disk bytes, not `openTextDocument`, for unopened files.** Documents opened-but-never-shown can be disposed by VS Code, firing `onDidCloseTextDocument`, which would wipe the diagnostics we just set. When a file *is* open, its live buffer is preferred (respects unsaved edits).
- **Bounded concurrency** (`runPool`, cap 4) keeps the extension host responsive — each treatment validation is several seconds of synchronous Zod recursion.
- **Status-bar summary is scoped to the scanned files only** (not every diagnostic in the collection), so counts can't attribute errors to files outside the glob.

## Design decisions

- **`.gitignore` is intentionally not applied.** `findFiles` honors `files.exclude`/`search.exclude` but not `.gitignore`. This means coverage can differ from `npx stagebook validate '**/*'` if a treatment file is gitignored but not search-excluded. Chosen for simplicity (no new dependency, no nested-gitignore edge cases); revisit if it causes noise.

## Testing

- New unit tests (vitest, following the repo convention that pure logic lives in `src/lib/` and vscode-glue in `extension.ts` is verified in the Extension Development Host):
  - `runPool`: concurrency cap, failure isolation (rejected *and* synchronously-thrown thunks), empty list, `limit < 1`, `limit > task count`.
  - `diagnosticSummary`: count aggregation, singular/plural/mixed formatting, affected-vs-scanned tooltip distinction.
- Full local suite green: `npm test` (vitest, all workspaces) + `npm test -w stagebook-vscode` (103 tests), extension bundles via esbuild, Prettier clean.
- Pre-PR review by three subagents (correctness, test coverage, security). Correctness flagged the status-bar over-counting (fixed); security found no blocking issues and confirmed the `isWithinWorkspace` traversal guards survive the refactor on both the `loadImport` and asset-check paths.

## Known limitation (follow-up candidate)

A sweep only *sets* diagnostics on globbed files; it doesn't clear stale diagnostics for a Stagebook file deleted from disk that was never closed in the editor. The scoped status-bar count no longer mis-reports those, but the squiggle lingers (pre-existing behavior, same as live editing then deleting).

## Manual verification checklist (Extension Dev Host)

- [ ] Command appears in the palette as "Stagebook: Validate Workspace".
- [ ] Running it populates Problems for unopened files; counts match live validation when those files are then opened.
- [ ] Status bar shows aggregate counts; clicking opens the Problems panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)