### PR TITLE
fix(examples): repair openResponse prompts + validate examples/ in CI

### DIFF
--- a/.github/workflows/validate-examples.yml
+++ b/.github/workflows/validate-examples.yml
@@ -1,0 +1,54 @@
+name: Validate examples
+
+# Guards the treatment/prompt files under examples/ against the repo's OWN
+# current schema (not a published version), so a schema change and the examples
+# it affects must stay in sync in the same PR — the gap that let 4 example
+# prompts drift broken undetected.
+#
+# The job runs on every PR/push so it always reports a status (and can safely
+# be added to branch-protection required checks without hanging PRs that don't
+# touch the relevant paths). The expensive build+validate steps are gated
+# behind an internal paths-filter, so unrelated PRs finish in seconds.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate examples
+    runs-on: ubuntu-latest
+    timeout-minutes: 4
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+          # Needed so dorny/paths-filter can diff base vs HEAD on push events.
+          fetch-depth: 0
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'examples/**'
+              - 'packages/stagebook/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - '.github/workflows/validate-examples.yml'
+      - uses: actions/setup-node@v5
+        if: steps.filter.outputs.relevant == 'true'
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+        if: steps.filter.outputs.relevant == 'true'
+      # Builds stagebook, then validates every example treatment + prompt with
+      # the freshly-built CLI (expand-and-validate, so post-hydration/cross-file
+      # rules run too).
+      - run: npm run validate:examples
+        if: steps.filter.outputs.relevant == 'true'

--- a/examples/prisoners-dilemma/prompts/feedback.prompt.md
+++ b/examples/prisoners-dilemma/prompts/feedback.prompt.md
@@ -9,3 +9,7 @@ maxLength: 400
 
 Was there a strategy you started with? Did your partner's behaviour
 change it? (Optional, 1–3 sentences.)
+
+---
+
+> e.g. "I opened by cooperating, then matched whatever my partner did."

--- a/examples/survey-experiment/prompts/comprehension.prompt.md
+++ b/examples/survey-experiment/prompts/comprehension.prompt.md
@@ -9,3 +9,7 @@ maxLength: 300
 
 A simple comprehension check — anything reasonable will do. (Required
 to advance.)
+
+---
+
+> e.g. "It described how remote work reshaped the way teams communicate."

--- a/examples/survey-experiment/prompts/feedback.prompt.md
+++ b/examples/survey-experiment/prompts/feedback.prompt.md
@@ -10,3 +10,7 @@ maxLength: 400
 If your answer to the start-time question shifted, what about the
 passage moved you? If it didn't shift, what would have? (Optional,
 1–3 sentences.)
+
+---
+
+> e.g. "It shifted a little — the point about long-term costs I hadn't weighed."

--- a/examples/ultimatum-game/prompts/feedback.prompt.md
+++ b/examples/ultimatum-game/prompts/feedback.prompt.md
@@ -9,3 +9,7 @@ maxLength: 400
 
 What drove your choice — fairness, payoff, anticipating the other
 player? (Optional, 1–3 sentences.)
+
+---
+
+> e.g. "I offered close to half — a lopsided split felt likely to be rejected."

--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
   "private": true,
   "license": "MIT",
-  "workspaces": ["packages/*", "apps/*"],
+  "workspaces": [
+    "packages/*",
+    "apps/*"
+  ],
   "scripts": {
     "build": "npm run build --workspaces --if-present",
     "test": "npm run test --workspaces --if-present",
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present",
     "format:check": "npm run format:check --workspaces --if-present",
+    "validate:examples": "npm run build -w stagebook && node packages/stagebook/bin/stagebook.js validate 'examples/**/*.stagebook.yaml' 'examples/**/*.prompt.md'",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "npm run lint --workspaces --if-present",
     "format": "npm run format --workspaces --if-present",
     "format:check": "npm run format:check --workspaces --if-present",
-    "validate:examples": "npm run build -w stagebook && node packages/stagebook/bin/stagebook.js validate 'examples/**/*.stagebook.yaml' 'examples/**/*.prompt.md'",
+    "validate:examples": "npm run build -w stagebook && node packages/stagebook/bin/stagebook.js validate \"examples/**/*.stagebook.yaml\" \"examples/**/*.prompt.md\"",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
The 5th tie-off item: fix the broken examples and stop them from silently breaking again.

## Problem

While dogfooding the validate GitHub Action (#441), validation surfaced that **4 example `openResponse` prompts fail `stagebook validate`** — each was missing its required third `---`-delimited section (an `openResponse` prompt's third section is a `>` placeholder). This went undetected because **`examples/` is validated nowhere in CI**.

## Fix

- **Repair the 4 prompts** — added a `> e.g. "…"` placeholder section, matching the established pattern (e.g. `examples/component-gallery/prompts/textarea_demo.prompt.md`), with hints that fit each question:
  - `examples/ultimatum-game/prompts/feedback.prompt.md`
  - `examples/prisoners-dilemma/prompts/feedback.prompt.md`
  - `examples/survey-experiment/prompts/comprehension.prompt.md`
  - `examples/survey-experiment/prompts/feedback.prompt.md`

  All **94** example files now validate clean (0 errors, 0 warnings).

- **Guard it in CI** — a root `validate:examples` script (also runnable locally) builds stagebook and validates every example treatment + prompt with the **freshly-built** CLI, so a schema change and the examples it affects must stay in sync in the same PR (not against a published version). A standalone `validate-examples.yml` runs it.

## Why the workflow is shaped this way

- **Standalone** (not added to `ci.yml`) to avoid merge conflicts with the four in-flight `ci.yml` PRs (#509/#511/#513/#515).
- **Always runs** (so it always reports a status and can be a required check without hanging PRs), but **gates the build+validate behind an internal `dorny/paths-filter`**, so PRs that don't touch `examples/**` or `packages/stagebook/**` finish in seconds. `persist-credentials: false`, `permissions: contents: read`.

## ⚠️ To fully enforce

Add **"Validate examples"** to the branch-protection required checks — otherwise a broken example shows a red ✗ but the PR stays mergeable (advisory only). The always-run/internal-filter shape above makes it safe to require.

## Verification

- `npm run validate:examples` → exit 0; all examples clean.
- Negative test: removing a third section from an example makes it exit 1 (the guard genuinely fails the job); restoring → exit 0.
- The `type: survey` line is a console **deprecation notice**, not a validation diagnostic (0 diagnostics, exit 0) — left as-is.
- YAML parses; Prettier clean. Folded in a review pass (completeness / guard correctness / workflow security).

🤖 Generated with [Claude Code](https://claude.com/claude-code)