### PR TITLE
Bump stagebook to 0.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13392,7 +13392,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Minor release adding the `getRequiredServices` host provisioning primitive.

## What's in

- **#510** — `getRequiredServices(hydratedFile, { loadPrompt })` in `stagebook/validate`: walks a hydrated treatment and reports which external services it requires, keyed by launch arm (`overall`, `byTreatment`, `byIntroSequence`, `byConsent`). A host (the manager) can provision exactly what the selected launch uses — coedit pod, Daily/WebRTC key, Qualtrics credentials — instead of always-on, and fail batch-open early when a required credential is missing. Ships with the `mergeRequiredServices` helper and the `RequiredServices` / `RequiredServicesReport` types.

## Compatibility

- No breaking changes — purely additive new exports from `stagebook/validate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)