### PR TITLE
chore: point annotator comment ref to talkbench/annotator

### DIFF
--- a/packages/stagebook/src/viewer/components/Viewer.tsx
+++ b/packages/stagebook/src/viewer/components/Viewer.tsx
@@ -605,8 +605,8 @@ const stageContainerStyle: React.CSSProperties = {
 
 // Bottom-of-stage breathing room (#234). Without this, long stages end
 // at a hard scroll-stop and participants have no signal they've reached
-// the end. 8rem matches the annotator's spacer (deliberation-lab/
-// annotator#138) so the visual rhythm is consistent across hosts.
+// the end. 8rem matches the annotator's spacer (talkbench/annotator#138)
+// so the visual rhythm is consistent across hosts.
 const stageBottomSpacerStyle: React.CSSProperties = {
   flexShrink: 0,
   height: "8rem",


### PR DESCRIPTION
Follow-up to #516 — the one rebrand reference I deliberately left pending because the annotator repo's new home was unconfirmed.

The bottom-spacer provenance comment in `Viewer.tsx` cited `deliberation-lab/annotator#138`. The annotator repo has moved to the `talkbench` org, so this is now `talkbench/annotator#138`.

Comment-only, no logic change. With this, the only remaining `deliberation-lab` strings in the repo are the intended keeps: the `deliberation-lab/deliberation-empirica` extraction-source reference and the arbitrary URL-parser test fixtures in `apps/viewer/src/lib/github.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)