### PR TITLE
chore: complete deliberation-lab → talkbench rename

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -45,7 +45,7 @@ The commit subject must follow the format `chore(release): bump stagebook to X.Y
 
 ## 3. Open the release PR
 
-Use this body shape (mirror what prior releases like [v0.10.4](https://github.com/deliberation-lab/stagebook/releases/tag/v0.10.4) and [v0.10.3](https://github.com/deliberation-lab/stagebook/releases/tag/v0.10.3) look like):
+Use this body shape (mirror what prior releases like [v0.10.4](https://github.com/talkbench/stagebook/releases/tag/v0.10.4) and [v0.10.3](https://github.com/talkbench/stagebook/releases/tag/v0.10.3) look like):
 
 ```
 Patch release picking up <one-line summary>.
@@ -131,7 +131,7 @@ gh issue view 360 --json state,closedAt
 For any that's still `OPEN`, close it with a reference to the PR + release tag:
 
 ```sh
-gh issue close <NNN> --comment "Fixed in #<PR> (released as [v<X.Y.Z>](https://github.com/deliberation-lab/stagebook/releases/tag/v<X.Y.Z>)). <one-line summary of what landed>"
+gh issue close <NNN> --comment "Fixed in #<PR> (released as [v<X.Y.Z>](https://github.com/talkbench/stagebook/releases/tag/v<X.Y.Z>)). <one-line summary of what landed>"
 ```
 
 ## What to avoid

--- a/.github/AGENT_INSTRUCTIONS.md
+++ b/.github/AGENT_INSTRUCTIONS.md
@@ -38,7 +38,7 @@ cloud sessions) working issues in this repo.
 9. Once CI is green, **mark the PR ready for review**
    (`gh pr ready <number>`). This triggers Copilot review.
 10. Wait for Copilot review comments
-    (`gh api repos/deliberation-lab/stagebook/pulls/<number>/comments`).
+    (`gh api repos/talkbench/stagebook/pulls/<number>/comments`).
     Address each with a follow-up commit, push, and re-check CI.
 11. Once CI is green and all Copilot comments are addressed, comment on the
     PR: **"Ready for review — @jamesphoughton"** and stop.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
       #      `--no-sandbox`. Fix: set `container.options: --user 1001`
       #      (matches the runner's UID) OR add `args: ["--no-sandbox"]`
       #      to the chromium launch options in playwright-ct.config.ts.
-      #      deliberation-lab's playwright_component.yml uses the
+      #      runner's playwright_component.yml uses the
       #      `--user 1001` form.
       #   2. The image tag MUST track the `@playwright/experimental-
       #      ct-react` version in package-lock.json (two places to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ stagebook/                          # workspace root
 - `stagebook` — schemas, utils, templates (no React dependency)
 - `stagebook/components` — React components, StagebookProvider (peer-depends on React)
 - `stagebook/viewer` — the reusable preview harness (`PreviewHost`, `Viewer`, introspection utils, mock state store, content-fn helpers). Wraps the `stagebook/components` rendering contract with a mock provider + dev chrome; zero-I/O (hosts supply content via callbacks), peer-depends on React. Consumed by the standalone viewer app (`apps/viewer`), the VS Code extension preview (`apps/vscode`), and external hosts (e.g. TalkBench's preview lens). **Rule of thumb: components render, validate diagnoses, viewer harnesses.**
-- `stagebook/validate` — `validateTreatmentSource`, `validatePromptSource`, `loadAndMergeImports`, `expandAndValidateWithImports`, `Diagnostic` type, and position-mapping helpers. Used by the VS Code extension, the viewer, and the CLI; consumed externally by manager / deliberation-lab / annotator
+- `stagebook/validate` — `validateTreatmentSource`, `validatePromptSource`, `loadAndMergeImports`, `expandAndValidateWithImports`, `Diagnostic` type, and position-mapping helpers. Used by the VS Code extension, the viewer, and the CLI; consumed externally by manager / runner / annotator
 - `stagebook` bin — the `stagebook` CLI (subcommands: `validate`). Reached via `npx --package=stagebook stagebook <cmd>` in study repos that don't otherwise have a JS toolchain
 
 Each directory has an `index.ts` barrel; `src/index.ts` re-exports the full public API for the main entrypoint.

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ This repository provides supporting infrastructure for translating stagebook man
 
 Stagebook is platform-agnostic. Define your study protocol once, then run it on any compatible platform.
 
-**[Try the Viewer](https://deliberation-lab.github.io/stagebook/viewer/)** — walk through any study from the participant's perspective. Paste a GitHub URL to a treatment file, or explore the built-in examples.
+**[Try the Viewer](https://talkbench.github.io/stagebook/viewer/)** — walk through any study from the participant's perspective. Paste a GitHub URL to a treatment file, or explore the built-in examples.
 
 ## Installation
 
 From GitHub (builds automatically on install):
 
 ```bash
-npm install deliberation-lab/stagebook
+npm install talkbench/stagebook
 ```
 
 Peer dependencies: `zod >= 3.23`, `js-yaml >= 4`. React components additionally peer-depend on `react >= 18` and `react-dom >= 18`.

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -3,12 +3,12 @@
   "displayName": "Stagebook",
   "description": "Validation, syntax highlighting, and preview for Stagebook treatment and prompt files",
   "version": "0.1.0",
-  "publisher": "deliberation-lab",
+  "publisher": "talkbench",
   "private": true,
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/deliberation-lab/stagebook.git",
+    "url": "https://github.com/talkbench/stagebook.git",
     "directory": "apps/vscode"
   },
   "engines": {

--- a/docs/decisions/2026-04-syntax-review-migration.md
+++ b/docs/decisions/2026-04-syntax-review-migration.md
@@ -508,14 +508,14 @@ synthesises the cross-cutting "why" patterns.
 
 Cross-cutting rationale: [`docs/decisions/principles.md`](principles.md).
 
-[#235]: https://github.com/deliberation-lab/stagebook/issues/235
-[#238]: https://github.com/deliberation-lab/stagebook/issues/238
-[#240]: https://github.com/deliberation-lab/stagebook/issues/240
-[#243]: https://github.com/deliberation-lab/stagebook/issues/243
-[#244]: https://github.com/deliberation-lab/stagebook/issues/244
-[#245]: https://github.com/deliberation-lab/stagebook/issues/245
-[#246]: https://github.com/deliberation-lab/stagebook/issues/246
-[#247]: https://github.com/deliberation-lab/stagebook/issues/247
-[#248]: https://github.com/deliberation-lab/stagebook/issues/248
-[#249]: https://github.com/deliberation-lab/stagebook/issues/249
-[#250]: https://github.com/deliberation-lab/stagebook/issues/250
+[#235]: https://github.com/talkbench/stagebook/issues/235
+[#238]: https://github.com/talkbench/stagebook/issues/238
+[#240]: https://github.com/talkbench/stagebook/issues/240
+[#243]: https://github.com/talkbench/stagebook/issues/243
+[#244]: https://github.com/talkbench/stagebook/issues/244
+[#245]: https://github.com/talkbench/stagebook/issues/245
+[#246]: https://github.com/talkbench/stagebook/issues/246
+[#247]: https://github.com/talkbench/stagebook/issues/247
+[#248]: https://github.com/talkbench/stagebook/issues/248
+[#249]: https://github.com/talkbench/stagebook/issues/249
+[#250]: https://github.com/talkbench/stagebook/issues/250

--- a/docs/decisions/2026-06-localization.md
+++ b/docs/decisions/2026-06-localization.md
@@ -369,7 +369,7 @@ Consumer caveats (corrected after the consumer-integration review — the
 - **Frontmatter `locale`** must be added to the shared `baseMetadataFields` (not
   per-type), because each metadata schema is `.strict()`.
 - **Playwright fallout is small** — a re-check found near-zero literal-`aria-label`
-  selectors in deliberation-lab and none in stagebook's own CT. Where they
+  selectors in runner and none in stagebook's own CT. Where they
   exist, assert against `defaultMessages.en.*` to decouple from copy. (Note the
   viewer's own "Waiting for other participants…" overlay is host-owned, not a
   stagebook catalog string.)
@@ -415,9 +415,9 @@ it needed).
 9. **Agent checklist** — `docs/localization-review-checklist.md` (may later
    graduate into a `.claude/skills/` verify-skill).
 10. **Consumer wiring** — viewer (`createViewerContext` + memo dep) and the
-    deliberation-lab adapter (net-new `game.get("treatment").locale` read, memo
+    runner adapter (net-new `game.get("treatment").locale` read, memo
     dep) set `locale` from the treatment, **gated on the DL server-side
     treatment-field passthrough**; right-size any literal-aria-label selectors.
 
-[#438]: https://github.com/deliberation-lab/stagebook/issues/438
-[#479]: https://github.com/deliberation-lab/stagebook/issues/479
+[#438]: https://github.com/talkbench/stagebook/issues/438
+[#479]: https://github.com/talkbench/stagebook/issues/479

--- a/docs/decisions/2026-07-consent-debrief.md
+++ b/docs/decisions/2026-07-consent-debrief.md
@@ -3,13 +3,13 @@
 Status: **accepted** — design settled in the [#481] comment thread
 (2026-07-02/03); this ADR records the outcome. Phase 1 (stagebook library
 + viewer) is implemented by the PR that links here; Phase 2
-(deliberation-lab integration + boilerplate library) follows in the host
+(runner integration + boilerplate library) follows in the host
 repo. Builds on the intro-sequence pairing model of [#499]
 ([2026-07-intro-sequence-pairing.md](./2026-07-intro-sequence-pairing.md)).
 
-[#481]: https://github.com/deliberation-lab/stagebook/issues/481
-[#499]: https://github.com/deliberation-lab/stagebook/issues/499
-[#479]: https://github.com/deliberation-lab/stagebook/issues/479
+[#481]: https://github.com/talkbench/stagebook/issues/481
+[#499]: https://github.com/talkbench/stagebook/issues/499
+[#479]: https://github.com/talkbench/stagebook/issues/479
 
 ## Motivation
 
@@ -53,7 +53,7 @@ responses plus the version-controlled content ARE the consent record.**
 | 10  | Step rules          | Consent steps get intro-style restrictions (advancement element required, no `shared` prompts, no position fields — pre-assignment, single participant); debrief gets exit-style (advancement + no shared).                                              |
 | 11  | Locale              | Consent arms declare their **own** locale (pre-assignment, like intro sequences); debrief inherits the treatment's. The locale-consistency rule covers both (new "consent arm" container kind).                                                          |
 | 12  | Templates           | New content types `consentArm` / `consent` / `debriefSteps` — a single-source `consentArm` template with `${locale}` broadcasts to one arm per locale, same pattern as the i18n gallery's treatments.                                                    |
-| 13  | Boilerplate         | **Per-institution**, not one global library: institutions maintain their own importable consent modules (e.g. `imports: [@your-inst/consent-gdpr]`) carrying their jurisdiction/IRB language; studies compose those + a study-specific addendum. This is where the institution-defaulting responsibility lands once deliberation-lab's hardcoded US/UK/EU statements are retired. Collisions with study keys surface as design-time validation errors; module authors use distinctive key names.                             |
+| 13  | Boilerplate         | **Per-institution**, not one global library: institutions maintain their own importable consent modules (e.g. `imports: [@your-inst/consent-gdpr]`) carrying their jurisdiction/IRB language; studies compose those + a study-specific addendum. This is where the institution-defaulting responsibility lands once runner's hardcoded US/UK/EU statements are retired. Collisions with study keys surface as design-time validation errors; module authors use distinctive key names.                             |
 
 ## Alternatives considered
 
@@ -93,7 +93,7 @@ interstitials narrating the platform steps it can't simulate.
 
 - Purely additive at the schema level — no migration (the breaking
   change of this release cycle is [#499]'s, which ships first).
-- deliberation-lab Phase 2: `consentName` selector, render consent first
+- runner Phase 2: `consentName` selector, render consent first
   / debrief last via the existing `GenericIntroExitStep` seam, retire
   the hardcoded legal statements, keep the markdown fallback.
 - Phase 3 (later): i18n-completeness warning (treatment locale with no

--- a/docs/decisions/2026-07-intro-sequence-pairing.md
+++ b/docs/decisions/2026-07-intro-sequence-pairing.md
@@ -4,9 +4,9 @@ Status: **accepted** — design settled in [#499] (see its comment thread for
 the full discussion, including the relationship to consent/debrief in
 [#481]). Implemented by the PR that links here.
 
-[#499]: https://github.com/deliberation-lab/stagebook/issues/499
-[#481]: https://github.com/deliberation-lab/stagebook/issues/481
-[#480]: https://github.com/deliberation-lab/stagebook/issues/480
+[#499]: https://github.com/talkbench/stagebook/issues/499
+[#481]: https://github.com/talkbench/stagebook/issues/481
+[#480]: https://github.com/talkbench/stagebook/issues/480
 
 ## Motivation
 
@@ -96,7 +96,7 @@ Key semantics:
 
 - Major version bump; every consumer's treatment files add
   `compatibleIntroSequences:` to each treatment (see the consumer issues filed from
-  [#499] for deliberation-lab, manager, annotator).
+  [#499] for runner, manager, annotator).
 - Hosts gain a launch-time guard (`checkPairing`) at the point where
   batch config selects `introSequenceName` + `treatments`.
 - The unsatisfiable-conditions rule ([#480]) and future cross-phase

--- a/docs/engineer/adding-a-locale.md
+++ b/docs/engineer/adding-a-locale.md
@@ -145,7 +145,7 @@ exercises that path. See the ADR's "Right-to-left" section.
 
 - **No consumer changes.** The public `locale` prop stays an open `string` with
   a runtime registered-set check (unknown → `en` + a `console.warn`). Adding a
-  locale touches stagebook's catalog, never deliberation-lab / annotator types —
+  locale touches stagebook's catalog, never runner / annotator types —
   it's backward compatible by construction.
 - **No browser detection.** Stagebook never reads the browser locale; the active
   locale comes from the treatment / intro sequence declaration. Assignment of

--- a/docs/engineer/integration-guide.md
+++ b/docs/engineer/integration-guide.md
@@ -130,7 +130,7 @@ If your file doesn't use `imports:`, the resolve step is a no-op (`importedTempl
 
 ### Diff orchestrator (for live editor diagnostics)
 
-The VS Code extension runs the same pipeline plus a [diff orchestrator](https://github.com/deliberation-lab/stagebook/issues/321) that distinguishes "real bug in both source and hydrated form" from "templating artifact that disappears after expansion." If your tooling needs the same fine-grained diagnostic routing (e.g., to display templating artifacts as warnings instead of errors), use `runValidationDiff`:
+The VS Code extension runs the same pipeline plus a [diff orchestrator](https://github.com/talkbench/stagebook/issues/321) that distinguishes "real bug in both source and hydrated form" from "templating artifact that disappears after expansion." If your tooling needs the same fine-grained diagnostic routing (e.g., to display templating artifacts as warnings instead of errors), use `runValidationDiff`:
 
 ```typescript
 import { runValidationDiff } from "stagebook";

--- a/docs/engineer/platform-requirements.md
+++ b/docs/engineer/platform-requirements.md
@@ -307,7 +307,7 @@ through to the JSONL export next to the host's other per-stage fields.
 Stagebook intentionally owns none of this: at this granularity it knows nothing
 the host doesn't. (The richer "which condition fired, with what resolved
 values" record — the one thing only stagebook could compute — was scoped out;
-see deliberation-lab/stagebook#199.)
+see talkbench/stagebook#199.)
 
 ---
 

--- a/docs/researcher/dispatchers.md
+++ b/docs/researcher/dispatchers.md
@@ -13,11 +13,11 @@ The first three are stateless or carry only a small piece of state (urn's remain
 
 > **Stagebook 0.14 breaking change.** `weighted-random`'s `weights` and `urn`'s `counts` and `decrements` are now **labeled objects** keyed by treatment name. The previous positional-array form (`counts: [10, 10, 10]`, `decrements: [[1,0,0], ...]`) was removed because it silently mis-mapped when treatments were renamed or reordered. The validator now rejects old positional configs with a migration hint pointing to this document; see [Why labels?](#why-labels) for the rationale.
 
-> **Stagebook 0.15 breaking change.** The `local-penalization` dispatcher (config-shape placeholder; implementation lived in deliberation-lab) was replaced by a simpler in-stagebook implementation with explicit state-in/state-out and softmax-based exploration. Batch configs using `type: "local-penalization"` need to be migrated; see [`softmax-knockdown` in detail](#softmax-knockdown-in-detail) below for the new shape.
+> **Stagebook 0.15 breaking change.** The `local-penalization` dispatcher (config-shape placeholder; implementation lived in runner) was replaced by a simpler in-stagebook implementation with explicit state-in/state-out and softmax-based exploration. Batch configs using `type: "local-penalization"` need to be migrated; see [`softmax-knockdown` in detail](#softmax-knockdown-in-detail) below for the new shape.
 >
 > **Stagebook 0.16 breaking change.** The dispatcher introduced in 0.15 was renamed from `weighted-knockdown` to `softmax-knockdown`. The original name was ambiguous — it could be read as "weighted-random with knockdowns" when the actual selection rule is softmax. The new name names the selection mechanism explicitly. Algorithm and config shape are unchanged; the only migration needed is `type: "weighted-knockdown"` → `type: "softmax-knockdown"`. Exported symbols follow the same rename: `weightedKnockdown` → `softmaxKnockdown`, `WeightedKnockdownDispatcherConfig` → `SoftmaxKnockdownDispatcherConfig`.
 >
-> **Stagebook 0.17 breaking change.** The file-reference key was renamed from `{ from: "..." }` to `{ file: "..." }` to match the manager + deliberation-lab convention. New shape: `counts: { file: "study1/counts.json" }`. The runtime check accepts both shapes during a one-release deprecation window; `{ from }` is removed in 0.18. (#466)
+> **Stagebook 0.17 breaking change.** The file-reference key was renamed from `{ from: "..." }` to `{ file: "..." }` to match the manager + runner convention. New shape: `counts: { file: "study1/counts.json" }`. The runtime check accepts both shapes during a one-release deprecation window; `{ from }` is removed in 0.18. (#466)
 
 ## `weighted-random` in detail
 
@@ -94,7 +94,7 @@ Three options, in increasing order of effort:
 
 ### Diagnostics
 
-The host (deliberation-lab in our deployment) gets the assignments back after every dispatch tick and can compute realized rates directly. If you're partway through a batch and the realized rate looks off relative to your target weights, the most likely cause is one of the two feasibility issues above. Check what fraction of your participants satisfy the constrained treatment's conditions; that fraction is roughly the ceiling on its realized rate.
+The host (runner in our deployment) gets the assignments back after every dispatch tick and can compute realized rates directly. If you're partway through a batch and the realized rate looks off relative to your target weights, the most likely cause is one of the two feasibility issues above. Check what fraction of your participants satisfy the constrained treatment's conditions; that fraction is roughly the ceiling on its realized rate.
 
 ## `urn` in detail
 
@@ -300,7 +300,7 @@ Every treatment with positive counts needs a row when you specify `decrements` �
 
 <a id="why-labels"></a>**Why labels?** Earlier versions of stagebook (≤ 0.13) accepted positional arrays here (`[30, 30, 30, 10, 10]`). That form silently mis-mapped if the treatment list got reordered or a treatment was renamed — the dispatcher would happily run with the wrong allocation. The labeled form makes the mapping explicit, so the validator catches drift instead of producing wrong assignments. If you have an old positional file, the validator at batch-creation time will refuse it with an error message pointing at this section; the dispatcher itself has a runtime guard for the same case, so even hand-constructed batches that bypass the validator will fail loudly rather than silently mis-route.
 
-File references are resolved by the host (deliberation-lab in our deployment), not by stagebook itself — stagebook's algorithm runs on already-resolved objects. The host enforces these path constraints: must be relative (no leading `/`), must not contain `..` segments, must not begin with a URL scheme (`https:`, `file:`, etc.), and is capped at 512 characters. The path is resolved against the same `assetBaseUrl` your treatment file is served from. The file is fetched at batch creation time and validated; a missing or malformed file fails batch creation rather than a later dispatch tick.
+File references are resolved by the host (runner in our deployment), not by stagebook itself — stagebook's algorithm runs on already-resolved objects. The host enforces these path constraints: must be relative (no leading `/`), must not contain `..` segments, must not begin with a URL scheme (`https:`, `file:`, etc.), and is capped at 512 characters. The path is resolved against the same `assetBaseUrl` your treatment file is served from. The file is fetched at batch creation time and validated; a missing or malformed file fails batch creation rather than a later dispatch tick.
 
 A typical workflow:
 
@@ -313,7 +313,7 @@ This keeps the offline computation auditable and the batch config readable.
 
 ### Exhaustion
 
-Once every bucket in the urn hits zero, no further assignments can be made. New arrivals to the lobby will sit until they hit the existing `lobbyTimeout`. A dedicated host-side admission gate — including a distinct `lobbyClosed` exit code — is proposed in deliberation-lab/deliberation-lab#269 but isn't shipped yet. For now: size your `counts` so the total matches or exceeds your recruitment target, plan for some over-recruitment slack to handle eligibility-tight conditions, and accept that any excess arrivals beyond `sum(counts)` will time out rather than be assigned.
+Once every bucket in the urn hits zero, no further assignments can be made. New arrivals to the lobby will sit until they hit the existing `lobbyTimeout`. A dedicated host-side admission gate — including a distinct `lobbyClosed` exit code — is proposed in talkbench/runner#269 but isn't shipped yet. For now: size your `counts` so the total matches or exceeds your recruitment target, plan for some over-recruitment slack to handle eligibility-tight conditions, and accept that any excess arrivals beyond `sum(counts)` will time out rather than be assigned.
 
 ### Realized vs. target Ns under eligibility constraints
 

--- a/docs/researcher/treatment-files.md
+++ b/docs/researcher/treatment-files.md
@@ -494,6 +494,6 @@ If your repo has a `CLAUDE.md` (or any agent-instruction file), add this block s
 > npx --package=stagebook stagebook validate <file>
 > ```
 >
-> Resolve all errors. For machine-readable output use `--format=json`; the JSON schema is documented [here](https://github.com/deliberation-lab/stagebook/blob/main/docs/researcher/treatment-files.md#json-output-schema). Exit codes: `0` clean, `1` schema errors, `2` couldn't read.
+> Resolve all errors. For machine-readable output use `--format=json`; the JSON schema is documented [here](https://github.com/talkbench/stagebook/blob/main/docs/researcher/treatment-files.md#json-output-schema). Exit codes: `0` clean, `1` schema errors, `2` couldn't read.
 
 Without this hook agents can edit treatment files but have no way to check their own work — the only signal that something is wrong reaches them after you open VS Code, read the Problems panel, and paste the error back.

--- a/examples/component-gallery/component-gallery.stagebook.yaml
+++ b/examples/component-gallery/component-gallery.stagebook.yaml
@@ -289,7 +289,7 @@ treatments:
             style: thin
           - type: trackedLink
             name: gallery_outbound
-            url: https://github.com/deliberation-lab/stagebook
+            url: https://github.com/talkbench/stagebook
             displayText: View stagebook on GitHub
           - type: submitButton
 

--- a/examples/component-gallery/prompts/done.prompt.md
+++ b/examples/component-gallery/prompts/done.prompt.md
@@ -10,4 +10,4 @@ intro / game / exit sequences, conditional rendering, references —
 see the **Annotated walkthrough** example next door.
 
 The components themselves live in
-[`packages/stagebook/src/components/form/`](https://github.com/deliberation-lab/stagebook/tree/main/packages/stagebook/src/components/form).
+[`packages/stagebook/src/components/form/`](https://github.com/talkbench/stagebook/tree/main/packages/stagebook/src/components/form).

--- a/examples/component-gallery/prompts/markdown_demo.prompt.md
+++ b/examples/component-gallery/prompts/markdown_demo.prompt.md
@@ -7,7 +7,7 @@ name: markdown_demo
 
 Paragraphs flow normally. **Bold**, *italic*, ~~strikethrough~~, and
 `inline code` all work. So do
-[external links](https://github.com/deliberation-lab/stagebook).
+[external links](https://github.com/talkbench/stagebook).
 
 ### Heading hierarchy
 

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -140,7 +140,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/deliberation-lab/stagebook.git"
+    "url": "git+https://github.com/talkbench/stagebook.git"
   },
   "license": "MIT"
 }

--- a/packages/stagebook/src/assets/PROVENANCE.md
+++ b/packages/stagebook/src/assets/PROVENANCE.md
@@ -2,7 +2,7 @@
 
 `InterVariable.woff2` is vendored (not fetched at runtime) so every participant
 sees the same font regardless of network, CSP, or CDN availability — the
-measurement-instrument guarantee. See deliberation-lab/stagebook#412.
+measurement-instrument guarantee. See talkbench/stagebook#412.
 
 | Field   | Value                                                                   |
 | ------- | ----------------------------------------------------------------------- |

--- a/packages/stagebook/src/components/Stage.scroll.ct.tsx
+++ b/packages/stagebook/src/components/Stage.scroll.ct.tsx
@@ -5,7 +5,7 @@ import type { StageConfig } from "./Stage";
 
 // Integration tests for the ScrollIndicator + useScrollAwareness wiring in
 // Stage.tsx — the three pieces work as a unit and were previously only
-// covered end-to-end via a cypress spec in the downstream deliberation-lab
+// covered end-to-end via a cypress spec in the downstream runner
 // repo. These tests exercise the four behavioral branches of the hook
 // (indicator on, dismiss via scroll, auto-peek at bottom, no re-fire after
 // dismiss) against the real Stage wrapper.

--- a/packages/stagebook/src/dispatch/contract.ts
+++ b/packages/stagebook/src/dispatch/contract.ts
@@ -15,7 +15,7 @@
 // different randomization claim worth a paper-defensible receipt.
 //
 // History: this harness is the generalization of
-// `dispatch.contract.test.js` from deliberation-lab, which was tightly
+// `dispatch.contract.test.js` from runner, which was tightly
 // coupled to a single algorithm's parameter shape. The scenario was
 // shrunk to just `{ players, treatments }`; algorithm-specific params
 // come from the registered factory (which can also generate them from

--- a/packages/stagebook/src/dispatch/randomization.test.ts
+++ b/packages/stagebook/src/dispatch/randomization.test.ts
@@ -4,9 +4,9 @@
 // reviewer: assignment is unbiased w.r.t. arrival order, position
 // within a group, irrelevant player attributes, and pairwise co-
 // occurrence. Mirrors the 8-test reference suite that landed in
-// deliberation-lab#268 for the BO-style dispatcher.
+// talkbench/runner#268 for the BO-style dispatcher.
 //
-// Sizing rationale (same as deliberation-lab):
+// Sizing rationale (same as runner):
 //   - M chosen so binomial SE is small enough to catch ≥2% absolute
 //     deviations at α=1e-4, while staying within ~30s per test.
 //   - chi-square critical values pinned via lookup table — keeps the

--- a/packages/stagebook/src/dispatch/softmaxKnockdown.ts
+++ b/packages/stagebook/src/dispatch/softmaxKnockdown.ts
@@ -43,7 +43,7 @@ export interface SoftmaxKnockdownResult {
  * State-in / state-out: callers thread `newState.payoffs` into the
  * next call's `payoffs`. The dispatcher itself is pure — no closure
  * mutation — which makes mirroring the dispatcher state to a host
- * heartbeat (deliberation-lab#275) and post-hoc replay both
+ * heartbeat (talkbench/runner#275) and post-hoc replay both
  * straightforward.
  *
  * Algorithm sketch (per call):

--- a/packages/stagebook/src/dispatch/types.ts
+++ b/packages/stagebook/src/dispatch/types.ts
@@ -2,7 +2,7 @@
 //
 // Three concerns live here:
 //   - The structural Treatment / Assignment shapes the dispatchers consume
-//     and produce. They mirror the deliberation-lab dispatcher shapes so
+//     and produce. They mirror the runner dispatcher shapes so
 //     hosts can call into either without translating.
 //   - The EligibilityTable interface — a pre-computed lookup for "is
 //     player P eligible for treatment T's position p?" Decouples the
@@ -101,8 +101,8 @@ export type PlayerDataSnapshot = Record<string, Record<string, unknown>>;
  *  either form at the boundary.
  *
  *  Key renamed from `from` to `file` in stagebook 0.17 to match the
- *  manager + deliberation-lab convention that had already converged on
- *  `{ file }` (deliberation-lab#273, manager#305). The runtime check
+ *  manager + runner convention that had already converged on
+ *  `{ file }` (talkbench/runner#273, manager#305). The runtime check
  *  in `validateDispatcherConfig` accepts both shapes for one release
  *  as a compat shim; `{ from }` will be removed in 0.18. (#466) */
 export interface FileReference {

--- a/packages/stagebook/src/dispatch/validateDispatcherConfig.test.ts
+++ b/packages/stagebook/src/dispatch/validateDispatcherConfig.test.ts
@@ -167,7 +167,7 @@ describe("validateDispatcherConfig", () => {
 
     test("also recognizes the deprecated `{ from }` file-ref shape (0.17 compat shim)", () => {
       // The key renamed from `from` to `file` in 0.17 to match the
-      // manager + deliberation-lab convention (#466). The runtime
+      // manager + runner convention (#466). The runtime
       // accepts both shapes for one release so existing configs keep
       // working; `{ from }` is removed in 0.18.
       const r = validateDispatcherConfig(

--- a/packages/stagebook/src/dispatch/validateDispatcherConfig.ts
+++ b/packages/stagebook/src/dispatch/validateDispatcherConfig.ts
@@ -576,7 +576,7 @@ function isNonNegativeFiniteNumber(v: unknown): boolean {
 
 /** Detect a host-side file reference that hasn't been resolved yet.
  *  Accepts both `{ file: "..." }` (the canonical 0.17 shape, matches
- *  manager + deliberation-lab) and `{ from: "..." }` (the deprecated
+ *  manager + runner) and `{ from: "..." }` (the deprecated
  *  shape, removed in 0.18). The validator's job is just to recognize
  *  the shape so it can emit a clear "host must resolve before calling"
  *  error rather than mis-parsing the object as inline data. (#466) */

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -458,7 +458,7 @@ export interface ValidateResolvedOptions {
    * contexts (e.g. the VS Code extension's expansion preview)
    * where `${field}` placeholders are expected because the host
    * hasn't bound them yet. Production hosts (annotator,
-   * deliberation-lab) leave this off so unbound fields surface as
+   * runner) leave this off so unbound fields surface as
    * errors before the participant sees a broken page.
    */
   skipUnresolved?: boolean;

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -131,7 +131,7 @@ export const fileSchema = z
     (value) => {
       // Defer all content-shape checks to post-fill when the path
       // contains a `${field}` placeholder (#398). The host (annotator,
-      // deliberation-lab) binds the slot before the participant sees
+      // runner) binds the slot before the participant sees
       // the page; `resolvedTreatmentFileSchema` runs the strict checks
       // on the substituted value. A leak (placeholder still present
       // after fillTemplates) gets caught there with a clear message.


### PR DESCRIPTION
Completes the `deliberation-lab` → `talkbench` org/repo rebrand across the repo.

## Why now

The **v0.22.0 npm publish failed** provenance verification:

```
npm error 422 - Error verifying sigstore provenance bundle:
package.json "repository.url" is "git+https://github.com/deliberation-lab/stagebook.git",
expected to match "https://github.com/talkbench/stagebook" from provenance
```

`--provenance` requires `packages/stagebook/package.json`'s `repository.url` to match the actual repo. Fixing that unblocks the release; while here, this sweeps the rest of the rebrand residue.

## Renamed

- **`deliberation-lab/stagebook` → `talkbench/stagebook`** (this repo): `package.json` `repository.url` (**the publish blocker**, shipped in the tarball), `src/assets/PROVENANCE.md` (also shipped), README (the viewer link was a live **404**; git-install shorthand), `.github/AGENT_INSTRUCTIONS.md` (`gh api` target was wrong), examples, docs self-links, ADR issue-link footers, and the `cut-release` skill's example URLs.
- **`deliberation-lab/deliberation-lab` → `talkbench/runner`** (the downstream host repo): `deliberation-lab#NNN` issue shorthands → `talkbench/runner#NNN`; prose "deliberation-lab" (the host) → "runner".
- **VS Code `publisher`**: `deliberation-lab` → `talkbench`.
- **Viewer Pages URL**: `deliberation-lab.github.io` → `talkbench.github.io` (verified `talkbench.github.io/stagebook/viewer/` → 200, old → 404).

## Deliberately left as-is

- `deliberation-lab/deliberation-empirica` — the extraction-source repo (historical provenance).
- `apps/viewer/src/lib/github.test.ts` — `deliberation-lab/example` is arbitrary URL-parser **test data**, not a rebrand reference.
- `deliberation-lab/annotator#138` (`Viewer.tsx`) — the **annotator** repo's post-rebrand home isn't confirmed; flagged for follow-up. (Is it `talkbench/annotator`?)

Comment/doc/config only — no source logic changed. Lint, build, and the dispatch test suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)