### PR TITLE
fix(validate): suppress provable intro/exit advancement warning (#347); close #321 umbrella

### DIFF
--- a/apps/viewer/src/lib/loader.ts
+++ b/apps/viewer/src/lib/loader.ts
@@ -39,9 +39,10 @@ type FetchFn = (
  *
  * Diagnostics come from `validateTreatmentWithDiff` — the same import-aware,
  * diff-based validator the VS Code extension drives its Problems panel from —
- * so the messages, positions, and severities match the editor exactly (a
- * template that injects an advancement element shows as a warning, not an
- * error; a schema slip inside an imported template is reported; etc.).
+ * so the messages, positions, and severities match the editor exactly (a step
+ * whose advancement element is injected by a provably-resolving template
+ * produces no diagnostic at all (#347); a schema slip inside an imported
+ * template is reported; etc.).
  *
  * Validation is non-fatal: a file with only warnings still renders (warnings
  * ride along in `diagnostics`); a file with structural errors returns a null
@@ -124,11 +125,11 @@ export async function loadTreatmentFromUrl(
 
   // Build the render object. Normally we render the schema-validated merged
   // object; but when the pre-fill schema rejects it while the diff validator
-  // found no error (only warnings), the rejection is a template artifact that
-  // resolves on hydration — e.g. a step whose only advancement element is
-  // injected by a template invocation. Expand from the merged object in that
-  // case so the preview still opens. A real structural error keeps the
-  // placeholder.
+  // found no error (only warnings, or — for a provably-resolving template —
+  // no diagnostic at all), the rejection is a template artifact that resolves
+  // on hydration — e.g. a step whose only advancement element is injected by a
+  // template invocation (#347). Expand from the merged object in that case so
+  // the preview still opens. A real structural error keeps the placeholder.
   const parsed = safeParseTreatmentFile(loadResult.merged);
   const hasError = diagnostics.some((d) => d.severity === "error");
   const expandInput: TreatmentFileType | null = parsed.success

--- a/packages/stagebook/src/schemas/runValidationDiff.test.ts
+++ b/packages/stagebook/src/schemas/runValidationDiff.test.ts
@@ -93,15 +93,18 @@ treatments:
     });
   });
 
-  describe("source-only issues — templating artifacts", () => {
-    it("classifies intro-step-needs-advancement as source-only when a template provides it", () => {
-      // The intro step's only direct child is a `template:` invocation.
-      // The source-pass schema's refinement counts this as missing an
-      // advancement element (template invocations aren't submit buttons
-      // / surveys / qualtrics / submit-on-complete mediaPlayer). After
-      // hydration the template expands to include a submitButton, so
-      // the hydrated-pass passes. Diff classifies as source-only and
-      // recommends suppressing it.
+  describe("intro/exit advancement-element source-only suppression (#347)", () => {
+    // A `template:` invocation in an intro/exit step whose definition
+    // lexically resolves to an advancement element should NOT surface the
+    // "needs advancement element" warning: the author did the right thing
+    // and the source-pass refinement simply can't see through the
+    // invocation. The warning still fires in `sourceIssues` (the raw
+    // record), but is dropped from the surfaced `sourceOnly` bucket.
+
+    const hasAdvancementMessage = (i: { message: string }) =>
+      i.message.toLowerCase().includes("advancement element");
+
+    it("suppresses the intro-step warning when a `template:` (contentType elements) resolves to an advancement element", () => {
       const source = `templates:
   - name: advanceBtn
     contentType: elements
@@ -124,22 +127,180 @@ treatments:
 `;
       const result = runValidationDiff({ source });
       expect(result.hydrationError).toBeNull();
-      // The advancement-element rule fires in source but not in hydrated.
-      const advancementIssue = result.sourceIssues.find((i) =>
-        i.message.toLowerCase().includes("advancement element"),
-      );
-      expect(advancementIssue).toBeDefined();
-      // It's classified as source-only (not matched).
-      expect(
-        result.sourceOnly.some((i) =>
-          i.message.toLowerCase().includes("advancement element"),
-        ),
-      ).toBe(true);
-      expect(
-        result.matched.some((i) =>
-          i.message.toLowerCase().includes("advancement element"),
-        ),
-      ).toBe(false);
+      // The raw source pass still records the artifact ...
+      expect(result.sourceIssues.some(hasAdvancementMessage)).toBe(true);
+      // ... but it is neither a real bug (matched) nor surfaced (sourceOnly).
+      expect(result.matched.some(hasAdvancementMessage)).toBe(false);
+      expect(result.sourceOnly.some(hasAdvancementMessage)).toBe(false);
+    });
+
+    it("suppresses the exit-step warning when the template is contentType `element` (singular)", () => {
+      const source = `templates:
+  - name: submit
+    contentType: element
+    content:
+      type: submitButton
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+    exitSequence:
+      - name: thanks
+        elements:
+          - template: submit
+`;
+      const result = runValidationDiff({ source });
+      expect(result.hydrationError).toBeNull();
+      expect(result.sourceOnly.some(hasAdvancementMessage)).toBe(false);
+      expect(result.matched.some(hasAdvancementMessage)).toBe(false);
+    });
+
+    it("suppresses when the template resolves via mediaPlayer with submitOnComplete: true", () => {
+      const source = `templates:
+  - name: video
+    contentType: elements
+    content:
+      - type: mediaPlayer
+        url: https://example.com/v.mp4
+        submitOnComplete: true
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - template: video
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+      const result = runValidationDiff({ source });
+      expect(result.hydrationError).toBeNull();
+      expect(result.sourceOnly.some(hasAdvancementMessage)).toBe(false);
+    });
+
+    it("does NOT suppress a genuine no-advancement step (real bug stays surfaced as `matched`)", () => {
+      // Safety: suppression keys off the step's actual contents, not
+      // bucket membership. A concrete step with no way to advance fires
+      // the rule in BOTH passes, so it lands in `matched` (a real error)
+      // and must never be dropped.
+      const source = `introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: submitButton
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+    exitSequence:
+      - name: broken
+        elements:
+          - type: display
+            reference: self.prompt.x
+`;
+      const result = runValidationDiff({ source });
+      expect(result.hydrationError).toBeNull();
+      expect(result.matched.some(hasAdvancementMessage)).toBe(true);
+      expect(result.sourceOnly.some(hasAdvancementMessage)).toBe(false);
+    });
+
+    it("never fully hides a real no-advancement bug, even mixed with a suppressible artifact", () => {
+      // Both a suppressible artifact (intro step → resolving template)
+      // and a real bug (concrete exit step, no advancement) share the
+      // identical message. The v1 multiset diff matches by
+      // `(code, normalized_message)`, so the two collapse and get routed
+      // by order — the real bug can land in either `matched` or
+      // `sourceOnly` (an acknowledged option-1 limitation, see #321). The
+      // invariant that must hold regardless: the advancement problem is
+      // still surfaced somewhere, and suppression — which only checks
+      // step contents — cannot drop the concrete-no-advancement step.
+      const source = `templates:
+  - name: advanceBtn
+    contentType: elements
+    content:
+      - type: submitButton
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - template: advanceBtn
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+    exitSequence:
+      - name: broken
+        elements:
+          - type: display
+            reference: self.prompt.x
+`;
+      const result = runValidationDiff({ source });
+      expect(result.hydrationError).toBeNull();
+      const stillSurfaced =
+        result.matched.some(hasAdvancementMessage) ||
+        result.sourceOnly.some(hasAdvancementMessage);
+      expect(stillSurfaced).toBe(true);
+    });
+
+    it("KEEPS the warning when the invoked template is defined but resolves through a further (unresolved-at-one-level) template", () => {
+      // The step invokes `wrap`, whose content is itself only another
+      // `template:` invocation — no lexical advancement element one level
+      // deep. Hydration still succeeds (wrap → inner → submitButton) so
+      // this lands in sourceOnly, but the static one-level check can't
+      // prove it, so we conservatively keep the warning.
+      const source = `templates:
+  - name: wrap
+    contentType: elements
+    content:
+      - template: inner
+  - name: inner
+    contentType: elements
+    content:
+      - type: submitButton
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - template: wrap
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+      const result = runValidationDiff({ source });
+      expect(result.hydrationError).toBeNull();
+      // Kept as a source-only warning (not provable one level deep).
+      expect(result.sourceOnly.some(hasAdvancementMessage)).toBe(true);
     });
   });
 

--- a/packages/stagebook/src/schemas/runValidationDiff.test.ts
+++ b/packages/stagebook/src/schemas/runValidationDiff.test.ts
@@ -302,6 +302,159 @@ treatments:
       // Kept as a source-only warning (not provable one level deep).
       expect(result.sourceOnly.some(hasAdvancementMessage)).toBe(true);
     });
+
+    it("suppresses when the resolving template comes from importedTemplates (module reuse — the #347 motivation)", () => {
+      // The template lives in an imported module, not the root file. The
+      // orchestrator merges importedTemplates into the set used for both
+      // passes AND for suppression, so a shared `surveyAndSubmit`-style
+      // module template must be resolvable here too.
+      const source = `introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - template: advanceBtn
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+      const result = runValidationDiff({
+        source,
+        importedTemplates: [
+          {
+            name: "advanceBtn",
+            contentType: "elements",
+            content: [{ type: "submitButton" }],
+          },
+        ],
+      });
+      expect(result.hydrationError).toBeNull();
+      expect(result.sourceOnly.some(hasAdvancementMessage)).toBe(false);
+    });
+
+    it("suppresses when the template resolves to a survey (auto-submitting) element", () => {
+      const source = `templates:
+  - name: poll
+    contentType: elements
+    content:
+      - type: survey
+        surveyName: TIPI
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - template: poll
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+      const result = runValidationDiff({ source });
+      expect(result.hydrationError).toBeNull();
+      expect(result.sourceOnly.some(hasAdvancementMessage)).toBe(false);
+    });
+
+    it("suppresses when a singular `element` template resolves to a qualtrics survey", () => {
+      const source = `templates:
+  - name: q
+    contentType: element
+    content:
+      type: qualtrics
+      url: https://example.qualtrics.com/survey
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - template: q
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+      const result = runValidationDiff({ source });
+      expect(result.hydrationError).toBeNull();
+      expect(result.sourceOnly.some(hasAdvancementMessage)).toBe(false);
+    });
+
+    it("suppresses a mixed step where one element is a non-advancement display and another is a resolving template", () => {
+      const source = `templates:
+  - name: advanceBtn
+    contentType: elements
+    content:
+      - type: submitButton
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - type: display
+            reference: self.prompt.x
+          - template: advanceBtn
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: display
+            reference: self.prompt.x
+          - type: submitButton
+`;
+      const result = runValidationDiff({ source });
+      expect(result.hydrationError).toBeNull();
+      expect(result.sourceOnly.some(hasAdvancementMessage)).toBe(false);
+    });
+
+    it("does NOT silently suppress a parameterized template name — it surfaces as a hydration error", () => {
+      // A `template: ${x}` name can't be resolved pre-fill; fillTemplates
+      // can't expand it either, so hydration fails and the raw source
+      // issue (including the advancement warning) is all callers get. The
+      // point: the author still sees an error, nothing is hidden.
+      const source = `templates:
+  - name: real
+    contentType: elements
+    content:
+      - type: submitButton
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - template: \${which}
+            fields:
+              which: real
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: submitButton
+`;
+      const result = runValidationDiff({ source });
+      expect(result.hydrationError).not.toBeNull();
+      // Buckets are empty on hydration failure; the warning survives in
+      // the raw source record so the caller can still surface something.
+      expect(result.sourceOnly).toEqual([]);
+      expect(result.sourceIssues.some(hasAdvancementMessage)).toBe(true);
+    });
   });
 
   describe("hydrated-only issues — revealed by expansion", () => {

--- a/packages/stagebook/src/schemas/runValidationDiff.ts
+++ b/packages/stagebook/src/schemas/runValidationDiff.ts
@@ -2,6 +2,10 @@ import type { ZodIssue } from "zod";
 import { load as loadYaml } from "js-yaml";
 import { fillTemplates } from "../templates/fillTemplates.js";
 import { safeParseTreatmentFile } from "./safeParseTreatmentFile.js";
+import {
+  ADVANCEMENT_ELEMENT_MESSAGE,
+  isAdvancementElement,
+} from "./treatment.js";
 
 /**
  * Diff-based validation orchestrator.
@@ -268,9 +272,124 @@ export function runValidationDiff({
     hydratedIssues,
     hydrated: expanded,
     matched,
-    sourceOnly,
+    sourceOnly: suppressResolvedAdvancementWarnings(
+      sourceOnly,
+      merged,
+      mergedTemplates ?? [],
+    ),
     hydratedOnly,
   };
+}
+
+/**
+ * #347: drop intro/exit "needs advancement element" warnings from the
+ * source-only bucket when the offending step's element list contains a
+ * `template:` invocation that provably resolves — one level deep — to a
+ * lexical advancement element.
+ *
+ * Such warnings reach `sourceOnly` precisely because the hydrated pass
+ * did NOT re-fire them: after expansion the step gained an advancement
+ * element. We still confirm the resolution statically (rather than
+ * trusting bucket membership alone), because the multiset diff can
+ * alias a genuine "step has no way to advance" bug into this bucket
+ * when two steps carry the identical message — and that bug must not be
+ * silently dropped.
+ *
+ * Scope is deliberately the bare `ADVANCEMENT_ELEMENT_MESSAGE` — the
+ * usage-site form. The same rule firing while validating a template's
+ * own `content:` carries the templateSchema's "Invalid content for
+ * contentType '...': " prefix (see `stripTemplateContentPrefix`) and is
+ * left untouched: a template definition is validated in isolation, and
+ * its invocation sites get their own diagnosis.
+ */
+function suppressResolvedAdvancementWarnings(
+  sourceOnly: ZodIssue[],
+  merged: Record<string, unknown>,
+  mergedTemplates: unknown[],
+): ZodIssue[] {
+  const isAdvancementWarning = (issue: ZodIssue) =>
+    issue.code === "custom" && issue.message === ADVANCEMENT_ELEMENT_MESSAGE;
+
+  if (!sourceOnly.some(isAdvancementWarning)) return sourceOnly;
+
+  const templatesByName = indexTemplatesByName(mergedTemplates);
+
+  return sourceOnly.filter((issue) => {
+    if (!isAdvancementWarning(issue)) return true;
+    // Keep the warning unless we can positively prove the step's
+    // elements resolve to an advancement element via a template.
+    const elements = getAtPath(merged, issue.path);
+    return !elementsProvablyAdvanceViaTemplate(elements, templatesByName);
+  });
+}
+
+/** First-wins index of `templates` by `name`, skipping malformed entries. */
+function indexTemplatesByName(
+  templates: unknown[],
+): Map<string, Record<string, unknown>> {
+  const byName = new Map<string, Record<string, unknown>>();
+  for (const tmpl of templates) {
+    if (tmpl && typeof tmpl === "object" && !Array.isArray(tmpl)) {
+      const name = (tmpl as Record<string, unknown>).name;
+      if (typeof name === "string" && !byName.has(name)) {
+        byName.set(name, tmpl as Record<string, unknown>);
+      }
+    }
+  }
+  return byName;
+}
+
+/**
+ * True when `elements` is an array containing at least one `template:`
+ * invocation that resolves — one level deep — to a lexical advancement
+ * element.
+ */
+function elementsProvablyAdvanceViaTemplate(
+  elements: unknown,
+  templatesByName: Map<string, Record<string, unknown>>,
+): boolean {
+  if (!Array.isArray(elements)) return false;
+  return elements.some((el) =>
+    templateInvocationResolvesToAdvancement(el, templatesByName),
+  );
+}
+
+function templateInvocationResolvesToAdvancement(
+  element: unknown,
+  templatesByName: Map<string, Record<string, unknown>>,
+): boolean {
+  if (!element || typeof element !== "object" || Array.isArray(element)) {
+    return false;
+  }
+  const name = (element as Record<string, unknown>).template;
+  // Only concrete, statically-known template names. A parameterized
+  // name (`template: ${x}`) can't be resolved pre-fill — keep the warning.
+  if (typeof name !== "string" || name.includes("${")) return false;
+
+  const tmpl = templatesByName.get(name);
+  if (!tmpl) return false;
+
+  // Only `elements` / `element` templates can inject an advancement
+  // element into a step's element list. Other contentTypes are the wrong
+  // shape here; if one is (mis)used, hydration surfaces that separately.
+  const { contentType, content } = tmpl;
+  if (contentType === "elements") {
+    return Array.isArray(content) && content.some(isAdvancementElement);
+  }
+  if (contentType === "element") {
+    return isAdvancementElement(content);
+  }
+  return false;
+}
+
+/** Navigate `obj` along a Zod issue path (mixed string/number segments). */
+function getAtPath(obj: unknown, path: (string | number)[]): unknown {
+  let acc: unknown = obj;
+  for (const key of path) {
+    if (acc === null || typeof acc !== "object") return undefined;
+    acc = (acc as Record<string | number, unknown>)[key];
+  }
+  return acc;
 }
 
 /**

--- a/packages/stagebook/src/schemas/runValidationDiff.ts
+++ b/packages/stagebook/src/schemas/runValidationDiff.ts
@@ -32,7 +32,14 @@ import {
  *                    template's content has `contentType:
  *                    introExitStep` (or similar) and the inner
  *                    refinement fires on its own pre-fill view of
- *                    the elements list.
+ *                    the elements list. NOTE: the usage-site form of
+ *                    this artifact is now dropped from `sourceOnly`
+ *                    when the invocation provably resolves one level
+ *                    deep to an advancement element (see
+ *                    `suppressResolvedAdvancementWarnings`, #347); the
+ *                    instances that remain here are the non-provable
+ *                    ones (parameterized name, deeper nesting) and the
+ *                    prefixed template-content form.
  *
  *                  - real bugs that didn't survive hydration into a
  *                    matched pair. The most common: an unused

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -1806,7 +1806,18 @@ export const introExitStepsSchema = introExitStepsBaseSchema;
 // intro/exit step: submitButton (explicit), survey/qualtrics (auto-submit on
 // completion), or mediaPlayer with submitOnComplete: true (auto-submits when
 // playback ends).
-function isAdvancementElement(element: ElementType): boolean {
+//
+// Deliberately checks *literal* values (`el.type === "submitButton"`,
+// `el.submitOnComplete === true`). A templated field such as
+// `type: ${kind}` or `submitOnComplete: ${flag}` yields `false` — the
+// element's advancement status can't be proven pre-fill. Callers that
+// suppress the intro/exit warning by looking through templates rely on
+// this: only a lexically-concrete advancement element counts (#347).
+//
+// Exported so the diff orchestrator (`runValidationDiff`) can prove a
+// `template:` invocation in an intro/exit step resolves to an
+// advancement element and suppress the source-only warning.
+export function isAdvancementElement(element: unknown): boolean {
   if (!element || typeof element !== "object") return false;
   const el = element as Record<string, unknown>;
   if (el.type === "submitButton") return true;
@@ -1815,6 +1826,14 @@ function isAdvancementElement(element: ElementType): boolean {
   if (el.type === "mediaPlayer" && el.submitOnComplete === true) return true;
   return false;
 }
+
+// The single canonical message for the intro/exit advancement-element
+// requirement. Shared by `introStepsSchema` and `exitStepsSchema` and
+// matched by `runValidationDiff` when deciding whether a source-only
+// instance is a suppressible templating artifact (#347). Keep the two
+// in lockstep — the diff matches on exact message text.
+export const ADVANCEMENT_ELEMENT_MESSAGE =
+  "Intro/exit step must include at least one advancement element: submitButton, survey, qualtrics, or mediaPlayer with submitOnComplete: true.";
 
 export const introStepsSchema = introExitStepsBaseSchema.superRefine(
   (data, ctx) => {
@@ -1868,8 +1887,7 @@ export const introStepsSchema = introExitStepsBaseSchema.superRefine(
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: [stepIdx, "elements"],
-            message:
-              "Intro/exit step must include at least one advancement element: submitButton, survey, qualtrics, or mediaPlayer with submitOnComplete: true.",
+            message: ADVANCEMENT_ELEMENT_MESSAGE,
           });
         }
       }
@@ -1900,8 +1918,7 @@ export const exitStepsSchema = introExitStepsBaseSchema.superRefine(
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
             path: [stepIdx, "elements"],
-            message:
-              "Intro/exit step must include at least one advancement element: submitButton, survey, qualtrics, or mediaPlayer with submitOnComplete: true.",
+            message: ADVANCEMENT_ELEMENT_MESSAGE,
           });
         }
       }

--- a/packages/stagebook/src/validate/validateTreatmentDiff.test.ts
+++ b/packages/stagebook/src/validate/validateTreatmentDiff.test.ts
@@ -103,7 +103,7 @@ treatments:
   });
 
   describe("templating artifacts (sourceOnly → warning)", () => {
-    it("downgrades the intro-step advancement-element refinement to warning when a template provides it", async () => {
+    it("suppresses the intro-step advancement-element warning when a template provably provides it (#347)", async () => {
       const source = `templates:
   - name: advanceBtn
     contentType: elements
@@ -128,15 +128,51 @@ treatments:
         source,
         loadImport: noImports,
       });
-      // The advancement-element rule fires source-only. The orchestrator
-      // classifies it as sourceOnly. We surface as warning (not error).
+      // The template `advanceBtn` lexically resolves to a submitButton, so
+      // the source-pass artifact is proven reducible and produces no
+      // diagnostic at all (neither warning nor error).
+      const advancementDiags = result.diagnostics.filter((d) =>
+        d.message.toLowerCase().includes("advancement element"),
+      );
+      expect(advancementDiags).toEqual([]);
+    });
+
+    it("still surfaces an advancement error when the resolved step genuinely can't advance", async () => {
+      // Same shape, but the invoked template injects only a display — no
+      // advancement element even after expansion. The rule fires in both
+      // passes (matched) and must surface as an error, not be suppressed.
+      const source = `templates:
+  - name: justText
+    contentType: elements
+    content:
+      - type: display
+        reference: self.prompt.foo
+introSequences:
+  - name: i
+    introSteps:
+      - name: s
+        elements:
+          - template: justText
+treatments:
+  - name: t
+    playerCount: 1
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+          - type: display
+            reference: self.prompt.foo
+          - type: submitButton
+`;
+      const result = await validateTreatmentWithDiff({
+        source,
+        loadImport: noImports,
+      });
       const advancementDiags = result.diagnostics.filter((d) =>
         d.message.toLowerCase().includes("advancement element"),
       );
       expect(advancementDiags.length).toBeGreaterThan(0);
-      expect(advancementDiags.every((d) => d.severity === "warning")).toBe(
-        true,
-      );
+      expect(advancementDiags.some((d) => d.severity === "error")).toBe(true);
     });
   });
 


### PR DESCRIPTION
## What & why

Closes the last follow-up of the validator-architecture umbrella.

**#347** — An intro/exit step whose only advancement element is injected by a `template:` invocation triggered the "needs advancement element" refinement in the diff orchestrator's *source* pass. Because the *hydrated* pass expands the template and passes, the diff classified it as `sourceOnly` and surfaced a yellow warning — noise, since the author did the right thing (e.g. moving the survey + submit into a shared `surveyAndSubmit` module template, which became common after `imports:` in #277).

`runValidationDiff` now drops a source-only advancement warning when the offending step's element list contains a `template:` invocation that **provably resolves, one level deep, to a lexical advancement element** — a template of `contentType: elements`/`element` whose content lexically contains a `submitButton`, `survey`, `qualtrics`, or `mediaPlayer` with `submitOnComplete: true`.

**#321** — the umbrella "lexical vs post-fill rule scopes" design. Its core architecture already shipped across #322, #324, #327, #328, #330, #334, #332, #345 (the diff orchestrator, pre-hydration semantic checks, strict-by-default references, etc.). #347 was the sole remaining follow-up, so this PR closes both.

## Conservative by design — real bugs stay visible

- Only the **bare usage-site message** is suppressed. The same rule firing inside a template's own `content:` carries the `"Invalid content for contentType '...': "` prefix and is left untouched.
- **Parameterized names** (`template: ${x}`) and **deeper template-of-template nesting** aren't provable one level deep → warning kept (parameterized names actually surface as a hydration error, so nothing is hidden).
- Suppression checks the **step's actual contents**, not bucket membership. A concrete no-advancement step (a real bug, which lands in `matched`) is never dropped — even under the v1 multiset-diff message aliasing (#321 option-1 limitation).

## Changes

- `packages/stagebook/src/schemas/treatment.ts` — export `isAdvancementElement` (widened to `unknown`) and a shared `ADVANCEMENT_ELEMENT_MESSAGE` constant (previously duplicated across the intro/exit refinements).
- `packages/stagebook/src/schemas/runValidationDiff.ts` — `suppressResolvedAdvancementWarnings` + helpers; filters the `sourceOnly` bucket.
- `apps/viewer/src/lib/loader.ts` — refresh comments (the provable case now yields *no* diagnostic, not a warning); the render fallback is unchanged and still correct.
- Tests: new `#347` suite in `runValidationDiff.test.ts` and updated `validateTreatmentDiff.test.ts`.

## Test plan

- `npm test` — 1601 (lib) + 184 (viewer) + 110 (vscode) pass.
- `npm run test:ct:all` — passes except the known rotating webkit `:focus-visible` focus-ring flakes (unrelated; this change touches no components).
- `npm run lint`, `npm run build` — clean.
- Pre-PR review by 3 subagents (correctness / test-coverage / security): correctness & security **clean**; coverage findings folded in (imports path, survey/qualtrics, mixed step, parameterized-name behavior).

Closes #347, closes #321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)