### PR TITLE
refactor(schema)!: rename treatment field introSequences → compatibleIntroSequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ The template engine supports field substitution (`${fieldName}`), nested templat
 | Export                  | Description                                                                                          |
 | ----------------------- | ---------------------------------------------------------------------------------------------------- |
 | `treatmentFileSchema`   | Top-level schema for a treatment YAML file (templates, consent, introSequences, treatments)          |
-| `treatmentSchema`       | Single treatment with playerCount, introSequences, gameStages, exitSequence, debrief                 |
+| `treatmentSchema`       | Single treatment with playerCount, compatibleIntroSequences, gameStages, exitSequence, debrief       |
 | `consentArmSchema`      | Single named consent arm with its own locale and steps (#481)                                        |
 | `consentSchema`         | Top-level `consent:` array of arms — the host selects one by name                                    |
 | `debriefStepsSchema`    | Per-treatment `debrief:` step list, rendered by the host after its own wrap-up                       |

--- a/apps/viewer/src/lib/exampleCatalog.test.ts
+++ b/apps/viewer/src/lib/exampleCatalog.test.ts
@@ -20,7 +20,7 @@ treatments:
     notes: |
       A **Markdown** note describing the treatment.
     playerCount: 1
-    introSequences: [intro]
+    compatibleIntroSequences: [intro]
     gameStages:
       - name: only
         duration: 10

--- a/apps/viewer/src/lib/loader.test.ts
+++ b/apps/viewer/src/lib/loader.test.ts
@@ -13,7 +13,7 @@ introSequences:
 treatments:
   - name: treatment1
     playerCount: 2
-    introSequences: [intro1]
+    compatibleIntroSequences: [intro1]
     gameStages:
       - name: stage1
         duration: 10
@@ -98,7 +98,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: two
-    introSequences: [i]
+    compatibleIntroSequences: [i]
     gameStages:
       - name: g
         duration: 10
@@ -136,7 +136,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
-    introSequences: [i]
+    compatibleIntroSequences: [i]
     gameStages:
       - name: g
         duration: 10
@@ -179,7 +179,7 @@ treatments:
   - name: t
     playerCount: 2
     playerCount: 3
-    introSequences: [i]
+    compatibleIntroSequences: [i]
     gameStages:
       - name: g
         duration: 10
@@ -216,7 +216,7 @@ introSequences:
 treatments:
   - name: treatment1
     playerCount: 2
-    introSequences: [intro1]
+    compatibleIntroSequences: [intro1]
     gameStages:
       - name: stage1
         duration: 10
@@ -265,7 +265,7 @@ imports:
 treatments:
   - name: t
     playerCount: 1
-    introSequences: [i]
+    compatibleIntroSequences: [i]
     gameStages:
       - name: s
         duration: 10
@@ -295,7 +295,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
-    introSequences: [i]
+    compatibleIntroSequences: [i]
     locale: he
     gameStages:
       - name: g
@@ -336,7 +336,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
-    introSequences: [i]
+    compatibleIntroSequences: [i]
     locale: he
     gameStages:
       - name: g
@@ -373,7 +373,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
-    introSequences: [i]
+    compatibleIntroSequences: [i]
     locale: he
     gameStages:
       - name: g
@@ -409,7 +409,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
-    introSequences: [i]
+    compatibleIntroSequences: [i]
     locale: he
     gameStages:
       - name: g
@@ -459,7 +459,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
-    introSequences: [i]
+    compatibleIntroSequences: [i]
     gameStages:
       - name: g
         duration: 10
@@ -485,7 +485,7 @@ treatments:
 treatments:
   - name: t
     playerCount: 1
-    introSequences: [i]
+    compatibleIntroSequences: [i]
     locale: he
     gameStages:
       - name: g
@@ -535,7 +535,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
-    introSequences: [i]
+    compatibleIntroSequences: [i]
     gameStages:
       - name: g
         duration: 10

--- a/apps/viewer/src/lib/treatment.test.ts
+++ b/apps/viewer/src/lib/treatment.test.ts
@@ -13,7 +13,7 @@ introSequences:
 treatments:
   - name: treatment1
     playerCount: 2
-    introSequences: [intro1]
+    compatibleIntroSequences: [intro1]
     gameStages:
       - name: stage1
         duration: 10
@@ -35,7 +35,7 @@ introSequences:
 treatments:
   - name: control
     playerCount: 1
-    introSequences: [intro1]
+    compatibleIntroSequences: [intro1]
     gameStages:
       - name: stage1
         duration: 10
@@ -45,7 +45,7 @@ treatments:
             file: prompts/q1.prompt.md
   - name: experimental
     playerCount: 2
-    introSequences: [intro1]
+    compatibleIntroSequences: [intro1]
     gameStages:
       - name: stage1
         duration: 15
@@ -78,7 +78,7 @@ introSequences:
 treatments:
   - name: treatment1
     playerCount: 1
-    introSequences: [intro1]
+    compatibleIntroSequences: [intro1]
     gameStages:
       - template: questionStage
         fields:
@@ -111,7 +111,7 @@ introSequences:
 treatments:
   - name: treatment1
     playerCount: 1
-    introSequences: [intro1]
+    compatibleIntroSequences: [intro1]
     gameStages:
       - template: questionStage
         fields:

--- a/apps/vscode/src/lib/semanticTokens.ts
+++ b/apps/vscode/src/lib/semanticTokens.ts
@@ -68,6 +68,7 @@ const enumValues = new Set([
 
 const sectionKeys = new Set([
   "introSequences",
+  "compatibleIntroSequences",
   "introSteps",
   "gameStages",
   "elements",

--- a/docs/decisions/2026-07-intro-sequence-pairing.md
+++ b/docs/decisions/2026-07-intro-sequence-pairing.md
@@ -32,7 +32,7 @@ sequence a treatment may follow.
 ## Decision
 
 **Each treatment declares the intro sequences it may follow — a required
-`introSequences:` array of names (option B of [#499]).** The treatment is
+`compatibleIntroSequences:` array of names (option B of [#499]).** The treatment is
 the consumer of intro-provided data, so it declares its supplier set; and
 treatments are the heavily-templated, more-numerous side, so the
 declaration lives where templates already fan out.
@@ -41,13 +41,13 @@ declaration lives where templates already fan out.
 treatments:
   - name: negotiation_high_stakes
     playerCount: 2
-    introSequences: [prolific_en, prolific_es] # refs must resolve in BOTH
+    compatibleIntroSequences: [prolific_en, prolific_es] # refs must resolve in BOTH
     gameStages: [...]
 ```
 
 Key semantics:
 
-- **Required — breaking.** Absence is a schema error. `introSequences: []`
+- **Required — breaking.** Absence is a schema error. `compatibleIntroSequences: []`
   declares "no intro sequence": the host may only launch the treatment
   without one. There is no back-compat mode; existing files add one line
   per treatment (the error message carries the `[]` escape hatch, the
@@ -95,7 +95,7 @@ Key semantics:
 ## Consequences
 
 - Major version bump; every consumer's treatment files add
-  `introSequences:` to each treatment (see the consumer issues filed from
+  `compatibleIntroSequences:` to each treatment (see the consumer issues filed from
   [#499] for deliberation-lab, manager, annotator).
 - Hosts gain a launch-time guard (`checkPairing`) at the point where
   batch config selects `introSequenceName` + `treatments`.
@@ -103,3 +103,14 @@ Key semantics:
   checks (consent/debrief, [#481]) extend a pairing-aware model instead
   of the union model; locale-coherence between treatments and their
   declared sequences becomes statically checkable.
+
+## Addendum — field name (July 2026)
+
+The treatment-level field was originally named `introSequences:`, matching
+the top-level collection. Sitting next to `gameStages:` it read as though
+*all* the listed sequences run as part of the participant's experience,
+when the relationship is the opposite — the treatment is *compatible with*
+each listed sequence, and the host launches it after exactly **one** of
+them. Renamed to `compatibleIntroSequences:` before any study adopted the
+syntax, to make the ANY-of-these (not ALL) meaning read off the key and to
+disambiguate the treatment field from the same-named top-level collection.

--- a/docs/engineer/api-reference.md
+++ b/docs/engineer/api-reference.md
@@ -9,7 +9,7 @@ All schemas are [Zod](https://zod.dev/) objects. Use `.safeParse(data)` for vali
 | Export                  | Description                                                                             |
 | ----------------------- | --------------------------------------------------------------------------------------- |
 | `treatmentFileSchema`   | Top-level schema for `.stagebook.yaml` files                                            |
-| `treatmentSchema`       | Single treatment (name, playerCount, introSequences, gameStages, exitSequence, debrief) |
+| `treatmentSchema`       | Single treatment (name, playerCount, compatibleIntroSequences, gameStages, exitSequence, debrief) |
 | `stageSchema`           | Game stage (name, duration, elements, discussion)                                       |
 | `elementSchema`         | Any element type (discriminated union on `type`)                                        |
 | `promptSchema`          | Prompt element specifically                                                             |
@@ -130,7 +130,7 @@ The `stagebook/validate` subpath exports the position-aware validators shared by
 
 ### `checkPairing(file, { introSequenceName }, treatmentNames)`
 
-Launch-time guard for the treatment-level `introSequences:` declaration (#499). Hosts call it at batch launch — the point where batch config selects an intro sequence and a set of treatments.
+Launch-time guard for the treatment-level `compatibleIntroSequences:` declaration (#499). Hosts call it at batch launch — the point where batch config selects an intro sequence and a set of treatments.
 
 ```typescript
 import { checkPairing, type Diagnostic } from "stagebook/validate";
@@ -146,7 +146,7 @@ const diagnostics: Diagnostic[] = checkPairing(
 
 1. The named intro sequence exists (when one is selected).
 2. Every named treatment exists.
-3. Every treatment **lists** the selected sequence in its `introSequences:` — or declares `[]` when launching without one. The declaration is a constraint, not just a data dependency: a treatment that references no intro data still may not run after a sequence it doesn't list.
+3. Every treatment **lists** the selected sequence in its `compatibleIntroSequences:` — or declares `[]` when launching without one. The declaration is a constraint, not just a data dependency: a treatment that references no intro data still may not run after a sequence it doesn't list.
 4. Every reference in each treatment resolves under that specific sequence.
 
 Expects **expanded** input (e.g. the output of `expandAndValidateWithImports` or the host's own hydration pipeline); an unresolved `${...}` placeholder in a selected treatment's declaration is reported as an error rather than guessed around. Diagnostics carry `range: null` — this is a runtime check with no source-position mapping, so hosts render messages only. Deliberately intro-only: consent arms have no pairing relationship, so there is no `consentName` parameter.

--- a/docs/engineer/integration-guide.md
+++ b/docs/engineer/integration-guide.md
@@ -238,7 +238,7 @@ The hydration step also resolves broadcast expansion — a single template with 
 
 ## Launch-Time Pairing Guard
 
-Every treatment declares which intro sequences it may follow (`introSequences:` — required; `[]` means "runs without one"). The host picks the actual pairing at batch launch: batch config selects an `introSequenceName` and a set of treatment names. That's where to call `checkPairing` — after hydration, before creating the batch:
+Every treatment declares which intro sequences it may follow (`compatibleIntroSequences:` — required; `[]` means "runs without one"). The host picks the actual pairing at batch launch: batch config selects an `introSequenceName` and a set of treatment names. That's where to call `checkPairing` — after hydration, before creating the batch:
 
 ```typescript
 import { checkPairing } from "stagebook/validate";
@@ -255,7 +255,7 @@ if (diagnostics.length > 0) {
 }
 ```
 
-Pass `introSequenceName: null` for a batch that launches without an intro sequence — only treatments declaring `introSequences: []` may run that way (map any host-side `"none"` sentinel to `null` before calling). The check verifies that the selected sequence and treatments exist, that every selected treatment lists the selected sequence (the declaration is a constraint — even a treatment that references no intro data may not run after a sequence it doesn't list), and that every reference in each treatment resolves under that specific sequence. Design-time validation checks every _declared_ pairing; `checkPairing` guards that the pairing the batch actually runs is one of them.
+Pass `introSequenceName: null` for a batch that launches without an intro sequence — only treatments declaring `compatibleIntroSequences: []` may run that way (map any host-side `"none"` sentinel to `null` before calling). The check verifies that the selected sequence and treatments exist, that every selected treatment lists the selected sequence (the declaration is a constraint — even a treatment that references no intro data may not run after a sequence it doesn't list), and that every reference in each treatment resolves under that specific sequence. Design-time validation checks every _declared_ pairing; `checkPairing` guards that the pairing the batch actually runs is one of them.
 
 ## Consent and Debrief Placement
 

--- a/docs/engineer/platform-requirements.md
+++ b/docs/engineer/platform-requirements.md
@@ -325,7 +325,7 @@ From the treatment file:
 From the batch configuration (platform-specific):
 
 - Which treatments to run
-- Which intro sequence participants complete first — must be one that every selected treatment lists in its `introSequences:`; validate the pairing at batch launch with `checkPairing` from `stagebook/validate` (see the [integration guide](./integration-guide.md#launch-time-pairing-guard))
+- Which intro sequence participants complete first — must be one that every selected treatment lists in its `compatibleIntroSequences:`; validate the pairing at batch launch with `checkPairing` from `stagebook/validate` (see the [integration guide](./integration-guide.md#launch-time-pairing-guard))
 - Which consent arm participants see (when the file declares top-level `consent:`) — selected by name via a `consentName`-style config field; consent has no pairing with treatments, so the only launch-time check is that the name exists (see [Consent and Debrief Placement](./integration-guide.md#consent-and-debrief-placement))
 - Payoff weights (for optimizing assignment across treatments)
 

--- a/docs/researcher/conditions.md
+++ b/docs/researcher/conditions.md
@@ -350,7 +350,7 @@ Conditions in `groupComposition` control which participants fill which positions
 treatments:
   - name: cross_partisan
     playerCount: 2
-    introSequences: [onboarding] # the sequence that runs the partyAffiliation survey
+    compatibleIntroSequences: [onboarding] # the sequence that runs the partyAffiliation survey
     groupComposition:
       - position: 0
         title: "Democrat"
@@ -493,7 +493,7 @@ introSteps → gameStages → exitSequence
 
 Referencing a stage that hasn't run yet is rejected. External references (`entryUrl.params.*`, `attributes.*`) are always valid — they come from the platform, not a stage. The one exception is `attributes.sampleId`, which is assigned at game-stage start: reading it during intro / groupComposition is rejected like a forward reference.
 
-References that resolve from intro-step data are checked against the treatment's declared `introSequences:` (see [Pairing Treatments with Intro Sequences](treatment-files.md#pairing-treatments-with-intro-sequences)): the key must be provided by **every** sequence the treatment lists, not just one of them — a batch can run the treatment after any listed sequence, so the reference must hold under all of them. A reference whose key exists only in a sequence the treatment doesn't list gets a hint suggesting you add that sequence.
+References that resolve from intro-step data are checked against the treatment's declared `compatibleIntroSequences:` (see [Pairing Treatments with Intro Sequences](treatment-files.md#pairing-treatments-with-intro-sequences)): the key must be provided by **every** sequence the treatment lists, not just one of them — a batch can run the treatment after any listed sequence, so the reference must hold under all of them. A reference whose key exists only in a sequence the treatment doesn't list gets a hint suggesting you add that sequence.
 
 `groupComposition` is stricter: it runs before the game starts, so its conditions can only reference intro-phase or external data. Referencing game or exit data from `groupComposition` is rejected.
 

--- a/docs/researcher/syntax-reference.md
+++ b/docs/researcher/syntax-reference.md
@@ -192,7 +192,7 @@ Consent steps take the intro-step constraints (advancement element required, no 
 treatments:
   - name: <name>
     playerCount: <integer>
-    introSequences: [<names>] # required; [] = runs without an intro sequence
+    compatibleIntroSequences: [<names>] # required; [] = runs without an intro sequence
     groupComposition: # optional
       - position: 0
         title: "Role A"
@@ -204,7 +204,7 @@ treatments:
 
 Position indices in `showToPositions`, `hideFromPositions`, `groupComposition`, and discussion `rooms` must be < `playerCount`.
 
-`introSequences` (#499) names the intro sequences the treatment may follow; names resolve against the top-level `introSequences:` collection. Dangling names error; duplicates warn; every game/exit/`groupComposition` reference to intro-provided data must resolve in **every** listed sequence. `${field}` placeholders allowed, whole-field or per-item (like `groupComposition`).
+`compatibleIntroSequences` (#499) names the intro sequences the treatment may follow; names resolve against the top-level `introSequences:` collection. Dangling names error; duplicates warn; every game/exit/`groupComposition` reference to intro-provided data must resolve in **every** listed sequence. `${field}` placeholders allowed, whole-field or per-item (like `groupComposition`).
 
 ## 11. Prompt Files
 

--- a/docs/researcher/templates.md
+++ b/docs/researcher/templates.md
@@ -96,7 +96,7 @@ templates:
     content:
       name: ${treatmentName}
       playerCount: 2
-      introSequences: []
+      compatibleIntroSequences: []
       gameStages:
         - template: innerStage
           fields:
@@ -114,7 +114,7 @@ templates:
 
 Templates are expanded recursively until no template blocks remain.
 
-Note that a `contentType: treatment` template declares the required `introSequences:` field once in its content, and every instantiation inherits it. To vary the pairing per instantiation, use a `${field}` placeholder (whole-field or per-item) and fill it like any other field.
+Note that a `contentType: treatment` template declares the required `compatibleIntroSequences:` field once in its content, and every instantiation inherits it. To vary the pairing per instantiation, use a `${field}` placeholder (whole-field or per-item) and fill it like any other field.
 
 ## Templates in Broadcast Axes
 
@@ -212,7 +212,7 @@ introSequences:
 treatments:
   - name: my_study
     playerCount: 1
-    introSequences: [intro]
+    compatibleIntroSequences: [intro]
     exitSequence:
       - name: post
         elements:

--- a/docs/researcher/treatment-files.md
+++ b/docs/researcher/treatment-files.md
@@ -37,7 +37,7 @@ templates:
 treatments:
   - name: my_study
     playerCount: 1
-    introSequences: [] # this file defines no intro sequences
+    compatibleIntroSequences: [] # this file defines no intro sequences
     gameStages:
       - name: intro
         duration: 60
@@ -95,7 +95,7 @@ treatments:
   - name: two_player_discussion
     notes: Simple two-player video discussion
     playerCount: 2
-    introSequences: [default]
+    compatibleIntroSequences: [default]
 
     gameStages:
       - name: Discussion
@@ -128,16 +128,16 @@ treatments:
 
 ## Pairing Treatments with Intro Sequences
 
-Every treatment must declare which intro sequences it may follow, via a required `introSequences:` field:
+Every treatment must declare which intro sequences it may follow, via a required `compatibleIntroSequences:` field:
 
 ```yaml
 treatments:
   - name: two_player_discussion
     playerCount: 2
-    introSequences: [default]
+    compatibleIntroSequences: [default]
 ```
 
-Names resolve against the top-level `introSequences:` collection (after imports are merged) — arm names are per-collection namespaces, so a treatment and an intro sequence may share a name without conflict. Use `introSequences: []` for a treatment that runs without an intro sequence; the host may then only launch it intro-less. Omitting the field is an error — the pairing must be explicit.
+Names resolve against the top-level `introSequences:` collection (after imports are merged) — arm names are per-collection namespaces, so a treatment and an intro sequence may share a name without conflict. Use `compatibleIntroSequences: []` for a treatment that runs without an intro sequence; the host may then only launch it intro-less. Omitting the field is an error — the pairing must be explicit.
 
 Why declare it? Treatments consume data participants produce during intro steps (`self.prompt.<name>`, `self.survey.<name>...`). Without the declaration, a reference was accepted if _any_ intro sequence in the file provided the key — even when the batch ran a different one, where the reference silently never resolves and the participant gets stuck. With it:
 
@@ -149,14 +149,14 @@ Why declare it? Treatments consume data participants produce during intro steps 
 Listing multiple sequences is normal when different recruitment pathways feed the same treatments — references must then resolve in all of them:
 
 ```yaml
-introSequences: [prolific_en, prolific_es] # refs must resolve in BOTH
+compatibleIntroSequences: [prolific_en, prolific_es] # refs must resolve in BOTH
 ```
 
 `${field}` placeholders work here the same way they do in `groupComposition` — the whole field or individual items can be placeholders, filled at template-expansion time:
 
 ```yaml
-introSequences: ${sequences} # whole field
-introSequences: [${pathway}_onboarding] # per item
+compatibleIntroSequences: ${sequences} # whole field
+compatibleIntroSequences: [${pathway}_onboarding] # per item
 ```
 
 ## Consent
@@ -186,7 +186,7 @@ consent:
 
 - **The host selects one arm by name** (a `consentName`-style batch-config field). Arm names must be unique within `consent:` only — collection namespaces are separate, so a consent arm, an intro sequence, and a treatment may all be named `default`.
 - **Arms declare their own locale.** Consent runs before treatment assignment, so it can't inherit a treatment's locale — same as intro sequences. Two arms may share a locale (e.g., different jurisdictions in the same language). For single-source localized consent, see [the `consentArm` template pattern](templates.md#single-source-localized-consent).
-- **Consent is study-level, not per-treatment.** It's an IRB artifact, invariant across manipulations — which is why there's no pairing field like `introSequences:`. Consent's only obligation to the rest of the study is negative: don't collide. Storage keys in consent arms are collision-checked against **every** intro sequence and **every** treatment; reusing a key across two arms is fine (a participant only ever sees one arm).
+- **Consent is study-level, not per-treatment.** It's an IRB artifact, invariant across manipulations — which is why there's no pairing field like `compatibleIntroSequences:`. Consent's only obligation to the rest of the study is negative: don't collide. Storage keys in consent arms are collision-checked against **every** intro sequence and **every** treatment; reusing a key across two arms is fine (a participant only ever sees one arm).
 - **Consent steps follow the intro-step rules**: each step needs an advancement element, no `shared` prompts, no position fields (consent runs pre-assignment, for a single participant).
 
 ### The gated-submit pattern
@@ -219,7 +219,7 @@ Because debrief is per-treatment, **per-condition debriefs are just different tr
 treatments:
   - name: deception_arm
     playerCount: 2
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - name: main_task
         duration: 300
@@ -312,7 +312,7 @@ Optionally define requirements for who fills each position:
 treatments:
   - name: cross_partisan
     playerCount: 2
-    introSequences: [onboarding] # the sequence that runs the partyAffiliation survey
+    compatibleIntroSequences: [onboarding] # the sequence that runs the partyAffiliation survey
     groupComposition:
       - position: 0
         title: "Democrat"

--- a/examples/annotated-walkthrough/walkthrough.stagebook.yaml
+++ b/examples/annotated-walkthrough/walkthrough.stagebook.yaml
@@ -16,7 +16,7 @@ templates:
       notes: A two-person text discussion about ${topicLabel}, annotated as a syntax tour.
       playerCount: 2
       # intro sequences this treatment may follow; [] = none
-      introSequences: [onboarding]
+      compatibleIntroSequences: [onboarding]
       groupComposition:
         - position: 0
           title: Familiar

--- a/examples/component-gallery/component-gallery.stagebook.yaml
+++ b/examples/component-gallery/component-gallery.stagebook.yaml
@@ -27,7 +27,7 @@ treatments:
       Components covered: Markdown, RadioGroup, CheckboxGroup, Select,
       TextArea, Slider, ListSorter, SubmitButton.
     playerCount: 1
-    introSequences: [gallery_intro]
+    compatibleIntroSequences: [gallery_intro]
     gameStages:
       - name: markdown
         duration: 600

--- a/examples/i18n-gallery/i18n-gallery.stagebook.yaml
+++ b/examples/i18n-gallery/i18n-gallery.stagebook.yaml
@@ -91,7 +91,7 @@ templates:
       playerCount: 1
       # ${locale} threads here too, so each arm pairs with its
       # same-locale intro sequence.
-      introSequences: ["gallery intro ${locale}"]
+      compatibleIntroSequences: ["gallery intro ${locale}"]
       gameStages:
         - name: choices
           duration: 600

--- a/examples/imports-walkthrough/imports-walkthrough.stagebook.yaml
+++ b/examples/imports-walkthrough/imports-walkthrough.stagebook.yaml
@@ -36,7 +36,7 @@ introSequences:
 treatments:
   - name: imports_demo
     playerCount: 1
-    introSequences: [intro]
+    compatibleIntroSequences: [intro]
     gameStages:
       - name: main
         duration: 60

--- a/examples/prisoners-dilemma/prisoners-dilemma.stagebook.yaml
+++ b/examples/prisoners-dilemma/prisoners-dilemma.stagebook.yaml
@@ -119,7 +119,7 @@ treatments:
       The template returns 2 stages (choice + outcome), so this
       treatment ends up with 2 game stages plus the shared exit step.
     playerCount: 2
-    introSequences: [orientation]
+    compatibleIntroSequences: [orientation]
     gameStages:
       - template: roundTemplate
         fields:
@@ -140,7 +140,7 @@ treatments:
       prompt is named `choice_round_<N>` (where N is 1, 2, or 3), so
       references from one round don't collide with another's.
     playerCount: 2
-    introSequences: [orientation]
+    compatibleIntroSequences: [orientation]
     gameStages:
       - template: roundTemplate
         broadcast:

--- a/examples/survey-experiment/survey-experiment.stagebook.yaml
+++ b/examples/survey-experiment/survey-experiment.stagebook.yaml
@@ -18,7 +18,7 @@ templates:
       name: Survey experiment - ${condition}
       notes: A single-player pre/post attitude study with a ${condition} reading manipulation.
       playerCount: 1
-      introSequences: [orientation]
+      compatibleIntroSequences: [orientation]
 
       gameStages:
         - name: pre_attitude

--- a/examples/ultimatum-game/ultimatum-game.stagebook.yaml
+++ b/examples/ultimatum-game/ultimatum-game.stagebook.yaml
@@ -8,7 +8,7 @@ treatments:
       and responder are working from the same stage but seeing
       different content.
     playerCount: 2
-    introSequences: [orientation]
+    compatibleIntroSequences: [orientation]
     groupComposition:
       - position: 0
         title: Proposer

--- a/packages/stagebook/src/cli/validate.test.ts
+++ b/packages/stagebook/src/cli/validate.test.ts
@@ -43,7 +43,7 @@ let tmp: string;
 const MINIMAL_TREATMENT = `treatments:
   - name: t1
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - name: s1
         duration: 10
@@ -60,7 +60,7 @@ introSequences:
 const TREATMENT_WITH_SCHEMA_ERROR = `treatments:
   - name: t1
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - name: s1
         duration: 10
@@ -103,7 +103,7 @@ afterAll(async () => {
 
 describe("stagebook validate CLI", () => {
   describe("exit codes", () => {
-    it("exits 1 with the requiredness message when a treatment omits introSequences (#499)", async () => {
+    it("exits 1 with the requiredness message when a treatment omits compatibleIntroSequences (#499)", async () => {
       const missing = `treatments:
   - name: no_pairing
     playerCount: 1
@@ -117,7 +117,7 @@ describe("stagebook validate CLI", () => {
       await writeFile(file, missing);
       const r = await runCli([file]);
       expect(r.code).toBe(1);
-      expect(r.stdout).toContain("must declare `introSequences:`");
+      expect(r.stdout).toContain("must declare `compatibleIntroSequences:`");
       // Position walks up to the treatment node — a real location, not 0:0.
       expect(r.stdout).toMatch(/:\d+:\d+/);
     });
@@ -336,7 +336,7 @@ describe("stagebook validate CLI", () => {
 treatments:
   - name: t
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - name: s
         duration: 10
@@ -365,7 +365,7 @@ introSequences:
       const evil = `treatments:
   - name: t
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - name: s
         duration: 10
@@ -396,7 +396,7 @@ introSequences:
       const tplRefTreatment = `treatments:
   - name: t
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - template: missing_template
 introSequences:
@@ -430,7 +430,7 @@ describe("locale-consistency rule", () => {
       "  - name: t1",
       ...(locale ? [`    locale: ${locale}`] : []),
       "    playerCount: 1",
-      "    introSequences: []",
+      "    compatibleIntroSequences: []",
       "    gameStages:",
       "      - name: s1",
       "        duration: 10",
@@ -515,7 +515,7 @@ describe("unsatisfiable-condition rule", () => {
       "treatments:",
       "  - name: t1",
       "    playerCount: 1",
-      "    introSequences: []",
+      "    compatibleIntroSequences: []",
       "    gameStages:",
       "      - name: s1",
       "        duration: 10",
@@ -593,7 +593,7 @@ describe("locale rule through template expansion", () => {
       name: study-\${locale}
       locale: \${locale}
       playerCount: 1
-      introSequences: []
+      compatibleIntroSequences: []
       gameStages:
         - name: s1
           duration: 10
@@ -691,7 +691,7 @@ treatments:
       "  - name: t1",
       "    locale: he",
       "    playerCount: 1",
-      "    introSequences: []",
+      "    compatibleIntroSequences: []",
       "    gameStages:",
       "      - name: s1",
       "        duration: 10",
@@ -717,7 +717,7 @@ treatments:
       "  - name: t1",
       "    locale: he",
       "    playerCount: 1",
-      "    introSequences: []",
+      "    compatibleIntroSequences: []",
       "    gameStages:",
       "      - name: s1",
       "        duration: 10",
@@ -753,7 +753,7 @@ describe("locale rule — intro sequences", () => {
       "treatments:",
       "  - name: t1",
       "    playerCount: 1",
-      "    introSequences: [intro1]",
+      "    compatibleIntroSequences: [intro1]",
       "    gameStages:",
       "      - name: s1",
       "        duration: 10",

--- a/packages/stagebook/src/schemas/consentDebrief.test.ts
+++ b/packages/stagebook/src/schemas/consentDebrief.test.ts
@@ -73,7 +73,7 @@ function minimalTreatment(
   return {
     name: "t",
     playerCount: 1,
-    introSequences: [],
+    compatibleIntroSequences: [],
     gameStages: [
       {
         name: "s1",
@@ -169,7 +169,10 @@ describe("schema: top-level consent collection", () => {
       consent: [consentArm("default", ["ack"])],
       introSequences: [seq("default", ["color"])],
       treatments: [
-        minimalTreatment({ name: "default", introSequences: ["default"] }),
+        minimalTreatment({
+          name: "default",
+          compatibleIntroSequences: ["default"],
+        }),
       ],
     });
     expect(crossCollection.success).toBe(true);
@@ -249,7 +252,7 @@ describe("references: consent closed scope", () => {
         },
       ],
       introSequences: [seq("a", ["color"])],
-      treatments: [minimalTreatment({ introSequences: ["a"] })],
+      treatments: [minimalTreatment({ compatibleIntroSequences: ["a"] })],
     });
     expect(
       issues.some(
@@ -329,7 +332,7 @@ describe("references: consent closed scope", () => {
           ],
         },
       ],
-      treatments: [minimalTreatment({ introSequences: ["a"] })],
+      treatments: [minimalTreatment({ compatibleIntroSequences: ["a"] })],
     });
     expect(issues.some((i) => /audit-only/i.test(i.message))).toBe(true);
   });
@@ -391,7 +394,7 @@ describe("references: debrief", () => {
       introSequences: [seq("a", ["color"]), seq("b", ["shape"])],
       treatments: [
         minimalTreatment({
-          introSequences: ["a", "b"],
+          compatibleIntroSequences: ["a", "b"],
           debrief: [
             {
               name: "purpose",
@@ -419,7 +422,7 @@ describe("collisions: consent × everything; debrief in treatment scope", () => 
     const collisions = collectStorageKeyCollisions({
       consent: [consentArm("c", ["shared_key"])],
       introSequences: [seq("a", ["shared_key"])],
-      treatments: [minimalTreatment({ introSequences: [] })],
+      treatments: [minimalTreatment({ compatibleIntroSequences: [] })],
     });
     expect(collisions.length).toBeGreaterThan(0);
   });
@@ -531,7 +534,7 @@ describe("resolved: consent and debrief post-fill shapes", () => {
         {
           name: "t",
           playerCount: 1,
-          introSequences: [],
+          compatibleIntroSequences: [],
           gameStages: [
             {
               name: "s1",
@@ -641,7 +644,7 @@ describe("audit-only rule fires at every non-consent site", () => {
       ],
       treatments: [
         minimalTreatment({
-          introSequences: ["a"],
+          compatibleIntroSequences: ["a"],
           gameStages: [
             {
               name: "s1",
@@ -821,7 +824,7 @@ describe("whole-value template invocations at step-list positions don't throw", 
       },
       {
         introSequences: [{ name: "a", introSteps: { template: "t" } }],
-        treatments: [minimalTreatment({ introSequences: ["a"] })],
+        treatments: [minimalTreatment({ compatibleIntroSequences: ["a"] })],
       },
       {
         treatments: [minimalTreatment({ exitSequence: { template: "t" } })],

--- a/packages/stagebook/src/schemas/introSequencePairing.test.ts
+++ b/packages/stagebook/src/schemas/introSequencePairing.test.ts
@@ -6,7 +6,7 @@ import { validateResolvedTreatmentFile } from "./resolved.js";
 import { validateTreatmentSource } from "../validate/validateTreatment.js";
 
 /**
- * Treatment-level `introSequences:` pairing (#499).
+ * Treatment-level `compatibleIntroSequences:` pairing (#499).
  *
  * Covers the four cooperating pieces:
  *   - schema: the field is required on every treatment (breaking)
@@ -38,9 +38,9 @@ function seq(name: string, elementNames: string[]): Record<string, unknown> {
 
 function treatment(opts: {
   name?: string;
-  introSequences?: unknown;
+  compatibleIntroSequences?: unknown;
   gameStages?: Record<string, unknown>[];
-  omitIntroSequences?: boolean;
+  omitCompatibleIntroSequences?: boolean;
 }): Record<string, unknown> {
   const t: Record<string, unknown> = {
     name: opts.name ?? "t",
@@ -53,8 +53,8 @@ function treatment(opts: {
       },
     ],
   };
-  if (!opts.omitIntroSequences) {
-    t.introSequences = opts.introSequences ?? [];
+  if (!opts.omitCompatibleIntroSequences) {
+    t.compatibleIntroSequences = opts.compatibleIntroSequences ?? [];
   }
   return t;
 }
@@ -81,30 +81,57 @@ function stageReferencing(key: string): Record<string, unknown> {
 
 // --- schema: required field ------------------------------------------------
 
-describe("schema: introSequences is required on every treatment", () => {
-  test("treatment without introSequences → error mentioning the field", () => {
+describe("schema: compatibleIntroSequences is required on every treatment", () => {
+  test("treatment without compatibleIntroSequences → error mentioning the field", () => {
     const result = treatmentFileSchema.safeParse({
-      treatments: [treatment({ omitIntroSequences: true })],
+      treatments: [treatment({ omitCompatibleIntroSequences: true })],
     });
     expect(result.success).toBe(false);
     const messages = result.success
       ? []
       : result.error.issues.map((i) => i.message);
     expect(
-      messages.some((m) => /must declare `?introSequences`?/i.test(m)),
+      messages.some((m) =>
+        /must declare `?compatibleIntroSequences`?/i.test(m),
+      ),
     ).toBe(true);
   });
 
-  test("introSequences: [] is accepted", () => {
+  test("compatibleIntroSequences: [] is accepted", () => {
     const result = treatmentFileSchema.safeParse({
-      treatments: [treatment({ introSequences: [] })],
+      treatments: [treatment({ compatibleIntroSequences: [] })],
     });
     expect(result.success).toBe(true);
   });
 
+  test("the old name `introSequences` on a treatment is rejected as an unrecognized key", () => {
+    // Regression guard for the #499 → compatibleIntroSequences rename: the
+    // field was renamed to disambiguate ANY-of-these from the same-named
+    // top-level `introSequences:` collection. `baseTreatmentSchema` is
+    // strict, so the stale name must surface as an unrecognized key (and
+    // still trip the requiredness error for the new one), never silently
+    // pass. `introSequences` remains valid at the FILE level, so this
+    // guards specifically against re-introducing it on a treatment.
+    const t = treatment({ omitCompatibleIntroSequences: true });
+    t.introSequences = ["onboarding"];
+    const result = treatmentFileSchema.safeParse({ treatments: [t] });
+    expect(result.success).toBe(false);
+    const messages = result.success
+      ? []
+      : result.error.issues.map((i) => i.message);
+    expect(
+      messages.some((m) => /Unrecognized key.*introSequences/.test(m)),
+    ).toBe(true);
+    expect(
+      messages.some((m) =>
+        /must declare `?compatibleIntroSequences`?/i.test(m),
+      ),
+    ).toBe(true);
+  });
+
   test("whole-field ${...} placeholder is accepted pre-fill", () => {
     const result = treatmentFileSchema.safeParse({
-      treatments: [treatment({ introSequences: "${intros}" })],
+      treatments: [treatment({ compatibleIntroSequences: "${intros}" })],
     });
     expect(result.success).toBe(true);
   });
@@ -112,7 +139,7 @@ describe("schema: introSequences is required on every treatment", () => {
   test("per-item ${...} placeholder is accepted pre-fill", () => {
     const result = treatmentFileSchema.safeParse({
       introSequences: [seq("a", ["color"])],
-      treatments: [treatment({ introSequences: ["${pathway}"] })],
+      treatments: [treatment({ compatibleIntroSequences: ["${pathway}"] })],
     });
     expect(result.success).toBe(true);
   });
@@ -120,14 +147,16 @@ describe("schema: introSequences is required on every treatment", () => {
 
 // --- walker: name resolution ------------------------------------------------
 
-describe("walker: introSequences name resolution", () => {
+describe("walker: compatibleIntroSequences name resolution", () => {
   test("dangling sequence name → error naming treatment and sequence", () => {
     const issues = validateTreatmentFileReferences({
       introSequences: [seq("a", ["color"])],
-      treatments: [treatment({ name: "tx", introSequences: ["a", "ghost"] })],
+      treatments: [
+        treatment({ name: "tx", compatibleIntroSequences: ["a", "ghost"] }),
+      ],
     });
     const issue = issues.find((i) =>
-      i.path.join(".").endsWith("treatments.0.introSequences.1"),
+      i.path.join(".").endsWith("treatments.0.compatibleIntroSequences.1"),
     );
     expect(issue).toBeDefined();
     expect(issue?.message).toContain('"tx"');
@@ -138,10 +167,10 @@ describe("walker: introSequences name resolution", () => {
   test("duplicate entry → issue worded as a duplicate (warning severity downstream)", () => {
     const issues = validateTreatmentFileReferences({
       introSequences: [seq("a", ["color"])],
-      treatments: [treatment({ introSequences: ["a", "a"] })],
+      treatments: [treatment({ compatibleIntroSequences: ["a", "a"] })],
     });
     const issue = issues.find((i) =>
-      i.path.join(".").endsWith("treatments.0.introSequences.1"),
+      i.path.join(".").endsWith("treatments.0.compatibleIntroSequences.1"),
     );
     expect(issue).toBeDefined();
     expect(issue?.message).toMatch(/duplicate/i);
@@ -159,7 +188,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
-    introSequences: [a, a]
+    compatibleIntroSequences: [a, a]
     gameStages:
       - name: s1
         duration: 60
@@ -177,7 +206,7 @@ treatments:
       introSequences: [seq("a", ["color"])],
       treatments: [
         treatment({
-          introSequences: ["ghost"],
+          compatibleIntroSequences: ["ghost"],
           gameStages: [stageReferencing("color")],
         }),
       ],
@@ -191,21 +220,25 @@ treatments:
   test("duplicate + dangling combined → one dangling (idx 0), one duplicate (idx 1)", () => {
     const issues = validateTreatmentFileReferences({
       introSequences: [seq("a", ["color"])],
-      treatments: [treatment({ introSequences: ["ghost", "ghost"] })],
+      treatments: [treatment({ compatibleIntroSequences: ["ghost", "ghost"] })],
     });
     const dangling = issues.filter((i) =>
       /but no intro sequence with that name/.test(i.message),
     );
     const dups = issues.filter((i) => /duplicate entry/.test(i.message));
     expect(dangling).toHaveLength(1);
-    expect(dangling[0].path.join(".")).toBe("treatments.0.introSequences.0");
+    expect(dangling[0].path.join(".")).toBe(
+      "treatments.0.compatibleIntroSequences.0",
+    );
     expect(dups).toHaveLength(1);
-    expect(dups[0].path.join(".")).toBe("treatments.0.introSequences.1");
+    expect(dups[0].path.join(".")).toBe(
+      "treatments.0.compatibleIntroSequences.1",
+    );
   });
 
   test("no introSequences collection in file → name checks are skipped", () => {
     const issues = validateTreatmentFileReferences({
-      treatments: [treatment({ introSequences: ["ghost"] })],
+      treatments: [treatment({ compatibleIntroSequences: ["ghost"] })],
     });
     expect(
       issues.filter((i) => /lists intro sequence/.test(i.message)),
@@ -221,7 +254,7 @@ describe("walker: references must resolve in every listed sequence", () => {
       introSequences: [seq("a", ["color"]), seq("b", ["color"])],
       treatments: [
         treatment({
-          introSequences: ["a", "b"],
+          compatibleIntroSequences: ["a", "b"],
           gameStages: [stageReferencing("color")],
         }),
       ],
@@ -234,7 +267,7 @@ describe("walker: references must resolve in every listed sequence", () => {
       introSequences: [seq("a", ["color"]), seq("b", ["shape"])],
       treatments: [
         treatment({
-          introSequences: ["a", "b"],
+          compatibleIntroSequences: ["a", "b"],
           gameStages: [stageReferencing("color")],
         }),
       ],
@@ -250,7 +283,7 @@ describe("walker: references must resolve in every listed sequence", () => {
       introSequences: [seq("a", ["color"]), seq("c", ["shape"])],
       treatments: [
         treatment({
-          introSequences: ["a"],
+          compatibleIntroSequences: ["a"],
           gameStages: [stageReferencing("shape")],
         }),
       ],
@@ -260,12 +293,12 @@ describe("walker: references must resolve in every listed sequence", () => {
     expect(issue?.message).toContain('"c"');
   });
 
-  test("introSequences: [] with an intro-style reference → unknown-ref error", () => {
+  test("compatibleIntroSequences: [] with an intro-style reference → unknown-ref error", () => {
     const issues = validateTreatmentFileReferences({
       introSequences: [seq("a", ["color"])],
       treatments: [
         treatment({
-          introSequences: [],
+          compatibleIntroSequences: [],
           gameStages: [stageReferencing("color")],
         }),
       ],
@@ -278,7 +311,7 @@ describe("walker: references must resolve in every listed sequence", () => {
       introSequences: [seq("a", ["color"]), seq("b", [])],
       treatments: [
         treatment({
-          introSequences: ["a", "b"],
+          compatibleIntroSequences: ["a", "b"],
           gameStages: [
             {
               name: "produce",
@@ -302,7 +335,7 @@ describe("walker: references must resolve in every listed sequence", () => {
         {
           name: "t",
           playerCount: 1,
-          introSequences: ["a", "b"],
+          compatibleIntroSequences: ["a", "b"],
           groupComposition: [
             {
               position: 0,
@@ -350,7 +383,7 @@ describe("walker: references must resolve in every listed sequence", () => {
       introSequences: [seq("a", ["color"])],
       treatments: [
         treatment({
-          introSequences: "${intros}",
+          compatibleIntroSequences: "${intros}",
           gameStages: [stageReferencing("color")],
         }),
       ],
@@ -363,7 +396,7 @@ describe("walker: references must resolve in every listed sequence", () => {
       introSequences: [seq("a", ["color"])],
       treatments: [
         treatment({
-          introSequences: ["${pathway}", "ghost"],
+          compatibleIntroSequences: ["${pathway}", "ghost"],
           gameStages: [stageReferencing("color")],
         }),
       ],
@@ -381,7 +414,7 @@ describe("walker: references must resolve in every listed sequence", () => {
       introSequences: [seq("a", ["color"])],
       treatments: [
         treatment({
-          omitIntroSequences: true,
+          omitCompatibleIntroSequences: true,
           gameStages: [stageReferencing("color")],
         }),
       ],
@@ -399,7 +432,7 @@ describe("collisions: intro × treatment cross-pairs narrow to declared pairs", 
       {
         name: "t",
         playerCount: 1,
-        introSequences: declared,
+        compatibleIntroSequences: declared,
         gameStages: [
           {
             name: "s1",
@@ -432,7 +465,7 @@ describe("collisions: intro × treatment cross-pairs narrow to declared pairs", 
 
 // --- resolved: post-fill leak checks -----------------------------------------
 
-describe("resolved: introSequences must be concrete post-fill", () => {
+describe("resolved: compatibleIntroSequences must be concrete post-fill", () => {
   const resolvedStage = {
     name: "s1",
     duration: 60,
@@ -445,7 +478,7 @@ describe("resolved: introSequences must be concrete post-fill", () => {
         {
           name: "t",
           playerCount: 1,
-          introSequences: "${intros}",
+          compatibleIntroSequences: "${intros}",
           gameStages: [resolvedStage],
         },
       ],
@@ -459,7 +492,7 @@ describe("resolved: introSequences must be concrete post-fill", () => {
         {
           name: "t",
           playerCount: 1,
-          introSequences: ["${pathway}"],
+          compatibleIntroSequences: ["${pathway}"],
           gameStages: [resolvedStage],
         },
       ],
@@ -480,7 +513,7 @@ describe("resolved: introSequences must be concrete post-fill", () => {
         {
           name: "t",
           playerCount: 1,
-          introSequences: ["a"],
+          compatibleIntroSequences: ["a"],
           gameStages: [resolvedStage],
         },
       ],
@@ -498,12 +531,12 @@ describe("resolved: placeholder leaks are tagged for authoring contexts", () => 
     duration: 60,
     elements: [{ type: "submitButton", name: "done" }],
   };
-  const fileWith = (introSequences: unknown) => ({
+  const fileWith = (compatibleIntroSequences: unknown) => ({
     treatments: [
       {
         name: "t",
         playerCount: 1,
-        introSequences,
+        compatibleIntroSequences,
         gameStages: [resolvedStage],
       },
     ],
@@ -529,7 +562,7 @@ describe("resolved: placeholder leaks are tagged for authoring contexts", () => 
         {
           name: "t",
           playerCount: 1,
-          introSequences: 5,
+          compatibleIntroSequences: 5,
           gameStages: [resolvedStage],
         },
       ],
@@ -538,20 +571,20 @@ describe("resolved: placeholder leaks are tagged for authoring contexts", () => 
     const messages = result.success
       ? []
       : result.error.issues.map((i) => i.message);
-    expect(messages.some((m) => /must declare `introSequences:`/.test(m))).toBe(
-      true,
-    );
+    expect(
+      messages.some((m) => /must declare `compatibleIntroSequences:`/.test(m)),
+    ).toBe(true);
   });
 });
 
 describe("resolved: plain-string shape error is NOT masked as a placeholder leak", () => {
-  test("introSequences: 'onboarding' → hard error everywhere, with array suggestion", () => {
+  test("compatibleIntroSequences: 'onboarding' → hard error everywhere, with array suggestion", () => {
     const file = {
       treatments: [
         {
           name: "t",
           playerCount: 1,
-          introSequences: "onboarding",
+          compatibleIntroSequences: "onboarding",
           gameStages: [
             {
               name: "s1",
@@ -566,7 +599,9 @@ describe("resolved: plain-string shape error is NOT masked as a placeholder leak
     expect(strict.success).toBe(false);
     expect(
       strict.issues.some((i) =>
-        /Did you mean `introSequences: \[onboarding\]`/.test(i.message),
+        /Did you mean `compatibleIntroSequences: \[onboarding\]`/.test(
+          i.message,
+        ),
       ),
     ).toBe(true);
     // A shape error is not a binding problem — skipUnresolved must NOT hide it.

--- a/packages/stagebook/src/schemas/locale.test.ts
+++ b/packages/stagebook/src/schemas/locale.test.ts
@@ -46,7 +46,7 @@ function minimalTreatment(extra: Record<string, unknown> = {}) {
   return {
     name: "t1",
     playerCount: 1,
-    introSequences: [],
+    compatibleIntroSequences: [],
     gameStages: [
       {
         name: "stage1",
@@ -92,7 +92,7 @@ describe("resolvedTreatmentSchema.locale (post-fill)", () => {
   const resolvedBase = {
     name: "t1",
     playerCount: 1,
-    introSequences: [],
+    compatibleIntroSequences: [],
     gameStages: [
       {
         name: "stage1",

--- a/packages/stagebook/src/schemas/resolved.test.ts
+++ b/packages/stagebook/src/schemas/resolved.test.ts
@@ -61,7 +61,7 @@ describe("resolved schemas strip researcher `notes`", () => {
         name: "t_with_notes",
         notes: "Top-level treatment rationale.",
         playerCount: 2,
-        introSequences: [],
+        compatibleIntroSequences: [],
         gameStages: [
           {
             name: "s_with_notes",
@@ -150,7 +150,7 @@ describe("resolved schemas strip researcher `notes`", () => {
         {
           name: "t",
           playerCount: 2,
-          introSequences: [],
+          compatibleIntroSequences: [],
           gameStages: [
             {
               name: "s",
@@ -421,7 +421,7 @@ describe("validateResolvedTreatmentFile (#398)", () => {
       {
         name: "t",
         playerCount: 1,
-        introSequences: [],
+        compatibleIntroSequences: [],
         gameStages: [
           {
             name: "stage1",

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -291,18 +291,18 @@ export const resolvedTreatmentSchema = z.object({
   // entry still carrying `${...}`) are tagged `unresolved-placeholder`
   // (filtered in authoring contexts via `skipUnresolved`, hard errors in
   // production hosts); a plain non-placeholder string is a SHAPE error
-  // (`introSequences: onboarding` instead of `[onboarding]`) and stays a
+  // (`compatibleIntroSequences: onboarding` instead of `[onboarding]`) and stays a
   // hard error everywhere — misdiagnosing it as a binding problem would
   // let authoring contexts silently swallow it. The per-item check is
   // explicit because nameSchema deliberately ACCEPTS `${field}`
   // placeholders (legal pre-fill).
-  introSequences: z
+  compatibleIntroSequences: z
     .array(
       nameSchema.superRefine((name, ctx) => {
         if (name.includes("${")) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            message: `introSequences entry is an unresolved \`${name}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
+            message: `compatibleIntroSequences entry is an unresolved \`${name}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
             params: { reason: "unresolved-placeholder" },
           });
         }
@@ -313,13 +313,13 @@ export const resolvedTreatmentSchema = z.object({
         if (value.includes("${")) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            message: `introSequences is an unresolved \`${value}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
+            message: `compatibleIntroSequences is an unresolved \`${value}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
             params: { reason: "unresolved-placeholder" },
           });
         } else {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,
-            message: `introSequences must be an array of intro-sequence names; got the string "${value}". Did you mean \`introSequences: [${value}]\`?`,
+            message: `compatibleIntroSequences must be an array of intro-sequence names; got the string "${value}". Did you mean \`compatibleIntroSequences: [${value}]\`?`,
           });
         }
       }),

--- a/packages/stagebook/src/schemas/runValidationDiff.test.ts
+++ b/packages/stagebook/src/schemas/runValidationDiff.test.ts
@@ -26,7 +26,7 @@ describe("runValidationDiff", () => {
 treatments:
   - name: t
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - name: g
         duration: 10
@@ -792,7 +792,7 @@ treatments:
           content: {
             name: "t",
             playerCount: 1,
-            introSequences: [],
+            compatibleIntroSequences: [],
             gameStages: [
               {
                 name: "g",
@@ -868,7 +868,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
-    introSequences: [expanded]
+    compatibleIntroSequences: [expanded]
     gameStages:
       - name: s1
         duration: 60
@@ -918,7 +918,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
-    introSequences: [onboarding, gohst]
+    compatibleIntroSequences: [onboarding, gohst]
     gameStages:
       - name: s1
         duration: 60
@@ -960,7 +960,7 @@ introSequences:
 treatments:
   - name: t
     playerCount: 1
-    introSequences: [onboarding]
+    compatibleIntroSequences: [onboarding]
     gameStages:
       - name: s1
         duration: 60

--- a/packages/stagebook/src/schemas/safeParseTreatmentFile.test.ts
+++ b/packages/stagebook/src/schemas/safeParseTreatmentFile.test.ts
@@ -137,7 +137,7 @@ function makeBaseTreatmentFile(): Record<string, unknown> {
       {
         name: "study1",
         playerCount: 1,
-        introSequences: [],
+        compatibleIntroSequences: [],
         gameStages: [
           {
             name: "stage1",
@@ -298,7 +298,7 @@ describe("safeParseTreatmentFile — stage / treatment / discussion / player", (
     );
     expect(issue).toBeDefined();
     expect(issue!.message).toBe(
-      "Unrecognized key 'plyerCount' on treatment. Did you mean 'playerCount'? Valid keys: name, notes, playerCount, introSequences, locale, groupComposition, gameStages, exitSequence, debrief",
+      "Unrecognized key 'plyerCount' on treatment. Did you mean 'playerCount'? Valid keys: name, notes, playerCount, compatibleIntroSequences, locale, groupComposition, gameStages, exitSequence, debrief",
     );
   });
 

--- a/packages/stagebook/src/schemas/storageKeyCollisions.test.ts
+++ b/packages/stagebook/src/schemas/storageKeyCollisions.test.ts
@@ -123,7 +123,7 @@ describe("collectStorageKeyCollisions", () => {
       treatments: [
         {
           name: "t1",
-          introSequences: ["intro1"],
+          compatibleIntroSequences: ["intro1"],
           gameStages: [
             {
               name: "stage1",
@@ -212,7 +212,7 @@ describe("collectStorageKeyCollisions", () => {
       treatments: [
         {
           name: "treatment_A",
-          introSequences: ["intro1"],
+          compatibleIntroSequences: ["intro1"],
           gameStages: [
             {
               name: "stage1",
@@ -224,7 +224,7 @@ describe("collectStorageKeyCollisions", () => {
         },
         {
           name: "treatment_B",
-          introSequences: ["intro1"],
+          compatibleIntroSequences: ["intro1"],
           gameStages: [
             {
               name: "stage1",

--- a/packages/stagebook/src/schemas/storageKeyCollisions.ts
+++ b/packages/stagebook/src/schemas/storageKeyCollisions.ts
@@ -200,7 +200,7 @@ export function collectStorageKeyCollisions(
     name: unknown;
     idx: number;
     keys: Map<string, Path[]>;
-    /** Concrete declared `introSequences:` names (#499), or null when
+    /** Concrete declared `compatibleIntroSequences:` names (#499), or null when
      *  the declaration can't be interpreted statically (missing field,
      *  whole-field or per-item `${...}` placeholder) — cross-pair
      *  checks are skipped for that treatment rather than guessed. */
@@ -213,10 +213,10 @@ export function collectStorageKeyCollisions(
       name?: unknown;
       gameStages?: unknown;
       exitSequence?: unknown;
-      introSequences?: unknown;
+      compatibleIntroSequences?: unknown;
       debrief?: unknown;
     };
-    const declaredRaw = t.introSequences;
+    const declaredRaw = t.compatibleIntroSequences;
     const declared =
       Array.isArray(declaredRaw) &&
       declaredRaw.every(
@@ -341,7 +341,7 @@ export function collectStorageKeyCollisions(
   }
 
   // Cross-pair: each treatment × the intro sequences it DECLARES via
-  // `introSequences:` (#499) — collision scope follows pairing scope. A
+  // `compatibleIntroSequences:` (#499) — collision scope follows pairing scope. A
   // participant only ever flows from a declared sequence into the
   // treatment, so a key shared with a never-paired sequence is not a
   // collision anyone can experience. Treatments whose declaration isn't

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -298,7 +298,7 @@ test("validate entire file", () => {
       {
         name: "treatment1",
         playerCount: 2,
-        introSequences: [],
+        compatibleIntroSequences: [],
         groupComposition: [
           { position: 0, title: "Bill" },
           { position: 1, title: "Ted" },
@@ -372,7 +372,7 @@ test("treatment accepts an optional notes field with Markdown", () => {
         name: "treatment1",
         notes: "A **markdown** description of what this treatment does.",
         playerCount: 1,
-        introSequences: [],
+        compatibleIntroSequences: [],
         gameStages: [
           {
             name: "stage1",
@@ -2212,7 +2212,7 @@ test("groupComposition field on a treatment accepts a ${field} placeholder (#284
       {
         name: "varies",
         playerCount: 4,
-        introSequences: [],
+        compatibleIntroSequences: [],
         groupComposition: "${composition}",
         gameStages: [
           {
@@ -2256,7 +2256,7 @@ test("end-to-end: rooms placeholder resolves through fillTemplates and re-valida
       {
         name: "example",
         playerCount: 4,
-        introSequences: [],
+        compatibleIntroSequences: [],
         gameStages: [
           {
             template: "storytelling_round",
@@ -2332,7 +2332,7 @@ test("end-to-end: an unbound complex placeholder survives fillTemplates and is r
       {
         name: "broken",
         playerCount: 2,
-        introSequences: [],
+        compatibleIntroSequences: [],
         gameStages: [
           {
             name: "stage1",
@@ -2527,7 +2527,7 @@ test("treatment-shape file: `imports:` plus `treatments:`", () => {
       {
         name: "t1",
         playerCount: 1,
-        introSequences: [],
+        compatibleIntroSequences: [],
         gameStages: [
           {
             name: "stage1",

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -2034,19 +2034,24 @@ export const introSequencesSchema = altTemplateContext(
  *  this message to append the file's defined sequence names, so the
  *  schema-level text carries the `[]` escape hatch and the walker's
  *  dangling-name error carries the "which names exist" half. */
-export const INTRO_SEQUENCES_REQUIRED_MESSAGE =
-  "Each treatment must declare `introSequences:` — the intro sequences it " +
-  "may follow. Use `introSequences: []` for a treatment that runs without " +
-  "an intro sequence.";
+export const COMPATIBLE_INTRO_SEQUENCES_REQUIRED_MESSAGE =
+  "Each treatment must declare `compatibleIntroSequences:` — the intro " +
+  "sequences it may follow. Use `compatibleIntroSequences: []` for a " +
+  "treatment that runs without an intro sequence.";
 
 export const baseTreatmentSchema = z
   .object({
     name: nameSchema,
     notes: z.string().optional(),
     playerCount: z.number(),
-    // Which intro sequences this treatment may follow, by name (#499).
-    // REQUIRED — the pairing must be explicit; `[]` means "no intro
-    // sequence" (the host may only launch this treatment without one).
+    // The intro sequences this treatment is COMPATIBLE with, by name —
+    // any one of which supplies the treatment's precursor materials
+    // (#499). This is a disjunction, not a sequence of steps: the host
+    // launches the treatment after exactly ONE of these. REQUIRED — the
+    // pairing must be explicit; `[]` means "no intro sequence" (the host
+    // may only launch this treatment without one). Named `compatible…`
+    // rather than `introSequences` so it doesn't read as "all of these
+    // run" when sitting next to `gameStages`.
     // Names resolve against the top-level `introSequences:` collection
     // only (arm names are per-collection namespaces). Items are plain
     // strings rather than `nameSchema` so per-item `${field}`
@@ -2056,18 +2061,22 @@ export const baseTreatmentSchema = z
     // provides every referenced key" rule live in validateReferences.ts;
     // post-fill leaks are caught by `resolvedTreatmentSchema`.
     // The union-level errorMap keeps the guidance message on wrong-typed
-    // values (e.g. `introSequences: 5`), which would otherwise surface as
-    // a bare "Invalid input" — the union discards sub-schema
+    // values (e.g. `compatibleIntroSequences: 5`), which would otherwise
+    // surface as a bare "Invalid input" — the union discards sub-schema
     // invalid_type_error messages when no option matches.
-    introSequences: z.union(
+    compatibleIntroSequences: z.union(
       [
         z.array(z.string().min(1), {
-          required_error: INTRO_SEQUENCES_REQUIRED_MESSAGE,
-          invalid_type_error: INTRO_SEQUENCES_REQUIRED_MESSAGE,
+          required_error: COMPATIBLE_INTRO_SEQUENCES_REQUIRED_MESSAGE,
+          invalid_type_error: COMPATIBLE_INTRO_SEQUENCES_REQUIRED_MESSAGE,
         }),
         fieldPlaceholderSchema,
       ],
-      { errorMap: () => ({ message: INTRO_SEQUENCES_REQUIRED_MESSAGE }) },
+      {
+        errorMap: () => ({
+          message: COMPATIBLE_INTRO_SEQUENCES_REQUIRED_MESSAGE,
+        }),
+      },
     ),
     // Participant-facing language for this treatment (BCP-47, e.g. `he`).
     // Drives stagebook's chrome catalog + RTL when the host wires it onto the

--- a/packages/stagebook/src/schemas/validateReferences.ts
+++ b/packages/stagebook/src/schemas/validateReferences.ts
@@ -196,7 +196,7 @@ export function validateTreatmentFileReferences(
 
   // Intro-phase produced keys, tracked per sequence (#499) plus the
   // merged union. Which set a treatment validates against depends on
-  // its declared `introSequences:` pairing — see resolvePairing below.
+  // its declared `compatibleIntroSequences:` pairing — see resolvePairing below.
   //
   // `collectStepKeys` iterates a step's elements; `collectProducedKeys`
   // operates on a single element and skips anything that isn't an
@@ -285,7 +285,7 @@ export function validateTreatmentFileReferences(
   return issues;
 }
 
-/** Result of interpreting one treatment's declared `introSequences:`. */
+/** Result of interpreting one treatment's declared `compatibleIntroSequences:`. */
 interface PairingResolution {
   /** Intro keys the treatment's references may resolve against: the
    *  union of the declared sequences' keys, or the file-wide union
@@ -299,8 +299,8 @@ interface PairingResolution {
 }
 
 /**
- * Interpret a treatment's `introSequences:` declaration (#499) and emit
- * name-resolution issues. Returns which intro keys the treatment may
+ * Interpret a treatment's `compatibleIntroSequences:` declaration (#499)
+ * and emit name-resolution issues. Returns which intro keys the treatment may
  * reference and (when provable) the per-sequence sets for the positive
  * check.
  *
@@ -333,7 +333,7 @@ function resolvePairing({
     availableIntroKeys: introProducedKeys,
     declaredKeySets: null,
   };
-  const declared = treatment.introSequences;
+  const declared = treatment.compatibleIntroSequences;
   if (!Array.isArray(declared)) return fallback;
 
   const treatmentName =
@@ -356,8 +356,8 @@ function resolvePairing({
     }
     if (seen.has(entry)) {
       issues.push({
-        path: [...treatmentPath, "introSequences", entryIdx],
-        message: `Treatment "${treatmentName}" lists intro sequence "${entry}" more than once in \`introSequences:\` (duplicate entry).`,
+        path: [...treatmentPath, "compatibleIntroSequences", entryIdx],
+        message: `Treatment "${treatmentName}" lists intro sequence "${entry}" more than once in \`compatibleIntroSequences:\` (duplicate entry).`,
         severity: "warning",
       });
       return;
@@ -370,7 +370,7 @@ function resolvePairing({
           ? ` Defined in this file: ${defined.join(", ")}.`
           : " This file defines no named intro sequences.";
       issues.push({
-        path: [...treatmentPath, "introSequences", entryIdx],
+        path: [...treatmentPath, "compatibleIntroSequences", entryIdx],
         message: `Treatment "${treatmentName}" lists intro sequence "${entry}", but no intro sequence with that name is defined.${definedNote}`,
       });
       return;
@@ -453,8 +453,8 @@ function validateStepSequence({
 }
 
 /** Pairing context for the positive per-sequence check (#499). Present
- *  only when the treatment's `introSequences:` declaration was fully
- *  concrete and resolvable. */
+ *  only when the treatment's `compatibleIntroSequences:` declaration was
+ *  fully concrete and resolvable. */
 interface PairingContext {
   /** name → produced keys, for each sequence the treatment declares. */
   declaredKeySets: Map<string, Set<string>>;
@@ -917,7 +917,7 @@ function applyRules({
           undeclaredProducers.length > 1 ? "s" : ""
         } ${undeclaredProducers.join(", ")} — add ${
           undeclaredProducers.length > 1 ? "them" : "it"
-        } to this treatment's \`introSequences:\` if this treatment may follow ${
+        } to this treatment's \`compatibleIntroSequences:\` if this treatment may follow ${
           undeclaredProducers.length > 1 ? "them" : "it"
         }.`;
       }
@@ -947,7 +947,7 @@ function applyRules({
         path: site.path,
         message: `Reference "${refStr}" is not provided by intro sequence${
           missing.length > 1 ? "s" : ""
-        } ${missing.join(", ")} listed in this treatment's \`introSequences:\`. A treatment's references must resolve in every intro sequence it may follow.`,
+        } ${missing.join(", ")} listed in this treatment's \`compatibleIntroSequences:\`. A treatment's references must resolve in every intro sequence it may follow.`,
       });
       return;
     }

--- a/packages/stagebook/src/validate/checkPairing.test.ts
+++ b/packages/stagebook/src/validate/checkPairing.test.ts
@@ -37,7 +37,7 @@ const FILE = {
     {
       name: "uses_color",
       playerCount: 1,
-      introSequences: ["prolific"],
+      compatibleIntroSequences: ["prolific"],
       gameStages: [
         {
           name: "s1",
@@ -57,7 +57,7 @@ const FILE = {
     {
       name: "standalone",
       playerCount: 1,
-      introSequences: [],
+      compatibleIntroSequences: [],
       gameStages: [
         {
           name: "s1",
@@ -107,7 +107,7 @@ describe("checkPairing", () => {
     ).toBe(true);
   });
 
-  test("launching without an intro sequence: only introSequences:[] treatments pass", () => {
+  test("launching without an intro sequence: only compatibleIntroSequences:[] treatments pass", () => {
     const ok = checkPairing(FILE, { introSequenceName: null }, ["standalone"]);
     expect(ok).toHaveLength(0);
 
@@ -118,7 +118,7 @@ describe("checkPairing", () => {
   test("listed sequence that fails to provide a referenced key → error", () => {
     // Force the constraint through: pretend uses_color listed pilot too.
     const file = structuredClone(FILE) as typeof FILE;
-    (file.treatments[0].introSequences as string[]).push("pilot");
+    (file.treatments[0].compatibleIntroSequences as string[]).push("pilot");
     const diags = checkPairing(file, { introSequenceName: "pilot" }, [
       "uses_color",
     ]);
@@ -132,7 +132,7 @@ describe("checkPairing", () => {
     (file.treatments as Record<string, unknown>[]).push({
       ...structuredClone(FILE.treatments[0]),
       name: "wants_color_from_pilot",
-      introSequences: ["pilot"],
+      compatibleIntroSequences: ["pilot"],
     });
     const diags = checkPairing(file, { introSequenceName: "pilot" }, [
       "uses_color", // constraint fail: doesn't list pilot
@@ -188,7 +188,7 @@ describe("checkPairing", () => {
 
   test("unexpanded placeholder in a selected treatment → error telling host to expand first", () => {
     const file = structuredClone(FILE) as Record<string, unknown>;
-    (file.treatments as Record<string, unknown>[])[0].introSequences =
+    (file.treatments as Record<string, unknown>[])[0].compatibleIntroSequences =
       "${intros}";
     const diags = checkPairing(file, { introSequenceName: "prolific" }, [
       "uses_color",
@@ -200,10 +200,8 @@ describe("checkPairing", () => {
 describe("checkPairing input hygiene (Copilot review)", () => {
   test("array with non-string entries → uninterpretable-declaration error, not a confusing constraint error", () => {
     const file = structuredClone(FILE) as Record<string, unknown>;
-    (file.treatments as Record<string, unknown>[])[0].introSequences = [
-      5,
-      "prolific",
-    ];
+    (file.treatments as Record<string, unknown>[])[0].compatibleIntroSequences =
+      [5, "prolific"];
     const diags = checkPairing(file, { introSequenceName: "prolific" }, [
       "uses_color",
     ]);
@@ -232,7 +230,7 @@ describe("debrief under checkPairing (#481)", () => {
         {
           name: "t",
           playerCount: 1,
-          introSequences: ["a", "b"],
+          compatibleIntroSequences: ["a", "b"],
           gameStages: [
             {
               name: "s1",

--- a/packages/stagebook/src/validate/checkPairing.ts
+++ b/packages/stagebook/src/validate/checkPairing.ts
@@ -2,7 +2,7 @@
  * Runtime pairing guard (#499).
  *
  * `checkPairing` is the host-facing half of the treatment-level
- * `introSequences:` declaration: called at batch launch with the
+ * `compatibleIntroSequences:` declaration: called at batch launch with the
  * already-expanded treatment file, the selected intro sequence (or
  * null for an intro-less launch), and the selected treatment names.
  * It verifies:
@@ -10,7 +10,7 @@
  *   1. the named intro sequence exists (when one is selected);
  *   2. every selected treatment exists;
  *   3. every selected treatment LISTS the selected sequence in its
- *      `introSequences:` — or declares `[]` for an intro-less launch
+ *      `compatibleIntroSequences:` — or declares `[]` for an intro-less launch
  *      (the declaration is a constraint, not just a data dependency:
  *      a treatment with no intro references still may not run after a
  *      sequence it doesn't list);
@@ -119,7 +119,7 @@ export function checkPairing(
   const constraintOk: Record<string, unknown>[] = [];
   for (const treatment of selectedTreatments) {
     const name = String(treatment.name);
-    const declared = treatment.introSequences;
+    const declared = treatment.compatibleIntroSequences;
     if (
       typeof declared === "string" ||
       !Array.isArray(declared) ||
@@ -127,7 +127,7 @@ export function checkPairing(
     ) {
       diagnostics.push(
         error(
-          `Treatment "${name}" has an uninterpretable \`introSequences:\` declaration (${describeDeclaration(
+          `Treatment "${name}" has an uninterpretable \`compatibleIntroSequences:\` declaration (${describeDeclaration(
             declared,
           )}). Expand templates and bind all \`\${...}\` placeholders before calling checkPairing.`,
         ),
@@ -137,7 +137,7 @@ export function checkPairing(
     if (declared.some((d) => typeof d === "string" && d.includes("${"))) {
       diagnostics.push(
         error(
-          `Treatment "${name}" still carries an unresolved \`\${...}\` placeholder in \`introSequences:\`. Expand templates and bind all placeholders before calling checkPairing.`,
+          `Treatment "${name}" still carries an unresolved \`\${...}\` placeholder in \`compatibleIntroSequences:\`. Expand templates and bind all placeholders before calling checkPairing.`,
         ),
       );
       continue;
@@ -148,7 +148,7 @@ export function checkPairing(
           error(
             `Treatment "${name}" may only follow intro sequence${
               declared.length > 1 ? "s" : ""
-            } ${declared.map((d) => `"${String(d)}"`).join(", ")}. Launching without an intro sequence is only allowed for treatments declaring \`introSequences: []\`.`,
+            } ${declared.map((d) => `"${String(d)}"`).join(", ")}. Launching without an intro sequence is only allowed for treatments declaring \`compatibleIntroSequences: []\`.`,
           ),
         );
         continue;
@@ -156,7 +156,7 @@ export function checkPairing(
     } else if (!declared.includes(introSequenceName)) {
       diagnostics.push(
         error(
-          `Treatment "${name}" does not list intro sequence "${introSequenceName}" in its \`introSequences:\` (${
+          `Treatment "${name}" does not list intro sequence "${introSequenceName}" in its \`compatibleIntroSequences:\` (${
             declared.length > 0
               ? `allowed: ${declared.map((d) => `"${String(d)}"`).join(", ")}`
               : "it declares `[]` — no intro sequence"
@@ -181,7 +181,7 @@ export function checkPairing(
       introSequences: selectedSequence ? [selectedSequence] : undefined,
       treatments: constraintOk.map((t) => ({
         ...t,
-        introSequences: selectedSequence ? [introSequenceName] : [],
+        compatibleIntroSequences: selectedSequence ? [introSequenceName] : [],
       })),
     };
     for (const issue of validateTreatmentFileReferences(synthetic)) {

--- a/packages/stagebook/src/validate/expandAndValidate.test.ts
+++ b/packages/stagebook/src/validate/expandAndValidate.test.ts
@@ -21,7 +21,7 @@ introSequences:
 treatments:
   - name: study1
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - template: myStage`;
       const result = expandAndValidate(src);
@@ -56,7 +56,7 @@ introSequences:
 treatments:
   - name: study1
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - template: badStage
         fields:
@@ -89,7 +89,7 @@ introSequences:
 treatments:
   - name: study1
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - template: badStage
         fields:
@@ -169,7 +169,7 @@ introSequences:
 treatments:
   - name: study1
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - template: manyStage
         broadcast:
@@ -196,15 +196,15 @@ ${broadcastItems}`;
   });
 });
 
-describe("introSequences placeholder binding (#499)", () => {
-  it("binds whole-field and per-item introSequences placeholders through fillTemplates", () => {
+describe("compatibleIntroSequences placeholder binding (#499)", () => {
+  it("binds whole-field and per-item compatibleIntroSequences placeholders through fillTemplates", () => {
     const src = `templates:
   - name: study
     contentType: treatment
     content:
       name: t_\${pathway}
       playerCount: 1
-      introSequences:
+      compatibleIntroSequences:
         - \${pathway}
       gameStages:
         - name: s1
@@ -226,6 +226,6 @@ treatments:
     expect(result.diagnostics.filter((d) => d.severity === "error")).toEqual(
       [],
     );
-    expect(result.fullYaml).toMatch(/introSequences:\n {6}- a/);
+    expect(result.fullYaml).toMatch(/compatibleIntroSequences:\n {6}- a/);
   });
 });

--- a/packages/stagebook/src/validate/parseTreatmentSource.test.ts
+++ b/packages/stagebook/src/validate/parseTreatmentSource.test.ts
@@ -25,7 +25,7 @@ const loaderFromMap = (files: Record<string, string>) => {
 const validTreatment = `treatments:
   - name: t
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - name: s
         duration: 10
@@ -58,7 +58,7 @@ treatments:
     content:
       name: t
       playerCount: 1
-      introSequences: []
+      compatibleIntroSequences: []
       gameStages:
         - name: s
           duration: 10
@@ -252,7 +252,7 @@ treatments:
     content:
       name: t
       playerCount: 1
-      introSequences: []
+      compatibleIntroSequences: []
       gameStages:
         - name: s
           duration: 10

--- a/packages/stagebook/src/validate/validateTreatment.test.ts
+++ b/packages/stagebook/src/validate/validateTreatment.test.ts
@@ -13,7 +13,7 @@ describe("validateTreatmentSource", () => {
 treatments:
   - name: study1
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - name: stage1
         duration: 300
@@ -68,7 +68,7 @@ treatments:
         duration: 300
         elements:
           - type: submitButton`;
-      // Missing playerCount and introSequences
+      // Missing playerCount and compatibleIntroSequences
       const result = validateTreatmentSource(src);
       expect(result.diagnostics.length).toBeGreaterThan(0);
       expect(result.diagnostics[0].severity).toBe("error");

--- a/packages/stagebook/src/validate/validateTreatment.ts
+++ b/packages/stagebook/src/validate/validateTreatment.ts
@@ -64,7 +64,7 @@ export function validateTreatmentSource(source: string): ValidationResult {
           : undefined;
       const isUnrecognizedKey =
         params !== undefined && typeof params.badKey === "string";
-      // Lint-level issues (e.g. duplicate `introSequences:` entries,
+      // Lint-level issues (e.g. duplicate `compatibleIntroSequences:` entries,
       // #499) self-mark via params.severity — see validateReferences.ts.
       const severity = params?.severity === "warning" ? "warning" : "error";
 

--- a/packages/stagebook/src/validate/validateTreatmentDiff.test.ts
+++ b/packages/stagebook/src/validate/validateTreatmentDiff.test.ts
@@ -40,7 +40,7 @@ describe("validateTreatmentWithDiff", () => {
 treatments:
   - name: t
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - name: g
         duration: 10

--- a/packages/stagebook/src/validate/validateTreatmentDiff.ts
+++ b/packages/stagebook/src/validate/validateTreatmentDiff.ts
@@ -164,7 +164,7 @@ export async function validateTreatmentWithDiff({
   for (const issue of diff.matched) {
     diagnostics.push({
       message: appendPathIfMissing(issue),
-      // Lint-level walker issues (duplicate `introSequences:` entries,
+      // Lint-level walker issues (duplicate `compatibleIntroSequences:` entries,
       // #499) self-mark warning via params.severity; real bugs stay
       // errors.
       severity: issueSeverity(issue),

--- a/packages/stagebook/src/viewer/lib/previewResolution.test.ts
+++ b/packages/stagebook/src/viewer/lib/previewResolution.test.ts
@@ -27,7 +27,7 @@ templates:
 treatments:
   - name: treatment1
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - template: questionStage
         fields:
@@ -50,7 +50,7 @@ templates:
 treatments:
   - name: treatment1
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - template: questionStage
         fields:
@@ -81,7 +81,7 @@ introSequences:
 treatments:
   - name: treatment1
     playerCount: 1
-    introSequences: [intro1]
+    compatibleIntroSequences: [intro1]
     gameStages:
       - name: stage1
         duration: 10
@@ -108,7 +108,7 @@ templates:
 treatments:
   - name: treatment1
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - template: questionStage
         fields:
@@ -124,7 +124,7 @@ const NO_TEMPLATE_YAML = `
 treatments:
   - name: treatment1
     playerCount: 1
-    introSequences: []
+    compatibleIntroSequences: []
     gameStages:
       - name: stage1
         duration: 10


### PR DESCRIPTION
## What

Renames the **treatment-level** pairing field `introSequences` → `compatibleIntroSequences`. The same-named **top-level `introSequences:` collection** (the array of intro-sequence definitions) and the `introSequences` **contentType enum** value are deliberately unchanged.

## Why

The field (added in #499) declares which intro sequences a treatment may follow. Named `introSequences` and sitting next to `gameStages:`, it read as though *all* the listed sequences run as part of the participant's experience — when the relationship is the opposite: the treatment is *compatible with* each listed sequence, and the host launches it after exactly **one** of them (ANY-of-these, not ALL).

`compatibleIntroSequences` makes that meaning read off the key and disambiguates the treatment field from the identically-named top-level collection. No study has adopted the syntax yet, so this is the right moment to rename — the field isn't carried in any deployed treatment file.

## Scope

The rename touches only the treatment field; every file-level collection reference (`file.introSequences`, `["introSequences", n, "introSteps"]` paths, `introSequencesSchema`, the contentType enum) is left as-is.

- **Schema**: `treatment.ts` (field + comments), `resolved.ts` (`resolvedTreatmentSchema` key + leak messages). Exported constant `INTRO_SEQUENCES_REQUIRED_MESSAGE` → `COMPATIBLE_INTRO_SEQUENCES_REQUIRED_MESSAGE`.
- **Validators**: `validateReferences.ts` (pairing resolution + messages/paths), `storageKeyCollisions.ts` (collision-scope pairing read), `checkPairing.ts` (launch guard + synthetic-file rewrite), `validateTreatment.ts` / `validateTreatmentDiff.ts` comments.
- **Tooling**: VS Code `semanticTokens.ts` adds `compatibleIntroSequences` to the highlighted section keys (keeps `introSequences` for the collection).
- **Examples** (7 studies), **docs** (researcher + engineer + syntax reference), and the #499 ADR (with a rename addendum).
- **Tests**: ~130 occurrences across 27 files updated; added a regression test that the stale `introSequences` name on a treatment is rejected as an unrecognized key.

## Breaking change

This is a breaking schema change (the field name is part of the authoring API). Per the #499 ADR it warrants a major version bump; the version bump / release is handled separately by the release process.

## Verification

- vitest: lib **1872**, viewer **78**, vscode **110** — all green
- Playwright CT (chromium): **582** passed
- lint + prettier (`src/**/*.{ts,tsx}`): clean
- CLI validates all 7 examples cleanly; the old field name now errors with `Unrecognized key 'introSequences' on treatment … Valid keys: … compatibleIntroSequences …`
- Pre-PR review (correctness / test-coverage / security subagents): no findings — collision check and `checkPairing` guard both confirmed reading the correct renamed key (no silent no-op), no over-rename of the collection.

Refs #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)