### PR TITLE
feat(schema)!: require treatment-level introSequences pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ for (const d of diagnostics) {
 }
 ```
 
+The same subpath exports `checkPairing(file, { introSequenceName }, treatmentNames)` — a launch-time guard hosts call where batch config pairs an intro sequence with treatments (pass `introSequenceName: null` for intro-less launches). See the [API reference](docs/engineer/api-reference.md) and [integration guide](docs/engineer/integration-guide.md#launch-time-pairing-guard).
+
 ### Validating a prompt file
 
 `promptFileSchema` takes raw markdown, parses it, and validates structure, metadata, response format, and slider labels in a single pass:
@@ -156,7 +158,7 @@ The template engine supports field substitution (`${fieldName}`), nested templat
 | Export                  | Description                                                                                          |
 | ----------------------- | ---------------------------------------------------------------------------------------------------- |
 | `treatmentFileSchema`   | Top-level schema for a treatment YAML file (templates, introSequences, treatments)                   |
-| `treatmentSchema`       | Single treatment with playerCount, gameStages, exitSequence                                          |
+| `treatmentSchema`       | Single treatment with playerCount, introSequences, gameStages, exitSequence                          |
 | `stageSchema`           | Game stage with name, duration, elements, discussion; validates element time bounds against duration |
 | `elementSchema`         | Any DSL element (prompt, display, survey, timer, etc.) with conditional rendering support            |
 | `promptSchema`          | Prompt element with file reference and optional shared flag                                          |

--- a/apps/viewer/src/lib/exampleCatalog.test.ts
+++ b/apps/viewer/src/lib/exampleCatalog.test.ts
@@ -20,6 +20,7 @@ treatments:
     notes: |
       A **Markdown** note describing the treatment.
     playerCount: 1
+    introSequences: [intro]
     gameStages:
       - name: only
         duration: 10

--- a/apps/viewer/src/lib/loader.test.ts
+++ b/apps/viewer/src/lib/loader.test.ts
@@ -13,6 +13,7 @@ introSequences:
 treatments:
   - name: treatment1
     playerCount: 2
+    introSequences: [intro1]
     gameStages:
       - name: stage1
         duration: 10
@@ -97,6 +98,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: two
+    introSequences: [i]
     gameStages:
       - name: g
         duration: 10
@@ -134,6 +136,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
+    introSequences: [i]
     gameStages:
       - name: g
         duration: 10
@@ -176,6 +179,7 @@ treatments:
   - name: t
     playerCount: 2
     playerCount: 3
+    introSequences: [i]
     gameStages:
       - name: g
         duration: 10
@@ -212,6 +216,7 @@ introSequences:
 treatments:
   - name: treatment1
     playerCount: 2
+    introSequences: [intro1]
     gameStages:
       - name: stage1
         duration: 10
@@ -260,6 +265,7 @@ imports:
 treatments:
   - name: t
     playerCount: 1
+    introSequences: [i]
     gameStages:
       - name: s
         duration: 10
@@ -289,6 +295,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
+    introSequences: [i]
     locale: he
     gameStages:
       - name: g
@@ -329,6 +336,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
+    introSequences: [i]
     locale: he
     gameStages:
       - name: g
@@ -365,6 +373,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
+    introSequences: [i]
     locale: he
     gameStages:
       - name: g
@@ -400,6 +409,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
+    introSequences: [i]
     locale: he
     gameStages:
       - name: g
@@ -449,6 +459,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
+    introSequences: [i]
     gameStages:
       - name: g
         duration: 10
@@ -474,6 +485,7 @@ treatments:
 treatments:
   - name: t
     playerCount: 1
+    introSequences: [i]
     locale: he
     gameStages:
       - name: g
@@ -523,6 +535,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
+    introSequences: [i]
     gameStages:
       - name: g
         duration: 10

--- a/apps/viewer/src/lib/previewResolution.test.ts
+++ b/apps/viewer/src/lib/previewResolution.test.ts
@@ -20,6 +20,7 @@ templates:
 treatments:
   - name: treatment1
     playerCount: 1
+    introSequences: []
     gameStages:
       - template: questionStage
         fields:
@@ -42,6 +43,7 @@ templates:
 treatments:
   - name: treatment1
     playerCount: 1
+    introSequences: []
     gameStages:
       - template: questionStage
         fields:
@@ -72,6 +74,7 @@ introSequences:
 treatments:
   - name: treatment1
     playerCount: 1
+    introSequences: [intro1]
     gameStages:
       - name: stage1
         duration: 10
@@ -98,6 +101,7 @@ templates:
 treatments:
   - name: treatment1
     playerCount: 1
+    introSequences: []
     gameStages:
       - template: questionStage
         fields:
@@ -113,6 +117,7 @@ const NO_TEMPLATE_YAML = `
 treatments:
   - name: treatment1
     playerCount: 1
+    introSequences: []
     gameStages:
       - name: stage1
         duration: 10

--- a/apps/viewer/src/lib/treatment.test.ts
+++ b/apps/viewer/src/lib/treatment.test.ts
@@ -13,6 +13,7 @@ introSequences:
 treatments:
   - name: treatment1
     playerCount: 2
+    introSequences: [intro1]
     gameStages:
       - name: stage1
         duration: 10
@@ -34,6 +35,7 @@ introSequences:
 treatments:
   - name: control
     playerCount: 1
+    introSequences: [intro1]
     gameStages:
       - name: stage1
         duration: 10
@@ -43,6 +45,7 @@ treatments:
             file: prompts/q1.prompt.md
   - name: experimental
     playerCount: 2
+    introSequences: [intro1]
     gameStages:
       - name: stage1
         duration: 15
@@ -75,6 +78,7 @@ introSequences:
 treatments:
   - name: treatment1
     playerCount: 1
+    introSequences: [intro1]
     gameStages:
       - template: questionStage
         fields:
@@ -107,6 +111,7 @@ introSequences:
 treatments:
   - name: treatment1
     playerCount: 1
+    introSequences: [intro1]
     gameStages:
       - template: questionStage
         fields:

--- a/docs/decisions/2026-07-intro-sequence-pairing.md
+++ b/docs/decisions/2026-07-intro-sequence-pairing.md
@@ -1,0 +1,105 @@
+# Treatment ↔ intro-sequence pairing (July 2026)
+
+Status: **accepted** — design settled in [#499] (see its comment thread for
+the full discussion, including the relationship to consent/debrief in
+[#481]). Implemented by the PR that links here.
+
+[#499]: https://github.com/deliberation-lab/stagebook/issues/499
+[#481]: https://github.com/deliberation-lab/stagebook/issues/481
+[#480]: https://github.com/deliberation-lab/stagebook/issues/480
+
+## Motivation
+
+The link between intro sequences and treatments was **implied, not
+declared**. Treatments reference values participants submit during intro
+steps (`self.prompt.<name>.value`), but nothing recorded *which* intro
+sequence(s) a treatment expects. Two consequences:
+
+1. **Design-time validation was unsound.** The reference validator merged
+   intro-produced keys across *every* sequence in the file, so a reference
+   validated if *any* sequence provided the key — even though the host
+   might run a different one, where the reference silently never resolves
+   and the participant gets stuck.
+2. **No run-time guard.** The host pairs an intro sequence with treatments
+   in batch config; nothing verified the pairing was one the file's
+   authors considered valid.
+
+Multiple intro sequences per treatment are a real use case (different
+recruitment pathways or populations feeding the same treatments), so the
+relationship is many-to-many, and references must hold against **every**
+sequence a treatment may follow.
+
+## Decision
+
+**Each treatment declares the intro sequences it may follow — a required
+`introSequences:` array of names (option B of [#499]).** The treatment is
+the consumer of intro-provided data, so it declares its supplier set; and
+treatments are the heavily-templated, more-numerous side, so the
+declaration lives where templates already fan out.
+
+```yaml
+treatments:
+  - name: negotiation_high_stakes
+    playerCount: 2
+    introSequences: [prolific_en, prolific_es] # refs must resolve in BOTH
+    gameStages: [...]
+```
+
+Key semantics:
+
+- **Required — breaking.** Absence is a schema error. `introSequences: []`
+  declares "no intro sequence": the host may only launch the treatment
+  without one. There is no back-compat mode; existing files add one line
+  per treatment (the error message carries the `[]` escape hatch, the
+  dangling-name error enumerates the defined sequences).
+- **Names resolve per-collection.** Arm names are per-collection
+  namespaces — a treatment, an intro sequence, and (later, [#481]) a
+  consent arm may share a name. The list resolves against the top-level
+  `introSequences:` collection only.
+- **Positive check.** Every game/exit/groupComposition reference that
+  resolves from intro data must be provided by **every** listed sequence
+  (it stands down when an earlier own stage produces the key). An
+  unknown reference whose key exists in a *non-listed* sequence gets a
+  hint to add that sequence.
+- **Collision scope follows pairing scope.** The intro × treatment
+  storage-key collision check narrows from all pairs to declared pairs —
+  a key shared with a never-paired sequence is not a collision any
+  participant can experience. (Consent, by contrast, will be checked
+  against *everything*, because it has no pairing — see [#481].)
+- **Can't-prove posture ([#480]).** Unresolved `${...}` placeholders in
+  the declaration skip the pairing checks for that treatment (concrete
+  sibling entries are still name-checked); the post-fill resolved schema
+  catches leaked placeholders. A file with no `introSequences:`
+  collection skips name/positive checks (the other half may live in an
+  importing file).
+- **Runtime guard.** `checkPairing(file, { introSequenceName },
+  treatmentNames)` (exported from `stagebook/validate`) verifies at batch
+  launch: the sequence exists, each treatment exists and *lists* it (the
+  declaration is a constraint, not just a data dependency), and every
+  reference resolves under that specific sequence. Intro-only by design —
+  consent arms have no pairing relationship, so there is no `consentName`
+  parameter.
+
+## Alternatives considered
+
+- **Point-forward** (intro sequence lists treatments): reads in
+  participant-flow direction, but the dependency arrow is backwards from
+  the data dependency; every new treatment edits every feeding sequence.
+- **Derived compatibility** (compute provides ⊇ requires, no syntax):
+  zero authoring burden but can only express *data* compatibility, not
+  intent — a treatment referencing no intro data would be "compatible"
+  with every sequence even when population/consent scoping says
+  otherwise. The declared list expresses intent; the derived relation is
+  what validation checks against it.
+
+## Consequences
+
+- Major version bump; every consumer's treatment files add
+  `introSequences:` to each treatment (see the consumer issues filed from
+  [#499] for deliberation-lab, manager, annotator).
+- Hosts gain a launch-time guard (`checkPairing`) at the point where
+  batch config selects `introSequenceName` + `treatments`.
+- The unsatisfiable-conditions rule ([#480]) and future cross-phase
+  checks (consent/debrief, [#481]) extend a pairing-aware model instead
+  of the union model; locale-coherence between treatments and their
+  declared sequences becomes statically checkable.

--- a/docs/engineer/api-reference.md
+++ b/docs/engineer/api-reference.md
@@ -6,21 +6,21 @@ All schemas are [Zod](https://zod.dev/) objects. Use `.safeParse(data)` for vali
 
 ### Treatment File
 
-| Export                  | Description                                                        |
-| ----------------------- | ------------------------------------------------------------------ |
-| `treatmentFileSchema`   | Top-level schema for `.stagebook.yaml` files                       |
-| `treatmentSchema`       | Single treatment (name, playerCount, gameStages, exitSequence)     |
-| `stageSchema`           | Game stage (name, duration, elements, discussion)                  |
-| `elementSchema`         | Any element type (discriminated union on `type`)                   |
-| `promptSchema`          | Prompt element specifically                                        |
-| `discussionSchema`      | Discussion configuration                                           |
-| `conditionSchema`       | Single condition (reference, comparator, value, position)          |
-| `conditionsSchema`      | Array of conditions                                                |
-| `referenceSchema`       | Reference string validator (parses and validates `type.name.path`) |
-| `introSequenceSchema`   | Intro sequence with named steps                                    |
-| `introExitStepSchema`   | Single intro or exit step                                          |
-| `templateSchema`        | Template definition (name, contentType, content)                   |
-| `templateContextSchema` | Template usage (template, fields, broadcast)                       |
+| Export                  | Description                                                                    |
+| ----------------------- | ------------------------------------------------------------------------------ |
+| `treatmentFileSchema`   | Top-level schema for `.stagebook.yaml` files                                   |
+| `treatmentSchema`       | Single treatment (name, playerCount, introSequences, gameStages, exitSequence) |
+| `stageSchema`           | Game stage (name, duration, elements, discussion)                              |
+| `elementSchema`         | Any element type (discriminated union on `type`)                               |
+| `promptSchema`          | Prompt element specifically                                                    |
+| `discussionSchema`      | Discussion configuration                                                       |
+| `conditionSchema`       | Single condition (reference, comparator, value, position)                      |
+| `conditionsSchema`      | Array of conditions                                                            |
+| `referenceSchema`       | Reference string validator (parses and validates `type.name.path`)             |
+| `introSequenceSchema`   | Intro sequence with named steps                                                |
+| `introExitStepSchema`   | Single intro or exit step                                                      |
+| `templateSchema`        | Template definition (name, contentType, content)                               |
+| `templateContextSchema` | Template usage (template, fields, broadcast)                                   |
 
 ### Prompt File
 
@@ -119,6 +119,33 @@ const expanded = fillTemplates({
 Throws if any `${field}` placeholders remain unresolved.
 
 Also exported: `expandTemplate`, `substituteFields`, `recursivelyFillTemplates` for lower-level control.
+
+## Validation (`stagebook/validate`)
+
+The `stagebook/validate` subpath exports the position-aware validators shared by the CLI, the VS Code extension, and the viewer: `validateTreatmentSource`, `validatePromptSource`, `loadAndMergeImports`, `expandAndValidateWithImports`, the `Diagnostic` type, and position-mapping helpers.
+
+### `checkPairing(file, { introSequenceName }, treatmentNames)`
+
+Launch-time guard for the treatment-level `introSequences:` declaration (#499). Hosts call it at batch launch — the point where batch config selects an intro sequence and a set of treatments.
+
+```typescript
+import { checkPairing, type Diagnostic } from "stagebook/validate";
+
+const diagnostics: Diagnostic[] = checkPairing(
+  expandedFile, // post fillTemplates / import merge
+  { introSequenceName: "prolific_en" }, // or null for an intro-less launch
+  ["negotiation_high_stakes", "control"],
+);
+```
+
+**Returns:** `Diagnostic[]` — empty means the pairing is valid. Checks, in order:
+
+1. The named intro sequence exists (when one is selected).
+2. Every named treatment exists.
+3. Every treatment **lists** the selected sequence in its `introSequences:` — or declares `[]` when launching without one. The declaration is a constraint, not just a data dependency: a treatment that references no intro data still may not run after a sequence it doesn't list.
+4. Every reference in each treatment resolves under that specific sequence.
+
+Expects **expanded** input (e.g. the output of `expandAndValidateWithImports` or the host's own hydration pipeline); an unresolved `${...}` placeholder in a selected treatment's declaration is reported as an error rather than guessed around. Diagnostics carry `range: null` — this is a runtime check with no source-position mapping, so hosts render messages only. Deliberately intro-only: consent arms have no pairing relationship, so there is no `consentName` parameter.
 
 ## React Components
 

--- a/docs/engineer/integration-guide.md
+++ b/docs/engineer/integration-guide.md
@@ -90,9 +90,7 @@ const raw = loadYaml(readFileSync(yamlPath, "utf-8")) as ParsedFile;
 //    post-merge list of just the *imported* template definitions.
 const rootDir = dirname(yamlPath);
 const loaded = new Map<string, ParsedFile>();
-const queue = (raw.imports ?? []).map((p) =>
-  resolveImportPath(yamlPath, p),
-);
+const queue = (raw.imports ?? []).map((p) => resolveImportPath(yamlPath, p));
 while (queue.length > 0) {
   const importPath = queue.shift()!;
   if (loaded.has(importPath)) continue;
@@ -198,8 +196,8 @@ const loaded = new Map();
 const queue = rootImports.map((p) => resolveImportPath(rootPath, p));
 while (queue.length > 0) {
   const path = queue.shift();
-  if (loaded.has(path)) continue;          // dedup — prevents cycles
-  const text = await loadFile(path);       // host's loader
+  if (loaded.has(path)) continue; // dedup — prevents cycles
+  const text = await loadFile(path); // host's loader
   const { parsed, imports } = parseTreatmentYaml(text);
   loaded.set(path, parsed);
   queue.push(...imports.map((p) => resolveImportPath(path, p)));
@@ -237,6 +235,27 @@ If your study doesn't use `imports:`, steps 2-3 are no-ops (`rootImports` is emp
 **Important:** The `<Stage>` component and `<Element>` component expect **hydrated** data. If you pass a stage that still contains `{ template: "..." }` objects or `${field}` placeholders, rendering will fail. Always run `fillTemplates()` before passing data to components.
 
 The hydration step also resolves broadcast expansion — a single template with `broadcast: { d0: [...], d1: [...] }` may produce multiple stages or elements via cartesian product. This happens during `fillTemplates()`, not during rendering.
+
+## Launch-Time Pairing Guard
+
+Every treatment declares which intro sequences it may follow (`introSequences:` — required; `[]` means "runs without one"). The host picks the actual pairing at batch launch: batch config selects an `introSequenceName` and a set of treatment names. That's where to call `checkPairing` — after hydration, before creating the batch:
+
+```typescript
+import { checkPairing } from "stagebook/validate";
+
+const diagnostics = checkPairing(
+  hydrated, // the expanded file from the pipeline above
+  { introSequenceName: batchConfig.introSequenceName ?? null },
+  batchConfig.treatmentNames,
+);
+if (diagnostics.length > 0) {
+  // Refuse to launch. Diagnostics carry `range: null` (runtime check,
+  // no source positions) — render the messages.
+  throw new Error(diagnostics.map((d) => d.message).join("\n"));
+}
+```
+
+Pass `introSequenceName: null` for a batch that launches without an intro sequence — only treatments declaring `introSequences: []` may run that way (map any host-side `"none"` sentinel to `null` before calling). The check verifies that the selected sequence and treatments exist, that every selected treatment lists the selected sequence (the declaration is a constraint — even a treatment that references no intro data may not run after a sequence it doesn't list), and that every reference in each treatment resolves under that specific sequence. Design-time validation checks every _declared_ pairing; `checkPairing` guards that the pairing the batch actually runs is one of them.
 
 ## Implementing a StagebookProvider
 

--- a/docs/engineer/platform-requirements.md
+++ b/docs/engineer/platform-requirements.md
@@ -325,6 +325,7 @@ From the treatment file:
 From the batch configuration (platform-specific):
 
 - Which treatments to run
+- Which intro sequence participants complete first — must be one that every selected treatment lists in its `introSequences:`; validate the pairing at batch launch with `checkPairing` from `stagebook/validate` (see the [integration guide](./integration-guide.md#launch-time-pairing-guard))
 - Payoff weights (for optimizing assignment across treatments)
 
 ### The Assignment Problem

--- a/docs/researcher/conditions.md
+++ b/docs/researcher/conditions.md
@@ -350,6 +350,7 @@ Conditions in `groupComposition` control which participants fill which positions
 treatments:
   - name: cross_partisan
     playerCount: 2
+    introSequences: [onboarding] # the sequence that runs the partyAffiliation survey
     groupComposition:
       - position: 0
         title: "Democrat"
@@ -469,6 +470,8 @@ introSteps → gameStages → exitSequence
 ```
 
 Referencing a stage that hasn't run yet is rejected. External references (`entryUrl.params.*`, `attributes.*`) are always valid — they come from the platform, not a stage. The one exception is `attributes.sampleId`, which is assigned at game-stage start: reading it during intro / groupComposition is rejected like a forward reference.
+
+References that resolve from intro-step data are checked against the treatment's declared `introSequences:` (see [Pairing Treatments with Intro Sequences](treatment-files.md#pairing-treatments-with-intro-sequences)): the key must be provided by **every** sequence the treatment lists, not just one of them — a batch can run the treatment after any listed sequence, so the reference must hold under all of them. A reference whose key exists only in a sequence the treatment doesn't list gets a hint suggesting you add that sequence.
 
 `groupComposition` is stricter: it runs before the game starts, so its conditions can only reference intro-phase or external data. Referencing game or exit data from `groupComposition` is rejected.
 

--- a/docs/researcher/syntax-reference.md
+++ b/docs/researcher/syntax-reference.md
@@ -174,6 +174,7 @@ Constraints: no `shared` prompts, no `position`/`showToPositions`/`hideFromPosit
 treatments:
   - name: <name>
     playerCount: <integer>
+    introSequences: [<names>] # required; [] = runs without an intro sequence
     groupComposition: # optional
       - position: 0
         title: "Role A"
@@ -183,6 +184,8 @@ treatments:
 ```
 
 Position indices in `showToPositions`, `hideFromPositions`, `groupComposition`, and discussion `rooms` must be < `playerCount`.
+
+`introSequences` (#499) names the intro sequences the treatment may follow; names resolve against the top-level `introSequences:` collection. Dangling names error; duplicates warn; every game/exit/`groupComposition` reference to intro-provided data must resolve in **every** listed sequence. `${field}` placeholders allowed, whole-field or per-item (like `groupComposition`).
 
 ## 11. Prompt Files
 

--- a/docs/researcher/templates.md
+++ b/docs/researcher/templates.md
@@ -23,12 +23,12 @@ templates:
         - type: submitButton
 ```
 
-| Field | Required | Description |
-|-------|----------|-------------|
-| `name` | yes | Unique identifier |
-| `contentType` | yes | What the template produces. One of: `element`, `elements`, `stage`, `stages`, `treatment`, `treatments`, `introSequence`, `introSequences`, `introExitStep`, `introSteps`, `exitSteps`, `condition`, `conditions`, `reference`, `player`, `groupComposition`, `discussion`, `broadcastAxisValues` |
-| `notes` | no | Researcher-facing comments (one-liner or multi-line) |
-| `content` | yes | The YAML structure to instantiate |
+| Field         | Required | Description                                                                                                                                                                                                                                                                                       |
+| ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | yes      | Unique identifier                                                                                                                                                                                                                                                                                 |
+| `contentType` | yes      | What the template produces. One of: `element`, `elements`, `stage`, `stages`, `treatment`, `treatments`, `introSequence`, `introSequences`, `introExitStep`, `introSteps`, `exitSteps`, `condition`, `conditions`, `reference`, `player`, `groupComposition`, `discussion`, `broadcastAxisValues` |
+| `notes`       | no       | Researcher-facing comments (one-liner or multi-line)                                                                                                                                                                                                                                              |
+| `content`     | yes      | The YAML structure to instantiate                                                                                                                                                                                                                                                                 |
 
 ## Using Templates
 
@@ -52,9 +52,9 @@ Placeholders use the `${fieldName}` syntax. They can appear in string values, as
 
 ```yaml
 content:
-  name: ${prefix}_study           # embedded in a string
-  file: ${promptFile}             # standalone (can be any type)
-  message: "Hello ${name}!"       # embedded in a string
+  name: ${prefix}_study # embedded in a string
+  file: ${promptFile} # standalone (can be any type)
+  message: "Hello ${name}!" # embedded in a string
 ```
 
 Field keys can contain letters, numbers, and underscores.
@@ -96,6 +96,7 @@ templates:
     content:
       name: ${treatmentName}
       playerCount: 2
+      introSequences: []
       gameStages:
         - template: innerStage
           fields:
@@ -112,6 +113,8 @@ templates:
 ```
 
 Templates are expanded recursively until no template blocks remain.
+
+Note that a `contentType: treatment` template declares the required `introSequences:` field once in its content, and every instantiation inherits it. To vary the pairing per instantiation, use a `${field}` placeholder (whole-field or per-item) and fill it like any other field.
 
 ## Templates in Broadcast Axes
 
@@ -135,7 +138,7 @@ treatments:
 
 ## The `prefix:` convention for reusable modules
 
-Templates that get invoked more than once — including templates *imported* from another file (see [treatment-files.md](treatment-files.md#imports)) — need a way to give each invocation's elements unique names. Stagebook saves participant responses keyed by `<elementType>_<name>`, so two invocations of the same template with the same element names overwrite each other.
+Templates that get invoked more than once — including templates _imported_ from another file (see [treatment-files.md](treatment-files.md#imports)) — need a way to give each invocation's elements unique names. Stagebook saves participant responses keyed by `<elementType>_<name>`, so two invocations of the same template with the same element names overwrite each other.
 
 The convention: **module templates take a `prefix:` field, and use it inside every named element.**
 
@@ -167,24 +170,25 @@ introSequences:
         elements:
           - template: tipi_questions
             fields:
-              prefix: preTIPI    # → preTIPI_q1, preTIPI_q2
+              prefix: preTIPI # → preTIPI_q1, preTIPI_q2
         # ... other intro elements
 treatments:
   - name: my_study
     playerCount: 1
+    introSequences: [intro]
     exitSequence:
       - name: post
         elements:
           - template: tipi_questions
             fields:
-              prefix: postTIPI   # → postTIPI_q1, postTIPI_q2
+              prefix: postTIPI # → postTIPI_q1, postTIPI_q2
 ```
 
 Each invocation now produces unique storage keys (`prompt_preTIPI_q1`, `prompt_postTIPI_q1`, …) — no collisions, exports keep responses separable.
 
 ### Modules that invoke other modules: extend the prefix
 
-When a module template invokes another module template, it should *extend* the prefix it received before passing it down — adding its own subnamespace. This keeps the convention compositional through arbitrary nesting:
+When a module template invokes another module template, it should _extend_ the prefix it received before passing it down — adding its own subnamespace. This keeps the convention compositional through arbitrary nesting:
 
 ```yaml
 # In a "battery" module that bundles a TIPI questionnaire + a Likert scale:
@@ -194,7 +198,7 @@ templates:
     content:
       - template: tipi_questions
         fields:
-          prefix: ${prefix}_tipi      # caller's prefix + this module's subnamespace
+          prefix: ${prefix}_tipi # caller's prefix + this module's subnamespace
       - template: likert_scale
         fields:
           prefix: ${prefix}_likert

--- a/docs/researcher/treatment-files.md
+++ b/docs/researcher/treatment-files.md
@@ -36,6 +36,7 @@ templates:
 treatments:
   - name: my_study
     playerCount: 1
+    introSequences: [] # this file defines no intro sequences
     gameStages:
       - name: intro
         duration: 60
@@ -58,7 +59,7 @@ Each study follows a three-phase structure:
 
 ### 1. Intro Sequence (asynchronous, solo)
 
-Completed individually before group assignment. Typically includes consent, setup checks, and researcher-defined surveys or prompts. You can define multiple intro sequences, but each batch uses exactly one.
+Completed individually before group assignment. Typically includes consent, setup checks, and researcher-defined surveys or prompts. You can define multiple intro sequences, but each batch uses exactly one — and each treatment declares which sequences it may follow (see [Pairing Treatments with Intro Sequences](#pairing-treatments-with-intro-sequences)).
 
 ### 2. Game Stages (synchronous, group)
 
@@ -91,6 +92,7 @@ treatments:
   - name: two_player_discussion
     notes: Simple two-player video discussion
     playerCount: 2
+    introSequences: [default]
 
     gameStages:
       - name: Discussion
@@ -119,6 +121,39 @@ treatments:
             file: exit/debrief.prompt.md
           - type: submitButton
             buttonText: Finish
+```
+
+## Pairing Treatments with Intro Sequences
+
+Every treatment must declare which intro sequences it may follow, via a required `introSequences:` field:
+
+```yaml
+treatments:
+  - name: two_player_discussion
+    playerCount: 2
+    introSequences: [default]
+```
+
+Names resolve against the top-level `introSequences:` collection (after imports are merged) — arm names are per-collection namespaces, so a treatment and an intro sequence may share a name without conflict. Use `introSequences: []` for a treatment that runs without an intro sequence; the host may then only launch it intro-less. Omitting the field is an error — the pairing must be explicit.
+
+Why declare it? Treatments consume data participants produce during intro steps (`self.prompt.<name>`, `self.survey.<name>...`). Without the declaration, a reference was accepted if _any_ intro sequence in the file provided the key — even when the batch ran a different one, where the reference silently never resolves and the participant gets stuck. With it:
+
+- Every game/exit/`groupComposition` reference to intro-provided data must resolve in **every** listed sequence (unless an earlier stage in the treatment itself produces the key). If a reference's key exists only in a sequence you didn't list, the error hints at adding that sequence.
+- A name that doesn't match any defined intro sequence is an error (the message lists the defined names); listing the same name twice is a warning.
+- Storage-key collision checks between intro sequences and treatments run only for declared pairs — a key shared with a sequence the treatment never follows isn't a collision any participant can experience.
+- At batch launch, the host verifies the selected intro sequence is one that every selected treatment lists (see `checkPairing` in the [engineer docs](../engineer/integration-guide.md)).
+
+Listing multiple sequences is normal when different recruitment pathways feed the same treatments — references must then resolve in all of them:
+
+```yaml
+introSequences: [prolific_en, prolific_es] # refs must resolve in BOTH
+```
+
+`${field}` placeholders work here the same way they do in `groupComposition` — the whole field or individual items can be placeholders, filled at template-expansion time:
+
+```yaml
+introSequences: ${sequences} # whole field
+introSequences: [${pathway}_onboarding] # per item
 ```
 
 ## Stages
@@ -179,6 +214,7 @@ Optionally define requirements for who fills each position:
 treatments:
   - name: cross_partisan
     playerCount: 2
+    introSequences: [onboarding] # the sequence that runs the partyAffiliation survey
     groupComposition:
       - position: 0
         title: "Democrat"

--- a/examples/annotated-walkthrough/walkthrough.stagebook.yaml
+++ b/examples/annotated-walkthrough/walkthrough.stagebook.yaml
@@ -15,6 +15,8 @@ templates:
       name: Annotated walkthrough - ${topicLabel}
       notes: A two-person text discussion about ${topicLabel}, annotated as a syntax tour.
       playerCount: 2
+      # intro sequences this treatment may follow; [] = none
+      introSequences: [onboarding]
       groupComposition:
         - position: 0
           title: Familiar

--- a/examples/component-gallery/component-gallery.stagebook.yaml
+++ b/examples/component-gallery/component-gallery.stagebook.yaml
@@ -27,6 +27,7 @@ treatments:
       Components covered: Markdown, RadioGroup, CheckboxGroup, Select,
       TextArea, Slider, ListSorter, SubmitButton.
     playerCount: 1
+    introSequences: [gallery_intro]
     gameStages:
       - name: markdown
         duration: 600

--- a/examples/i18n-gallery/i18n-gallery.stagebook.yaml
+++ b/examples/i18n-gallery/i18n-gallery.stagebook.yaml
@@ -50,6 +50,9 @@ templates:
       name: i18n gallery ${locale}
       locale: ${locale}
       playerCount: 1
+      # ${locale} threads here too, so each arm pairs with its
+      # same-locale intro sequence.
+      introSequences: ["gallery intro ${locale}"]
       gameStages:
         - name: choices
           duration: 600

--- a/examples/imports-walkthrough/imports-walkthrough.stagebook.yaml
+++ b/examples/imports-walkthrough/imports-walkthrough.stagebook.yaml
@@ -36,6 +36,7 @@ introSequences:
 treatments:
   - name: imports_demo
     playerCount: 1
+    introSequences: [intro]
     gameStages:
       - name: main
         duration: 60

--- a/examples/prisoners-dilemma/prisoners-dilemma.stagebook.yaml
+++ b/examples/prisoners-dilemma/prisoners-dilemma.stagebook.yaml
@@ -119,6 +119,7 @@ treatments:
       The template returns 2 stages (choice + outcome), so this
       treatment ends up with 2 game stages plus the shared exit step.
     playerCount: 2
+    introSequences: [orientation]
     gameStages:
       - template: roundTemplate
         fields:
@@ -139,6 +140,7 @@ treatments:
       prompt is named `choice_round_<N>` (where N is 1, 2, or 3), so
       references from one round don't collide with another's.
     playerCount: 2
+    introSequences: [orientation]
     gameStages:
       - template: roundTemplate
         broadcast:

--- a/examples/survey-experiment/survey-experiment.stagebook.yaml
+++ b/examples/survey-experiment/survey-experiment.stagebook.yaml
@@ -18,6 +18,7 @@ templates:
       name: Survey experiment - ${condition}
       notes: A single-player pre/post attitude study with a ${condition} reading manipulation.
       playerCount: 1
+      introSequences: [orientation]
 
       gameStages:
         - name: pre_attitude

--- a/examples/ultimatum-game/ultimatum-game.stagebook.yaml
+++ b/examples/ultimatum-game/ultimatum-game.stagebook.yaml
@@ -8,6 +8,7 @@ treatments:
       and responder are working from the same stage but seeing
       different content.
     playerCount: 2
+    introSequences: [orientation]
     groupComposition:
       - position: 0
         title: Proposer

--- a/packages/stagebook/src/cli/validate.test.ts
+++ b/packages/stagebook/src/cli/validate.test.ts
@@ -43,6 +43,7 @@ let tmp: string;
 const MINIMAL_TREATMENT = `treatments:
   - name: t1
     playerCount: 1
+    introSequences: []
     gameStages:
       - name: s1
         duration: 10
@@ -59,6 +60,7 @@ introSequences:
 const TREATMENT_WITH_SCHEMA_ERROR = `treatments:
   - name: t1
     playerCount: 1
+    introSequences: []
     gameStages:
       - name: s1
         duration: 10
@@ -315,6 +317,7 @@ describe("stagebook validate CLI", () => {
 treatments:
   - name: t
     playerCount: 1
+    introSequences: []
     gameStages:
       - name: s
         duration: 10
@@ -343,6 +346,7 @@ introSequences:
       const evil = `treatments:
   - name: t
     playerCount: 1
+    introSequences: []
     gameStages:
       - name: s
         duration: 10
@@ -373,6 +377,7 @@ introSequences:
       const tplRefTreatment = `treatments:
   - name: t
     playerCount: 1
+    introSequences: []
     gameStages:
       - template: missing_template
 introSequences:
@@ -406,6 +411,7 @@ describe("locale-consistency rule", () => {
       "  - name: t1",
       ...(locale ? [`    locale: ${locale}`] : []),
       "    playerCount: 1",
+      "    introSequences: []",
       "    gameStages:",
       "      - name: s1",
       "        duration: 10",
@@ -490,6 +496,7 @@ describe("unsatisfiable-condition rule", () => {
       "treatments:",
       "  - name: t1",
       "    playerCount: 1",
+      "    introSequences: []",
       "    gameStages:",
       "      - name: s1",
       "        duration: 10",
@@ -567,6 +574,7 @@ describe("locale rule through template expansion", () => {
       name: study-\${locale}
       locale: \${locale}
       playerCount: 1
+      introSequences: []
       gameStages:
         - name: s1
           duration: 10
@@ -664,6 +672,7 @@ treatments:
       "  - name: t1",
       "    locale: he",
       "    playerCount: 1",
+      "    introSequences: []",
       "    gameStages:",
       "      - name: s1",
       "        duration: 10",
@@ -689,6 +698,7 @@ treatments:
       "  - name: t1",
       "    locale: he",
       "    playerCount: 1",
+      "    introSequences: []",
       "    gameStages:",
       "      - name: s1",
       "        duration: 10",
@@ -724,6 +734,7 @@ describe("locale rule — intro sequences", () => {
       "treatments:",
       "  - name: t1",
       "    playerCount: 1",
+      "    introSequences: [intro1]",
       "    gameStages:",
       "      - name: s1",
       "        duration: 10",

--- a/packages/stagebook/src/cli/validate.test.ts
+++ b/packages/stagebook/src/cli/validate.test.ts
@@ -103,6 +103,25 @@ afterAll(async () => {
 
 describe("stagebook validate CLI", () => {
   describe("exit codes", () => {
+    it("exits 1 with the requiredness message when a treatment omits introSequences (#499)", async () => {
+      const missing = `treatments:
+  - name: no_pairing
+    playerCount: 1
+    gameStages:
+      - name: s1
+        duration: 60
+        elements:
+          - type: submitButton
+`;
+      const file = join(tmp, "missing-intro-sequences.stagebook.yaml");
+      await writeFile(file, missing);
+      const r = await runCli([file]);
+      expect(r.code).toBe(1);
+      expect(r.stdout).toContain("must declare `introSequences:`");
+      // Position walks up to the treatment node — a real location, not 0:0.
+      expect(r.stdout).toMatch(/:\d+:\d+/);
+    });
+
     it("exits 0 for a clean treatment file", async () => {
       const r = await runCli([join(tmp, "valid.stagebook.yaml")]);
       expect(r.code).toBe(0);

--- a/packages/stagebook/src/schemas/introSequencePairing.test.ts
+++ b/packages/stagebook/src/schemas/introSequencePairing.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, test } from "vitest";
+import { treatmentFileSchema } from "./treatment.js";
+import { validateTreatmentFileReferences } from "./validateReferences.js";
+import { collectStorageKeyCollisions } from "./storageKeyCollisions.js";
+import { validateResolvedTreatmentFile } from "./resolved.js";
+
+/**
+ * Treatment-level `introSequences:` pairing (#499).
+ *
+ * Covers the four cooperating pieces:
+ *   - schema: the field is required on every treatment (breaking)
+ *   - walker: name resolution + the positive per-pair reference check
+ *   - collisions: intro × treatment cross-pairs narrow to declared pairs
+ *   - resolved: post-fill leak checks
+ */
+
+// --- fixture builders ------------------------------------------------------
+
+function promptEl(name: string): Record<string, unknown> {
+  return { type: "prompt", file: `${name}.prompt.md`, name };
+}
+
+function seq(name: string, elementNames: string[]): Record<string, unknown> {
+  return {
+    name,
+    introSteps: [
+      {
+        name: `${name}-step`,
+        elements: [
+          ...elementNames.map(promptEl),
+          { type: "submitButton", name: `${name}-next` },
+        ],
+      },
+    ],
+  };
+}
+
+function treatment(opts: {
+  name?: string;
+  introSequences?: unknown;
+  gameStages?: Record<string, unknown>[];
+  omitIntroSequences?: boolean;
+}): Record<string, unknown> {
+  const t: Record<string, unknown> = {
+    name: opts.name ?? "t",
+    playerCount: 1,
+    gameStages: opts.gameStages ?? [
+      {
+        name: "s1",
+        duration: 60,
+        elements: [{ type: "submitButton", name: "done" }],
+      },
+    ],
+  };
+  if (!opts.omitIntroSequences) {
+    t.introSequences = opts.introSequences ?? [];
+  }
+  return t;
+}
+
+/** Stage whose element is gated on an intro-provided prompt answer. */
+function stageReferencing(key: string): Record<string, unknown> {
+  return {
+    name: "s1",
+    duration: 60,
+    elements: [
+      {
+        type: "submitButton",
+        name: "done",
+        conditions: [
+          {
+            reference: `self.prompt.${key}`,
+            comparator: "exists",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+// --- schema: required field ------------------------------------------------
+
+describe("schema: introSequences is required on every treatment", () => {
+  test("treatment without introSequences → error mentioning the field", () => {
+    const result = treatmentFileSchema.safeParse({
+      treatments: [treatment({ omitIntroSequences: true })],
+    });
+    expect(result.success).toBe(false);
+    const messages = result.success
+      ? []
+      : result.error.issues.map((i) => i.message);
+    expect(
+      messages.some((m) => /must declare `?introSequences`?/i.test(m)),
+    ).toBe(true);
+  });
+
+  test("introSequences: [] is accepted", () => {
+    const result = treatmentFileSchema.safeParse({
+      treatments: [treatment({ introSequences: [] })],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("whole-field ${...} placeholder is accepted pre-fill", () => {
+    const result = treatmentFileSchema.safeParse({
+      treatments: [treatment({ introSequences: "${intros}" })],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("per-item ${...} placeholder is accepted pre-fill", () => {
+    const result = treatmentFileSchema.safeParse({
+      introSequences: [seq("a", ["color"])],
+      treatments: [treatment({ introSequences: ["${pathway}"] })],
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// --- walker: name resolution ------------------------------------------------
+
+describe("walker: introSequences name resolution", () => {
+  test("dangling sequence name → error naming treatment and sequence", () => {
+    const issues = validateTreatmentFileReferences({
+      introSequences: [seq("a", ["color"])],
+      treatments: [treatment({ name: "tx", introSequences: ["a", "ghost"] })],
+    });
+    const issue = issues.find((i) =>
+      i.path.join(".").endsWith("treatments.0.introSequences.1"),
+    );
+    expect(issue).toBeDefined();
+    expect(issue?.message).toContain('"tx"');
+    expect(issue?.message).toContain('"ghost"');
+    expect(issue?.message).toMatch(/lists intro sequence/);
+  });
+
+  test("duplicate entry → issue worded as a duplicate (warning severity downstream)", () => {
+    const issues = validateTreatmentFileReferences({
+      introSequences: [seq("a", ["color"])],
+      treatments: [treatment({ introSequences: ["a", "a"] })],
+    });
+    const issue = issues.find((i) =>
+      i.path.join(".").endsWith("treatments.0.introSequences.1"),
+    );
+    expect(issue).toBeDefined();
+    expect(issue?.message).toMatch(/duplicate/i);
+  });
+
+  test("no introSequences collection in file → name checks are skipped", () => {
+    const issues = validateTreatmentFileReferences({
+      treatments: [treatment({ introSequences: ["ghost"] })],
+    });
+    expect(
+      issues.filter((i) => /lists intro sequence/.test(i.message)),
+    ).toHaveLength(0);
+  });
+});
+
+// --- walker: positive per-pair reference check -------------------------------
+
+describe("walker: references must resolve in every listed sequence", () => {
+  test("key provided by all listed sequences → no issue", () => {
+    const issues = validateTreatmentFileReferences({
+      introSequences: [seq("a", ["color"]), seq("b", ["color"])],
+      treatments: [
+        treatment({
+          introSequences: ["a", "b"],
+          gameStages: [stageReferencing("color")],
+        }),
+      ],
+    });
+    expect(issues).toHaveLength(0);
+  });
+
+  test("key missing from one listed sequence → error naming that sequence", () => {
+    const issues = validateTreatmentFileReferences({
+      introSequences: [seq("a", ["color"]), seq("b", ["shape"])],
+      treatments: [
+        treatment({
+          introSequences: ["a", "b"],
+          gameStages: [stageReferencing("color")],
+        }),
+      ],
+    });
+    const issue = issues.find((i) => /not provided by/i.test(i.message));
+    expect(issue).toBeDefined();
+    expect(issue?.message).toContain('"b"');
+    expect(issue?.message).not.toContain('"a"');
+  });
+
+  test("key provided only by a non-listed sequence → unknown-ref error with a hint", () => {
+    const issues = validateTreatmentFileReferences({
+      introSequences: [seq("a", ["color"]), seq("c", ["shape"])],
+      treatments: [
+        treatment({
+          introSequences: ["a"],
+          gameStages: [stageReferencing("shape")],
+        }),
+      ],
+    });
+    const issue = issues.find((i) => /doesn't match any/i.test(i.message));
+    expect(issue).toBeDefined();
+    expect(issue?.message).toContain('"c"');
+  });
+
+  test("introSequences: [] with an intro-style reference → unknown-ref error", () => {
+    const issues = validateTreatmentFileReferences({
+      introSequences: [seq("a", ["color"])],
+      treatments: [
+        treatment({
+          introSequences: [],
+          gameStages: [stageReferencing("color")],
+        }),
+      ],
+    });
+    expect(issues.some((i) => /doesn't match any/i.test(i.message))).toBe(true);
+  });
+
+  test("key produced by an earlier own game stage → listed sequences need not provide it", () => {
+    const issues = validateTreatmentFileReferences({
+      introSequences: [seq("a", ["color"]), seq("b", [])],
+      treatments: [
+        treatment({
+          introSequences: ["a", "b"],
+          gameStages: [
+            {
+              name: "produce",
+              duration: 60,
+              elements: [promptEl("color"), { type: "submitButton" }],
+            },
+            stageReferencing("color"),
+          ],
+        }),
+      ],
+    });
+    expect(
+      issues.filter((i) => /not provided by/i.test(i.message)),
+    ).toHaveLength(0);
+  });
+
+  test("whole-field placeholder → positive check and name checks are skipped", () => {
+    const issues = validateTreatmentFileReferences({
+      introSequences: [seq("a", ["color"])],
+      treatments: [
+        treatment({
+          introSequences: "${intros}",
+          gameStages: [stageReferencing("color")],
+        }),
+      ],
+    });
+    expect(issues).toHaveLength(0);
+  });
+
+  test("per-item placeholder → positive check skipped, concrete dangling names still flagged", () => {
+    const issues = validateTreatmentFileReferences({
+      introSequences: [seq("a", ["color"])],
+      treatments: [
+        treatment({
+          introSequences: ["${pathway}", "ghost"],
+          gameStages: [stageReferencing("color")],
+        }),
+      ],
+    });
+    expect(issues.some((i) => /lists intro sequence/.test(i.message))).toBe(
+      true,
+    );
+    expect(
+      issues.filter((i) => /not provided by/i.test(i.message)),
+    ).toHaveLength(0);
+  });
+
+  test("missing field → walker falls back to union (schema owns the requiredness error)", () => {
+    const issues = validateTreatmentFileReferences({
+      introSequences: [seq("a", ["color"])],
+      treatments: [
+        treatment({
+          omitIntroSequences: true,
+          gameStages: [stageReferencing("color")],
+        }),
+      ],
+    });
+    expect(issues).toHaveLength(0);
+  });
+});
+
+// --- collisions: narrowed to declared pairs ----------------------------------
+
+describe("collisions: intro × treatment cross-pairs narrow to declared pairs", () => {
+  const fileWithSharedKey = (declared: unknown) => ({
+    introSequences: [seq("a", ["color"]), seq("b", ["shape"])],
+    treatments: [
+      {
+        name: "t",
+        playerCount: 1,
+        introSequences: declared,
+        gameStages: [
+          {
+            name: "s1",
+            duration: 60,
+            // `shape` collides with sequence b only.
+            elements: [promptEl("shape"), { type: "submitButton" }],
+          },
+        ],
+      },
+    ],
+  });
+
+  test("collision with a declared sequence → flagged", () => {
+    const collisions = collectStorageKeyCollisions(fileWithSharedKey(["b"]));
+    expect(collisions.length).toBeGreaterThan(0);
+  });
+
+  test("collision only with a non-declared sequence → not flagged", () => {
+    const collisions = collectStorageKeyCollisions(fileWithSharedKey(["a"]));
+    expect(collisions).toHaveLength(0);
+  });
+
+  test("placeholder declaration → cross-pair check skipped for that treatment", () => {
+    const collisions = collectStorageKeyCollisions(
+      fileWithSharedKey("${intros}"),
+    );
+    expect(collisions).toHaveLength(0);
+  });
+});
+
+// --- resolved: post-fill leak checks -----------------------------------------
+
+describe("resolved: introSequences must be concrete post-fill", () => {
+  const resolvedStage = {
+    name: "s1",
+    duration: 60,
+    elements: [{ type: "submitButton", name: "done" }],
+  };
+
+  test("leaked whole-field placeholder → error", () => {
+    const { success } = validateResolvedTreatmentFile({
+      treatments: [
+        {
+          name: "t",
+          playerCount: 1,
+          introSequences: "${intros}",
+          gameStages: [resolvedStage],
+        },
+      ],
+    });
+    expect(success).toBe(false);
+  });
+
+  test("leaked per-item placeholder → error", () => {
+    const { success } = validateResolvedTreatmentFile({
+      treatments: [
+        {
+          name: "t",
+          playerCount: 1,
+          introSequences: ["${pathway}"],
+          gameStages: [resolvedStage],
+        },
+      ],
+    });
+    expect(success).toBe(false);
+  });
+
+  test("missing field post-fill → error", () => {
+    const { success } = validateResolvedTreatmentFile({
+      treatments: [{ name: "t", playerCount: 1, gameStages: [resolvedStage] }],
+    });
+    expect(success).toBe(false);
+  });
+
+  test("concrete names → clean", () => {
+    const { success, issues } = validateResolvedTreatmentFile({
+      treatments: [
+        {
+          name: "t",
+          playerCount: 1,
+          introSequences: ["a"],
+          gameStages: [resolvedStage],
+        },
+      ],
+    });
+    expect(issues).toHaveLength(0);
+    expect(success).toBe(true);
+  });
+});

--- a/packages/stagebook/src/schemas/introSequencePairing.test.ts
+++ b/packages/stagebook/src/schemas/introSequencePairing.test.ts
@@ -543,3 +543,34 @@ describe("resolved: placeholder leaks are tagged for authoring contexts", () => 
     );
   });
 });
+
+describe("resolved: plain-string shape error is NOT masked as a placeholder leak", () => {
+  test("introSequences: 'onboarding' → hard error everywhere, with array suggestion", () => {
+    const file = {
+      treatments: [
+        {
+          name: "t",
+          playerCount: 1,
+          introSequences: "onboarding",
+          gameStages: [
+            {
+              name: "s1",
+              duration: 60,
+              elements: [{ type: "submitButton", name: "done" }],
+            },
+          ],
+        },
+      ],
+    };
+    const strict = validateResolvedTreatmentFile(file);
+    expect(strict.success).toBe(false);
+    expect(
+      strict.issues.some((i) =>
+        /Did you mean `introSequences: \[onboarding\]`/.test(i.message),
+      ),
+    ).toBe(true);
+    // A shape error is not a binding problem — skipUnresolved must NOT hide it.
+    const lax = validateResolvedTreatmentFile(file, { skipUnresolved: true });
+    expect(lax.issues.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/stagebook/src/schemas/introSequencePairing.test.ts
+++ b/packages/stagebook/src/schemas/introSequencePairing.test.ts
@@ -3,6 +3,7 @@ import { treatmentFileSchema } from "./treatment.js";
 import { validateTreatmentFileReferences } from "./validateReferences.js";
 import { collectStorageKeyCollisions } from "./storageKeyCollisions.js";
 import { validateResolvedTreatmentFile } from "./resolved.js";
+import { validateTreatmentSource } from "../validate/validateTreatment.js";
 
 /**
  * Treatment-level `introSequences:` pairing (#499).
@@ -146,6 +147,62 @@ describe("walker: introSequences name resolution", () => {
     expect(issue?.message).toMatch(/duplicate/i);
   });
 
+  test("duplicate entry surfaces as a WARNING through validateTreatmentSource", () => {
+    const src = `
+introSequences:
+  - name: a
+    introSteps:
+      - name: step
+        elements:
+          - { type: prompt, file: color.prompt.md, name: color }
+          - type: submitButton
+treatments:
+  - name: t
+    playerCount: 1
+    introSequences: [a, a]
+    gameStages:
+      - name: s1
+        duration: 60
+        elements:
+          - { type: submitButton, name: done }
+`;
+    const { diagnostics } = validateTreatmentSource(src);
+    const dup = diagnostics.find((d) => /duplicate entry/i.test(d.message));
+    expect(dup).toBeDefined();
+    expect(dup?.severity).toBe("warning");
+  });
+
+  test("dangling-only declaration → dangling error AND unknown-ref error (no union fallback)", () => {
+    const issues = validateTreatmentFileReferences({
+      introSequences: [seq("a", ["color"])],
+      treatments: [
+        treatment({
+          introSequences: ["ghost"],
+          gameStages: [stageReferencing("color")],
+        }),
+      ],
+    });
+    expect(issues.some((i) => /lists intro sequence/.test(i.message))).toBe(
+      true,
+    );
+    expect(issues.some((i) => /doesn't match any/i.test(i.message))).toBe(true);
+  });
+
+  test("duplicate + dangling combined → one dangling (idx 0), one duplicate (idx 1)", () => {
+    const issues = validateTreatmentFileReferences({
+      introSequences: [seq("a", ["color"])],
+      treatments: [treatment({ introSequences: ["ghost", "ghost"] })],
+    });
+    const dangling = issues.filter((i) =>
+      /but no intro sequence with that name/.test(i.message),
+    );
+    const dups = issues.filter((i) => /duplicate entry/.test(i.message));
+    expect(dangling).toHaveLength(1);
+    expect(dangling[0].path.join(".")).toBe("treatments.0.introSequences.0");
+    expect(dups).toHaveLength(1);
+    expect(dups[0].path.join(".")).toBe("treatments.0.introSequences.1");
+  });
+
   test("no introSequences collection in file → name checks are skipped", () => {
     const issues = validateTreatmentFileReferences({
       treatments: [treatment({ introSequences: ["ghost"] })],
@@ -236,6 +293,56 @@ describe("walker: references must resolve in every listed sequence", () => {
     expect(
       issues.filter((i) => /not provided by/i.test(i.message)),
     ).toHaveLength(0);
+  });
+
+  test("positive check fires at groupComposition and exit-step sites too", () => {
+    const issues = validateTreatmentFileReferences({
+      introSequences: [seq("a", ["color"]), seq("b", ["shape"])],
+      treatments: [
+        {
+          name: "t",
+          playerCount: 1,
+          introSequences: ["a", "b"],
+          groupComposition: [
+            {
+              position: 0,
+              title: "x",
+              conditions: [
+                { reference: "self.prompt.color", comparator: "exists" },
+              ],
+            },
+          ],
+          gameStages: [
+            {
+              name: "s1",
+              duration: 60,
+              elements: [{ type: "submitButton", name: "done" }],
+            },
+          ],
+          exitSequence: [
+            {
+              name: "exit1",
+              elements: [
+                {
+                  type: "submitButton",
+                  name: "bye",
+                  conditions: [
+                    { reference: "self.prompt.color", comparator: "exists" },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const pairingIssues = issues.filter((i) =>
+      /not provided by/i.test(i.message),
+    );
+    expect(pairingIssues.map((i) => i.path.join("."))).toEqual([
+      "treatments.0.groupComposition.0.conditions.0.reference",
+      "treatments.0.exitSequence.0.elements.0.conditions.0.reference",
+    ]);
   });
 
   test("whole-field placeholder → positive check and name checks are skipped", () => {
@@ -380,5 +487,59 @@ describe("resolved: introSequences must be concrete post-fill", () => {
     });
     expect(issues).toHaveLength(0);
     expect(success).toBe(true);
+  });
+});
+
+// --- resolved: both leak forms share the can't-prove posture ------------------
+
+describe("resolved: placeholder leaks are tagged for authoring contexts", () => {
+  const resolvedStage = {
+    name: "s1",
+    duration: 60,
+    elements: [{ type: "submitButton", name: "done" }],
+  };
+  const fileWith = (introSequences: unknown) => ({
+    treatments: [
+      {
+        name: "t",
+        playerCount: 1,
+        introSequences,
+        gameStages: [resolvedStage],
+      },
+    ],
+  });
+
+  test("whole-field and per-item leaks are both filtered under skipUnresolved", () => {
+    for (const leak of ["${intros}", ["${pathway}"]]) {
+      const lax = validateResolvedTreatmentFile(fileWith(leak), {
+        skipUnresolved: true,
+      });
+      expect(lax.issues).toHaveLength(0);
+      const strict = validateResolvedTreatmentFile(fileWith(leak));
+      expect(strict.success).toBe(false);
+      expect(
+        strict.issues.every((i) => i.reason === "unresolved-placeholder"),
+      ).toBe(true);
+    }
+  });
+
+  test("wrong-typed value keeps the guidance message pre-fill", () => {
+    const result = treatmentFileSchema.safeParse({
+      treatments: [
+        {
+          name: "t",
+          playerCount: 1,
+          introSequences: 5,
+          gameStages: [resolvedStage],
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    const messages = result.success
+      ? []
+      : result.error.issues.map((i) => i.message);
+    expect(messages.some((m) => /must declare `introSequences:`/.test(m))).toBe(
+      true,
+    );
   });
 });

--- a/packages/stagebook/src/schemas/locale.test.ts
+++ b/packages/stagebook/src/schemas/locale.test.ts
@@ -46,6 +46,7 @@ function minimalTreatment(extra: Record<string, unknown> = {}) {
   return {
     name: "t1",
     playerCount: 1,
+    introSequences: [],
     gameStages: [
       {
         name: "stage1",
@@ -91,6 +92,7 @@ describe("resolvedTreatmentSchema.locale (post-fill)", () => {
   const resolvedBase = {
     name: "t1",
     playerCount: 1,
+    introSequences: [],
     gameStages: [
       {
         name: "stage1",

--- a/packages/stagebook/src/schemas/resolved.test.ts
+++ b/packages/stagebook/src/schemas/resolved.test.ts
@@ -61,6 +61,7 @@ describe("resolved schemas strip researcher `notes`", () => {
         name: "t_with_notes",
         notes: "Top-level treatment rationale.",
         playerCount: 2,
+        introSequences: [],
         gameStages: [
           {
             name: "s_with_notes",
@@ -149,6 +150,7 @@ describe("resolved schemas strip researcher `notes`", () => {
         {
           name: "t",
           playerCount: 2,
+          introSequences: [],
           gameStages: [
             {
               name: "s",
@@ -419,6 +421,7 @@ describe("validateResolvedTreatmentFile (#398)", () => {
       {
         name: "t",
         playerCount: 1,
+        introSequences: [],
         gameStages: [
           {
             name: "stage1",

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -287,11 +287,15 @@ export const resolvedTreatmentSchema = z.object({
   name: nameSchema,
   playerCount: z.number(),
   // Post-fill the declared pairing (#499) must be a concrete array of
-  // sequence names. BOTH leak forms are tagged `unresolved-placeholder`
+  // sequence names. Placeholder LEAKS (whole-field string or per-item
+  // entry still carrying `${...}`) are tagged `unresolved-placeholder`
   // (filtered in authoring contexts via `skipUnresolved`, hard errors in
-  // production hosts): the whole-field form arrives as a string, and the
-  // per-item form needs an explicit check because nameSchema
-  // deliberately ACCEPTS `${field}` placeholders (legal pre-fill).
+  // production hosts); a plain non-placeholder string is a SHAPE error
+  // (`introSequences: onboarding` instead of `[onboarding]`) and stays a
+  // hard error everywhere — misdiagnosing it as a binding problem would
+  // let authoring contexts silently swallow it. The per-item check is
+  // explicit because nameSchema deliberately ACCEPTS `${field}`
+  // placeholders (legal pre-fill).
   introSequences: z
     .array(
       nameSchema.superRefine((name, ctx) => {
@@ -306,11 +310,18 @@ export const resolvedTreatmentSchema = z.object({
     )
     .or(
       z.string().superRefine((value, ctx) => {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `introSequences is an unresolved \`${value}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
-          params: { reason: "unresolved-placeholder" },
-        });
+        if (value.includes("${")) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `introSequences is an unresolved \`${value}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
+            params: { reason: "unresolved-placeholder" },
+          });
+        } else {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `introSequences must be an array of intro-sequence names; got the string "${value}". Did you mean \`introSequences: [${value}]\`?`,
+          });
+        }
       }),
     ),
   // Post-fill the locale is a concrete BCP-47 tag — no `${field}` placeholder

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -286,6 +286,23 @@ export type ResolvedIntroExitStepType = z.infer<
 export const resolvedTreatmentSchema = z.object({
   name: nameSchema,
   playerCount: z.number(),
+  // Post-fill the declared pairing (#499) must be a concrete array of
+  // sequence names. A whole-field `${...}` leak arrives as a string
+  // (type error); a per-item leak needs an explicit check because
+  // nameSchema deliberately ACCEPTS `${field}` placeholders (they're
+  // legal in pre-fill names) — tagged `unresolved-placeholder` like the
+  // other leak checks so authoring contexts can filter it.
+  introSequences: z.array(
+    nameSchema.superRefine((name, ctx) => {
+      if (name.includes("${")) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `introSequences entry is an unresolved \`${name}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
+          params: { reason: "unresolved-placeholder" },
+        });
+      }
+    }),
+  ),
   // Post-fill the locale is a concrete BCP-47 tag — no `${field}` placeholder
   // (a leaked placeholder fails the syntactic check, surfacing an unbound
   // locale). Optional; absent means English.

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -287,22 +287,32 @@ export const resolvedTreatmentSchema = z.object({
   name: nameSchema,
   playerCount: z.number(),
   // Post-fill the declared pairing (#499) must be a concrete array of
-  // sequence names. A whole-field `${...}` leak arrives as a string
-  // (type error); a per-item leak needs an explicit check because
-  // nameSchema deliberately ACCEPTS `${field}` placeholders (they're
-  // legal in pre-fill names) — tagged `unresolved-placeholder` like the
-  // other leak checks so authoring contexts can filter it.
-  introSequences: z.array(
-    nameSchema.superRefine((name, ctx) => {
-      if (name.includes("${")) {
+  // sequence names. BOTH leak forms are tagged `unresolved-placeholder`
+  // (filtered in authoring contexts via `skipUnresolved`, hard errors in
+  // production hosts): the whole-field form arrives as a string, and the
+  // per-item form needs an explicit check because nameSchema
+  // deliberately ACCEPTS `${field}` placeholders (legal pre-fill).
+  introSequences: z
+    .array(
+      nameSchema.superRefine((name, ctx) => {
+        if (name.includes("${")) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `introSequences entry is an unresolved \`${name}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
+            params: { reason: "unresolved-placeholder" },
+          });
+        }
+      }),
+    )
+    .or(
+      z.string().superRefine((value, ctx) => {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          message: `introSequences entry is an unresolved \`${name}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
+          message: `introSequences is an unresolved \`${value}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
           params: { reason: "unresolved-placeholder" },
         });
-      }
-    }),
-  ),
+      }),
+    ),
   // Post-fill the locale is a concrete BCP-47 tag — no `${field}` placeholder
   // (a leaked placeholder fails the syntactic check, surfacing an unbound
   // locale). Optional; absent means English.

--- a/packages/stagebook/src/schemas/runValidationDiff.test.ts
+++ b/packages/stagebook/src/schemas/runValidationDiff.test.ts
@@ -26,6 +26,7 @@ describe("runValidationDiff", () => {
 treatments:
   - name: t
     playerCount: 1
+    introSequences: []
     gameStages:
       - name: g
         duration: 10
@@ -791,6 +792,7 @@ treatments:
           content: {
             name: "t",
             playerCount: 1,
+            introSequences: [],
             gameStages: [
               {
                 name: "g",

--- a/packages/stagebook/src/schemas/runValidationDiff.test.ts
+++ b/packages/stagebook/src/schemas/runValidationDiff.test.ts
@@ -848,3 +848,136 @@ treatments:
     });
   });
 });
+
+describe("introSequences pairing artifacts (#499)", () => {
+  it("routes pairing artifacts from a template-driven introSequences collection to sourceOnly", () => {
+    const source = `templates:
+  - name: introTpl
+    contentType: introSequence
+    content:
+      name: \${seqName}
+      introSteps:
+        - name: step
+          elements:
+            - { type: prompt, file: color.prompt.md, name: color }
+            - type: submitButton
+introSequences:
+  - template: introTpl
+    fields:
+      seqName: expanded
+treatments:
+  - name: t
+    playerCount: 1
+    introSequences: [expanded]
+    gameStages:
+      - name: s1
+        duration: 60
+        elements:
+          - type: submitButton
+            name: done
+            conditions:
+              - { reference: self.prompt.color, comparator: exists }`;
+    const result = runValidationDiff({ source, importedTemplates: [] });
+    expect(result.hydrationError).toBeNull();
+    // Both source-pass artifacts (dangling name + unknown ref) are
+    // templating noise: post-hydration the sequence exists and provides
+    // the key — they must land in sourceOnly (warnings), not matched.
+    expect(result.matched).toHaveLength(0);
+    expect(
+      result.sourceOnly.some((i) =>
+        /lists intro sequence "expanded"/.test(i.message),
+      ),
+    ).toBe(true);
+    expect(result.hydratedOnly).toHaveLength(0);
+  });
+});
+
+describe("advisory suffixes must not break cross-pass matching (#499 review)", () => {
+  // The dangling-name and unknown-ref messages carry advisory tails that
+  // enumerate the file's sequences — template expansion changes those
+  // enumerations, so the same real error renders differently across the
+  // two passes. normalizeIssueKey strips the tails; without that, these
+  // real errors demote from matched/error to sourceOnly/warning.
+  it("dangling name stays a matched error when another sequence is template-generated", () => {
+    const source = `templates:
+  - name: makeSeq
+    contentType: introSequence
+    content:
+      name: generated_seq
+      introSteps:
+        - name: step
+          elements:
+            - type: submitButton
+introSequences:
+  - name: onboarding
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+  - template: makeSeq
+treatments:
+  - name: t
+    playerCount: 1
+    introSequences: [onboarding, gohst]
+    gameStages:
+      - name: s1
+        duration: 60
+        elements:
+          - type: submitButton
+            name: done`;
+    const result = runValidationDiff({ source, importedTemplates: [] });
+    expect(result.hydrationError).toBeNull();
+    expect(
+      result.matched.some((i) =>
+        /lists intro sequence "gohst"/.test(i.message),
+      ),
+    ).toBe(true);
+    expect(
+      result.sourceOnly.some((i) =>
+        /lists intro sequence "gohst"/.test(i.message),
+      ),
+    ).toBe(false);
+  });
+
+  it("unknown-ref stays a matched error when the hint's producer is template-generated", () => {
+    const source = `templates:
+  - name: makeSeq
+    contentType: introSequence
+    content:
+      name: alt_pathway
+      introSteps:
+        - name: step
+          elements:
+            - { type: prompt, file: color.prompt.md, name: color }
+            - type: submitButton
+introSequences:
+  - name: onboarding
+    introSteps:
+      - name: welcome
+        elements:
+          - type: submitButton
+  - template: makeSeq
+treatments:
+  - name: t
+    playerCount: 1
+    introSequences: [onboarding]
+    gameStages:
+      - name: s1
+        duration: 60
+        elements:
+          - type: submitButton
+            name: done
+            conditions:
+              - { reference: self.prompt.color, comparator: exists }`;
+    const result = runValidationDiff({ source, importedTemplates: [] });
+    expect(result.hydrationError).toBeNull();
+    // The reference is genuinely unresolvable under the declared pairing
+    // in BOTH passes — only the hydrated pass can name alt_pathway in its
+    // hint. Must still match as a real error.
+    expect(
+      result.matched.some((i) =>
+        /doesn't match any prompt element/.test(i.message),
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/stagebook/src/schemas/runValidationDiff.ts
+++ b/packages/stagebook/src/schemas/runValidationDiff.ts
@@ -142,13 +142,36 @@ export interface ValidationDiffResult {
  * directly.
  */
 export function normalizeIssueKey(issue: ZodIssue): string {
-  return `${issue.code}|${stripTemplateContentPrefix(issue.message)}`;
+  return `${issue.code}|${stripAdvisorySuffixes(
+    stripTemplateContentPrefix(issue.message),
+  )}`;
 }
 
 const TEMPLATE_CONTENT_PREFIX_RE = /^Invalid content for contentType '[^']+': /;
 
 function stripTemplateContentPrefix(message: string): string {
   return message.replace(TEMPLATE_CONTENT_PREFIX_RE, "");
+}
+
+/** Advisory suffixes on #499 pairing messages enumerate the file's
+ *  known intro sequences ("Defined in this file: …") or point at an
+ *  undeclared producer ("The key IS produced by intro sequence …").
+ *  Template expansion changes what those enumerations contain, so the
+ *  same underlying error renders differently on the source and
+ *  hydrated passes — matching on the raw message would demote a real
+ *  dangling-name or unresolvable-reference error from matched/error to
+ *  sourceOnly/warning. Strip the advisory tail from the KEY only; the
+ *  displayed message keeps its guidance. */
+const ADVISORY_SUFFIX_RES = [
+  / Defined in this file: .*$/s,
+  / This file defines no named intro sequences\..*$/s,
+  / The key IS produced by intro sequence.*$/s,
+];
+
+function stripAdvisorySuffixes(message: string): string {
+  let out = message;
+  for (const re of ADVISORY_SUFFIX_RES) out = out.replace(re, "");
+  return out;
 }
 
 export function runValidationDiff({

--- a/packages/stagebook/src/schemas/safeParseTreatmentFile.test.ts
+++ b/packages/stagebook/src/schemas/safeParseTreatmentFile.test.ts
@@ -137,6 +137,7 @@ function makeBaseTreatmentFile(): Record<string, unknown> {
       {
         name: "study1",
         playerCount: 1,
+        introSequences: [],
         gameStages: [
           {
             name: "stage1",
@@ -297,7 +298,7 @@ describe("safeParseTreatmentFile — stage / treatment / discussion / player", (
     );
     expect(issue).toBeDefined();
     expect(issue!.message).toBe(
-      "Unrecognized key 'plyerCount' on treatment. Did you mean 'playerCount'? Valid keys: name, notes, playerCount, locale, groupComposition, gameStages, exitSequence",
+      "Unrecognized key 'plyerCount' on treatment. Did you mean 'playerCount'? Valid keys: name, notes, playerCount, introSequences, locale, groupComposition, gameStages, exitSequence",
     );
   });
 

--- a/packages/stagebook/src/schemas/storageKeyCollisions.test.ts
+++ b/packages/stagebook/src/schemas/storageKeyCollisions.test.ts
@@ -123,6 +123,7 @@ describe("collectStorageKeyCollisions", () => {
       treatments: [
         {
           name: "t1",
+          introSequences: ["intro1"],
           gameStages: [
             {
               name: "stage1",
@@ -211,6 +212,7 @@ describe("collectStorageKeyCollisions", () => {
       treatments: [
         {
           name: "treatment_A",
+          introSequences: ["intro1"],
           gameStages: [
             {
               name: "stage1",
@@ -222,6 +224,7 @@ describe("collectStorageKeyCollisions", () => {
         },
         {
           name: "treatment_B",
+          introSequences: ["intro1"],
           gameStages: [
             {
               name: "stage1",

--- a/packages/stagebook/src/schemas/storageKeyCollisions.ts
+++ b/packages/stagebook/src/schemas/storageKeyCollisions.ts
@@ -200,6 +200,11 @@ export function collectStorageKeyCollisions(
     name: unknown;
     idx: number;
     keys: Map<string, Path[]>;
+    /** Concrete declared `introSequences:` names (#499), or null when
+     *  the declaration can't be interpreted statically (missing field,
+     *  whole-field or per-item `${...}` placeholder) — cross-pair
+     *  checks are skipped for that treatment rather than guessed. */
+    declared: string[] | null;
   }[] = [];
   const treatments = Array.isArray(root.treatments) ? root.treatments : [];
   treatments.forEach((treatment, tIdx) => {
@@ -208,7 +213,16 @@ export function collectStorageKeyCollisions(
       name?: unknown;
       gameStages?: unknown;
       exitSequence?: unknown;
+      introSequences?: unknown;
     };
+    const declaredRaw = t.introSequences;
+    const declared =
+      Array.isArray(declaredRaw) &&
+      declaredRaw.every(
+        (n): n is string => typeof n === "string" && !n.includes("${"),
+      )
+        ? declaredRaw
+        : null;
     const keys = new Map<string, Path[]>();
     const gameStages = Array.isArray(t.gameStages) ? t.gameStages : [];
     gameStages.forEach((stage, stageIdx) => {
@@ -232,14 +246,26 @@ export function collectStorageKeyCollisions(
     });
     if (keys.size === 0) return;
     out.push(...emitDuplicates(keys, `treatment ${describe(t.name, tIdx)}`));
-    treatmentMaps.push({ name: t.name, idx: tIdx, keys });
+    treatmentMaps.push({ name: t.name, idx: tIdx, keys, declared });
   });
 
-  // Cross-pair: every (introSequence × treatment) combination. A participant
-  // who flows from intro_i into treatment_j sees both sets, so any key
-  // appearing in both is a collision for that participant.
+  // Cross-pair: each treatment × the intro sequences it DECLARES via
+  // `introSequences:` (#499) — collision scope follows pairing scope. A
+  // participant only ever flows from a declared sequence into the
+  // treatment, so a key shared with a never-paired sequence is not a
+  // collision anyone can experience. Treatments whose declaration isn't
+  // statically interpretable (placeholder / missing field) skip the
+  // cross-pair check — can't-prove posture, matching the reference
+  // validator.
   for (const intro of introMaps) {
     for (const treatment of treatmentMaps) {
+      if (
+        treatment.declared === null ||
+        typeof intro.name !== "string" ||
+        !treatment.declared.includes(intro.name)
+      ) {
+        continue;
+      }
       const cross = crossDuplicates(intro.keys, treatment.keys);
       out.push(
         ...emitDuplicates(

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -298,6 +298,7 @@ test("validate entire file", () => {
       {
         name: "treatment1",
         playerCount: 2,
+        introSequences: [],
         groupComposition: [
           { position: 0, title: "Bill" },
           { position: 1, title: "Ted" },
@@ -371,6 +372,7 @@ test("treatment accepts an optional notes field with Markdown", () => {
         name: "treatment1",
         notes: "A **markdown** description of what this treatment does.",
         playerCount: 1,
+        introSequences: [],
         gameStages: [
           {
             name: "stage1",
@@ -2210,6 +2212,7 @@ test("groupComposition field on a treatment accepts a ${field} placeholder (#284
       {
         name: "varies",
         playerCount: 4,
+        introSequences: [],
         groupComposition: "${composition}",
         gameStages: [
           {
@@ -2253,6 +2256,7 @@ test("end-to-end: rooms placeholder resolves through fillTemplates and re-valida
       {
         name: "example",
         playerCount: 4,
+        introSequences: [],
         gameStages: [
           {
             template: "storytelling_round",
@@ -2328,6 +2332,7 @@ test("end-to-end: an unbound complex placeholder survives fillTemplates and is r
       {
         name: "broken",
         playerCount: 2,
+        introSequences: [],
         gameStages: [
           {
             name: "stage1",
@@ -2522,6 +2527,7 @@ test("treatment-shape file: `imports:` plus `treatments:`", () => {
       {
         name: "t1",
         playerCount: 1,
+        introSequences: [],
         gameStages: [
           {
             name: "stage1",

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -1958,11 +1958,37 @@ export const introSequencesSchema = altTemplateContext(
     .nonempty(),
 );
 
+/** Static half of the requiredness error (#499). The walker can't reach
+ *  this message to append the file's defined sequence names, so the
+ *  schema-level text carries the `[]` escape hatch and the walker's
+ *  dangling-name error carries the "which names exist" half. */
+export const INTRO_SEQUENCES_REQUIRED_MESSAGE =
+  "Each treatment must declare `introSequences:` — the intro sequences it " +
+  "may follow. Use `introSequences: []` for a treatment that runs without " +
+  "an intro sequence.";
+
 export const baseTreatmentSchema = z
   .object({
     name: nameSchema,
     notes: z.string().optional(),
     playerCount: z.number(),
+    // Which intro sequences this treatment may follow, by name (#499).
+    // REQUIRED — the pairing must be explicit; `[]` means "no intro
+    // sequence" (the host may only launch this treatment without one).
+    // Names resolve against the top-level `introSequences:` collection
+    // only (arm names are per-collection namespaces). Items are plain
+    // strings rather than `nameSchema` so per-item `${field}`
+    // placeholders survive to fillTemplates; the whole field may also
+    // be a single `${field}` placeholder, mirroring `groupComposition`.
+    // Dangling names, duplicates, and the "every listed sequence
+    // provides every referenced key" rule live in validateReferences.ts;
+    // post-fill leaks are caught by `resolvedTreatmentSchema`.
+    introSequences: z
+      .array(z.string().min(1), {
+        required_error: INTRO_SEQUENCES_REQUIRED_MESSAGE,
+        invalid_type_error: INTRO_SEQUENCES_REQUIRED_MESSAGE,
+      })
+      .or(fieldPlaceholderSchema),
     // Participant-facing language for this treatment (BCP-47, e.g. `he`).
     // Drives stagebook's chrome catalog + RTL when the host wires it onto the
     // provider. Optional — absent means English (the runtime resolves an

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -1983,12 +1983,20 @@ export const baseTreatmentSchema = z
     // Dangling names, duplicates, and the "every listed sequence
     // provides every referenced key" rule live in validateReferences.ts;
     // post-fill leaks are caught by `resolvedTreatmentSchema`.
-    introSequences: z
-      .array(z.string().min(1), {
-        required_error: INTRO_SEQUENCES_REQUIRED_MESSAGE,
-        invalid_type_error: INTRO_SEQUENCES_REQUIRED_MESSAGE,
-      })
-      .or(fieldPlaceholderSchema),
+    // The union-level errorMap keeps the guidance message on wrong-typed
+    // values (e.g. `introSequences: 5`), which would otherwise surface as
+    // a bare "Invalid input" — the union discards sub-schema
+    // invalid_type_error messages when no option matches.
+    introSequences: z.union(
+      [
+        z.array(z.string().min(1), {
+          required_error: INTRO_SEQUENCES_REQUIRED_MESSAGE,
+          invalid_type_error: INTRO_SEQUENCES_REQUIRED_MESSAGE,
+        }),
+        fieldPlaceholderSchema,
+      ],
+      { errorMap: () => ({ message: INTRO_SEQUENCES_REQUIRED_MESSAGE }) },
+    ),
     // Participant-facing language for this treatment (BCP-47, e.g. `he`).
     // Drives stagebook's chrome catalog + RTL when the host wires it onto the
     // provider. Optional — absent means English (the runtime resolves an
@@ -2349,6 +2357,10 @@ export const treatmentFileSchema = z
         code: z.ZodIssueCode.custom,
         path: issue.path,
         message: issue.message,
+        // Lint-level walker issues (#499 duplicate entries) mark
+        // themselves "warning"; the diagnostic layers read this back
+        // via params so severity survives the zod round-trip.
+        ...(issue.severity ? { params: { severity: issue.severity } } : {}),
       });
     }
     // Storage-key collision detection (#281): every `{type}_{name}` key

--- a/packages/stagebook/src/schemas/validateReferences.ts
+++ b/packages/stagebook/src/schemas/validateReferences.ts
@@ -52,6 +52,12 @@ function normalizeReference(input: unknown): ReferenceType | null {
 export interface ReferenceValidationIssue {
   path: (string | number)[];
   message: string;
+  /** Lint-level issues (duplicate `introSequences:` entries) carry
+   *  "warning"; absent means error. Threaded through the schema's
+   *  superRefine as zod `params.severity` so the diagnostic layers
+   *  (validateTreatment, validateTreatmentDiff) can downgrade without
+   *  message sniffing. */
+  severity?: "error" | "warning";
 }
 
 /** Discriminator for which rules apply at a given reference site. */
@@ -309,11 +315,10 @@ function resolvePairing({
       return;
     }
     if (seen.has(entry)) {
-      // "duplicate" wording is load-bearing: the validate layer maps
-      // messages matching /unique|duplicate/i to warning severity.
       issues.push({
         path: [...treatmentPath, "introSequences", entryIdx],
         message: `Treatment "${treatmentName}" lists intro sequence "${entry}" more than once in \`introSequences:\` (duplicate entry).`,
+        severity: "warning",
       });
       return;
     }

--- a/packages/stagebook/src/schemas/validateReferences.ts
+++ b/packages/stagebook/src/schemas/validateReferences.ts
@@ -169,8 +169,9 @@ export function validateTreatmentFileReferences(
     }
   }
 
-  // Intro-phase produced keys — merged across every intro sequence. Game
-  // stages and exit steps are allowed to reference any intro-phase key.
+  // Intro-phase produced keys, tracked per sequence (#499) plus the
+  // merged union. Which set a treatment validates against depends on
+  // its declared `introSequences:` pairing — see resolvePairing below.
   //
   // `collectStepKeys` iterates a step's elements; `collectProducedKeys`
   // operates on a single element and skips anything that isn't an
@@ -178,11 +179,19 @@ export function validateTreatmentFileReferences(
   // bug (#321 follow-up) that left this set empty — the result was
   // silently masked by a `globalProducedKeys` fallthrough that's been
   // removed (strict-by-default). Intro keys now flow correctly.
+  const introKeysBySequence = new Map<string, Set<string>>();
   const introProducedKeys = new Set<string>();
   for (const seq of introSequences) {
     if (!isRecord(seq)) continue;
+    const seqKeys = new Set<string>();
     for (const step of toArray(seq.introSteps)) {
-      for (const key of collectStepKeys(step)) introProducedKeys.add(key);
+      for (const key of collectStepKeys(step)) {
+        seqKeys.add(key);
+        introProducedKeys.add(key);
+      }
+    }
+    if (typeof seq.name === "string") {
+      introKeysBySequence.set(seq.name, seqKeys);
     }
   }
 
@@ -201,18 +210,140 @@ export function validateTreatmentFileReferences(
     });
   });
 
-  // Each treatment has its own game/exit rank space.
+  // Each treatment has its own game/exit rank space, scoped to the
+  // intro sequences it declares (#499).
   treatments.forEach((treatment, treatmentIdx) => {
     if (!isRecord(treatment)) return;
+    const pairing = resolvePairing({
+      treatment,
+      treatmentPath: ["treatments", treatmentIdx],
+      introKeysBySequence,
+      hasIntroCollection: treatmentFile.introSequences !== undefined,
+      introProducedKeys,
+      issues,
+    });
     validateTreatment({
       treatment,
       treatmentPath: ["treatments", treatmentIdx],
-      introProducedKeys,
+      introProducedKeys: pairing.availableIntroKeys,
+      pairing: pairing.declaredKeySets
+        ? {
+            declaredKeySets: pairing.declaredKeySets,
+            introKeysBySequence,
+          }
+        : undefined,
       issues,
     });
   });
 
   return issues;
+}
+
+/** Result of interpreting one treatment's declared `introSequences:`. */
+interface PairingResolution {
+  /** Intro keys the treatment's references may resolve against: the
+   *  union of the declared sequences' keys, or the file-wide union
+   *  when the declaration can't be interpreted (placeholder, missing
+   *  field, or no introSequences collection to resolve against). */
+  availableIntroKeys: Set<string>;
+  /** Per-declared-sequence key sets for the positive "every listed
+   *  sequence provides it" check. Null when the check must be skipped
+   *  (can't-prove posture, #480). */
+  declaredKeySets: Map<string, Set<string>> | null;
+}
+
+/**
+ * Interpret a treatment's `introSequences:` declaration (#499) and emit
+ * name-resolution issues. Returns which intro keys the treatment may
+ * reference and (when provable) the per-sequence sets for the positive
+ * check.
+ *
+ * Can't-prove cases fall back to the pre-#499 union behavior so a single
+ * root cause (unresolved placeholder, missing required field — the
+ * schema already errors on that) doesn't cascade into noise:
+ *   - field missing or not an array/string → union, no checks
+ *   - whole-field `${...}` placeholder → union, no checks
+ *   - any per-item `${...}` placeholder → union, dangling-name checks
+ *     still run on the concrete items
+ *   - no `introSequences:` collection in the file → union (empty), no
+ *     name checks (the other half may live in an importing file)
+ */
+function resolvePairing({
+  treatment,
+  treatmentPath,
+  introKeysBySequence,
+  hasIntroCollection,
+  introProducedKeys,
+  issues,
+}: {
+  treatment: Record<string, unknown>;
+  treatmentPath: (string | number)[];
+  introKeysBySequence: Map<string, Set<string>>;
+  hasIntroCollection: boolean;
+  introProducedKeys: Set<string>;
+  issues: ReferenceValidationIssue[];
+}): PairingResolution {
+  const fallback: PairingResolution = {
+    availableIntroKeys: introProducedKeys,
+    declaredKeySets: null,
+  };
+  const declared = treatment.introSequences;
+  if (!Array.isArray(declared)) return fallback;
+
+  const treatmentName =
+    typeof treatment.name === "string" ? treatment.name : "(unnamed)";
+  const seen = new Set<string>();
+  let provable = true;
+  const concreteNames: string[] = [];
+
+  declared.forEach((entry, entryIdx) => {
+    if (typeof entry !== "string") {
+      // Malformed item — schema's job, not ours.
+      provable = false;
+      return;
+    }
+    if (entry.includes("${")) {
+      // Unresolved template placeholder: the full set is unknowable on
+      // this pass, but concrete siblings can still be name-checked.
+      provable = false;
+      return;
+    }
+    if (seen.has(entry)) {
+      // "duplicate" wording is load-bearing: the validate layer maps
+      // messages matching /unique|duplicate/i to warning severity.
+      issues.push({
+        path: [...treatmentPath, "introSequences", entryIdx],
+        message: `Treatment "${treatmentName}" lists intro sequence "${entry}" more than once in \`introSequences:\` (duplicate entry).`,
+      });
+      return;
+    }
+    seen.add(entry);
+    if (hasIntroCollection && !introKeysBySequence.has(entry)) {
+      const defined = [...introKeysBySequence.keys()];
+      const definedNote =
+        defined.length > 0
+          ? ` Defined in this file: ${defined.join(", ")}.`
+          : " This file defines no named intro sequences.";
+      issues.push({
+        path: [...treatmentPath, "introSequences", entryIdx],
+        message: `Treatment "${treatmentName}" lists intro sequence "${entry}", but no intro sequence with that name is defined.${definedNote}`,
+      });
+      return;
+    }
+    concreteNames.push(entry);
+  });
+
+  if (!hasIntroCollection || !provable) return fallback;
+
+  const declaredKeySets = new Map<string, Set<string>>();
+  const availableIntroKeys = new Set<string>();
+  for (const name of concreteNames) {
+    const keys = introKeysBySequence.get(name);
+    if (!keys) continue; // dangling — already reported above
+    declaredKeySets.set(name, keys);
+    for (const key of keys) availableIntroKeys.add(key);
+  }
+  return { availableIntroKeys, declaredKeySets };
 }
 
 // ---------------------------------------------------------------------------
@@ -264,15 +395,32 @@ function validateStepSequence({
   });
 }
 
+/** Pairing context for the positive per-sequence check (#499). Present
+ *  only when the treatment's `introSequences:` declaration was fully
+ *  concrete and resolvable. */
+interface PairingContext {
+  /** name → produced keys, for each sequence the treatment declares. */
+  declaredKeySets: Map<string, Set<string>>;
+  /** name → produced keys for EVERY sequence in the file — used to
+   *  hint when a reference's producer exists but isn't declared. */
+  introKeysBySequence: Map<string, Set<string>>;
+  /** key → earliest own (game/exit) producer rank, ignoring intro
+   *  seeding. Lets the positive check stand down when the treatment
+   *  itself produces the key before the referencing site. */
+  ownProducedAt: Map<string, number>;
+}
+
 function validateTreatment({
   treatment,
   treatmentPath,
   introProducedKeys,
+  pairing,
   issues,
 }: {
   treatment: Record<string, unknown>;
   treatmentPath: (string | number)[];
   introProducedKeys: Set<string>;
+  pairing?: Omit<PairingContext, "ownProducedAt">;
   issues: ReferenceValidationIssue[];
 }): void {
   const gameStages = toArray(treatment.gameStages);
@@ -282,6 +430,11 @@ function validateTreatment({
   // at a single virtual rank (RANK_INTRO) before game stages; its produced
   // keys are in `introProducedKeys` and treated as "always earlier."
   const producedAt = new Map<string, number>();
+  // Own-production ranks, kept separately from the intro-seeded map: a
+  // key both intro-provided and own-produced resolves at RANK_INTRO in
+  // `producedAt` (earliest wins), which would otherwise hide the own
+  // producer from the positive pairing check.
+  const ownProducedAt = new Map<string, number>();
   // Pre-seed intro keys at RANK_INTRO so forward comparisons always place
   // them before any game/exit rank.
   for (const key of introProducedKeys) {
@@ -290,14 +443,20 @@ function validateTreatment({
   gameStages.forEach((stage, idx) => {
     for (const key of collectStepKeys(stage)) {
       if (!producedAt.has(key)) producedAt.set(key, RANK_GAME_BASE + idx);
+      if (!ownProducedAt.has(key)) ownProducedAt.set(key, RANK_GAME_BASE + idx);
     }
   });
   exitSequence.forEach((step, idx) => {
     for (const key of collectStepKeys(step)) {
       if (!producedAt.has(key))
         producedAt.set(key, RANK_GAME_BASE + gameStages.length + idx);
+      if (!ownProducedAt.has(key))
+        ownProducedAt.set(key, RANK_GAME_BASE + gameStages.length + idx);
     }
   });
+  const pairingContext: PairingContext | undefined = pairing
+    ? { ...pairing, ownProducedAt }
+    : undefined;
 
   // groupComposition runs before any stage — can only reference intro +
   // external.
@@ -326,6 +485,7 @@ function validateTreatment({
         producedAt,
         issues,
         allowedProducerRanks: new Set([RANK_INTRO]),
+        pairing: pairingContext,
       });
     }
   });
@@ -342,6 +502,7 @@ function validateTreatment({
         producedAt,
         issues,
         phaseLabel: "game stage",
+        pairing: pairingContext,
       });
     }
     // Discussion conditions nested under the stage
@@ -364,6 +525,7 @@ function validateTreatment({
           producedAt,
           issues,
           phaseLabel: "game stage",
+          pairing: pairingContext,
         });
       }
     }
@@ -381,6 +543,7 @@ function validateTreatment({
         producedAt,
         issues,
         phaseLabel: "exit step",
+        pairing: pairingContext,
       });
     }
   });
@@ -499,6 +662,7 @@ function applyRules({
   laterPhaseKeys,
   allowedProducerRanks,
   phaseLabel,
+  pairing,
 }: {
   site: RefSite;
   enclosingRank: number;
@@ -516,6 +680,10 @@ function applyRules({
   allowedProducerRanks?: Set<number>;
   /** Context word used in error messages — "game stage", "intro step", … */
   phaseLabel?: string;
+  /** Treatment walkers only (#499): declared-pairing context for the
+   *  "every listed sequence provides it" check and the undeclared-
+   *  sequence hint on unknown references. */
+  pairing?: PairingContext;
 }): void {
   // Try to derive the storage key from the (already normalised) ref.
   let referenceKey: string;
@@ -613,11 +781,56 @@ function applyRules({
     const reachableDescription = inIntroSequence
       ? "earlier in this intro sequence"
       : "in this treatment's intro, game, or exit stages (or in a template this treatment invokes)";
+    // #499: if some sequence in the file DOES produce the key but this
+    // treatment doesn't declare it, say so — the fix is usually to add
+    // the sequence to `introSequences:`, not to rename anything.
+    let undeclaredHint = "";
+    if (pairing) {
+      const undeclaredProducers = [...pairing.introKeysBySequence]
+        .filter(
+          ([name, keys]) =>
+            keys.has(referenceKey) && !pairing.declaredKeySets.has(name),
+        )
+        .map(([name]) => `"${name}"`);
+      if (undeclaredProducers.length > 0) {
+        undeclaredHint = ` The key IS produced by intro sequence${
+          undeclaredProducers.length > 1 ? "s" : ""
+        } ${undeclaredProducers.join(", ")} — add ${
+          undeclaredProducers.length > 1 ? "them" : "it"
+        } to this treatment's \`introSequences:\` if this treatment may follow ${
+          undeclaredProducers.length > 1 ? "them" : "it"
+        }.`;
+      }
+    }
     issues.push({
       path: site.path,
-      message: `Reference "${refStr}" doesn't match any ${refType} element reachable from ${scopeDescription}. Check the name — no element produces the storage key "${referenceKey}" ${reachableDescription}.`,
+      message: `Reference "${refStr}" doesn't match any ${refType} element reachable from ${scopeDescription}. Check the name — no element produces the storage key "${referenceKey}" ${reachableDescription}.${undeclaredHint}`,
     });
     return;
+  }
+
+  // #499 positive pairing check: a reference that resolves from intro
+  // data must be provided by EVERY intro sequence this treatment
+  // declares — the host may launch the treatment after any of them.
+  // Stands down when the treatment itself produces the key at or
+  // before the referencing site (then no sequence needs to supply it).
+  if (
+    pairing &&
+    producerRank === RANK_INTRO &&
+    (pairing.ownProducedAt.get(referenceKey) ?? Infinity) > enclosingRank
+  ) {
+    const missing = [...pairing.declaredKeySets]
+      .filter(([, keys]) => !keys.has(referenceKey))
+      .map(([name]) => `"${name}"`);
+    if (missing.length > 0) {
+      issues.push({
+        path: site.path,
+        message: `Reference "${refStr}" is not provided by intro sequence${
+          missing.length > 1 ? "s" : ""
+        } ${missing.join(", ")} listed in this treatment's \`introSequences:\`. A treatment's references must resolve in every intro sequence it may follow.`,
+      });
+      return;
+    }
   }
 
   // groupComposition: target must be in the allowed-rank whitelist.

--- a/packages/stagebook/src/validate/checkPairing.test.ts
+++ b/packages/stagebook/src/validate/checkPairing.test.ts
@@ -126,6 +126,59 @@ describe("checkPairing", () => {
     expect(diags.some((d) => /color/.test(d.message))).toBe(true);
   });
 
+  test("mixed selection: constraint failure and data failure name the right treatments", () => {
+    const file = structuredClone(FILE) as typeof FILE;
+    // third treatment: lists pilot but references color (which pilot lacks)
+    (file.treatments as Record<string, unknown>[]).push({
+      ...structuredClone(FILE.treatments[0]),
+      name: "wants_color_from_pilot",
+      introSequences: ["pilot"],
+    });
+    const diags = checkPairing(file, { introSequenceName: "pilot" }, [
+      "uses_color", // constraint fail: doesn't list pilot
+      "wants_color_from_pilot", // data fail: pilot doesn't provide color
+      "standalone", // constraint fail: declares []
+    ]);
+    // The data-check error must name wants_color_from_pilot — NOT
+    // uses_color (filtered out of the walker run by the constraint
+    // check, so synthetic indices shift).
+    const dataDiag = diags.find(
+      (d) => /color/.test(d.message) && /In treatment/.test(d.message),
+    );
+    expect(dataDiag?.message).toContain('"wants_color_from_pilot"');
+    expect(dataDiag?.message).not.toContain('"uses_color"');
+    expect(diags.some((d) => d.message.includes('"uses_color"'))).toBe(true);
+    expect(diags.some((d) => d.message.includes('"standalone"'))).toBe(true);
+  });
+
+  test("empty treatmentNames → vacuous pass (contract: nothing selected, nothing to check)", () => {
+    expect(checkPairing(FILE, { introSequenceName: "prolific" }, [])).toEqual(
+      [],
+    );
+  });
+
+  test("duplicate names in treatmentNames → one diagnostic per occurrence", () => {
+    const diags = checkPairing(FILE, { introSequenceName: "pilot" }, [
+      "uses_color",
+      "uses_color",
+    ]);
+    expect(
+      diags.filter((d) => d.message.includes('"uses_color"')),
+    ).toHaveLength(2);
+  });
+
+  test("selected sequence but file has no introSequences collection → single clear error", () => {
+    const diags = checkPairing(
+      { treatments: FILE.treatments },
+      { introSequenceName: "prolific" },
+      ["uses_color"],
+    );
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toContain(
+      "The file defines no named intro sequences.",
+    );
+  });
+
   test("diagnostics carry null ranges (runtime check, no source positions)", () => {
     const diags = checkPairing(FILE, { introSequenceName: "ghost" }, [
       "uses_color",

--- a/packages/stagebook/src/validate/checkPairing.test.ts
+++ b/packages/stagebook/src/validate/checkPairing.test.ts
@@ -196,3 +196,18 @@ describe("checkPairing", () => {
     expect(diags.some((d) => /placeholder|expand/i.test(d.message))).toBe(true);
   });
 });
+
+describe("checkPairing input hygiene (Copilot review)", () => {
+  test("array with non-string entries → uninterpretable-declaration error, not a confusing constraint error", () => {
+    const file = structuredClone(FILE) as Record<string, unknown>;
+    (file.treatments as Record<string, unknown>[])[0].introSequences = [
+      5,
+      "prolific",
+    ];
+    const diags = checkPairing(file, { introSequenceName: "prolific" }, [
+      "uses_color",
+    ]);
+    expect(diags).toHaveLength(1);
+    expect(diags[0].message).toMatch(/uninterpretable/);
+  });
+});

--- a/packages/stagebook/src/validate/checkPairing.test.ts
+++ b/packages/stagebook/src/validate/checkPairing.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "vitest";
+import { checkPairing } from "./checkPairing.js";
+
+/**
+ * Runtime pairing guard (#499). `checkPairing` is what a host calls at
+ * batch launch, with the already-expanded treatment file, to verify
+ * that the selected intro sequence may legally precede every selected
+ * treatment and provides everything they reference.
+ */
+
+function promptEl(name: string): Record<string, unknown> {
+  return { type: "prompt", file: `${name}.prompt.md`, name };
+}
+
+const FILE = {
+  introSequences: [
+    {
+      name: "prolific",
+      introSteps: [
+        {
+          name: "survey",
+          elements: [promptEl("color"), { type: "submitButton" }],
+        },
+      ],
+    },
+    {
+      name: "pilot",
+      introSteps: [
+        {
+          name: "welcome",
+          elements: [promptEl("shape"), { type: "submitButton" }],
+        },
+      ],
+    },
+  ],
+  treatments: [
+    {
+      name: "uses_color",
+      playerCount: 1,
+      introSequences: ["prolific"],
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          elements: [
+            {
+              type: "submitButton",
+              name: "done",
+              conditions: [
+                { reference: "self.prompt.color", comparator: "exists" },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
+      name: "standalone",
+      playerCount: 1,
+      introSequences: [],
+      gameStages: [
+        {
+          name: "s1",
+          duration: 60,
+          elements: [{ type: "submitButton", name: "done" }],
+        },
+      ],
+    },
+  ],
+};
+
+describe("checkPairing", () => {
+  test("valid pairing → no diagnostics", () => {
+    const diags = checkPairing(FILE, { introSequenceName: "prolific" }, [
+      "uses_color",
+    ]);
+    expect(diags).toHaveLength(0);
+  });
+
+  test("unknown intro sequence → error listing defined names", () => {
+    const diags = checkPairing(FILE, { introSequenceName: "ghost" }, [
+      "uses_color",
+    ]);
+    expect(diags.length).toBeGreaterThan(0);
+    expect(diags[0].severity).toBe("error");
+    expect(diags[0].message).toContain("ghost");
+    expect(diags[0].message).toContain("prolific");
+    expect(diags[0].message).toContain("pilot");
+  });
+
+  test("unknown treatment name → error", () => {
+    const diags = checkPairing(FILE, { introSequenceName: "prolific" }, [
+      "nope",
+    ]);
+    expect(diags.some((d) => d.message.includes('"nope"'))).toBe(true);
+  });
+
+  test("treatment does not list the selected sequence → error", () => {
+    const diags = checkPairing(FILE, { introSequenceName: "pilot" }, [
+      "uses_color",
+    ]);
+    expect(
+      diags.some(
+        (d) =>
+          d.message.includes('"uses_color"') && d.message.includes('"pilot"'),
+      ),
+    ).toBe(true);
+  });
+
+  test("launching without an intro sequence: only introSequences:[] treatments pass", () => {
+    const ok = checkPairing(FILE, { introSequenceName: null }, ["standalone"]);
+    expect(ok).toHaveLength(0);
+
+    const bad = checkPairing(FILE, { introSequenceName: null }, ["uses_color"]);
+    expect(bad.length).toBeGreaterThan(0);
+  });
+
+  test("listed sequence that fails to provide a referenced key → error", () => {
+    // Force the constraint through: pretend uses_color listed pilot too.
+    const file = structuredClone(FILE) as typeof FILE;
+    (file.treatments[0].introSequences as string[]).push("pilot");
+    const diags = checkPairing(file, { introSequenceName: "pilot" }, [
+      "uses_color",
+    ]);
+    expect(diags.length).toBeGreaterThan(0);
+    expect(diags.some((d) => /color/.test(d.message))).toBe(true);
+  });
+
+  test("diagnostics carry null ranges (runtime check, no source positions)", () => {
+    const diags = checkPairing(FILE, { introSequenceName: "ghost" }, [
+      "uses_color",
+    ]);
+    expect(diags.every((d) => d.range === null)).toBe(true);
+  });
+
+  test("unexpanded placeholder in a selected treatment → error telling host to expand first", () => {
+    const file = structuredClone(FILE) as Record<string, unknown>;
+    (file.treatments as Record<string, unknown>[])[0].introSequences =
+      "${intros}";
+    const diags = checkPairing(file, { introSequenceName: "prolific" }, [
+      "uses_color",
+    ]);
+    expect(diags.some((d) => /placeholder|expand/i.test(d.message))).toBe(true);
+  });
+});

--- a/packages/stagebook/src/validate/checkPairing.ts
+++ b/packages/stagebook/src/validate/checkPairing.ts
@@ -54,6 +54,18 @@ function toArray(v: unknown): unknown[] {
   return Array.isArray(v) ? v : [];
 }
 
+/** Render a malformed declaration for the error message without
+ *  trusting it: JSON.stringify throws on cyclic graphs (YAML anchors
+ *  can produce them), and this branch's whole job is to return a
+ *  diagnostic rather than crash the host's launch path. */
+function describeDeclaration(declared: unknown): string {
+  try {
+    return JSON.stringify(declared) ?? String(declared);
+  } catch {
+    return `a cyclic or non-serializable ${typeof declared}`;
+  }
+}
+
 export function checkPairing(
   file: unknown,
   selection: PairingSelection,
@@ -111,7 +123,7 @@ export function checkPairing(
     if (typeof declared === "string" || !Array.isArray(declared)) {
       diagnostics.push(
         error(
-          `Treatment "${name}" has an uninterpretable \`introSequences:\` declaration (${JSON.stringify(
+          `Treatment "${name}" has an uninterpretable \`introSequences:\` declaration (${describeDeclaration(
             declared,
           )}). Expand templates and bind all \`\${...}\` placeholders before calling checkPairing.`,
         ),

--- a/packages/stagebook/src/validate/checkPairing.ts
+++ b/packages/stagebook/src/validate/checkPairing.ts
@@ -120,7 +120,11 @@ export function checkPairing(
   for (const treatment of selectedTreatments) {
     const name = String(treatment.name);
     const declared = treatment.introSequences;
-    if (typeof declared === "string" || !Array.isArray(declared)) {
+    if (
+      typeof declared === "string" ||
+      !Array.isArray(declared) ||
+      declared.some((d) => typeof d !== "string")
+    ) {
       diagnostics.push(
         error(
           `Treatment "${name}" has an uninterpretable \`introSequences:\` declaration (${describeDeclaration(

--- a/packages/stagebook/src/validate/checkPairing.ts
+++ b/packages/stagebook/src/validate/checkPairing.ts
@@ -1,0 +1,180 @@
+/**
+ * Runtime pairing guard (#499).
+ *
+ * `checkPairing` is the host-facing half of the treatment-level
+ * `introSequences:` declaration: called at batch launch with the
+ * already-expanded treatment file, the selected intro sequence (or
+ * null for an intro-less launch), and the selected treatment names.
+ * It verifies:
+ *
+ *   1. the named intro sequence exists (when one is selected);
+ *   2. every selected treatment exists;
+ *   3. every selected treatment LISTS the selected sequence in its
+ *      `introSequences:` — or declares `[]` for an intro-less launch
+ *      (the declaration is a constraint, not just a data dependency:
+ *      a treatment with no intro references still may not run after a
+ *      sequence it doesn't list);
+ *   4. every reference in each selected treatment resolves under the
+ *      selected sequence specifically — by re-running the reference
+ *      walker over a synthetic file narrowed to exactly this pairing.
+ *
+ * Deliberately intro-only: consent arms (#481) have no pairing
+ * relationship (negative-only obligations), so there is no
+ * `consentName` parameter.
+ *
+ * Expects EXPANDED input (post `fillTemplates` / import merge — e.g.
+ * the output of `expandAndValidateWithImports` or the host's own
+ * hydration pipeline). An unresolved `${...}` placeholder in a
+ * selected treatment's declaration is reported as an error rather
+ * than guessed around: at launch time nothing further will expand it.
+ *
+ * Diagnostics carry `range: null` — this is a runtime check with no
+ * source-position mapping; hosts render messages only.
+ */
+
+import { validateTreatmentFileReferences } from "../schemas/validateReferences.js";
+import type { Diagnostic } from "./types.js";
+
+export interface PairingSelection {
+  /** Name of the selected intro sequence, or null/undefined when the
+   *  batch launches without one. Hosts using a `"none"` sentinel
+   *  should map it to null before calling. */
+  introSequenceName?: string | null;
+}
+
+function error(message: string): Diagnostic {
+  return { message, severity: "error", range: null };
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === "object" && !Array.isArray(v);
+}
+
+function toArray(v: unknown): unknown[] {
+  return Array.isArray(v) ? v : [];
+}
+
+export function checkPairing(
+  file: unknown,
+  selection: PairingSelection,
+  treatmentNames: string[],
+): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  if (!isRecord(file)) {
+    return [error("checkPairing: treatment file is not an object.")];
+  }
+
+  const sequences = toArray(file.introSequences).filter(isRecord);
+  const sequenceNames = sequences
+    .map((s) => s.name)
+    .filter((n): n is string => typeof n === "string");
+
+  const introSequenceName = selection.introSequenceName ?? null;
+  let selectedSequence: Record<string, unknown> | null = null;
+  if (introSequenceName !== null) {
+    selectedSequence =
+      sequences.find((s) => s.name === introSequenceName) ?? null;
+    if (selectedSequence === null) {
+      return [
+        error(
+          `Intro sequence "${introSequenceName}" is not defined in this treatment file. ${
+            sequenceNames.length > 0
+              ? `Defined: ${sequenceNames.join(", ")}.`
+              : "The file defines no named intro sequences."
+          }`,
+        ),
+      ];
+    }
+  }
+
+  const treatments = toArray(file.treatments).filter(isRecord);
+  const selectedTreatments: Record<string, unknown>[] = [];
+  for (const name of treatmentNames) {
+    const treatment = treatments.find((t) => t.name === name);
+    if (!treatment) {
+      diagnostics.push(
+        error(
+          `Treatment "${name}" is not defined in this treatment file (after expansion).`,
+        ),
+      );
+      continue;
+    }
+    selectedTreatments.push(treatment);
+  }
+
+  // Constraint check: the selected sequence must be listed (or the
+  // declaration must be [] for an intro-less launch).
+  const constraintOk: Record<string, unknown>[] = [];
+  for (const treatment of selectedTreatments) {
+    const name = String(treatment.name);
+    const declared = treatment.introSequences;
+    if (typeof declared === "string" || !Array.isArray(declared)) {
+      diagnostics.push(
+        error(
+          `Treatment "${name}" has an uninterpretable \`introSequences:\` declaration (${JSON.stringify(
+            declared,
+          )}). Expand templates and bind all \`\${...}\` placeholders before calling checkPairing.`,
+        ),
+      );
+      continue;
+    }
+    if (declared.some((d) => typeof d === "string" && d.includes("${"))) {
+      diagnostics.push(
+        error(
+          `Treatment "${name}" still carries an unresolved \`\${...}\` placeholder in \`introSequences:\`. Expand templates and bind all placeholders before calling checkPairing.`,
+        ),
+      );
+      continue;
+    }
+    if (introSequenceName === null) {
+      if (declared.length > 0) {
+        diagnostics.push(
+          error(
+            `Treatment "${name}" may only follow intro sequence${
+              declared.length > 1 ? "s" : ""
+            } ${declared.map((d) => `"${String(d)}"`).join(", ")}. Launching without an intro sequence is only allowed for treatments declaring \`introSequences: []\`.`,
+          ),
+        );
+        continue;
+      }
+    } else if (!declared.includes(introSequenceName)) {
+      diagnostics.push(
+        error(
+          `Treatment "${name}" does not list intro sequence "${introSequenceName}" in its \`introSequences:\` (${
+            declared.length > 0
+              ? `allowed: ${declared.map((d) => `"${String(d)}"`).join(", ")}`
+              : "it declares `[]` — no intro sequence"
+          }). The host may only pair a treatment with a sequence it lists.`,
+        ),
+      );
+      continue;
+    }
+    constraintOk.push(treatment);
+  }
+
+  // Data check: re-run the reference walker over a synthetic file
+  // narrowed to exactly this pairing. Rewriting each treatment's
+  // declaration to the selected sequence makes the walker's positive
+  // check mean precisely "resolves under THIS sequence".
+  if (constraintOk.length > 0) {
+    const synthetic = {
+      introSequences: selectedSequence ? [selectedSequence] : undefined,
+      treatments: constraintOk.map((t) => ({
+        ...t,
+        introSequences: selectedSequence ? [introSequenceName] : [],
+      })),
+    };
+    for (const issue of validateTreatmentFileReferences(synthetic)) {
+      // Translate synthetic-file indices back to names for readability.
+      let context = "";
+      if (issue.path[0] === "treatments" && typeof issue.path[1] === "number") {
+        context = `In treatment "${String(constraintOk[issue.path[1]]?.name)}": `;
+      } else if (issue.path[0] === "introSequences") {
+        context = `In intro sequence "${introSequenceName ?? ""}": `;
+      }
+      diagnostics.push(error(`${context}${issue.message}`));
+    }
+  }
+
+  return diagnostics;
+}

--- a/packages/stagebook/src/validate/expandAndValidate.test.ts
+++ b/packages/stagebook/src/validate/expandAndValidate.test.ts
@@ -195,3 +195,37 @@ ${broadcastItems}`;
     });
   });
 });
+
+describe("introSequences placeholder binding (#499)", () => {
+  it("binds whole-field and per-item introSequences placeholders through fillTemplates", () => {
+    const src = `templates:
+  - name: study
+    contentType: treatment
+    content:
+      name: t_\${pathway}
+      playerCount: 1
+      introSequences:
+        - \${pathway}
+      gameStages:
+        - name: s1
+          duration: 60
+          elements:
+            - { type: submitButton, name: done }
+introSequences:
+  - name: a
+    introSteps:
+      - name: step
+        elements:
+          - type: submitButton
+treatments:
+  - template: study
+    fields:
+      pathway: a`;
+    const result = expandAndValidate(src);
+    expect(result.expandError).toBeNull();
+    expect(result.diagnostics.filter((d) => d.severity === "error")).toEqual(
+      [],
+    );
+    expect(result.fullYaml).toMatch(/introSequences:\n {6}- a/);
+  });
+});

--- a/packages/stagebook/src/validate/expandAndValidate.test.ts
+++ b/packages/stagebook/src/validate/expandAndValidate.test.ts
@@ -21,6 +21,7 @@ introSequences:
 treatments:
   - name: study1
     playerCount: 1
+    introSequences: []
     gameStages:
       - template: myStage`;
       const result = expandAndValidate(src);
@@ -55,6 +56,7 @@ introSequences:
 treatments:
   - name: study1
     playerCount: 1
+    introSequences: []
     gameStages:
       - template: badStage
         fields:
@@ -87,6 +89,7 @@ introSequences:
 treatments:
   - name: study1
     playerCount: 1
+    introSequences: []
     gameStages:
       - template: badStage
         fields:
@@ -166,6 +169,7 @@ introSequences:
 treatments:
   - name: study1
     playerCount: 1
+    introSequences: []
     gameStages:
       - template: manyStage
         broadcast:

--- a/packages/stagebook/src/validate/index.ts
+++ b/packages/stagebook/src/validate/index.ts
@@ -16,3 +16,4 @@ export * from "./validatePrompt.js";
 export * from "./expandTreatment.js";
 export * from "./expandAndValidate.js";
 export * from "./validateTreatmentDiff.js";
+export * from "./checkPairing.js";

--- a/packages/stagebook/src/validate/parseTreatmentSource.test.ts
+++ b/packages/stagebook/src/validate/parseTreatmentSource.test.ts
@@ -25,6 +25,7 @@ const loaderFromMap = (files: Record<string, string>) => {
 const validTreatment = `treatments:
   - name: t
     playerCount: 1
+    introSequences: []
     gameStages:
       - name: s
         duration: 10
@@ -57,6 +58,7 @@ treatments:
     content:
       name: t
       playerCount: 1
+      introSequences: []
       gameStages:
         - name: s
           duration: 10
@@ -250,6 +252,7 @@ treatments:
     content:
       name: t
       playerCount: 1
+      introSequences: []
       gameStages:
         - name: s
           duration: 10

--- a/packages/stagebook/src/validate/validateTreatment.test.ts
+++ b/packages/stagebook/src/validate/validateTreatment.test.ts
@@ -13,6 +13,7 @@ describe("validateTreatmentSource", () => {
 treatments:
   - name: study1
     playerCount: 1
+    introSequences: []
     gameStages:
       - name: stage1
         duration: 300

--- a/packages/stagebook/src/validate/validateTreatment.ts
+++ b/packages/stagebook/src/validate/validateTreatment.ts
@@ -59,11 +59,14 @@ export function validateTreatmentSource(source: string): ValidationResult {
       const params =
         issue.code === "custom"
           ? ((issue as { params?: unknown }).params as
-              | { badKey?: unknown }
+              | { badKey?: unknown; severity?: unknown }
               | undefined)
           : undefined;
       const isUnrecognizedKey =
         params !== undefined && typeof params.badKey === "string";
+      // Lint-level issues (e.g. duplicate `introSequences:` entries,
+      // #499) self-mark via params.severity — see validateReferences.ts.
+      const severity = params?.severity === "warning" ? "warning" : "error";
 
       let range = isUnrecognizedKey
         ? mapper.resolveKey(issue.path)
@@ -90,7 +93,7 @@ export function validateTreatmentSource(source: string): ValidationResult {
 
       diagnostics.push({
         message,
-        severity: "error",
+        severity,
         range,
       });
     }

--- a/packages/stagebook/src/validate/validateTreatmentDiff.test.ts
+++ b/packages/stagebook/src/validate/validateTreatmentDiff.test.ts
@@ -40,6 +40,7 @@ describe("validateTreatmentWithDiff", () => {
 treatments:
   - name: t
     playerCount: 1
+    introSequences: []
     gameStages:
       - name: g
         duration: 10

--- a/packages/stagebook/src/validate/validateTreatmentDiff.ts
+++ b/packages/stagebook/src/validate/validateTreatmentDiff.ts
@@ -164,7 +164,10 @@ export async function validateTreatmentWithDiff({
   for (const issue of diff.matched) {
     diagnostics.push({
       message: appendPathIfMissing(issue),
-      severity: "error",
+      // Lint-level walker issues (duplicate `introSequences:` entries,
+      // #499) self-mark warning via params.severity; real bugs stay
+      // errors.
+      severity: issueSeverity(issue),
       range: resolveIssueRange(mapper, issue),
     });
   }
@@ -340,6 +343,18 @@ function formatPath(path: (string | number)[]): string {
     }
   }
   return out;
+}
+
+/** Severity for a matched-bucket issue: lint-level walker issues carry
+ *  `params.severity === "warning"` (see validateReferences.ts, #499);
+ *  everything else is an error. */
+function issueSeverity(
+  issue: ZodIssue | PreHydrationIssue,
+): "error" | "warning" {
+  const params = (issue as { params?: unknown }).params as
+    | { severity?: unknown }
+    | undefined;
+  return params?.severity === "warning" ? "warning" : "error";
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements #499: every treatment must declare which intro sequences it may follow via a **required** `introSequences:` field, turning the implied intro↔treatment relationship into a declared, validated one. Design settled in the #499 comment thread; recorded in the ADR (`docs/decisions/2026-07-intro-sequence-pairing.md`).

**BREAKING**: treatments without `introSequences:` no longer validate. `[]` = "runs without an intro sequence". Needs a major version bump on release.

## What's in here

**Schema** (`treatment.ts`, `resolved.ts`)
- `introSequences` required on every treatment; whole-field and per-item `${...}` placeholders accepted pre-fill (same machinery as `groupComposition`); both leak forms tagged `unresolved-placeholder` post-fill (filtered in authoring contexts, hard errors in production hosts).

**Reference validation** (`validateReferences.ts`)
- Intro-provided keys now resolve against the treatment's **declared** sequences instead of the file-wide union (the old model let a reference validate against sequence A while the host ran sequence B).
- Positive check: a reference resolved from intro data must be provided by **every** listed sequence; stands down when an earlier own stage produces the key.
- Dangling names error (enumerating defined sequences); duplicates warn (severity threaded via zod `params` through both diagnostic layers); unknown refs hint when a **non-listed** sequence produces the key.
- Can't-prove posture (#480): unresolved placeholders skip the pairing checks; a file with no `introSequences:` collection skips name checks.

**Collision narrowing** (`storageKeyCollisions.ts`)
- Intro × treatment cross-pair checks run only for declared pairs — collision scope follows pairing scope (principle recorded on #481).

**Runtime guard** (`validate/checkPairing.ts`, new export)
- `checkPairing(file, { introSequenceName }, treatmentNames)` for hosts at batch launch: sequence exists, each treatment exists and lists it (`null` = intro-less launch, only legal for `[]` treatments), and every reference resolves under that specific sequence. Intro-only by design — consent (#481) has no pairing relationship.

**Migration in-repo**
- All 7 example studies, viewer fixtures, and ~30 test files migrated; the i18n gallery now demonstrates per-item `${locale}` pairing (each locale arm follows its matching intro).
- Researcher + engineer docs updated (treatment-files, syntax-reference, templates, conditions, api-reference, integration-guide, platform-requirements, README).
- ADR: `docs/decisions/2026-07-intro-sequence-pairing.md`.

## Pre-PR review (3 subagents: correctness / coverage / security)

All findings addressed in the second commit:
- **Correctness (2 MEDIUM)**: advisory message tails ("Defined in this file: …", "The key IS produced by …") changed between source/hydrated passes under template-generated sequences, demoting real errors to warnings in the diff orchestrator — the match key now strips advisory tails. Plus: whole-field placeholder posture aligned with per-item; union errorMap keeps the guidance message on wrong-typed values.
- **Coverage**: duplicate-entry warning severity was claimed but unimplemented — now threaded end-to-end; added tests for mixed `checkPairing` selections (index→name translation), groupComposition/exit positive-check sites, diff-orchestrator routing, placeholder binding through `fillTemplates`, CLI requiredness error with position.
- **Security**: no findings (pure validation code, no new auth/isolation surface); hardened `checkPairing` against cyclic YAML-anchor input in its error path.

## Test plan

- 30 new tests in `introSequencePairing.test.ts` + `checkPairing.test.ts`, plus review-driven regression tests (diff matching, severity, CLI position)
- Full suite: stagebook 1706, viewer 184, vscode 110 — all green; Playwright CT suite green; lint + format clean
- Every example study validates via the branch CLI

## Consumer rollout

Consumer issues with per-repo migration instructions will be filed on deliberation-lab, manager, and annotator (linking this PR) right after it opens. Release sequencing per #499/#481: this anchors the major bump; #481's consent/debrief phases land after as additive minors.

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)
