### PR TITLE
Bump stagebook to 0.20.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13392,7 +13392,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Minor release adding consent/debrief schema support, the `stagebook/viewer` preview harness subpath, and several new validation rules.

## What's in

- **#501** — Consent & debrief are now first-class schema components: consent arms and per-treatment debrief (#481 phase 1). New schema fields, viewer preview support, i18n example, docs, and an ADR.
- **#503** — The preview harness is now published as the `stagebook/viewer` subpath export (PreviewHost, Viewer, introspection utils, mock state store, content-fn helpers), so external hosts no longer reach into internals.
- **#500** — Treatment-level introSequences pairing is now required and validated. (Breaking — see Compatibility.)
- **#498** — Validation flags unsatisfiable conditions (dead gates).
- **#495** — The viewer surfaces validation diagnostics on load.
- **#493** — New VS Code "Validate Workspace" command.
- **#491** — Prompt locale-consistency runs in the editor and viewer.
- **#496** — Suppress the provable intro/exit advancement warning.
- **#497** — Docs: host records the stage-advance reason.

## Compatibility

- **Breaking (#500):** treatment files must now include treatment-level introSequences pairing; files that relied on the previous lax behavior will fail validation with a clear error. Add the required pairing to resolve.
- All other changes are additive (new schema fields, new `stagebook/viewer` export, new validation diagnostics).