### PR TITLE
feat(viewer): surface validation diagnostics on load (#440)

### DIFF
--- a/apps/viewer/src/App.test.tsx
+++ b/apps/viewer/src/App.test.tsx
@@ -1,0 +1,117 @@
+// @vitest-environment jsdom
+//
+// Routing coverage for the #440 load outcomes: the split between a file that
+// loaded-but-can't-render (→ diagnostics placeholder) and a hard failure like a
+// network/import error (→ plain error screen). Uses the same jsdom +
+// react-dom/client + act harness as the other viewer .test.tsx files, and mocks
+// the loader so the routing is exercised without any network.
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import React, { type ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { LoadResult } from "./lib/loader";
+
+const { mockLoad } = vi.hoisted(() => ({ mockLoad: vi.fn() }));
+vi.mock("./lib/loader", () => ({
+  loadTreatmentFromUrl: (url: string) => mockLoad(url) as Promise<LoadResult>,
+}));
+
+import { App } from "./App";
+
+async function render(node: ReactNode): Promise<{
+  container: HTMLElement;
+  unmount: () => void;
+}> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  let root: Root;
+  await act(async () => {
+    root = createRoot(container);
+    root.render(node);
+  });
+  // Flush the async auto-load (loading → resolved outcome).
+  await act(async () => {});
+  await act(async () => {});
+  return {
+    container,
+    unmount: () =>
+      act(() => {
+        root.unmount();
+        container.remove();
+      }),
+  };
+}
+
+beforeEach(() => {
+  mockLoad.mockReset();
+  // The App auto-loads whatever is in ?url= on mount.
+  window.history.replaceState(
+    {},
+    "",
+    "/?url=https://github.com/org/repo/blob/main/study.stagebook.yaml",
+  );
+});
+
+describe("App load routing (#440)", () => {
+  it("routes a null treatmentFile to the diagnostics placeholder", async () => {
+    mockLoad.mockResolvedValue({
+      treatmentFile: null,
+      diagnostics: [
+        {
+          message: "playerCount must be a number",
+          severity: "error",
+          range: { startLine: 4, startCol: 2, endLine: 4, endCol: 6 },
+          file: "study.stagebook.yaml",
+        },
+        {
+          message: "duplicate key",
+          severity: "warning",
+          range: null,
+          file: "study.stagebook.yaml",
+        },
+      ],
+      unresolvedFields: [],
+      rawBaseUrl: "",
+    } satisfies LoadResult);
+
+    const { container, unmount } = await render(<App />);
+    const text = container.textContent ?? "";
+    expect(text).toContain("can’t be previewed");
+    expect(text).toContain("2 problems found");
+    expect(text).toContain("playerCount must be a number");
+    expect(text).toContain("duplicate key");
+    unmount();
+  });
+
+  it("uses singular 'problem' for a single diagnostic", async () => {
+    mockLoad.mockResolvedValue({
+      treatmentFile: null,
+      diagnostics: [
+        {
+          message: "only one problem",
+          severity: "error",
+          range: null,
+          file: "study.stagebook.yaml",
+        },
+      ],
+      unresolvedFields: [],
+      rawBaseUrl: "",
+    } satisfies LoadResult);
+
+    const { container, unmount } = await render(<App />);
+    expect(container.textContent ?? "").toContain("1 problem found");
+    unmount();
+  });
+
+  it("routes a thrown error (network/import failure) to the error screen", async () => {
+    mockLoad.mockRejectedValue(new Error("Failed to fetch imported file"));
+
+    const { container, unmount } = await render(<App />);
+    const text = container.textContent ?? "";
+    expect(text).toContain("Failed to load");
+    expect(text).toContain("Failed to fetch imported file");
+    // The diagnostics placeholder must NOT be used for hard failures.
+    expect(text).not.toContain("can’t be previewed");
+    unmount();
+  });
+});

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -332,7 +332,7 @@ function UnrenderableScreen({
     <div style={centeredStyle}>
       <div style={{ maxWidth: "40rem", width: "100%", padding: "2rem" }}>
         <p style={{ color: "#ef4444", fontWeight: 600 }}>
-          This file can’t be previewed until its errors are fixed
+          This file can’t be previewed until the problems below are fixed
         </p>
         <p
           style={{

--- a/apps/viewer/src/App.tsx
+++ b/apps/viewer/src/App.tsx
@@ -1,10 +1,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import type { TreatmentFileType } from "stagebook";
 import { loadTreatmentFromUrl } from "./lib/loader";
-import {
-  TreatmentValidationError,
-  type ValidationIssue,
-} from "./lib/treatment";
+import type { ViewerDiagnostic } from "./lib/diagnostics";
 import { createUrlContentFns } from "./lib/contentFns";
 import { needsOverviewPicker } from "./lib/selection";
 import {
@@ -16,6 +13,10 @@ import {
 import { LandingPage } from "./components/LandingPage";
 import { OverviewPage } from "./components/OverviewPage";
 import { PreviewHost } from "./components/PreviewHost";
+import {
+  DiagnosticsDrawer,
+  DiagnosticsList,
+} from "./components/DiagnosticsPanel";
 
 type ContentFns = ReturnType<typeof createUrlContentFns>;
 
@@ -27,6 +28,7 @@ type AppState =
       treatmentFile: TreatmentFileType;
       contentFns: ContentFns;
       readmeContent: string | null;
+      diagnostics: ViewerDiagnostic[];
     }
   | {
       phase: "viewing";
@@ -34,12 +36,19 @@ type AppState =
       contentFns: ContentFns;
       selectedIntroIndex: number;
       selectedTreatmentIndex: number;
+      diagnostics: ViewerDiagnostic[];
+    }
+  | {
+      // File has errors that prevent rendering — show a placeholder plus the
+      // diagnostics that caused it (#440).
+      phase: "unrenderable";
+      diagnostics: ViewerDiagnostic[];
+      url?: string;
     }
   | {
       phase: "error";
       message: string;
       url?: string;
-      validationIssues?: ValidationIssue[];
     };
 
 export function App() {
@@ -54,6 +63,7 @@ export function App() {
       treatmentFile: TreatmentFileType,
       contentFns: ContentFns,
       seq: number,
+      diagnostics: ViewerDiagnostic[],
     ) => {
       const readmeContent = await contentFns
         .getTextContent("README.md")
@@ -69,6 +79,7 @@ export function App() {
           treatmentFile,
           contentFns,
           readmeContent,
+          diagnostics,
         });
       } else {
         setState({
@@ -77,6 +88,7 @@ export function App() {
           contentFns,
           selectedIntroIndex: 0,
           selectedTreatmentIndex: 0,
+          diagnostics,
         });
       }
     },
@@ -88,22 +100,25 @@ export function App() {
       const seq = ++loadSeqRef.current;
       setState({ phase: "loading", url });
       try {
-        const { treatmentFile, rawBaseUrl } = await loadTreatmentFromUrl(url);
+        const { treatmentFile, diagnostics, rawBaseUrl } =
+          await loadTreatmentFromUrl(url);
         if (seq !== loadSeqRef.current) return;
+        if (treatmentFile === null) {
+          setState({ phase: "unrenderable", diagnostics, url });
+          return;
+        }
         await enterTreatment(
           treatmentFile,
           createUrlContentFns(rawBaseUrl),
           seq,
+          diagnostics,
         );
       } catch (err) {
         if (seq !== loadSeqRef.current) return;
-        const validationIssues =
-          err instanceof TreatmentValidationError ? err.issues : undefined;
         setState({
           phase: "error",
           message: err instanceof Error ? err.message : String(err),
           url,
-          validationIssues,
         });
       }
     },
@@ -115,19 +130,19 @@ export function App() {
       const seq = ++loadSeqRef.current;
       try {
         const treatmentFile = prepareExampleTreatment(entry);
+        // Bundled examples are curated and validated in CI, so they carry no
+        // load-time diagnostics.
         await enterTreatment(
           treatmentFile,
           createExampleContentFns(entry),
           seq,
+          [],
         );
       } catch (err) {
         if (seq !== loadSeqRef.current) return;
-        const validationIssues =
-          err instanceof TreatmentValidationError ? err.issues : undefined;
         setState({
           phase: "error",
           message: err instanceof Error ? err.message : String(err),
-          validationIssues,
         });
       }
     },
@@ -160,41 +175,56 @@ export function App() {
       return (
         <ErrorScreen
           message={state.message}
-          validationIssues={state.validationIssues}
+          onRetry={state.url ? () => handleLoad(state.url!) : undefined}
+          onBack={() => setState({ phase: "landing" })}
+        />
+      );
+
+    case "unrenderable":
+      return (
+        <UnrenderableScreen
+          diagnostics={state.diagnostics}
           onRetry={state.url ? () => handleLoad(state.url!) : undefined}
           onBack={() => setState({ phase: "landing" })}
         />
       );
 
     case "overview": {
-      const { treatmentFile, contentFns, readmeContent } = state;
+      const { treatmentFile, contentFns, readmeContent, diagnostics } = state;
       return (
-        <OverviewPage
-          treatmentFile={treatmentFile}
-          readmeContent={readmeContent}
-          onBack={() => setState({ phase: "landing" })}
-          onSelect={(introIndex, treatmentIndex) => {
-            setState({
-              phase: "viewing",
-              treatmentFile,
-              contentFns,
-              selectedIntroIndex: introIndex,
-              selectedTreatmentIndex: treatmentIndex,
-            });
-          }}
-        />
+        <>
+          <OverviewPage
+            treatmentFile={treatmentFile}
+            readmeContent={readmeContent}
+            onBack={() => setState({ phase: "landing" })}
+            onSelect={(introIndex, treatmentIndex) => {
+              setState({
+                phase: "viewing",
+                treatmentFile,
+                contentFns,
+                selectedIntroIndex: introIndex,
+                selectedTreatmentIndex: treatmentIndex,
+                diagnostics,
+              });
+            }}
+          />
+          <DiagnosticsDrawer diagnostics={diagnostics} />
+        </>
       );
     }
 
     case "viewing":
       return (
-        <ViewingPhase
-          treatmentFile={state.treatmentFile}
-          contentFns={state.contentFns}
-          selectedIntroIndex={state.selectedIntroIndex}
-          selectedTreatmentIndex={state.selectedTreatmentIndex}
-          onBack={() => setState({ phase: "landing" })}
-        />
+        <>
+          <ViewingPhase
+            treatmentFile={state.treatmentFile}
+            contentFns={state.contentFns}
+            selectedIntroIndex={state.selectedIntroIndex}
+            selectedTreatmentIndex={state.selectedTreatmentIndex}
+            onBack={() => setState({ phase: "landing" })}
+          />
+          <DiagnosticsDrawer diagnostics={state.diagnostics} />
+        </>
       );
   }
 }
@@ -239,14 +269,16 @@ function LoadingScreen({ url }: { url: string }) {
   );
 }
 
+/**
+ * Terminal failure that isn't a file-content problem — a network error, a
+ * bad URL, or a failed import fetch. Shows the raw message.
+ */
 function ErrorScreen({
   message,
-  validationIssues,
   onRetry,
   onBack,
 }: {
   message: string;
-  validationIssues?: ValidationIssue[];
   onRetry?: () => void;
   onBack: () => void;
 }) {
@@ -254,40 +286,16 @@ function ErrorScreen({
     <div style={centeredStyle}>
       <div style={{ maxWidth: "36rem", width: "100%", padding: "2rem" }}>
         <p style={{ color: "#ef4444", fontWeight: 600 }}>Failed to load</p>
-
-        {validationIssues ? (
-          <>
-            <p
-              style={{
-                color: "#6b7280",
-                fontSize: "0.875rem",
-                marginTop: "0.5rem",
-              }}
-            >
-              The treatment file has validation errors:
-            </p>
-            <ul style={issueListStyle}>
-              {validationIssues.map((issue, i) => (
-                <li key={i} style={issueItemStyle}>
-                  <code style={issuePathStyle}>{issue.path}</code>
-                  <span>{issue.message}</span>
-                </li>
-              ))}
-            </ul>
-          </>
-        ) : (
-          <p
-            style={{
-              color: "#6b7280",
-              fontSize: "0.875rem",
-              marginTop: "0.5rem",
-              wordBreak: "break-word",
-            }}
-          >
-            {message}
-          </p>
-        )}
-
+        <p
+          style={{
+            color: "#6b7280",
+            fontSize: "0.875rem",
+            marginTop: "0.5rem",
+            wordBreak: "break-word",
+          }}
+        >
+          {message}
+        </p>
         <div style={{ marginTop: "1rem", display: "flex", gap: "0.5rem" }}>
           {onRetry && (
             <button onClick={onRetry} style={buttonStyle}>
@@ -306,32 +314,55 @@ function ErrorScreen({
   );
 }
 
-const issueListStyle: React.CSSProperties = {
-  listStyle: "none",
-  padding: 0,
-  marginTop: "0.75rem",
-  display: "flex",
-  flexDirection: "column",
-  gap: "0.5rem",
-};
-
-const issueItemStyle: React.CSSProperties = {
-  display: "flex",
-  flexDirection: "column",
-  gap: "0.125rem",
-  padding: "0.5rem 0.75rem",
-  backgroundColor: "#fef2f2",
-  borderRadius: "0.375rem",
-  border: "1px solid #fecaca",
-  fontSize: "0.875rem",
-  color: "#374151",
-};
-
-const issuePathStyle: React.CSSProperties = {
-  fontSize: "0.75rem",
-  color: "#9ca3af",
-  fontFamily: "monospace",
-};
+/**
+ * The file loaded but has validation errors that prevent rendering (YAML
+ * syntax, schema violations). Shows a placeholder plus the diagnostics that
+ * caused it — the same diagnostics the VS Code extension would flag (#440).
+ */
+function UnrenderableScreen({
+  diagnostics,
+  onRetry,
+  onBack,
+}: {
+  diagnostics: ViewerDiagnostic[];
+  onRetry?: () => void;
+  onBack: () => void;
+}) {
+  return (
+    <div style={centeredStyle}>
+      <div style={{ maxWidth: "40rem", width: "100%", padding: "2rem" }}>
+        <p style={{ color: "#ef4444", fontWeight: 600 }}>
+          This file can’t be previewed until its errors are fixed
+        </p>
+        <p
+          style={{
+            color: "#6b7280",
+            fontSize: "0.875rem",
+            margin: "0.5rem 0 0.75rem",
+          }}
+        >
+          {diagnostics.length === 1
+            ? "1 problem found:"
+            : `${diagnostics.length} problems found:`}
+        </p>
+        <DiagnosticsList diagnostics={diagnostics} />
+        <div style={{ marginTop: "1rem", display: "flex", gap: "0.5rem" }}>
+          {onRetry && (
+            <button onClick={onRetry} style={buttonStyle}>
+              Retry
+            </button>
+          )}
+          <button
+            onClick={onBack}
+            style={{ ...buttonStyle, backgroundColor: "#6b7280" }}
+          >
+            Back
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 const centeredStyle: React.CSSProperties = {
   display: "flex",

--- a/apps/viewer/src/components/DiagnosticsPanel.test.tsx
+++ b/apps/viewer/src/components/DiagnosticsPanel.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+//
+// Runtime render coverage for the load-time diagnostics UI (#440). Uses the
+// production-ish react-dom/client + act harness (matching the other viewer
+// .test.tsx files) so hook/render regressions surface here rather than in the
+// browser.
+import { describe, it, expect } from "vitest";
+import React, { type ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { DiagnosticsDrawer, DiagnosticsList } from "./DiagnosticsPanel";
+import type { ViewerDiagnostic } from "../lib/diagnostics";
+
+function render(node: ReactNode): {
+  container: HTMLElement;
+  unmount: () => void;
+} {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  let root: Root;
+  act(() => {
+    root = createRoot(container);
+    root.render(node);
+  });
+  return {
+    container,
+    unmount: () =>
+      act(() => {
+        root.unmount();
+        container.remove();
+      }),
+  };
+}
+
+function clickHeader(container: HTMLElement): void {
+  const button = container.querySelector("button");
+  if (!button) throw new Error("drawer header button not found");
+  act(() => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+const err = (
+  message: string,
+  file = "study.stagebook.yaml",
+): ViewerDiagnostic => ({
+  message,
+  severity: "error",
+  range: { startLine: 4, startCol: 2, endLine: 4, endCol: 6 },
+  file,
+});
+
+const warn = (
+  message: string,
+  file = "study.stagebook.yaml",
+): ViewerDiagnostic => ({
+  message,
+  severity: "warning",
+  range: null,
+  file,
+});
+
+describe("DiagnosticsDrawer", () => {
+  it("renders nothing when there are no diagnostics", () => {
+    const { container, unmount } = render(
+      <DiagnosticsDrawer diagnostics={[]} />,
+    );
+    expect(container.textContent).toBe("");
+    expect(container.querySelector("button")).toBeNull();
+    unmount();
+  });
+
+  it("summarizes counts with correct pluralization", () => {
+    const { container, unmount } = render(
+      <DiagnosticsDrawer diagnostics={[err("a"), err("b"), warn("c")]} />,
+    );
+    expect(container.querySelector("button")!.textContent).toContain(
+      "2 errors, 1 warning",
+    );
+    unmount();
+  });
+
+  it("shows a single warning label when there are no errors", () => {
+    const { container, unmount } = render(
+      <DiagnosticsDrawer diagnostics={[warn("only a warning")]} />,
+    );
+    expect(container.querySelector("button")!.textContent).toContain(
+      "1 warning",
+    );
+    expect(container.querySelector("button")!.textContent).not.toContain(
+      "error",
+    );
+    unmount();
+  });
+
+  it("collapses and expands the list when the header is toggled", () => {
+    const { container, unmount } = render(
+      <DiagnosticsDrawer diagnostics={[err("boom message")]} />,
+    );
+    // Expanded by default — the message is visible.
+    expect(container.textContent).toContain("boom message");
+    clickHeader(container); // collapse
+    expect(container.querySelectorAll("li")).toHaveLength(0);
+    clickHeader(container); // expand again
+    expect(container.textContent).toContain("boom message");
+    unmount();
+  });
+});
+
+describe("DiagnosticsList", () => {
+  it("renders message, file, and a 1-based position for ranged diagnostics", () => {
+    const { container, unmount } = render(
+      <DiagnosticsList diagnostics={[err("bad value", "a.stagebook.yaml")]} />,
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("bad value");
+    // 0-based range (4,2) → 1-based display (5:3).
+    expect(text).toContain("a.stagebook.yaml:5:3");
+    unmount();
+  });
+
+  it("omits the position for unpositioned diagnostics", () => {
+    const { container, unmount } = render(
+      <DiagnosticsList
+        diagnostics={[warn("locale mismatch", "prompts/q.prompt.md")]}
+      />,
+    );
+    const text = container.textContent ?? "";
+    expect(text).toContain("prompts/q.prompt.md");
+    expect(text).not.toContain("prompts/q.prompt.md:");
+    unmount();
+  });
+
+  it("orders errors ahead of warnings and positioned ahead of unpositioned", () => {
+    const { container, unmount } = render(
+      <DiagnosticsList
+        diagnostics={[warn("second unpositioned"), err("first positioned")]}
+      />,
+    );
+    const items = Array.from(container.querySelectorAll("li")).map(
+      (li) => li.textContent ?? "",
+    );
+    expect(items[0]).toContain("first positioned");
+    expect(items[1]).toContain("second unpositioned");
+    unmount();
+  });
+});

--- a/apps/viewer/src/components/DiagnosticsPanel.tsx
+++ b/apps/viewer/src/components/DiagnosticsPanel.tsx
@@ -9,6 +9,17 @@ import {
  * Format a count as "N error(s)" / "N warning(s)", omitting zero categories.
  * "2 errors, 1 warning" · "1 warning" · "3 errors".
  */
+/**
+ * A content-derived key so rows keep their identity when the list re-sorts
+ * (index keys would let React reuse the wrong row across a reorder). Position +
+ * severity + message is effectively unique; truly identical diagnostics are
+ * interchangeable, so a rare collision is harmless.
+ */
+function diagnosticKey(d: ViewerDiagnostic): string {
+  const pos = d.range ? `${d.range.startLine}:${d.range.startCol}` : "-";
+  return `${d.severity}|${d.file}|${pos}|${d.message}`;
+}
+
 function summaryLabel(errors: number, warnings: number): string {
   const parts: string[] = [];
   if (errors > 0) parts.push(`${errors} ${errors === 1 ? "error" : "errors"}`);
@@ -36,8 +47,8 @@ export function DiagnosticsList({
   const sorted = sortDiagnostics(diagnostics);
   return (
     <ul style={listStyle}>
-      {sorted.map((d, i) => (
-        <li key={i} style={rowStyle(d.severity)}>
+      {sorted.map((d) => (
+        <li key={diagnosticKey(d)} style={rowStyle(d.severity)}>
           <span style={iconStyle(d.severity)} aria-hidden>
             {d.severity === "error" ? "✕" : "⚠"}
           </span>

--- a/apps/viewer/src/components/DiagnosticsPanel.tsx
+++ b/apps/viewer/src/components/DiagnosticsPanel.tsx
@@ -1,0 +1,175 @@
+import { useState } from "react";
+import {
+  sortDiagnostics,
+  summarizeDiagnostics,
+  type ViewerDiagnostic,
+} from "../lib/diagnostics";
+
+/**
+ * Format a count as "N error(s)" / "N warning(s)", omitting zero categories.
+ * "2 errors, 1 warning" · "1 warning" · "3 errors".
+ */
+function summaryLabel(errors: number, warnings: number): string {
+  const parts: string[] = [];
+  if (errors > 0) parts.push(`${errors} ${errors === 1 ? "error" : "errors"}`);
+  if (warnings > 0) {
+    parts.push(`${warnings} ${warnings === 1 ? "warning" : "warnings"}`);
+  }
+  return parts.join(", ");
+}
+
+/**
+ * The ordered rows of a diagnostics list. Exported so the unrenderable-file
+ * placeholder can reuse the same rendering as the drawer.
+ *
+ * Positions (`Ln:Col`) are 1-based for display (library ranges are 0-based,
+ * LSP convention). They refer to the entry file's raw source — the same lines
+ * the VS Code extension's Problems panel points at. The viewer shows no source,
+ * so they're informational; the message's field path (e.g.
+ * `treatments[0].gameStages[1]`) is the primary locator.
+ */
+export function DiagnosticsList({
+  diagnostics,
+}: {
+  diagnostics: readonly ViewerDiagnostic[];
+}) {
+  const sorted = sortDiagnostics(diagnostics);
+  return (
+    <ul style={listStyle}>
+      {sorted.map((d, i) => (
+        <li key={i} style={rowStyle(d.severity)}>
+          <span style={iconStyle(d.severity)} aria-hidden>
+            {d.severity === "error" ? "✕" : "⚠"}
+          </span>
+          <div style={rowBodyStyle}>
+            <span>{d.message}</span>
+            <span style={metaStyle}>
+              {d.file}
+              {d.range
+                ? `:${d.range.startLine + 1}:${d.range.startCol + 1}`
+                : ""}
+            </span>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * A collapsible drawer pinned to the bottom of the viewport that surfaces
+ * validation diagnostics on load (#440). Renders nothing when there are no
+ * diagnostics (silent success). Persists while diagnostics are present —
+ * collapsing hides the list, not the drawer.
+ */
+export function DiagnosticsDrawer({
+  diagnostics,
+}: {
+  diagnostics: readonly ViewerDiagnostic[];
+}) {
+  const [expanded, setExpanded] = useState(true);
+  if (diagnostics.length === 0) return null;
+
+  const { errors, warnings } = summarizeDiagnostics(diagnostics);
+  const hasErrors = errors > 0;
+
+  return (
+    <div style={drawerStyle}>
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        style={headerStyle(hasErrors)}
+      >
+        <span style={iconStyle(hasErrors ? "error" : "warning")} aria-hidden>
+          {hasErrors ? "✕" : "⚠"}
+        </span>
+        <span style={{ fontWeight: 600 }}>
+          {summaryLabel(errors, warnings)}
+        </span>
+        <span style={{ marginLeft: "auto" }} aria-hidden>
+          {expanded ? "▾" : "▴"}
+        </span>
+      </button>
+      {expanded && (
+        <div style={bodyStyle}>
+          <DiagnosticsList diagnostics={diagnostics} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+const drawerStyle: React.CSSProperties = {
+  position: "fixed",
+  left: 0,
+  right: 0,
+  bottom: 0,
+  zIndex: 50,
+  backgroundColor: "white",
+  borderTop: "1px solid #e5e7eb",
+  boxShadow: "0 -2px 8px rgba(0, 0, 0, 0.06)",
+  fontSize: "0.8125rem",
+};
+
+const headerStyle = (hasErrors: boolean): React.CSSProperties => ({
+  display: "flex",
+  alignItems: "center",
+  gap: "0.5rem",
+  width: "100%",
+  padding: "0.5rem 0.875rem",
+  border: "none",
+  cursor: "pointer",
+  textAlign: "left",
+  backgroundColor: hasErrors ? "#fef2f2" : "#fffbeb",
+  color: hasErrors ? "#991b1b" : "#92400e",
+});
+
+const bodyStyle: React.CSSProperties = {
+  maxHeight: "40vh",
+  overflowY: "auto",
+  padding: "0.5rem 0.875rem",
+  borderTop: "1px solid #f3f4f6",
+};
+
+const listStyle: React.CSSProperties = {
+  listStyle: "none",
+  margin: 0,
+  padding: 0,
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.375rem",
+};
+
+const rowStyle = (
+  severity: ViewerDiagnostic["severity"],
+): React.CSSProperties => ({
+  display: "flex",
+  gap: "0.5rem",
+  padding: "0.375rem 0.5rem",
+  borderRadius: "0.375rem",
+  backgroundColor: severity === "error" ? "#fef2f2" : "#fffbeb",
+  border: `1px solid ${severity === "error" ? "#fecaca" : "#fde68a"}`,
+  color: "#374151",
+});
+
+const rowBodyStyle: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.125rem",
+  minWidth: 0,
+};
+
+const iconStyle = (
+  severity: ViewerDiagnostic["severity"],
+): React.CSSProperties => ({
+  flexShrink: 0,
+  color: severity === "error" ? "#dc2626" : "#d97706",
+  fontWeight: 700,
+});
+
+const metaStyle: React.CSSProperties = {
+  fontSize: "0.6875rem",
+  color: "#9ca3af",
+  fontFamily: "monospace",
+};

--- a/apps/viewer/src/lib/diagnostics.test.ts
+++ b/apps/viewer/src/lib/diagnostics.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from "vitest";
+import type { Diagnostic } from "stagebook/validate";
+import { sortDiagnostics, summarizeDiagnostics } from "./diagnostics";
+
+const at = (
+  startLine: number,
+  startCol: number,
+  severity: Diagnostic["severity"] = "error",
+  message = "msg",
+): Diagnostic => ({
+  message,
+  severity,
+  range: { startLine, startCol, endLine: startLine, endCol: startCol + 1 },
+});
+
+const nowhere = (
+  severity: Diagnostic["severity"] = "error",
+  message = "msg",
+): Diagnostic => ({ message, severity, range: null });
+
+describe("summarizeDiagnostics", () => {
+  it("counts errors and warnings", () => {
+    const summary = summarizeDiagnostics([
+      at(1, 0, "error"),
+      at(2, 0, "warning"),
+      nowhere("error"),
+    ]);
+    expect(summary).toEqual({ errors: 2, warnings: 1 });
+  });
+
+  it("returns zeroes for an empty list", () => {
+    expect(summarizeDiagnostics([])).toEqual({ errors: 0, warnings: 0 });
+  });
+});
+
+describe("sortDiagnostics", () => {
+  it("orders by line then column", () => {
+    const sorted = sortDiagnostics([at(5, 2), at(1, 9), at(1, 3), at(5, 1)]);
+    expect(sorted.map((d) => [d.range!.startLine, d.range!.startCol])).toEqual([
+      [1, 3],
+      [1, 9],
+      [5, 1],
+      [5, 2],
+    ]);
+  });
+
+  it("places unpositioned diagnostics last", () => {
+    const a = nowhere("error", "no range");
+    const b = at(3, 0, "error", "has range");
+    const sorted = sortDiagnostics([a, b]);
+    expect(sorted.map((d) => d.message)).toEqual(["has range", "no range"]);
+  });
+
+  it("sorts errors before warnings at the same position", () => {
+    const warn = at(2, 4, "warning", "warn");
+    const err = at(2, 4, "error", "err");
+    const sorted = sortDiagnostics([warn, err]);
+    expect(sorted.map((d) => d.message)).toEqual(["err", "warn"]);
+  });
+
+  it("sorts errors before warnings among unpositioned diagnostics", () => {
+    const warn = nowhere("warning", "warn");
+    const err = nowhere("error", "err");
+    const sorted = sortDiagnostics([warn, err]);
+    expect(sorted.map((d) => d.message)).toEqual(["err", "warn"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [at(3, 0), at(1, 0)];
+    const snapshot = [...input];
+    sortDiagnostics(input);
+    expect(input).toEqual(snapshot);
+  });
+});

--- a/apps/viewer/src/lib/diagnostics.ts
+++ b/apps/viewer/src/lib/diagnostics.ts
@@ -1,0 +1,60 @@
+import type { Diagnostic } from "stagebook/validate";
+
+/**
+ * A validation diagnostic tagged with the display path of the file it
+ * belongs to. The viewer surfaces diagnostics for the entry treatment file
+ * and, for locale-consistency errors, referenced prompt files — so unlike the
+ * library's `Diagnostic` (which is always relative to a single source string),
+ * the viewer needs to say *which* file each one refers to.
+ */
+export interface ViewerDiagnostic extends Diagnostic {
+  /** Display path of the file this diagnostic refers to. */
+  file: string;
+}
+
+export interface DiagnosticSummary {
+  errors: number;
+  warnings: number;
+}
+
+/** Count diagnostics by severity for the drawer header. */
+export function summarizeDiagnostics(
+  diagnostics: readonly Diagnostic[],
+): DiagnosticSummary {
+  let errors = 0;
+  let warnings = 0;
+  for (const d of diagnostics) {
+    if (d.severity === "error") errors += 1;
+    else warnings += 1;
+  }
+  return { errors, warnings };
+}
+
+const severityRank = (severity: Diagnostic["severity"]): number =>
+  severity === "error" ? 0 : 1;
+
+/**
+ * Order diagnostics for display: by source position (line, then column),
+ * with unpositioned diagnostics (`range === null`) last. Errors sort before
+ * warnings when positions tie, so the most severe issue at a location leads.
+ *
+ * Returns a new array; does not mutate the input.
+ */
+export function sortDiagnostics<T extends Diagnostic>(
+  diagnostics: readonly T[],
+): T[] {
+  return [...diagnostics].sort((a, b) => {
+    if (a.range && b.range) {
+      if (a.range.startLine !== b.range.startLine) {
+        return a.range.startLine - b.range.startLine;
+      }
+      if (a.range.startCol !== b.range.startCol) {
+        return a.range.startCol - b.range.startCol;
+      }
+      return severityRank(a.severity) - severityRank(b.severity);
+    }
+    if (a.range) return -1;
+    if (b.range) return 1;
+    return severityRank(a.severity) - severityRank(b.severity);
+  });
+}

--- a/apps/viewer/src/lib/loader.test.ts
+++ b/apps/viewer/src/lib/loader.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
 import { loadTreatmentFromUrl } from "./loader";
-import { TreatmentValidationError } from "./treatment";
 
 const MINIMAL_YAML = `
 introSequences:
@@ -57,20 +56,21 @@ function routedFetch(
   });
 }
 
+const BLOB_URL = "https://github.com/org/repo/blob/main/treatment.yaml";
+
 describe("loadTreatmentFromUrl", () => {
-  it("fetches, parses, and expands a treatment file", async () => {
+  it("fetches, parses, and expands a treatment file with no diagnostics", async () => {
     const fetch = mockFetch(MINIMAL_YAML);
-    const result = await loadTreatmentFromUrl(
-      "https://github.com/org/repo/blob/main/treatment.yaml",
-      fetch,
-    );
+    const result = await loadTreatmentFromUrl(BLOB_URL, fetch);
     expect(fetch).toHaveBeenCalledWith(
       expect.stringContaining(
         "https://raw.githubusercontent.com/org/repo/main/treatment.yaml",
       ),
     );
-    expect(result.treatmentFile.treatments).toHaveLength(1);
-    expect(result.treatmentFile.treatments[0].name).toBe("treatment1");
+    expect(result.treatmentFile).not.toBeNull();
+    expect(result.treatmentFile!.treatments).toHaveLength(1);
+    expect(result.treatmentFile!.treatments[0].name).toBe("treatment1");
+    expect(result.diagnostics).toEqual([]);
     expect(result.unresolvedFields).toEqual([]);
     expect(result.rawBaseUrl).toBe(
       "https://raw.githubusercontent.com/org/repo/main/",
@@ -79,22 +79,126 @@ describe("loadTreatmentFromUrl", () => {
 
   it("throws on fetch failure", async () => {
     const fetch = mockFetch("Not Found", false);
-    await expect(
-      loadTreatmentFromUrl(
-        "https://github.com/org/repo/blob/main/treatment.yaml",
-        fetch,
-      ),
-    ).rejects.toThrow("Failed to fetch");
+    await expect(loadTreatmentFromUrl(BLOB_URL, fetch)).rejects.toThrow(
+      "Failed to fetch",
+    );
   });
 
-  it("throws on invalid YAML", async () => {
+  // -- #440: validation diagnostics on load --
+
+  it("returns positioned diagnostics and a null file for a schema error (#440)", async () => {
+    const badYaml = `
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+treatments:
+  - name: t
+    playerCount: two
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+    const fetch = mockFetch(badYaml);
+    const result = await loadTreatmentFromUrl(BLOB_URL, fetch);
+
+    expect(result.treatmentFile).toBeNull();
+    expect(result.diagnostics.length).toBeGreaterThan(0);
+    const diag = result.diagnostics[0];
+    expect(diag.severity).toBe("error");
+    expect(diag.message).toMatch(/playerCount/);
+    // Positioned against the entry file the author is editing.
+    expect(diag.range).not.toBeNull();
+    expect(diag.file).toBe("treatment.yaml");
+    // The raw source already carries the (positioned) error, so the merged
+    // object's schema issues must NOT be appended on top — no unpositioned
+    // duplicate.
+    expect(result.diagnostics.every((d) => d.range !== null)).toBe(true);
+  });
+
+  it("falls back to merged schema issues when the error hides in an imported template (#440)", async () => {
+    // The root file is schema-clean, so raw-source validation finds nothing —
+    // but the imported template's content is invalid, so the merged object
+    // fails schema. The placeholder must still explain why.
+    const rootYaml = `
+imports:
+  - ./mod.stagebook.yaml
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+    const moduleYaml = `
+templates:
+  - name: bad_step
+    contentType: element
+    content:
+      type: notARealElementType
+`;
+    const fetch = routedFetch([
+      ["treatment.yaml", rootYaml],
+      ["mod.stagebook.yaml", moduleYaml],
+    ]);
+
+    const result = await loadTreatmentFromUrl(BLOB_URL, fetch);
+
+    expect(result.treatmentFile).toBeNull();
+    const diag = result.diagnostics.find((d) => /templates/.test(d.message));
+    expect(diag).toBeDefined();
+    expect(diag!.severity).toBe("error");
+    // The merged-object fallback has no source position.
+    expect(diag!.range).toBeNull();
+    expect(diag!.file).toBe("treatment.yaml");
+  });
+
+  it("surfaces a duplicate-key warning with a position and a null file (#440)", async () => {
+    // A duplicate key is a warning in the validator, but js-yaml refuses to
+    // build an object from it — so nothing renders, yet the positioned
+    // warning still explains why.
+    const dupYaml = `
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+treatments:
+  - name: t
+    playerCount: 2
+    playerCount: 3
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+    const fetch = mockFetch(dupYaml);
+    const result = await loadTreatmentFromUrl(BLOB_URL, fetch);
+
+    expect(result.treatmentFile).toBeNull();
+    expect(result.diagnostics.some((d) => d.severity === "warning")).toBe(true);
+    expect(result.diagnostics[0].range).not.toBeNull();
+  });
+
+  it("returns a diagnostic (not a throw) for invalid YAML (#440)", async () => {
     const fetch = mockFetch("{{bad yaml");
-    await expect(
-      loadTreatmentFromUrl(
-        "https://github.com/org/repo/blob/main/treatment.yaml",
-        fetch,
-      ),
-    ).rejects.toThrow();
+    const result = await loadTreatmentFromUrl(BLOB_URL, fetch);
+    expect(result.treatmentFile).toBeNull();
+    expect(result.diagnostics.length).toBeGreaterThan(0);
   });
 
   // -- #312: cross-file imports via URL --
@@ -135,10 +239,7 @@ templates:
       ["modules/consent.stagebook.yaml", moduleYaml],
     ]);
 
-    const result = await loadTreatmentFromUrl(
-      "https://github.com/org/repo/blob/main/treatment.yaml",
-      fetch,
-    );
+    const result = await loadTreatmentFromUrl(BLOB_URL, fetch);
 
     // Imports should have been fetched from the same repo + branch
     expect(fetch).toHaveBeenCalledWith(
@@ -148,9 +249,11 @@ templates:
     );
 
     // The template invocation resolved during expansion
-    expect(result.treatmentFile.introSequences?.[0].introSteps[0].name).toBe(
+    expect(result.treatmentFile).not.toBeNull();
+    expect(result.treatmentFile!.introSequences?.[0].introSteps[0].name).toBe(
       "consent",
     );
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("throws a clear error when an imported file 404s (#312)", async () => {
@@ -178,19 +281,14 @@ introSequences:
       // modules/missing.stagebook.yaml not routed → 404
     ]);
 
-    await expect(
-      loadTreatmentFromUrl(
-        "https://github.com/org/repo/blob/main/treatment.yaml",
-        fetch,
-      ),
-    ).rejects.toThrow(
+    await expect(loadTreatmentFromUrl(BLOB_URL, fetch)).rejects.toThrow(
       /Failed to fetch imported file 'modules\/missing\.stagebook\.yaml'.*HTTP 404.*same repo/s,
     );
   });
 
   // -- #483: prompt locale-consistency on load --
 
-  it("rejects when a he treatment references an untagged (en) prompt (#483)", async () => {
+  it("flags a he treatment referencing an untagged (en) prompt as a diagnostic (#483)", async () => {
     const rootYaml = `
 treatments:
   - name: t
@@ -215,12 +313,17 @@ introSequences:
       ["prompts/q.prompt.md", "---\ntype: noResponse\n---\nhello\n"],
     ]);
 
-    await expect(
-      loadTreatmentFromUrl(
-        "https://github.com/org/repo/blob/main/treatment.yaml",
-        fetch,
-      ),
-    ).rejects.toThrow(/authored in locale "en".*declares locale "he"/s);
+    const result = await loadTreatmentFromUrl(BLOB_URL, fetch);
+
+    // Locale mismatch doesn't block rendering — preview still available.
+    expect(result.treatmentFile).not.toBeNull();
+    const localeDiag = result.diagnostics.find((d) =>
+      /authored in locale "en".*declares locale "he"/s.test(d.message),
+    );
+    expect(localeDiag).toBeDefined();
+    // Tagged with the offending prompt's own path, not the treatment file.
+    expect(localeDiag!.file).toBe("prompts/q.prompt.md");
+    expect(localeDiag!.severity).toBe("error");
   });
 
   it("loads cleanly when the prompt is tagged with the treatment's locale (#483)", async () => {
@@ -251,14 +354,13 @@ introSequences:
       ],
     ]);
 
-    const result = await loadTreatmentFromUrl(
-      "https://github.com/org/repo/blob/main/treatment.yaml",
-      fetch,
-    );
-    expect(result.treatmentFile.treatments[0].name).toBe("t");
+    const result = await loadTreatmentFromUrl(BLOB_URL, fetch);
+    expect(result.treatmentFile).not.toBeNull();
+    expect(result.treatmentFile!.treatments[0].name).toBe("t");
+    expect(result.diagnostics).toEqual([]);
   });
 
-  it("does not reject on locale grounds when the prompt can't be fetched (#483)", async () => {
+  it("does not flag a locale mismatch when the prompt can't be fetched (#483)", async () => {
     // A missing prompt 404s; the locale rule skips it rather than emitting a
     // spurious mismatch. (Runtime rendering surfaces the missing file.)
     const rootYaml = `
@@ -285,11 +387,10 @@ introSequences:
       // prompts/q.prompt.md not routed → 404
     ]);
 
-    const result = await loadTreatmentFromUrl(
-      "https://github.com/org/repo/blob/main/treatment.yaml",
-      fetch,
-    );
-    expect(result.treatmentFile.treatments[0].name).toBe("t");
+    const result = await loadTreatmentFromUrl(BLOB_URL, fetch);
+    expect(result.treatmentFile).not.toBeNull();
+    expect(result.treatmentFile!.treatments[0].name).toBe("t");
+    expect(result.diagnostics).toEqual([]);
   });
 
   it("never fetches a schema-rejected prompt path for the locale check (#483)", async () => {
@@ -318,15 +419,16 @@ introSequences:
 `;
     const fetch = routedFetch([["treatment.yaml", rootYaml]]);
 
-    const err = await loadTreatmentFromUrl(
-      "https://github.com/org/repo/blob/main/treatment.yaml",
-      fetch,
-    ).catch((e: unknown) => e);
+    const result = await loadTreatmentFromUrl(BLOB_URL, fetch);
 
     // Rejected on schema grounds (relative-path rule), not locale grounds.
-    expect(err).toBeInstanceOf(Error);
-    expect((err as Error).message).toMatch(/relative path/);
-    expect((err as Error).message).not.toMatch(/authored in locale/);
+    expect(result.treatmentFile).toBeNull();
+    expect(
+      result.diagnostics.some((d) => /relative path/.test(d.message)),
+    ).toBe(true);
+    expect(
+      result.diagnostics.some((d) => /authored in locale/.test(d.message)),
+    ).toBe(false);
     // And the gated path was never fetched.
     const fetchedUrls = (fetch.mock.calls as unknown[][]).map(
       (args) => args[0] as string,
@@ -360,15 +462,16 @@ treatments:
       ["prompts/consent.prompt.md", "---\ntype: noResponse\n---\nhello\n"],
     ]);
 
-    await expect(
-      loadTreatmentFromUrl(
-        "https://github.com/org/repo/blob/main/treatment.yaml",
-        fetch,
+    const result = await loadTreatmentFromUrl(BLOB_URL, fetch);
+    expect(result.treatmentFile).not.toBeNull();
+    expect(
+      result.diagnostics.some((d) =>
+        /intro sequence "i".*declares locale "he"/s.test(d.message),
       ),
-    ).rejects.toThrow(/intro sequence "i".*declares locale "he"/s);
+    ).toBe(true);
   });
 
-  it("surfaces every mismatching prompt, not just the first (#483)", async () => {
+  it("surfaces every mismatching prompt as its own diagnostic (#483)", async () => {
     const rootYaml = `
 treatments:
   - name: t
@@ -397,13 +500,15 @@ introSequences:
       ["prompts/b.prompt.md", "---\ntype: noResponse\n---\nb\n"],
     ]);
 
-    const err = await loadTreatmentFromUrl(
-      "https://github.com/org/repo/blob/main/treatment.yaml",
-      fetch,
-    ).catch((e: unknown) => e);
-
-    expect(err).toBeInstanceOf(TreatmentValidationError);
-    expect((err as TreatmentValidationError).issues).toHaveLength(2);
+    const result = await loadTreatmentFromUrl(BLOB_URL, fetch);
+    const localeDiags = result.diagnostics.filter((d) =>
+      /authored in locale/.test(d.message),
+    );
+    expect(localeDiags).toHaveLength(2);
+    expect(localeDiags.map((d) => d.file).sort()).toEqual([
+      "prompts/a.prompt.md",
+      "prompts/b.prompt.md",
+    ]);
   });
 
   it("supports transitive imports (A imports B imports C) (#312)", async () => {
@@ -452,10 +557,7 @@ templates:
       ["surveys/shared.stagebook.yaml", sharedYaml],
     ]);
 
-    const result = await loadTreatmentFromUrl(
-      "https://github.com/org/repo/blob/main/treatment.yaml",
-      fetch,
-    );
+    const result = await loadTreatmentFromUrl(BLOB_URL, fetch);
 
     // Transitive import (shared.stagebook.yaml) was fetched relative to
     // its parent file (surveys/tipi.stagebook.yaml), not relative to the
@@ -467,7 +569,8 @@ templates:
     );
 
     // The nested template was resolved through both layers
-    const introStep = result.treatmentFile.introSequences?.[0].introSteps[0];
+    expect(result.treatmentFile).not.toBeNull();
+    const introStep = result.treatmentFile!.introSequences?.[0].introSteps[0];
     expect(introStep?.elements?.[0]).toMatchObject({
       type: "submitButton",
       buttonText: "Continue",

--- a/apps/viewer/src/lib/loader.test.ts
+++ b/apps/viewer/src/lib/loader.test.ts
@@ -114,16 +114,14 @@ treatments:
     // Positioned against the entry file the author is editing.
     expect(diag.range).not.toBeNull();
     expect(diag.file).toBe("treatment.yaml");
-    // The raw source already carries the (positioned) error, so the merged
-    // object's schema issues must NOT be appended on top — no unpositioned
-    // duplicate.
-    expect(result.diagnostics.every((d) => d.range !== null)).toBe(true);
   });
 
-  it("falls back to merged schema issues when the error hides in an imported template (#440)", async () => {
-    // The root file is schema-clean, so raw-source validation finds nothing —
-    // but the imported template's content is invalid, so the merged object
-    // fails schema. The placeholder must still explain why.
+  it("renders with a warning for a schema slip in an unused imported template (#440)", async () => {
+    // The bad template is defined in an import but never invoked. The diff
+    // validator downgrades such source-only artifacts to warnings (they don't
+    // survive hydration into a real bug), and expansion strips the unused
+    // template — so the preview still opens, with the warning in the drawer.
+    // This matches the VS Code extension's Problems panel.
     const rootYaml = `
 imports:
   - ./mod.stagebook.yaml
@@ -156,12 +154,10 @@ templates:
 
     const result = await loadTreatmentFromUrl(BLOB_URL, fetch);
 
-    expect(result.treatmentFile).toBeNull();
-    const diag = result.diagnostics.find((d) => /templates/.test(d.message));
+    expect(result.treatmentFile).not.toBeNull();
+    const diag = result.diagnostics.find((d) => /content/.test(d.message));
     expect(diag).toBeDefined();
-    expect(diag!.severity).toBe("error");
-    // The merged-object fallback has no source position.
-    expect(diag!.range).toBeNull();
+    expect(diag!.severity).toBe("warning");
     expect(diag!.file).toBe("treatment.yaml");
   });
 
@@ -321,9 +317,11 @@ introSequences:
       /authored in locale "en".*declares locale "he"/s.test(d.message),
     );
     expect(localeDiag).toBeDefined();
-    // Tagged with the offending prompt's own path, not the treatment file.
-    expect(localeDiag!.file).toBe("prompts/q.prompt.md");
     expect(localeDiag!.severity).toBe("error");
+    // The message names the offending prompt; the diagnostic is filed against
+    // the entry treatment file (no source token, same as the extension).
+    expect(localeDiag!.message).toContain("prompts/q.prompt.md");
+    expect(localeDiag!.file).toBe("treatment.yaml");
   });
 
   it("loads cleanly when the prompt is tagged with the treatment's locale (#483)", async () => {
@@ -505,10 +503,11 @@ introSequences:
       /authored in locale/.test(d.message),
     );
     expect(localeDiags).toHaveLength(2);
-    expect(localeDiags.map((d) => d.file).sort()).toEqual([
-      "prompts/a.prompt.md",
-      "prompts/b.prompt.md",
-    ]);
+    // Each mismatch is its own diagnostic, naming its prompt in the message.
+    const named = localeDiags
+      .map((d) => (d.message.match(/prompts\/[ab]\.prompt\.md/) ?? [])[0])
+      .sort();
+    expect(named).toEqual(["prompts/a.prompt.md", "prompts/b.prompt.md"]);
   });
 
   it("supports transitive imports (A imports B imports C) (#312)", async () => {

--- a/apps/viewer/src/lib/loader.ts
+++ b/apps/viewer/src/lib/loader.ts
@@ -1,14 +1,28 @@
 import { parseGitHubUrl } from "./github";
 import { expandTreatmentFile } from "./expandTreatmentFile";
-import { TreatmentValidationError } from "./treatment";
 import { safeParseTreatmentFile, type TreatmentFileType } from "stagebook";
 import {
   loadAndMergeImports,
+  validateTreatmentSource,
   checkPromptLocaleConsistencyWithLoader,
 } from "stagebook/validate";
+import type { ViewerDiagnostic } from "./diagnostics";
 
 export interface LoadResult {
-  treatmentFile: TreatmentFileType;
+  /**
+   * The parsed + expanded treatment file, or `null` when the file has errors
+   * that prevent it from rendering (YAML syntax, schema violations). When
+   * null, `diagnostics` explains why and the caller shows a placeholder.
+   */
+  treatmentFile: TreatmentFileType | null;
+  /**
+   * Validation diagnostics — the same rich, positioned diagnostics the VS Code
+   * extension shows in its Problems panel (schema errors + duplicate-key
+   * warnings, positioned against the entry file), plus prompt
+   * locale-consistency errors. Empty for a clean file. Present even when
+   * `treatmentFile` is set (warnings don't block rendering).
+   */
+  diagnostics: ViewerDiagnostic[];
   unresolvedFields: string[];
   rawBaseUrl: string;
 }
@@ -19,14 +33,28 @@ type FetchFn = (
 
 /**
  * Load a treatment file from a GitHub URL, resolving any `imports:`
- * against the same repo and branch as the entry-point file (#312).
+ * against the same repo and branch as the entry-point file (#312), and
+ * surfacing schema/warning diagnostics on load (#440).
+ *
+ * Validation is non-fatal: a file with only warnings still renders (its
+ * warnings ride along in `diagnostics`); a file with errors returns a null
+ * `treatmentFile` plus the positioned diagnostics that explain why. Network
+ * failures (unreachable root, unreadable import) still throw — those aren't
+ * file-content diagnostics.
+ *
+ * Diagnostics come from `validateTreatmentSource` over the entry file's raw
+ * source, so positions land in the file the author is editing and the messages
+ * match the VS Code extension's Problems panel. Rendering is driven off the
+ * imports-merged, template-expanded object, so a file can be simultaneously
+ * renderable and carry warnings.
+ *
  * Accepts an injectable fetch function for testing.
  */
 export async function loadTreatmentFromUrl(
   githubUrl: string,
   fetchFn: FetchFn = globalThis.fetch,
 ): Promise<LoadResult> {
-  const { rawFileUrl, rawBaseUrl } = parseGitHubUrl(githubUrl);
+  const { rawFileUrl, rawBaseUrl, filePath } = parseGitHubUrl(githubUrl);
 
   // Cache-bust: raw.githubusercontent.com has aggressive CDN caching
   const bustUrl = `${rawFileUrl}?t=${Date.now()}`;
@@ -56,28 +84,71 @@ export async function loadTreatmentFromUrl(
     return importResponse.text();
   };
 
-  // `loadAndMergeImports` (from stagebook/validate) parses the root YAML,
-  // recursively fetches every imported file via `loadImport`, and returns
-  // a discriminated result with the merged object (`imports:` stripped,
-  // `templates:` replaced by the merged set). It does not validate
-  // against `treatmentFileSchema` — we do that here so validation errors
-  // come through the same `TreatmentValidationError` path as the
-  // local-YAML flow.
+  // Rich, positioned diagnostics against the entry file's raw source — the same
+  // messages/positions the VS Code extension surfaces (#440). Tagged with the
+  // entry file's display path so the panel can attribute each one.
+  const diagnostics: ViewerDiagnostic[] = validateTreatmentSource(
+    rootYaml,
+  ).diagnostics.map((d) => ({ ...d, file: filePath }));
+
+  // `loadAndMergeImports` parses the root YAML, recursively fetches every
+  // imported file via `loadImport`, and returns the merged object (`imports:`
+  // stripped, `templates:` merged). We drive rendering off this path.
   const loadResult = await loadAndMergeImports({
     source: rootYaml,
     loadImport,
   });
   if (!loadResult.ok) {
+    if (loadResult.stage === "parse") {
+      // Root YAML couldn't be parsed (syntax error, duplicate key). Nothing
+      // renders; `diagnostics` already carries the positioned reason. Fall back
+      // to the raw message only if the validator produced nothing.
+      return {
+        treatmentFile: null,
+        diagnostics: diagnostics.length
+          ? diagnostics
+          : [
+              {
+                message: loadResult.message,
+                severity: "error",
+                range: null,
+                file: filePath,
+              },
+            ],
+        unresolvedFields: [],
+        rawBaseUrl,
+      };
+    }
+    // Import fetch / parse / merge failure — a network/structural problem the
+    // author resolves outside this file. Surface as a hard error (unchanged).
     throw new Error(loadResult.message);
   }
+
+  // Build the render object from the merged (imports-resolved) source.
   const parsed = safeParseTreatmentFile(loadResult.merged);
   if (!parsed.success) {
-    throw new TreatmentValidationError(
-      parsed.error.issues.map((issue) => ({
-        path: issue.path.join(".") || "(root)",
-        message: issue.message,
-      })),
-    );
+    // The merged object failed schema validation. Usually the raw-source
+    // diagnostics already explain it (positioned); but when the offending
+    // value lives inside an imported template, raw validation sees nothing —
+    // fall back to the merged object's schema issues (unpositioned) so the
+    // placeholder is never blank.
+    if (!diagnostics.some((d) => d.severity === "error")) {
+      for (const issue of parsed.error.issues) {
+        const path = issue.path.join(".") || "(root)";
+        diagnostics.push({
+          message: `${issue.message} (${path})`,
+          severity: "error",
+          range: null,
+          file: filePath,
+        });
+      }
+    }
+    return {
+      treatmentFile: null,
+      diagnostics,
+      unresolvedFields: [],
+      rawBaseUrl,
+    };
   }
 
   const { result, unresolvedFields } = expandTreatmentFile(parsed.data);
@@ -86,9 +157,9 @@ export async function loadTreatmentFromUrl(
   // every referenced prompt's frontmatter `locale` must match its container's
   // `locale` (both default `en`). Runs on the hydrated tree, fetching each
   // prompt's frontmatter from the same repo + branch as the entry-point file.
-  // Surfaced through the same `TreatmentValidationError` path as schema errors
-  // so it shows up in the preview's validation UI. Unreadable / unparseable
-  // prompts return null and are skipped — those failures surface elsewhere.
+  // Surfaced as diagnostics tagged with each prompt's own path. Unreadable /
+  // unparseable prompts return null and are skipped — those failures surface
+  // elsewhere. A mismatch doesn't block rendering, so the preview still shows.
   const loadPrompt = async (relPath: string): Promise<string | null> => {
     const promptResponse = await fetchFn(
       `${rawBaseUrl}${relPath}?t=${Date.now()}`,
@@ -99,14 +170,14 @@ export async function loadTreatmentFromUrl(
     fileObj: result,
     loadPrompt,
   });
-  if (localeMismatches.length > 0) {
-    throw new TreatmentValidationError(
-      localeMismatches.map((mismatch) => ({
-        path: mismatch.promptFile,
-        message: mismatch.message,
-      })),
-    );
+  for (const mismatch of localeMismatches) {
+    diagnostics.push({
+      message: mismatch.message,
+      severity: "error",
+      range: null,
+      file: mismatch.promptFile,
+    });
   }
 
-  return { treatmentFile: result, unresolvedFields, rawBaseUrl };
+  return { treatmentFile: result, diagnostics, unresolvedFields, rawBaseUrl };
 }

--- a/apps/viewer/src/lib/loader.ts
+++ b/apps/viewer/src/lib/loader.ts
@@ -3,8 +3,7 @@ import { expandTreatmentFile } from "./expandTreatmentFile";
 import { safeParseTreatmentFile, type TreatmentFileType } from "stagebook";
 import {
   loadAndMergeImports,
-  validateTreatmentSource,
-  checkPromptLocaleConsistencyWithLoader,
+  validateTreatmentWithDiff,
 } from "stagebook/validate";
 import type { ViewerDiagnostic } from "./diagnostics";
 
@@ -16,11 +15,13 @@ export interface LoadResult {
    */
   treatmentFile: TreatmentFileType | null;
   /**
-   * Validation diagnostics — the same rich, positioned diagnostics the VS Code
-   * extension shows in its Problems panel (schema errors + duplicate-key
-   * warnings, positioned against the entry file), plus prompt
-   * locale-consistency errors. Empty for a clean file. Present even when
-   * `treatmentFile` is set (warnings don't block rendering).
+   * Validation diagnostics — the same import-aware, positioned diagnostics the
+   * VS Code extension shows in its Problems panel: schema errors (including
+   * inside imported templates), template artifacts downgraded to warnings after
+   * hydration, YAML/duplicate-key issues, post-fill schema, and prompt
+   * locale-consistency. Empty for a clean file. Present even when
+   * `treatmentFile` is set (warnings, and non-structural errors like locale
+   * mismatches, don't block rendering).
    */
   diagnostics: ViewerDiagnostic[];
   unresolvedFields: string[];
@@ -34,19 +35,19 @@ type FetchFn = (
 /**
  * Load a treatment file from a GitHub URL, resolving any `imports:`
  * against the same repo and branch as the entry-point file (#312), and
- * surfacing schema/warning diagnostics on load (#440).
+ * surfacing validation diagnostics on load (#440).
  *
- * Validation is non-fatal: a file with only warnings still renders (its
- * warnings ride along in `diagnostics`); a file with errors returns a null
- * `treatmentFile` plus the positioned diagnostics that explain why. Network
- * failures (unreachable root, unreadable import) still throw — those aren't
- * file-content diagnostics.
+ * Diagnostics come from `validateTreatmentWithDiff` — the same import-aware,
+ * diff-based validator the VS Code extension drives its Problems panel from —
+ * so the messages, positions, and severities match the editor exactly (a
+ * template that injects an advancement element shows as a warning, not an
+ * error; a schema slip inside an imported template is reported; etc.).
  *
- * Diagnostics come from `validateTreatmentSource` over the entry file's raw
- * source, so positions land in the file the author is editing and the messages
- * match the VS Code extension's Problems panel. Rendering is driven off the
- * imports-merged, template-expanded object, so a file can be simultaneously
- * renderable and carry warnings.
+ * Validation is non-fatal: a file with only warnings still renders (warnings
+ * ride along in `diagnostics`); a file with structural errors returns a null
+ * `treatmentFile` plus the diagnostics that explain why. Only failure to fetch
+ * the entry file or one of its imports throws — those aren't file-content
+ * diagnostics.
  *
  * Accepts an injectable fetch function for testing.
  */
@@ -67,82 +68,52 @@ export async function loadTreatmentFromUrl(
 
   const rootYaml = await response.text();
 
-  // Fetch each `imports:` from the same repo + branch as the entry-point
-  // file. `canonicalPath` is POSIX-normalized (e.g. `modules/foo.stagebook.yaml`),
-  // and `rawBaseUrl` already has a trailing slash, so concatenation produces
-  // a valid raw.githubusercontent.com URL.
-  const loadImport = async (canonicalPath: string): Promise<string> => {
-    const importUrl = `${rawBaseUrl}${canonicalPath}?t=${Date.now()}`;
-    const importResponse = await fetchFn(importUrl);
-    if (!importResponse.ok) {
-      throw new Error(
-        `Failed to fetch imported file '${canonicalPath}' (HTTP ${importResponse.status}) — ` +
-          `make sure the file exists in the same repo as the entry-point file. ` +
-          `Tried: ${rawBaseUrl}${canonicalPath}`,
-      );
+  // Fetch each `imports:` from the same repo + branch as the entry-point file.
+  // Memoized so the two passes below (diff validation, then the merge for the
+  // render object) — plus the validator's own prompt locale-consistency fetches
+  // — hit the network at most once per path.
+  const importCache = new Map<string, Promise<string>>();
+  const loadImport = (canonicalPath: string): Promise<string> => {
+    let pending = importCache.get(canonicalPath);
+    if (!pending) {
+      pending = (async () => {
+        const importUrl = `${rawBaseUrl}${canonicalPath}?t=${Date.now()}`;
+        const importResponse = await fetchFn(importUrl);
+        if (!importResponse.ok) {
+          throw new Error(
+            `Failed to fetch imported file '${canonicalPath}' (HTTP ${importResponse.status}) — ` +
+              `make sure the file exists in the same repo as the entry-point file. ` +
+              `Tried: ${rawBaseUrl}${canonicalPath}`,
+          );
+        }
+        return importResponse.text();
+      })();
+      importCache.set(canonicalPath, pending);
     }
-    return importResponse.text();
+    return pending;
   };
 
-  // Rich, positioned diagnostics against the entry file's raw source — the same
-  // messages/positions the VS Code extension surfaces (#440). Tagged with the
-  // entry file's display path so the panel can attribute each one.
-  const diagnostics: ViewerDiagnostic[] = validateTreatmentSource(
-    rootYaml,
-  ).diagnostics.map((d) => ({ ...d, file: filePath }));
-
-  // `loadAndMergeImports` parses the root YAML, recursively fetches every
-  // imported file via `loadImport`, and returns the merged object (`imports:`
-  // stripped, `templates:` merged). We drive rendering off this path.
+  // Merge imports for the render object. A genuine import fetch/parse/merge
+  // failure is a network/structural problem the author resolves outside this
+  // file, so it stays a hard error (Retry-able) — unlike a root YAML syntax
+  // error (`stage: "parse"`), which we surface as a positioned diagnostic.
   const loadResult = await loadAndMergeImports({
     source: rootYaml,
     loadImport,
   });
-  if (!loadResult.ok) {
-    if (loadResult.stage === "parse") {
-      // Root YAML couldn't be parsed (syntax error, duplicate key). Nothing
-      // renders; `diagnostics` already carries the positioned reason. Fall back
-      // to the raw message only if the validator produced nothing.
-      return {
-        treatmentFile: null,
-        diagnostics: diagnostics.length
-          ? diagnostics
-          : [
-              {
-                message: loadResult.message,
-                severity: "error",
-                range: null,
-                file: filePath,
-              },
-            ],
-        unresolvedFields: [],
-        rawBaseUrl,
-      };
-    }
-    // Import fetch / parse / merge failure — a network/structural problem the
-    // author resolves outside this file. Surface as a hard error (unchanged).
+  if (!loadResult.ok && loadResult.stage !== "parse") {
     throw new Error(loadResult.message);
   }
 
-  // Build the render object from the merged (imports-resolved) source.
-  const parsed = safeParseTreatmentFile(loadResult.merged);
-  if (!parsed.success) {
-    // The merged object failed schema validation. Usually the raw-source
-    // diagnostics already explain it (positioned); but when the offending
-    // value lives inside an imported template, raw validation sees nothing —
-    // fall back to the merged object's schema issues (unpositioned) so the
-    // placeholder is never blank.
-    if (!diagnostics.some((d) => d.severity === "error")) {
-      for (const issue of parsed.error.issues) {
-        const path = issue.path.join(".") || "(root)";
-        diagnostics.push({
-          message: `${issue.message} (${path})`,
-          severity: "error",
-          range: null,
-          file: filePath,
-        });
-      }
-    }
+  // Positioned diagnostics from the extension's validator (see the doc comment).
+  // Tagged with the entry file's display path so the panel can attribute them.
+  const diagnostics: ViewerDiagnostic[] = (
+    await validateTreatmentWithDiff({ source: rootYaml, loadImport })
+  ).diagnostics.map((d) => ({ ...d, file: filePath }));
+
+  // Root YAML couldn't be parsed — nothing renders; `diagnostics` carries the
+  // positioned reason.
+  if (!loadResult.ok) {
     return {
       treatmentFile: null,
       diagnostics,
@@ -151,33 +122,40 @@ export async function loadTreatmentFromUrl(
     };
   }
 
-  const { result, unresolvedFields } = expandTreatmentFile(parsed.data);
-
-  // Post-hydration locale-consistency rule (ADR 2026-06-localization #6):
-  // every referenced prompt's frontmatter `locale` must match its container's
-  // `locale` (both default `en`). Runs on the hydrated tree, fetching each
-  // prompt's frontmatter from the same repo + branch as the entry-point file.
-  // Surfaced as diagnostics tagged with each prompt's own path. Unreadable /
-  // unparseable prompts return null and are skipped — those failures surface
-  // elsewhere. A mismatch doesn't block rendering, so the preview still shows.
-  const loadPrompt = async (relPath: string): Promise<string | null> => {
-    const promptResponse = await fetchFn(
-      `${rawBaseUrl}${relPath}?t=${Date.now()}`,
-    );
-    return promptResponse.ok ? promptResponse.text() : null;
-  };
-  const localeMismatches = await checkPromptLocaleConsistencyWithLoader({
-    fileObj: result,
-    loadPrompt,
-  });
-  for (const mismatch of localeMismatches) {
-    diagnostics.push({
-      message: mismatch.message,
-      severity: "error",
-      range: null,
-      file: mismatch.promptFile,
-    });
+  // Build the render object. Normally we render the schema-validated merged
+  // object; but when the pre-fill schema rejects it while the diff validator
+  // found no error (only warnings), the rejection is a template artifact that
+  // resolves on hydration — e.g. a step whose only advancement element is
+  // injected by a template invocation. Expand from the merged object in that
+  // case so the preview still opens. A real structural error keeps the
+  // placeholder.
+  const parsed = safeParseTreatmentFile(loadResult.merged);
+  const hasError = diagnostics.some((d) => d.severity === "error");
+  const expandInput: TreatmentFileType | null = parsed.success
+    ? parsed.data
+    : hasError
+      ? null
+      : (loadResult.merged as TreatmentFileType);
+  if (expandInput === null) {
+    return {
+      treatmentFile: null,
+      diagnostics,
+      unresolvedFields: [],
+      rawBaseUrl,
+    };
   }
 
-  return { treatmentFile: result, diagnostics, unresolvedFields, rawBaseUrl };
+  try {
+    const { result, unresolvedFields } = expandTreatmentFile(expandInput);
+    return { treatmentFile: result, diagnostics, unresolvedFields, rawBaseUrl };
+  } catch {
+    // Expansion blew up on a structurally-broken object the diff validator
+    // didn't flag as blocking — fall back to the placeholder rather than crash.
+    return {
+      treatmentFile: null,
+      diagnostics,
+      unresolvedFields: [],
+      rawBaseUrl,
+    };
+  }
 }


### PR DESCRIPTION
## Summary

The standalone viewer previously **threw a fatal, full-screen error** on any validation failure and **swallowed warnings entirely** — unlike the VS Code extension, which shows rich, positioned diagnostics in its Problems panel. This makes the viewer autovalidate on load and surface the *same* diagnostics the extension shows.

Behavior:
- **Clean file** → no diagnostics UI (silent success).
- **Renderable file with warnings** (or non-structural errors like a locale mismatch) → preview renders **plus** a collapsible bottom drawer listing the diagnostics.
- **Unrenderable file** (YAML syntax / structural schema error) → placeholder explaining it can't be previewed **plus** the diagnostics that caused it.
- **Hard failures** (unreachable entry URL, failed import fetch) → the existing plain error screen (Retry-able).

## Implementation

- **[`loader.ts`](../blob/feat/viewer-load-diagnostics-440/apps/viewer/src/lib/loader.ts)** — `loadTreatmentFromUrl` now returns `{ treatmentFile: … | null, diagnostics, … }` instead of throwing on validation failure. Diagnostics come from **`validateTreatmentWithDiff`** — the same import-aware, diff-based validator the VS Code extension drives its Problems panel from — so messages, positions, and severities match the editor exactly (a template that injects an advancement element is a *warning*, not an error; a schema slip inside an imported template is reported; a `templates:` issue that import merging resolves doesn't false-positive). Rendering is driven off the imports-merged/expanded object; when the pre-fill schema rejects the merged object but the validator found no error, the loader expands from the merged object anyway so template-driven previews still open.
- **`diagnostics.ts`** — `ViewerDiagnostic` type, `sortDiagnostics`, `summarizeDiagnostics`.
- **`DiagnosticsPanel.tsx`** — `DiagnosticsDrawer` (collapsible bottom drawer) + reusable `DiagnosticsList`.
- **`App.tsx`** — new `unrenderable` phase; threads `diagnostics` through the overview/viewing phases and renders the drawer as a bottom overlay.

## Scope / VS Code

Scoped to the standalone SPA (`App.tsx` / `loader.ts`). The VS Code extension embeds the shared `PreviewHost` from `stagebook-viewer/preview` (not `App`) and owns its own Problems-panel diagnostics, so the drawer does **not** appear there and nothing duplicates. Both paths now derive diagnostics from the same `validateTreatmentWithDiff`, so they're consistent by construction.

Depends on #439 (shipped `stagebook/validate`).

## Testing

- **184 viewer tests pass** (typecheck + Prettier clean, production build succeeds): loader cases (schema error, duplicate-key warning, invalid YAML → diagnostic not throw, unused-imported-template → warning + still renders, locale-mismatch renders + flags), `diagnostics` helper tests, jsdom render tests for the drawer/list, and App routing tests (null → placeholder, throw → error screen).
- Pre-push hook ran full lint + all workspace tests (viewer, vscode, library) — green.

## Review

Ran three pre-open review passes (correctness, security, coverage); then addressed both bot reviews inline:
- **Copilot** — neutral "problems" wording on the placeholder (a duplicate-key warning still blocks parsing); content-derived React keys for the diagnostics list.
- **Codex** — the three P2s all pointed at the raw-source validator diverging from the extension's import-aware diff validator; switched the loader to `validateTreatmentWithDiff`, which resolves all three (imported-template errors reported; import-merge-resolved issues no longer false-positive; template artifacts downgraded to warnings and their previews now open).

Fixes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)