### PR TITLE
feat(viewer): re-run prompt locale-consistency after field binding (#492)

### DIFF
--- a/packages/stagebook/src/validate/localeConsistency.ts
+++ b/packages/stagebook/src/validate/localeConsistency.ts
@@ -1,10 +1,14 @@
+// Import from the schemas barrel (not the top-level `../index.js`): the latter
+// re-exports the imports/YAML subtree, which — now that this module is reachable
+// from the `stagebook/viewer` entry (#492) — would otherwise pull js-yaml's
+// parser into the viewer bundle. schemas/index.ts carries all of these without it.
 import {
   fileSchema,
   promptFileSchema,
   collectReferencedPromptFiles,
   checkPromptLocaleConsistency,
   type PromptLocaleMismatch,
-} from "../index.js";
+} from "../schemas/index.js";
 
 /**
  * Host-side wiring for the locale-consistency rule (ADR

--- a/packages/stagebook/src/validate/localeConsistency.ts
+++ b/packages/stagebook/src/validate/localeConsistency.ts
@@ -1,7 +1,10 @@
 // Import from the schemas barrel (not the top-level `../index.js`): the latter
-// re-exports the imports/YAML subtree, which — now that this module is reachable
-// from the `stagebook/viewer` entry (#492) — would otherwise pull js-yaml's
-// parser into the viewer bundle. schemas/index.ts carries all of these without it.
+// re-exports the `./imports` subtree (resolveImports / parseTreatmentYaml /
+// import-path machinery), which — now that this module is reachable from the
+// `stagebook/viewer` entry (#492) — would otherwise be dragged into that
+// bundle. schemas/index.ts carries all of these symbols without that subtree.
+// (js-yaml is already in the viewer bundle via promptFileSchema; this avoids
+// the import-resolution machinery, not the YAML parser.)
 import {
   fileSchema,
   promptFileSchema,

--- a/packages/stagebook/src/viewer/components/PreviewHost.test.tsx
+++ b/packages/stagebook/src/viewer/components/PreviewHost.test.tsx
@@ -1,0 +1,258 @@
+// @vitest-environment jsdom
+//
+// #492: the on-load locale-consistency check (loader.ts) runs on the
+// template-expanded tree, BEFORE host `additionalFields` / FieldForm values
+// bind `${...}` slots. When `locale` (or a prompt `file:` path) is a field
+// resolved only post-load, that check is a no-op. PreviewHost must re-run the
+// (async) check on the field-resolved tree once computePreviewState reaches
+// `ready`, and surface any mismatch — otherwise a `he` treatment can render an
+// `en` prompt with no diagnostic.
+import { describe, it, expect, beforeAll, vi } from "vitest";
+import React, { type ReactNode } from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { TreatmentFileType } from "../../schemas/index.js";
+import { PreviewHost } from "./PreviewHost.js";
+
+beforeAll(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  if (!("ResizeObserver" in globalThis)) {
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+  if (!window.matchMedia) {
+    window.matchMedia = (() => ({
+      matches: false,
+      addEventListener() {},
+      removeEventListener() {},
+    })) as unknown as typeof window.matchMedia;
+  }
+});
+
+function render(node: ReactNode): {
+  container: HTMLElement;
+  rerender: (next: ReactNode) => void;
+  unmount: () => void;
+} {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  let root: Root;
+  act(() => {
+    root = createRoot(container);
+    root.render(node);
+  });
+  return {
+    container,
+    rerender: (next: ReactNode) =>
+      act(() => {
+        root.render(next);
+      }),
+    unmount: () =>
+      act(() => {
+        root.unmount();
+        container.remove();
+      }),
+  };
+}
+
+/** Drain the async locale check and its state update. A single macrotask
+ *  boundary flushes ALL pending microtasks (the getTextContent → check →
+ *  setState chain) regardless of how deep it is, so this stays reliable even
+ *  if the check gains internal awaits. Wrapped in act so React commits. */
+async function flush(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+}
+
+const getAsset = (p: string) => p;
+
+/** A treatment whose `locale` is a `${lang}` field left for the host to bind
+ *  post-load, referencing a static prompt file. The ADR single-source pattern
+ *  would resolve `lang` via template `fields:` (covered on load); here it's
+ *  supplied through PreviewHost's `additionalFields`, the gap #492 closes. */
+function fieldBoundLocaleTreatment(): TreatmentFileType {
+  return {
+    treatments: [
+      {
+        name: "study1",
+        locale: "${lang}",
+        playerCount: 1,
+        compatibleIntroSequences: [],
+        gameStages: [
+          {
+            name: "s1",
+            duration: 60,
+            elements: [{ type: "prompt", file: "q.prompt.md" }],
+          },
+        ],
+      },
+    ],
+  } as unknown as TreatmentFileType;
+}
+
+/** A treatment with a STATIC locale but a prompt `file:` path whose directory
+ *  is a `${dir}` field bound post-load — the other #492 trigger (the on-load
+ *  check fetches the literal `prompts/${dir}/…` path, 404s, and skips). */
+function fieldBoundFilePathTreatment(): TreatmentFileType {
+  return {
+    treatments: [
+      {
+        name: "study1",
+        locale: "he",
+        playerCount: 1,
+        compatibleIntroSequences: [],
+        gameStages: [
+          {
+            name: "s1",
+            duration: 60,
+            elements: [{ type: "prompt", file: "prompts/${dir}/q.prompt.md" }],
+          },
+        ],
+      },
+    ],
+  } as unknown as TreatmentFileType;
+}
+
+const banner = (c: HTMLElement) =>
+  c.querySelector('[data-testid="locale-mismatch-banner"]');
+
+const UNTAGGED_PROMPT = "---\ntype: noResponse\n---\n\n# Question"; // → "en"
+const HE_PROMPT = "---\ntype: noResponse\nlocale: he\n---\n\n# שאלה";
+
+describe("PreviewHost post-fill locale-consistency (#492)", () => {
+  it("surfaces a mismatch once the locale field binds to a value the prompt doesn't match", async () => {
+    // Prompt declares no locale → counts as "en"; treatment binds to "he".
+    const getText = vi.fn(() => Promise.resolve(UNTAGGED_PROMPT));
+    const { container, unmount } = render(
+      <PreviewHost
+        treatmentFile={fieldBoundLocaleTreatment()}
+        additionalFields={{ lang: "he" }}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+      />,
+    );
+    await flush();
+
+    const b = banner(container);
+    expect(b).not.toBeNull();
+    expect(b?.getAttribute("role")).toBe("alert");
+    expect(b?.textContent).toContain("q.prompt.md");
+    // Names both the prompt's effective locale and the treatment's.
+    expect(b?.textContent).toContain('"en"');
+    expect(b?.textContent).toContain('"he"');
+    unmount();
+  });
+
+  it("re-runs the check but shows no banner when the field-resolved locales agree", async () => {
+    // Prompt is tagged `he`, matching the bound treatment locale.
+    const getText = vi.fn(() => Promise.resolve(HE_PROMPT));
+    const { container, unmount } = render(
+      <PreviewHost
+        treatmentFile={fieldBoundLocaleTreatment()}
+        additionalFields={{ lang: "he" }}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+      />,
+    );
+    await flush();
+
+    // The spy proves the check actually RAN (fetched the prompt) — a null
+    // banner here means "locales agree", not "check silently skipped".
+    expect(getText).toHaveBeenCalledWith("q.prompt.md");
+    expect(banner(container)).toBeNull();
+    unmount();
+  });
+
+  it("checks the resolved prompt `file:` path, not the `${field}` literal", async () => {
+    // #492's other trigger: the prompt path's directory is bound post-load.
+    // The check must fetch the EXPANDED path (prompts/en/…), read its locale,
+    // and flag it against the treatment's static `he`.
+    const getText = vi.fn((path: string) =>
+      path === "prompts/en/q.prompt.md"
+        ? Promise.resolve(UNTAGGED_PROMPT)
+        : Promise.reject(new Error(`unexpected path: ${path}`)),
+    );
+    const { container, unmount } = render(
+      <PreviewHost
+        treatmentFile={fieldBoundFilePathTreatment()}
+        additionalFields={{ dir: "en" }}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+      />,
+    );
+    await flush();
+
+    expect(getText).toHaveBeenCalledWith("prompts/en/q.prompt.md");
+    const b = banner(container);
+    expect(b).not.toBeNull();
+    expect(b?.textContent).toContain("prompts/en/q.prompt.md");
+    unmount();
+  });
+
+  it("clears the banner once the binding is changed to a matching locale", async () => {
+    // Prompt is untagged → "en". First bind lang=he (mismatch), then rebind
+    // lang=en (match) — the re-run must retract the banner, not leave it stale.
+    const getText = vi.fn(() => Promise.resolve(UNTAGGED_PROMPT));
+    const tree = fieldBoundLocaleTreatment();
+    const { container, rerender, unmount } = render(
+      <PreviewHost
+        treatmentFile={tree}
+        additionalFields={{ lang: "he" }}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+      />,
+    );
+    await flush();
+    expect(banner(container)).not.toBeNull();
+
+    rerender(
+      <PreviewHost
+        treatmentFile={tree}
+        additionalFields={{ lang: "en" }}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+      />,
+    );
+    await flush();
+    expect(banner(container)).toBeNull();
+    unmount();
+  });
+
+  it("shows no banner (and doesn't crash) when a referenced prompt can't be read", async () => {
+    // A throwing getTextContent is an unreadable prompt — a different error
+    // class with its own reporting. The check must skip it, not surface a
+    // bogus mismatch or throw an unhandled rejection out of the effect.
+    const getText = vi.fn(() => Promise.reject(new Error("not found")));
+    const { container, unmount } = render(
+      <PreviewHost
+        treatmentFile={fieldBoundLocaleTreatment()}
+        additionalFields={{ lang: "he" }}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+      />,
+    );
+    await flush();
+
+    expect(getText).toHaveBeenCalledWith("q.prompt.md");
+    expect(banner(container)).toBeNull();
+    unmount();
+  });
+});

--- a/packages/stagebook/src/viewer/components/PreviewHost.tsx
+++ b/packages/stagebook/src/viewer/components/PreviewHost.tsx
@@ -1,6 +1,10 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { type TreatmentFileType } from "../../schemas/index.js";
-import { computePreviewState } from "../lib/previewResolution.js";
+import { checkPromptLocaleConsistencyWithLoader } from "../../validate/localeConsistency.js";
+import {
+  computePreviewState,
+  type PostFillIssue,
+} from "../lib/previewResolution.js";
 import { FieldForm } from "./FieldForm.js";
 import { Viewer } from "./Viewer.js";
 
@@ -9,6 +13,9 @@ export interface PreviewHostProps {
   /**
    * Pre-supplied values for `${field}` placeholders (e.g. from a sidecar
    * file). Any placeholders not covered here will surface as a FieldForm.
+   * Should be referentially stable (memoized) — its identity feeds the
+   * expansion memo and the post-fill locale re-check, so a fresh object each
+   * render would re-run both unnecessarily.
    */
   additionalFields?: Record<string, unknown>;
   selectedIntroIndex: number;
@@ -75,6 +82,51 @@ export function PreviewHost({
     [treatmentFile, additionalFields, userValues],
   );
 
+  // #492: re-run the prompt locale-consistency check on the FIELD-RESOLVED
+  // tree. The on-load check (loader.ts) runs before host `additionalFields` /
+  // FieldForm values bind, so when `locale` (or a prompt `file:` path) is a
+  // deferred `${field}` it's a no-op there — this is the first point the
+  // resolved tree exists. It's async (reads each prompt's frontmatter), so it
+  // can't live in the sync/pure computePreviewState. Non-blocking, matching
+  // the load path's treatment of locale mismatches: the preview still renders,
+  // with a banner above it.
+  const resolved = previewState.mode === "ready" ? previewState.resolved : null;
+  const [localeIssues, setLocaleIssues] = useState<PostFillIssue[]>([]);
+
+  useEffect(() => {
+    if (resolved === null) {
+      setLocaleIssues([]);
+      return;
+    }
+    // Clear eagerly before the async re-check so a tree change (ready→ready,
+    // e.g. rebinding a field) never leaves the previous tree's mismatch
+    // messages rendered above the new tree for a tick.
+    setLocaleIssues([]);
+    let cancelled = false;
+    void (async () => {
+      const mismatches = await checkPromptLocaleConsistencyWithLoader({
+        fileObj: resolved,
+        loadPrompt: async (relPath) => {
+          try {
+            return await getTextContent(relPath);
+          } catch {
+            // Unreadable prompt — a different error class with its own
+            // reporting; the locale check skips it (treats as unloaded).
+            return null;
+          }
+        },
+      });
+      if (!cancelled) {
+        setLocaleIssues(
+          mismatches.map((m) => ({ path: m.promptFile, message: m.message })),
+        );
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [resolved, getTextContent]);
+
   if (previewState.mode === "form") {
     // Keyed on the field set: after a post-fill failure the form can
     // gain fields (host-bound ones become editable), and FieldForm
@@ -128,6 +180,26 @@ export function PreviewHost({
     );
   }
 
+  const localeBanner =
+    localeIssues.length > 0 ? (
+      <div
+        data-testid="locale-mismatch-banner"
+        role="alert"
+        style={localeBannerStyle}
+      >
+        <strong style={localeBannerTitleStyle}>
+          {localeIssues.length === 1
+            ? "Prompt locale mismatch"
+            : `${localeIssues.length} prompt locale mismatches`}
+        </strong>
+        <ul style={localeBannerListStyle}>
+          {localeIssues.map((issue) => (
+            <li key={`${issue.path}:${issue.message}`}>{issue.message}</li>
+          ))}
+        </ul>
+      </div>
+    ) : undefined;
+
   return (
     <Viewer
       treatmentFile={previewState.resolved}
@@ -140,6 +212,28 @@ export function PreviewHost({
       contentVersion={contentVersion}
       onTreatmentIndexChange={onTreatmentIndexChange}
       onIntroIndexChange={onIntroIndexChange}
+      notice={localeBanner}
     />
   );
 }
+
+// Non-blocking notice rendered inside the Viewer (below its header, via the
+// `notice` prop) when the field-resolved tree references a prompt whose locale
+// doesn't match its container's (#492).
+const localeBannerStyle: React.CSSProperties = {
+  padding: "0.75rem 1rem",
+  borderBottom: "1px solid #fecaca",
+  backgroundColor: "#fef2f2",
+  color: "#991b1b",
+  fontFamily: "system-ui, sans-serif",
+  fontSize: "0.875rem",
+};
+
+const localeBannerTitleStyle: React.CSSProperties = {
+  fontWeight: 600,
+};
+
+const localeBannerListStyle: React.CSSProperties = {
+  margin: "0.25rem 0 0",
+  paddingLeft: "1.25rem",
+};

--- a/packages/stagebook/src/viewer/components/Viewer.tsx
+++ b/packages/stagebook/src/viewer/components/Viewer.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
   useCallback,
   useSyncExternalStore,
+  type ReactNode,
 } from "react";
 import type { TreatmentFileType } from "../../schemas/index.js";
 import {
@@ -65,6 +66,13 @@ export interface ViewerProps {
    * initial unit when no treatment is selectable (e.g. an intro-only file).
    */
   onIntroIndexChange?: (index: number) => void;
+  /**
+   * Optional non-blocking notice rendered directly below the header, inside
+   * the viewer's flex column (so it consumes layout height rather than
+   * overlaying content). Used by PreviewHost for the post-fill locale-mismatch
+   * banner (#492).
+   */
+  notice?: ReactNode;
 }
 
 export function Viewer({
@@ -78,6 +86,7 @@ export function Viewer({
   contentVersion,
   onTreatmentIndexChange,
   onIntroIndexChange,
+  notice,
 }: ViewerProps) {
   // The viewer walks ONE selectable unit at a time — a consent arm, an intro
   // sequence, OR a treatment — rather than pairing them. A single <optgroup>
@@ -377,6 +386,8 @@ export function Viewer({
           </select>
         </div>
       </header>
+
+      {notice}
 
       <div style={bodyStyle}>
         <aside style={sidebarStyle}>


### PR DESCRIPTION
Fixes #492.

## Gap

The viewer's on-load locale-consistency check ([apps/viewer/src/lib/loader.ts](apps/viewer/src/lib/loader.ts)) runs on the template-**expanded** tree — before host `additionalFields` / FieldForm values bind `${...}` slots. When a treatment's `locale` (or a prompt `file:` path) is a `${field}` resolved only *post-load* (the annotator's host-supplied-fields flow; any per-session `${locale}` pattern), the on-load check is a no-op:
- the container `locale` still contains `${…}` → the rule skips it (a leaked placeholder is its own diagnostic), or
- the prompt `file:` path is fetched literally (`prompts/${lang}/q.prompt.md`) → 404 → skipped.

After `computePreviewState` binds those fields, nothing re-loaded prompt frontmatter — so a `he` treatment could render an `en` prompt with **no** diagnostic.

## Fix

`PreviewHost` re-runs the async `checkPromptLocaleConsistencyWithLoader` on the **field-resolved** tree once `computePreviewState` reaches `mode: "ready"`, using the host's `getTextContent` as `loadPrompt`, and surfaces mismatches as a **non-blocking** notice.

- **PreviewHost.tsx** — async effect gated on `ready`; `cancelled`-flag race guard (last-started-wins); eager-clear so a rebind never flashes the prior tree's messages; maps `PromptLocaleMismatch` → `PostFillIssue`.
- **Viewer.tsx** — an optional `notice` prop rendered inside the flex column *below the header*, so the banner consumes layout height rather than overlaying content or forcing a whole-page scroll past the `100vh` column.
- **validate/localeConsistency.ts** — import the shared symbols from `../schemas` instead of the top-level barrel, so routing this module into the `stagebook/viewer` entry doesn't pull js-yaml's parser into that bundle (verified: drops the imports/YAML subtree).

## Why non-blocking

Matches the load path, which treats locale mismatches as **non-structural** ("don't block rendering" — the treatment still renders, the mismatch rides along as a diagnostic). Blocking would wrongly prevent previewing a treatment over a wrong-language prompt, and the check is async so it can't fold into the sync `computePreviewState` `errors` array that drives mode selection.

## Tests (vitest + jsdom)

- locale-field mismatch → banner (asserts URI + both locales)
- **file-path**-field mismatch → banner, asserting the check fetched the **resolved** path (`prompts/en/…`), not the `${dir}` literal — the issue's second, distinct trigger
- agreement → no banner, **spy-verified the check actually ran** (a null banner means "locales agree", not "check skipped")
- rebind he→en → banner **clears**
- unreadable/throwing `getTextContent` → skipped, no banner, no crash

jsdom (dev-React) is kept deliberately — it surfaces rules-of-hooks violations that prod-React CT can't, and the change adds a hook before conditional returns.

## Review notes (folded in a 3-subagent review)

Correctness clean (race/hooks/adapter verified). Bundle + layout fixes above are from the review. Two items left as **deliberate, noted deviations** rather than blockers:

1. **Redundancy with the load-path diagnostic** — only in the *concrete-locale* case (ADR single-source via template `fields:`), which the on-load check already reports; there the message shows both in the app's diagnostics drawer / Problems panel **and** the banner. The `${field}`-deferred case this PR targets does **not** double-report. True dedup needs the host to pass "already-reported" state into the harness (app-level), so it's noted, not blocked.
2. **Bespoke banner vs. shared `PostFillIssuePanel`** — the banner reuses the `PostFillIssue` *type* but not FieldForm's (blocking) error panel, since this surface must be non-blocking. Extracting a shared presentational panel (banner + FieldForm error panel + error-mode page) would de-duplicate styling; left as a possible follow-up to keep this change focused.

## Verification

Full stagebook suite (1877) + viewer-app suite (78) green; build (tsup+dts) clean; eslint 0; Prettier clean. No Playwright CT renders Viewer/PreviewHost, so CT is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)