### PR TITLE
ci: run CI in the merge queue (merge_group)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches: [main]
   push:
     branches: [main]
+  # Merge queue: GitHub tests each queued PR on a temporary `merge_group` ref
+  # (main + the PRs ahead of it). Without this trigger the required `CI Gate`
+  # check never runs in the queue and PRs hang. On this event every test job
+  # runs unconditionally (see the `|| github.event_name == 'merge_group'`
+  # guards below) — skipping via the paths-filter here would let `CI Gate` go
+  # green WITHOUT running the suite, merging the combined state untested.
+  merge_group:
 
 jobs:
   changes:
@@ -22,8 +29,12 @@ jobs:
         with:
           # Needed so dorny/paths-filter can diff base vs HEAD reliably on push events.
           fetch-depth: 0
+      # Skipped in the merge queue: there's no base/HEAD diff to compute, and
+      # every job runs unconditionally there anyway. Its outputs are then empty
+      # ('' != 'true'), so jobs run only via their `merge_group` guard.
       - uses: dorny/paths-filter@v3
         id: filter
+        if: github.event_name != 'merge_group'
         with:
           filters: |
             stagebook:
@@ -61,7 +72,7 @@ jobs:
   lint:
     name: Lint & Format
     needs: changes
-    if: needs.changes.outputs.lint == 'true'
+    if: needs.changes.outputs.lint == 'true' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
@@ -77,7 +88,7 @@ jobs:
   test-stagebook:
     name: Unit Tests (stagebook)
     needs: changes
-    if: needs.changes.outputs.stagebook == 'true'
+    if: needs.changes.outputs.stagebook == 'true' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
@@ -92,7 +103,7 @@ jobs:
   test-viewer:
     name: Unit Tests (viewer)
     needs: changes
-    if: needs.changes.outputs.viewer == 'true'
+    if: needs.changes.outputs.viewer == 'true' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
@@ -108,7 +119,7 @@ jobs:
   test-vscode:
     name: Unit Tests (vscode)
     needs: changes
-    if: needs.changes.outputs.vscode == 'true'
+    if: needs.changes.outputs.vscode == 'true' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 3
     steps:
@@ -124,7 +135,7 @@ jobs:
   package-vscode:
     name: Package (vscode)
     needs: changes
-    if: needs.changes.outputs.vscode == 'true'
+    if: needs.changes.outputs.vscode == 'true' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 4
     steps:
@@ -154,7 +165,7 @@ jobs:
   test-ct:
     name: Component Tests (${{ matrix.browser }} ${{ matrix.shard }}/4)
     needs: changes
-    if: needs.changes.outputs.ct == 'true'
+    if: needs.changes.outputs.ct == 'true' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     # Each shard runs ~1/4 of the suite at `--workers=1`, so per-shard
     # wall clock should be ~1-2 min over the ~30s setup baseline. 10


### PR DESCRIPTION
Prep to enable GitHub's **merge queue** — so PRs are tested against the exact combined state they'll create before landing (fixes the semantic-conflict / "never tested against current main" gap in a fast-forward-only workflow).

## What this changes (`ci.yml`)

- Adds the **`merge_group:`** trigger. The queue tests each PR on a temporary `merge_group` ref and gates on `CI Gate`; without this trigger that check never runs in the queue and PRs hang.
- Skips the `dorny/paths-filter` step on `merge_group` (there's no base/HEAD diff to compute there).
- Guards every conditional job with `|| github.event_name == 'merge_group'` so the **full** suite runs in the queue.

### The correctness reason for the guards

Without them, on a `merge_group` ref the paths-filter would report "nothing changed" → the test jobs **skip** → `CI Gate` (which treats skipped as non-failing) goes **green without running the tests** → the queue merges the combined state **untested**. The guards force every job to run on `merge_group`. Normal `pull_request`/`push` behavior (the paths-filter optimization) is unchanged.

## ⚙️ Steps for you (repo admin — I can't flip settings)

1. **Settings → Branches → the `main` protection rule → check "Require merge queue."** Configure:
   - **Merge method: Rebase** (keeps the linear/FF-only history you want).
   - Build concurrency / max group size: e.g. 5 / 5; wait-time-to-build: ~5 min (batches PRs so the queue tests `main+A+B+…` once rather than every prefix — keeps speculative CI cost down; it's free here anyway since the repo is public).
   - Keep **`CI Gate`** as the required status check.
2. That's it — the queue then serializes merges, testing each on the real combined state and auto-ejecting any that go red.

I can instead hand you the exact `gh api`/ruleset command if you'd rather script it than click.

## Follow-ups (I'll handle as I drain the other PRs)

- **#511** adds a `validate-action` job to `ci.yml`; when I rebase it onto this, I'll add the same `|| merge_group` guard to it.
- **#517**'s `validate-examples.yml` — if you make "Validate examples" a required check, it needs the same `merge_group:` trigger; I'll add it there.

## Merge order note

This PR has to land the **normal way** (it *is* the queue setup — chicken-and-egg). After it merges and you enable the queue, the remaining PRs (#511/#513/#515/#517) can drain **through** the queue.

## Verification

YAML parses; Prettier clean; guard expressions verified (`merge_group` → filter skipped → outputs empty → each job runs via the guard → `CI Gate` reflects real results).

🤖 Generated with [Claude Code](https://claude.com/claude-code)