### PR TITLE
feat(ci): publish the stagebook validate GitHub Action (#441)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,33 +274,47 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      # Happy path: run the composite action against the fixture study repo,
-      # exercising setup-node + npx + glob quoting + import resolution
-      # end-to-end. Pins the validator to the current release so the dogfood
-      # isn't coupled to unreleased schema changes on main.
+      # Stage the fixtures as standalone study repos OUTSIDE this monorepo.
+      # `npx`/`npm exec` resolve `stagebook` against the nearest project;
+      # run from the repo root, npm matches the requested version to this
+      # repo's own `packages/stagebook` workspace (same version) and tries to
+      # run it locally — uninstalled → "not found" — instead of fetching from
+      # npm. A real no-JS study repo has no such workspace, so validate from a
+      # plain directory the same way a study repo's CI would.
+      - name: Stage fixtures as standalone study repos
+        run: |
+          mkdir -p "$RUNNER_TEMP/study" "$RUNNER_TEMP/study-invalid"
+          cp -R validate-action/fixtures/. "$RUNNER_TEMP/study/"
+          cp -R validate-action/fixtures-invalid/. "$RUNNER_TEMP/study-invalid/"
+      # Happy path: run the composite action end-to-end (setup-node + npx +
+      # glob quoting + import resolution). Pins the validator to the current
+      # release so the dogfood isn't coupled to unreleased schema changes.
       - name: Valid fixtures (text) → exit 0
         uses: ./validate-action
         with:
           version: "0.21.0"
+          working-directory: ${{ runner.temp }}/study
           files: |
-            validate-action/fixtures/**/*.stagebook.yaml
-            validate-action/fixtures/**/*.prompt.md
+            **/*.stagebook.yaml
+            **/*.prompt.md
       # JSON output branch (also skips the problem matcher).
       - name: Valid fixtures (json)
         uses: ./validate-action
         with:
           version: "0.21.0"
           format: json
+          working-directory: ${{ runner.temp }}/study
           files: |
-            validate-action/fixtures/**/*.stagebook.yaml
-            validate-action/fixtures/**/*.prompt.md
+            **/*.stagebook.yaml
+            **/*.prompt.md
       # --no-expand branch (raw syntax only).
       - name: Valid treatment (no-expand)
         uses: ./validate-action
         with:
           version: "0.21.0"
           no-expand: "true"
-          files: validate-action/fixtures/**/*.stagebook.yaml
+          working-directory: ${{ runner.temp }}/study
+          files: "**/*.stagebook.yaml"
       # Negative case: the action must fail the job on a validation error.
       # `continue-on-error` lets the job survive so the next step can assert
       # the failure — this guards the exit-code propagation that is the whole
@@ -311,7 +325,8 @@ jobs:
         uses: ./validate-action
         with:
           version: "0.21.0"
-          files: validate-action/fixtures-invalid/**/*.prompt.md
+          working-directory: ${{ runner.temp }}/study-invalid
+          files: "**/*.prompt.md"
       - name: Assert the invalid fixture failed validation
         if: steps.expect_fail.outcome != 'failure'
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
       vscode: ${{ steps.filter.outputs.vscode }}
       ct: ${{ steps.filter.outputs.ct }}
       lint: ${{ steps.filter.outputs.lint }}
+      action: ${{ steps.filter.outputs.action }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -68,6 +69,9 @@ jobs:
               # All workflow files, so `format:check` guards them — a PR that
               # edits only a workflow (e.g. release-vscode.yml) still runs lint.
               - '.github/workflows/*.yml'
+            action:
+              - 'validate-action/**'
+              - '.github/workflows/ci.yml'
 
   lint:
     name: Lint & Format
@@ -256,6 +260,64 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+  validate-action:
+    name: Dogfood validate-action
+    needs: changes
+    if: needs.changes.outputs.action == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    # The action fetches + runs a network-downloaded package (npx), so scope
+    # this job to read-only — it never needs to write anything.
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      # Happy path: run the composite action against the fixture study repo,
+      # exercising setup-node + npx + glob quoting + import resolution
+      # end-to-end. Pins the validator to the current release so the dogfood
+      # isn't coupled to unreleased schema changes on main.
+      - name: Valid fixtures (text) → exit 0
+        uses: ./validate-action
+        with:
+          version: "0.21.0"
+          files: |
+            validate-action/fixtures/**/*.stagebook.yaml
+            validate-action/fixtures/**/*.prompt.md
+      # JSON output branch (also skips the problem matcher).
+      - name: Valid fixtures (json)
+        uses: ./validate-action
+        with:
+          version: "0.21.0"
+          format: json
+          files: |
+            validate-action/fixtures/**/*.stagebook.yaml
+            validate-action/fixtures/**/*.prompt.md
+      # --no-expand branch (raw syntax only).
+      - name: Valid treatment (no-expand)
+        uses: ./validate-action
+        with:
+          version: "0.21.0"
+          no-expand: "true"
+          files: validate-action/fixtures/**/*.stagebook.yaml
+      # Negative case: the action must fail the job on a validation error.
+      # `continue-on-error` lets the job survive so the next step can assert
+      # the failure — this guards the exit-code propagation that is the whole
+      # point of the action.
+      - name: Invalid fixture → non-zero
+        id: expect_fail
+        continue-on-error: true
+        uses: ./validate-action
+        with:
+          version: "0.21.0"
+          files: validate-action/fixtures-invalid/**/*.prompt.md
+      - name: Assert the invalid fixture failed validation
+        if: steps.expect_fail.outcome != 'failure'
+        run: |
+          echo "Expected validate-action to fail on the invalid fixture, got '${{ steps.expect_fail.outcome }}'" >&2
+          exit 1
+
   ci-gate:
     name: CI Gate
     if: always()
@@ -269,6 +331,7 @@ jobs:
         package-vscode,
         test-ct,
         build,
+        validate-action,
       ]
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
   validate-action:
     name: Dogfood validate-action
     needs: changes
-    if: needs.changes.outputs.action == 'true'
+    if: needs.changes.outputs.action == 'true' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     # The action fetches + runs a network-downloaded package (npx), so scope

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,11 @@ Never skip the red step. Tests document intent.
 
 ### Git Process
 
-- **Fast-forward only** merges (no merge commits, no squash)
+- **Squash and merge** via the GitHub merge queue — each PR lands as one
+  commit, keeping a linear history where every commit on `main` is a state
+  that passed CI. Don't use merge commits. (The queue tests each PR on the
+  real combined state — `main` + the PRs ahead of it — before it merges; CI
+  runs in the queue via the `merge_group` event, see `.github/workflows/ci.yml`.)
 - **Pre-commit hook:** lint-staged runs Prettier + ESLint on staged files
 - **Pre-push hook:** full lint + all tests across workspaces
 - **CI:** format check, lint, backend tests, frontend tests, Playwright e2e

--- a/validate-action/README.md
+++ b/validate-action/README.md
@@ -27,6 +27,10 @@ jobs:
           version: "0.21.0" # pin for reproducible validation
 ```
 
+> **Note:** `@v1` is a floating tag created when the first version is
+> released. Until it exists, pin `@main` or a commit SHA
+> (`talkbench/stagebook/validate-action@<sha>`).
+
 The CLI dispatches by suffix (`.stagebook.yaml` → treatment validator,
 `.prompt.md` → prompt validator), and by default expands templates and
 resolves `imports:` before checking the schema — so errors that only appear

--- a/validate-action/README.md
+++ b/validate-action/README.md
@@ -1,0 +1,87 @@
+# Stagebook Validate — GitHub Action
+
+Validate Stagebook treatment (`.stagebook.yaml`) and prompt (`.prompt.md`)
+files in CI. It's a thin wrapper around the bundled CLI
+(`npx --package=stagebook stagebook validate`), so it works in **study repos
+that have no JS toolchain** — no `package.json`, no `node_modules`. The action
+sets up Node, runs the published validator, and fails the job on any error.
+
+## Usage
+
+```yaml
+name: Validate treatments
+on: [push, pull_request]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: talkbench/stagebook/validate-action@v1
+        with:
+          # One entry per line. A block scalar avoids YAML's leading-`*`
+          # alias pitfall; the action passes globs to the CLI intact.
+          files: |
+            stagebook/**/*.stagebook.yaml
+            prompts/**/*.prompt.md
+          version: "0.21.0" # pin for reproducible validation
+```
+
+The CLI dispatches by suffix (`.stagebook.yaml` → treatment validator,
+`.prompt.md` → prompt validator), and by default expands templates and
+resolves `imports:` before checking the schema — so errors that only appear
+after template substitution are caught. Diagnostics are printed as
+`path:line:col: severity: message`, and (in the default `text` format) also
+surfaced as inline annotations on the PR via a problem matcher.
+
+## Passing globs
+
+Do **not** wrap glob entries in extra quotes. The action disables shell
+globbing internally (`set -f`) and hands globs to the CLI, which expands them
+recursively with its own globber. Wrapping an entry in quotes (e.g.
+`"'**/*.yaml'"`) would pass literal quote characters through and match nothing.
+
+The reason to use a block scalar (`files: |`) or a quoted YAML string is
+_YAML_, not the shell: a bare scalar beginning with `*` is parsed as a YAML
+alias. One entry per line sidesteps that and reads cleanly.
+
+Entries are split on whitespace, so an individual path or glob **cannot
+contain spaces** — `my study/**/*.stagebook.yaml` is read as two entries.
+Keep Stagebook files in space-free paths (they normally are).
+
+## Inline annotations and `working-directory`
+
+The problem matcher resolves diagnostic file paths against the repository
+root. The CLI prints them relative to its working directory, so inline PR
+annotations land on the right files only when `working-directory` is the repo
+root (the default). If you set `working-directory` to a subdirectory,
+validation still passes/fails the job correctly, but the inline annotations
+may not attach — prefer repo-root-relative globs over `working-directory`.
+
+## Inputs
+
+| Input               | Default    | Description                                                                                       |
+| ------------------- | ---------- | ------------------------------------------------------------------------------------------------- |
+| `files`             | (required) | Files/globs to validate, whitespace- or newline-separated.                                        |
+| `version`           | `latest`   | stagebook npm version: exact (`0.21.0`), a range, or `latest`. Pin for reproducibility.           |
+| `format`            | `text`     | `text` (with inline annotations) or `json` (machine-readable to stdout).                          |
+| `node-version`      | `24`       | Node.js version to set up.                                                                        |
+| `working-directory` | `.`        | Directory to run validation in.                                                                   |
+| `allow-empty`       | `false`    | When `true`, a glob matching no files is not an error (`--allow-empty`).                          |
+| `no-expand`         | `false`    | When `true`, check raw syntax only — skip template expansion + import resolution (`--no-expand`). |
+
+## Exit / job status
+
+The job passes or fails on the CLI's exit code:
+
+- `0` — no errors (warnings are allowed)
+- `1` — at least one validation error
+- `2` — a file couldn't be read, YAML was unparseable, a glob matched zero
+  files (override with `allow-empty: true`), or the inputs were invalid
+
+## Versioning
+
+Pin the action to a released major tag — `validate-action@v1` — so a study
+repo's CI is stable. Independently, pin the `version:` input to an exact
+stagebook release for byte-for-byte reproducible validation; leaving it at
+`latest` always uses the newest published rules.

--- a/validate-action/README.md
+++ b/validate-action/README.md
@@ -58,6 +58,17 @@ root (the default). If you set `working-directory` to a subdirectory,
 validation still passes/fails the job correctly, but the inline annotations
 may not attach — prefer repo-root-relative globs over `working-directory`.
 
+## Running inside an npm workspace
+
+This action is built for study repos with **no** JS toolchain, where `npx`
+cleanly fetches the pinned `stagebook`. If you instead run it from a
+directory that is itself an npm project/workspace declaring a `stagebook`
+package at the same version (as this monorepo does), `npx` resolves
+`stagebook` to that local package rather than fetching it — and fails if it
+isn't installed. In that case, run the action against a checkout that isn't
+inside the workspace (or `npm ci` first). This repo's own CI dogfood copies
+the fixtures to a temp directory for exactly this reason.
+
 ## Inputs
 
 | Input               | Default    | Description                                                                                       |

--- a/validate-action/action.yml
+++ b/validate-action/action.yml
@@ -1,0 +1,116 @@
+name: "Stagebook Validate"
+description: >-
+  Validate Stagebook treatment (.stagebook.yaml) and prompt (.prompt.md)
+  files in a repo with no JS toolchain — a thin wrapper around
+  `npx --package=stagebook stagebook validate`.
+author: "talkbench"
+branding:
+  icon: "check-circle"
+  color: "purple"
+
+inputs:
+  files:
+    description: >-
+      Files and/or globs to validate, whitespace- or newline-separated (a
+      YAML block scalar with one entry per line is clearest). The action
+      disables shell globbing internally and passes globs to the CLI intact
+      (it expands them recursively), so do NOT wrap entries in extra quotes.
+      See the action README for examples.
+    required: true
+  version:
+    description: >-
+      stagebook npm version to run: an exact version ("0.21.0"), a range,
+      or "latest" (default). Pin an exact version for reproducible
+      validation across runs.
+    required: false
+    default: "latest"
+  format:
+    description: 'Output format: "text" (default) or "json".'
+    required: false
+    default: "text"
+  node-version:
+    description: "Node.js version to set up."
+    required: false
+    default: "24"
+  working-directory:
+    description: "Directory to run validation in."
+    required: false
+    default: "."
+  allow-empty:
+    description: >-
+      When "true", a glob that matches no files is not an error
+      (passes --allow-empty). Default "false".
+    required: false
+    default: "false"
+  no-expand:
+    description: >-
+      When "true", skip template expansion + import resolution and check
+      raw syntax only (passes --no-expand). Default "false".
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-node@v5
+      with:
+        node-version: ${{ inputs.node-version }}
+    - name: Validate Stagebook files
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        SB_VERSION: ${{ inputs.version }}
+        SB_FILES: ${{ inputs.files }}
+        SB_FORMAT: ${{ inputs.format }}
+        SB_ALLOW_EMPTY: ${{ inputs.allow-empty }}
+        SB_NO_EXPAND: ${{ inputs.no-expand }}
+        MATCHER_DIR: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+
+        # Surface `path:line:col: severity: message` diagnostics as inline
+        # annotations on the PR. Additive only — the CLI's exit code (below)
+        # is what actually passes or fails the job.
+        if [ "$SB_FORMAT" != "json" ]; then
+          echo "::add-matcher::${MATCHER_DIR}/stagebook.problem-matcher.json"
+        fi
+
+        # Build one args array (always non-empty — starts with `validate`) so
+        # `"${args[@]}"` is safe under `set -u` even on bash < 4.4, where an
+        # empty-array expansion errors as "unbound variable".
+        # Constrain `version` to a plain npm version / range / dist-tag.
+        # `:` and `/` are the entry points for alias / git-URL / tarball /
+        # file specs (npm:, github:user/repo, https://…), which would
+        # redirect `--package=stagebook@<version>` to a different package.
+        # Defense-in-depth: the caller already controls their own job, but
+        # `format` is validated too and this keeps the wrapper honest.
+        case "$SB_VERSION" in
+          *[:/]*) echo "::error::input 'version' must be a version, range, or dist-tag (got '${SB_VERSION}')"; exit 2 ;;
+        esac
+
+        args=(validate)
+        case "$SB_FORMAT" in
+          text) ;;
+          json) args+=(--format=json) ;;
+          *) echo "::error::input 'format' must be 'text' or 'json' (got '${SB_FORMAT}')"; exit 2 ;;
+        esac
+        if [ "$SB_ALLOW_EMPTY" = "true" ]; then args+=(--allow-empty); fi
+        if [ "$SB_NO_EXPAND" = "true" ]; then args+=(--no-expand); fi
+
+        # Disable shell globbing so globs like '**/*.stagebook.yaml' reach the
+        # CLI intact. The CLI expands them recursively (tinyglobby); bash
+        # without `globstar` would expand `**` as a single level and silently
+        # under-match. Word-split `$SB_FILES` on whitespace/newlines with
+        # globbing off, appending each entry as a literal argument.
+        set -f
+        # shellcheck disable=SC2086
+        for entry in $SB_FILES; do args+=("$entry"); done
+        set +f
+
+        rc=0
+        npx --yes --package="stagebook@${SB_VERSION:-latest}" stagebook "${args[@]}" || rc=$?
+
+        if [ "$SB_FORMAT" != "json" ]; then
+          echo "::remove-matcher owner=stagebook::"
+        fi
+        exit "$rc"

--- a/validate-action/action.yml
+++ b/validate-action/action.yml
@@ -68,16 +68,6 @@ runs:
       run: |
         set -euo pipefail
 
-        # Surface `path:line:col: severity: message` diagnostics as inline
-        # annotations on the PR. Additive only — the CLI's exit code (below)
-        # is what actually passes or fails the job.
-        if [ "$SB_FORMAT" != "json" ]; then
-          echo "::add-matcher::${MATCHER_DIR}/stagebook.problem-matcher.json"
-        fi
-
-        # Build one args array (always non-empty — starts with `validate`) so
-        # `"${args[@]}"` is safe under `set -u` even on bash < 4.4, where an
-        # empty-array expansion errors as "unbound variable".
         # Constrain `version` to a plain npm version / range / dist-tag.
         # `:` and `/` are the entry points for alias / git-URL / tarball /
         # file specs (npm:, github:user/repo, https://…), which would
@@ -88,6 +78,9 @@ runs:
           *[:/]*) echo "::error::input 'version' must be a version, range, or dist-tag (got '${SB_VERSION}')"; exit 2 ;;
         esac
 
+        # Build one args array (always non-empty — starts with `validate`) so
+        # `"${args[@]}"` is safe under `set -u` even on bash < 4.4, where an
+        # empty-array expansion errors as "unbound variable".
         args=(validate)
         case "$SB_FORMAT" in
           text) ;;
@@ -106,6 +99,15 @@ runs:
         # shellcheck disable=SC2086
         for entry in $SB_FILES; do args+=("$entry"); done
         set +f
+
+        # Register the problem matcher only after inputs validate, so an early
+        # `exit 2` above can't leave it enabled for later steps in the job
+        # (matters under continue-on-error / if: always()). Text format only;
+        # surfaces `path:line:col: severity: message` diagnostics as inline PR
+        # annotations. Additive — the CLI's exit code is what passes/fails.
+        if [ "$SB_FORMAT" != "json" ]; then
+          echo "::add-matcher::${MATCHER_DIR}/stagebook.problem-matcher.json"
+        fi
 
         rc=0
         npx --yes --package="stagebook@${SB_VERSION:-latest}" stagebook "${args[@]}" || rc=$?

--- a/validate-action/fixtures-invalid/broken.prompt.md
+++ b/validate-action/fixtures-invalid/broken.prompt.md
@@ -1,0 +1,10 @@
+---
+type: multipleChoice
+name: Broken
+select: single
+---
+
+# Deliberately invalid: a multipleChoice prompt with no responses section
+
+This fixture is used by the CI dogfood's negative case — the action must
+exit non-zero (validation error) on it. Do NOT "fix" it.

--- a/validate-action/fixtures/modules/rating.prompt.md
+++ b/validate-action/fixtures/modules/rating.prompt.md
@@ -1,0 +1,16 @@
+---
+type: multipleChoice
+name: Rating
+select: single
+layout: vertical
+---
+
+# How clear were the instructions so far?
+
+---
+
+- Very clear
+- Somewhat clear
+- Neutral
+- Somewhat unclear
+- Very unclear

--- a/validate-action/fixtures/modules/survey.stagebook.yaml
+++ b/validate-action/fixtures/modules/survey.stagebook.yaml
@@ -1,0 +1,11 @@
+# Reusable module: a one-question survey template with no treatments of
+# its own. The `${prefix}` field on the named element lets a consumer
+# invoke it more than once without storage-key collisions.
+
+templates:
+  - name: mini_survey
+    contentType: elements
+    content:
+      - type: prompt
+        name: ${prefix}_rating
+        file: rating.prompt.md

--- a/validate-action/fixtures/study.stagebook.yaml
+++ b/validate-action/fixtures/study.stagebook.yaml
@@ -1,0 +1,37 @@
+# Fixture study for dogfooding the Stagebook validate GitHub Action.
+#
+# Kept intentionally small and on long-stable syntax: the dogfood job
+# exercises the ACTION mechanics (setup-node + npx + glob quoting +
+# import resolution + exit codes) end-to-end, not schema evolution. The
+# dogfood pins the published CLI (`stagebook@0.21.0` in ci.yml), so this
+# must stay valid against that release; bump both together when needed.
+#
+# Exercises: a treatment entry point, a referenced prompt file, and a
+# cross-file `imports:` module invoked with a `${prefix}` field.
+
+imports:
+  - ./modules/survey.stagebook.yaml
+
+introSequences:
+  - name: intro
+    introSteps:
+      - name: intake
+        elements:
+          - template: mini_survey
+            fields:
+              prefix: intake
+          - type: submitButton
+            buttonText: Continue
+
+treatments:
+  - name: fixture_demo
+    playerCount: 1
+    compatibleIntroSequences: [intro]
+    gameStages:
+      - name: main
+        duration: 60
+        elements:
+          - type: prompt
+            file: welcome.prompt.md
+          - type: submitButton
+            buttonText: Done

--- a/validate-action/fixtures/welcome.prompt.md
+++ b/validate-action/fixtures/welcome.prompt.md
@@ -1,0 +1,8 @@
+---
+name: welcome
+type: noResponse
+---
+
+# Welcome
+
+Thanks for taking part. Click **Done** when you are ready.

--- a/validate-action/stagebook.problem-matcher.json
+++ b/validate-action/stagebook.problem-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "stagebook",
+      "pattern": [
+        {
+          "regexp": "^(.+?):(\\d+):(\\d+):\\s+(error|warning):\\s+(.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "severity": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #441.

Publishes a composite GitHub Action at `validate-action/` that validates Stagebook treatment (`.stagebook.yaml`) and prompt (`.prompt.md`) files in **study repos that have no JS toolchain** — a thin wrapper around `npx --package=stagebook stagebook validate`. This finishes the validate-everywhere arc: the same validator now runs in the CLI, the editor, the viewer, and CI.

## What's here

- **`action.yml`** — `actions/setup-node` + a bash step that runs the published CLI. Inputs: `files` (required), `version` (default `latest`), `format`, `node-version`, `working-directory`, `allow-empty`, `no-expand`.
  - Disables shell globbing (`set -f`) so `**` globs reach the CLI's own recursive globber intact — bash without `globstar` would expand `**` as a single level and silently under-match (the glob-quoting gotcha from the issue).
  - Builds an always-non-empty `args` array so `"${args[@]}"` is safe under `set -u` even on bash < 4.4 (where an empty-array expansion errors).
  - Validates `version` (rejects `:`/`/`, which are the entry points for `npm:`/git/tarball/file specs that would redirect `--package`) and `format`.
- **`stagebook.problem-matcher.json`** — surfaces `path:line:col: severity: message` diagnostics as inline PR annotations (text format only).
- **`README.md`** — usage, glob-quoting guidance, the `working-directory`/annotation caveat, inputs, exit codes, versioning.
- **`fixtures/` + `fixtures-invalid/`** — a hermetic study repo (treatment + prompt + imported template module + multipleChoice prompt) plus one deliberately-broken prompt.
- **`ci.yml`** — an `action` paths-filter + a **dogfood** job (`uses: ./validate-action`, pinned to `0.21.0`) that runs valid text/json/no-expand and asserts the invalid fixture fails; scoped `permissions: contents: read`.

## Usage (once `v1` is tagged)

```yaml
- uses: actions/checkout@v5
- uses: talkbench/stagebook/validate-action@v1
  with:
    files: |
      stagebook/**/*.stagebook.yaml
      prompts/**/*.prompt.md
    version: "0.21.0"
```

## ⚠️ Post-merge action required

The README advertises `talkbench/stagebook/validate-action@v1`, **but that tag does not exist yet**. After this merges, create and maintain a floating major tag so consumers can pin `@v1`:

```bash
git tag -f v1 <merge-commit>   # and re-point v1 on each compatible change
git push -f origin v1
```
(Optionally an immutable `validate-action-v1.0.0` too.) Until `v1` exists, external `@v1` references will fail with "tag not found."

## Verification

- Real `npx --package=stagebook@0.21.0` end-to-end: valid fixtures → 0, broken prompt → 1, zero-match glob → 2, `--allow-empty` → 0.
- Args word-splitting (block-scalar + space-separated) verified on `/bin/bash` 3.2 (strictest) → globs reach the CLI literally.
- `act` confirmed the composite structure, `setup-node`, and `::add-matcher::`/`::remove-matcher::` registration (its only failure was npx PATH propagation inside a composite step — a known `act` limitation; the CI dogfood job is the authoritative end-to-end).
- Folded in a 3-subagent review (correctness / security / coverage): `version` validation, job `permissions`, expanded dogfood (json/no-expand/negative), and the space/working-directory docs.

## Discovered (separate, out of scope)

The dogfood approach surfaced that **4 example prompts fail validation** (`examples/{ultimatum-game,prisoners-dilemma,survey-experiment}/prompts/*.prompt.md` — openResponse/multipleChoice missing the third "responses" section), and `examples/` is validated **nowhere** in CI. Filing/fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)