### PR TITLE
Bump stagebook to 0.21.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13392,7 +13392,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Minor release (breaking, under 0.x semver) shipping the treatment-field rename.

## What's in

- **#506** — Rename the required treatment pairing field `introSequences` → `compatibleIntroSequences`, so its ANY-of-these (not ALL) meaning reads off the key and it no longer collides in the reader's mind with the top-level `introSequences:` collection it sits beside. Applied across schema, resolved schema, reference walker, storage-key collision check, the `checkPairing` launch guard, the diff pipeline, VS Code semantic tokens, examples, and docs. Refs #499.

## Compatibility

- **Breaking.** Treatment files using `introSequences:` at the treatment level must rename it to `compatibleIntroSequences:`. The old key now errors as an unrecognized key on the strict treatment schema, and the requiredness error names the new field. No study had adopted the #499 syntax yet, so no deployed treatment file carries the old name.
- The top-level `introSequences:` collection and the `introSequences` contentType enum value are unchanged.
- The exported constant `INTRO_SEQUENCES_REQUIRED_MESSAGE` is renamed to `COMPATIBLE_INTRO_SEQUENCES_REQUIRED_MESSAGE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)