### PR TITLE
feat(vscode): resolve asset:// media to local folders in the preview (#192)

### DIFF
--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -38,6 +38,13 @@ To see the real media while authoring, **mount each prefix to a local folder**:
 - To re-point a folder you picked by mistake, or to clear all mounts, run
   **`Stagebook: Configure Asset Folders`** from the Command Palette.
 
+A mounted prefix resolves everywhere it's used: `<video>`/`<img>`/`<audio>`,
+caption tracks, `asset://` prompt files, and `asset://` images inside a prompt
+body. The **banner** only lists prefixes referenced directly in the treatment
+YAML — a prefix that appears only in a prompt body or a field value won't be
+offered there, but a folder you've configured (or picked for another reference)
+still resolves it.
+
 Prefer a **committable, shared convention** for a team? Set
 [`stagebook.assetRoots`](#settings) instead — but note the paths are only used
 by this preview, and machine-specific absolute paths won't be portable across

--- a/apps/vscode/README.md
+++ b/apps/vscode/README.md
@@ -16,6 +16,43 @@ Validation, syntax highlighting, and live preview for Stagebook treatment
   file with templates and imports expanded.
 - **Validate Workspace** — `Stagebook: Validate Workspace` checks every
   Stagebook file in the folder at once.
+- **Local asset mounts** — preview media referenced by `asset://` URIs by
+  pointing each prefix at a folder on your machine (see below).
+
+## Previewing local assets (`asset://`)
+
+Treatments can reference platform-hosted media with an `asset://<prefix>/<path>`
+URI (e.g. `asset://group_recordings/session_01.mp4`). In production the platform
+resolves these; in the preview there is no platform, so by default an
+`asset://` reference shows a labeled placeholder.
+
+To see the real media while authoring, **mount each prefix to a local folder**:
+
+- When a preview references an unmapped prefix, a banner appears above it with a
+  **Choose folder…** button per prefix. Pick the folder that contains that
+  prefix's files and the media loads in place — no reload needed for folders
+  inside your workspace.
+- Your choices are remembered **per workspace** (in VS Code's storage) and are
+  **never written to the study** — `asset://` stays platform-resolved and the
+  `.stagebook.yaml` stays portable.
+- To re-point a folder you picked by mistake, or to clear all mounts, run
+  **`Stagebook: Configure Asset Folders`** from the Command Palette.
+
+Prefer a **committable, shared convention** for a team? Set
+[`stagebook.assetRoots`](#settings) instead — but note the paths are only used
+by this preview, and machine-specific absolute paths won't be portable across
+teammates (which is exactly why the per-workspace picker is the default).
+
+Mounting a folder grants the preview read access to it (via the webview's
+`localResourceRoots`); the mapping is always your explicit choice, never set by
+a treatment, and paths that try to escape a mounted folder (`../…`) are
+rejected.
+
+### Settings
+
+| Setting | Description |
+| --- | --- |
+| `stagebook.assetRoots` | An object mapping each `asset://` prefix to a local folder (absolute, or relative to the workspace root), e.g. `{ "group_recordings": "/Users/me/pilot_videos", "diagrams": "./media/diagrams" }`. Preview-only; an interactive pick for the same prefix overrides it. |
 
 ## Install
 

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -32,6 +32,10 @@
       {
         "command": "stagebook.validateWorkspace",
         "title": "Stagebook: Validate Workspace"
+      },
+      {
+        "command": "stagebook.configureAssetMounts",
+        "title": "Stagebook: Configure Asset Folders"
       }
     ],
     "menus": {
@@ -102,6 +106,21 @@
           "variable:stagebookYaml": "#9CDCFE",
           "string:stagebookYaml": "#DCDCAA",
           "property:stagebookYaml": "#569CD6"
+        }
+      }
+    },
+    "configuration": {
+      "title": "Stagebook",
+      "properties": {
+        "stagebook.assetRoots": {
+          "type": "object",
+          "scope": "resource",
+          "default": {},
+          "markdownDescription": "Map `asset://<prefix>/…` references to local folders so the stage preview can load them (#192). Each key is a prefix; each value is a folder path — absolute, or relative to the workspace root. This is a **preview-only** convenience: `asset://` is resolved by the platform at run time, so these paths are never part of the study.\n\nInteractive picks made from the preview's asset banner are remembered per-workspace and override an entry here for the same prefix. Prefer picking a folder from the banner unless you want a committable, shared convention.\n\nExample:\n```json\n{\n  \"group_recordings\": \"/Users/me/pilot_videos\",\n  \"diagrams\": \"./media/diagrams\"\n}\n```",
+          "additionalProperties": {
+            "type": "string",
+            "description": "A local folder path (absolute, or relative to the workspace root) to mount at this asset prefix."
+          }
         }
       }
     }

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -28,7 +28,13 @@ import {
   buildCompletionGlob,
   parseFilePathCompletionContext,
 } from "./lib/filePathCompletion";
-import { getReferencedAssets } from "stagebook";
+import { getReferencedAssets, collectAssetPrefixes } from "stagebook";
+import {
+  ASSET_MOUNTS_STATE_KEY,
+  mergeAssetMounts,
+  splitAssetMounts,
+  extraAssetRoots,
+} from "./lib/assetMounts";
 
 const diagnosticCollection =
   vscode.languages.createDiagnosticCollection("stagebook");
@@ -1068,6 +1074,128 @@ export function activate(context: vscode.ExtensionContext): void {
   let currentTreatmentDir: vscode.Uri | undefined;
   let currentWorkspaceRootFsPath: string | undefined;
 
+  // --- #192: asset:// local mount resolution ---
+  //
+  // Merge the `stagebook.assetRoots` setting (a committable shared convention;
+  // relative paths resolve against the workspace root) with the user's
+  // interactive folder picks in workspaceState (which win on conflict), into
+  // prefix → absolute directory. The setting is `scope: resource`, so it's read
+  // with the treatment URI to honor per-folder overrides in a multi-root
+  // workspace (matching the relative-path base below).
+  //
+  // The mount map is chosen by a human — a folder picked via showOpenDialog, or
+  // a setting the person committed to their own trusted workspace (a treatment
+  // FILE can never set it). Even a repo-committed setting only widens the
+  // webview's read-only `localResourceRoots`, gated by Workspace Trust and a
+  // strict CSP (no script/connect back-channel), so it can't exfiltrate.
+  const getAssetMountDirs = (): Record<string, string> =>
+    mergeAssetMounts(
+      vscode.workspace
+        .getConfiguration("stagebook", currentTreatmentUri)
+        .get<Record<string, unknown>>("assetRoots", {}),
+      context.workspaceState.get<Record<string, unknown>>(
+        ASSET_MOUNTS_STATE_KEY,
+        {},
+      ),
+      currentWorkspaceRootFsPath,
+    );
+
+  // dist + every workspace folder + only those mount dirs NOT already covered
+  // by one of those roots. The webview can only load resources under these
+  // roots, so a mount OUTSIDE the workspace (the point of #192) must be listed;
+  // a mount INSIDE the workspace is already covered recursively, so we omit it
+  // — adding it would change the root set and force a spurious reload on pick.
+  const buildLocalResourceRoots = (
+    mountDirs: Record<string, string>,
+  ): vscode.Uri[] => {
+    const baseRoots = [
+      vscode.Uri.joinPath(context.extensionUri, "dist"),
+      ...(vscode.workspace.workspaceFolders?.map((f) => f.uri) ?? []),
+    ];
+    const extra = extraAssetRoots(
+      Object.values(mountDirs),
+      baseRoots.map((uri) => uri.fsPath),
+    );
+    return [...baseRoots, ...extra.map((dir) => vscode.Uri.file(dir))];
+  };
+
+  // Post the current treatment to the webview, computing the asset-mount map
+  // (prefix → webview URI, for prefixes with a resolved dir) and the still-
+  // unmapped prefixes that drive the picker card.
+  const postTreatment = (panel: vscode.WebviewPanel): void => {
+    if (!currentTreatment || !currentTreatmentDir) return;
+    const { mounted, unmapped } = splitAssetMounts(
+      collectAssetPrefixes(currentTreatment),
+      getAssetMountDirs(),
+    );
+    const assetRoots: Record<string, string> = {};
+    for (const [prefix, dir] of Object.entries(mounted)) {
+      assetRoots[prefix] = panel.webview
+        .asWebviewUri(vscode.Uri.file(dir))
+        .toString();
+    }
+    panel.webview.postMessage({
+      type: "treatment",
+      treatmentFile: currentTreatment,
+      introIndex: 0,
+      treatmentIndex: 0,
+      webviewBaseUri: panel.webview
+        .asWebviewUri(currentTreatmentDir)
+        .toString(),
+      assetRoots,
+      unmappedAssetPrefixes: unmapped,
+    });
+  };
+
+  // Ensure the panel's localResourceRoots cover every mount dir, then refresh
+  // the webview's asset map. Reassigning `options` (a whole new object — an
+  // in-place array mutation is ignored) reloads the webview, which re-sends
+  // "ready" → postTreatment; when the roots already cover the mounts we post
+  // directly, no reload.
+  const syncAssetRoots = (panel: vscode.WebviewPanel): void => {
+    const desired = buildLocalResourceRoots(getAssetMountDirs());
+    const currentKeys = new Set(
+      (panel.webview.options.localResourceRoots ?? []).map((u) => u.toString()),
+    );
+    const desiredKeys = new Set(desired.map((u) => u.toString()));
+    const unchanged =
+      currentKeys.size === desiredKeys.size &&
+      [...desiredKeys].every((k) => currentKeys.has(k));
+    if (unchanged) {
+      postTreatment(panel);
+      return;
+    }
+    panel.webview.options = {
+      ...panel.webview.options,
+      localResourceRoots: desired,
+    };
+    // The reload triggers a fresh "ready" → postTreatment.
+  };
+
+  // Prompt for a folder to mount at `prefix`, persist it (workspace-scoped),
+  // and refresh the preview. Shared by the picker card and the configure
+  // command. A cancelled dialog leaves the mount unchanged.
+  const pickFolderForPrefix = async (prefix: string): Promise<void> => {
+    const picked = await vscode.window.showOpenDialog({
+      canSelectFiles: false,
+      canSelectFolders: true,
+      canSelectMany: false,
+      openLabel: "Mount as assets",
+      title: `Choose the folder for asset://${prefix}/`,
+      defaultUri: currentTreatmentDir,
+    });
+    if (!picked || picked.length === 0) return;
+    const next = {
+      ...context.workspaceState.get<Record<string, unknown>>(
+        ASSET_MOUNTS_STATE_KEY,
+        {},
+      ),
+      [prefix]: picked[0].fsPath,
+    };
+    await context.workspaceState.update(ASSET_MOUNTS_STATE_KEY, next);
+    if (previewPanel) syncAssetRoots(previewPanel);
+  };
+
   context.subscriptions.push(
     vscode.commands.registerCommand("stagebook.previewStage", async () => {
       const editor = vscode.window.activeTextEditor;
@@ -1105,7 +1233,20 @@ export function activate(context: vscode.ExtensionContext): void {
       currentTreatmentDir = vscode.Uri.joinPath(editor.document.uri, "..");
       currentWorkspaceRootFsPath = workspaceFolder.uri.fsPath;
 
+      // Pre-seed localResourceRoots with the configured/remembered asset
+      // mounts (#192) so an out-of-workspace mount is loadable up front — only
+      // a brand-new pick this session forces a reload (see syncAssetRoots).
+      const desiredRoots = buildLocalResourceRoots(getAssetMountDirs());
+
       if (previewPanel) {
+        // Keep the roots in sync with the current mounts (a setting edit or a
+        // prior pick may have changed them). Reassigning a new options object
+        // is required for the change to take effect; VS Code no-ops when the
+        // roots are unchanged.
+        previewPanel.webview.options = {
+          ...previewPanel.webview.options,
+          localResourceRoots: desiredRoots,
+        };
         previewPanel.reveal(vscode.ViewColumn.Beside);
       } else {
         previewPanel = vscode.window.createWebviewPanel(
@@ -1114,10 +1255,7 @@ export function activate(context: vscode.ExtensionContext): void {
           vscode.ViewColumn.Beside,
           {
             enableScripts: true,
-            localResourceRoots: [
-              vscode.Uri.joinPath(context.extensionUri, "dist"),
-              ...(vscode.workspace.workspaceFolders?.map((f) => f.uri) ?? []),
-            ],
+            localResourceRoots: desiredRoots,
           },
         );
         previewPanel.onDidDispose(() => {
@@ -1126,17 +1264,8 @@ export function activate(context: vscode.ExtensionContext): void {
 
         // Handle messages from the webview
         previewPanel.webview.onDidReceiveMessage(async (msg) => {
-          if (msg.type === "ready" && currentTreatment && currentTreatmentDir) {
-            const baseUri = previewPanel!.webview
-              .asWebviewUri(currentTreatmentDir)
-              .toString();
-            previewPanel?.webview.postMessage({
-              type: "treatment",
-              treatmentFile: currentTreatment,
-              introIndex: 0,
-              treatmentIndex: 0,
-              webviewBaseUri: baseUri,
-            });
+          if (msg.type === "ready") {
+            if (previewPanel) postTreatment(previewPanel);
           } else if (msg.type === "refresh") {
             // Re-read the source file, re-parse, and push the updated
             // treatment. Viewer state (stageIndex, position, saved responses,
@@ -1165,16 +1294,7 @@ export function activate(context: vscode.ExtensionContext): void {
               currentTreatment = refreshResult.data;
               // Panel may have been disposed while we were awaiting above.
               if (!previewPanel) return;
-              const baseUri = panel.webview
-                .asWebviewUri(treatmentDir)
-                .toString();
-              panel.webview.postMessage({
-                type: "treatment",
-                treatmentFile: refreshResult.data,
-                introIndex: 0,
-                treatmentIndex: 0,
-                webviewBaseUri: baseUri,
-              });
+              postTreatment(panel);
             } catch (err) {
               vscode.window.showErrorMessage(
                 `Refresh failed: ${err instanceof Error ? err.message : String(err)}`,
@@ -1225,6 +1345,13 @@ export function activate(context: vscode.ExtensionContext): void {
                 error: `Failed to read: ${filePath}`,
               });
             }
+          } else if (
+            msg.type === "pickAssetFolder" &&
+            typeof msg.prefix === "string"
+          ) {
+            // #192: the picker card asked to mount a local folder at this
+            // asset prefix. Prompt, persist, and refresh the preview.
+            await pickFolderForPrefix(msg.prefix);
           }
         });
       }
@@ -1234,6 +1361,52 @@ export function activate(context: vscode.ExtensionContext): void {
         context.extensionUri,
       );
     }),
+  );
+
+  // #192: manage the remembered asset-folder mounts — re-pick a wrong folder
+  // or clear them all (the recovery path when the picker card is gone because
+  // a prefix is already mapped to the wrong directory).
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "stagebook.configureAssetMounts",
+      async () => {
+        const picks = context.workspaceState.get<Record<string, unknown>>(
+          ASSET_MOUNTS_STATE_KEY,
+          {},
+        );
+        const entries = Object.entries(picks).filter(
+          ([, dir]) => typeof dir === "string" && dir.length > 0,
+        );
+        if (entries.length === 0) {
+          vscode.window.showInformationMessage(
+            "No asset folders are mounted for this workspace. Open a stage preview and use “Choose folder…” on the asset banner.",
+          );
+          return;
+        }
+        const CLEAR_ALL = "$(trash) Clear all asset mounts";
+        const selection = await vscode.window.showQuickPick(
+          [
+            ...entries.map(([prefix, dir]) => ({
+              label: `asset://${prefix}/`,
+              description: String(dir),
+              prefix: prefix as string | undefined,
+            })),
+            { label: CLEAR_ALL, description: "", prefix: undefined },
+          ],
+          {
+            title: "Stagebook asset mounts",
+            placeHolder: "Re-pick a folder for a prefix, or clear all mounts",
+          },
+        );
+        if (!selection) return;
+        if (selection.label === CLEAR_ALL) {
+          await context.workspaceState.update(ASSET_MOUNTS_STATE_KEY, {});
+          if (previewPanel) syncAssetRoots(previewPanel);
+          return;
+        }
+        if (selection.prefix) await pickFolderForPrefix(selection.prefix);
+      },
+    ),
   );
 
   // Validate the active document on activation (no debounce)

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -34,6 +34,7 @@ import {
   mergeAssetMounts,
   splitAssetMounts,
   extraAssetRoots,
+  parseMountedAsset,
 } from "./lib/assetMounts";
 
 const diagnosticCollection =
@@ -1119,21 +1120,30 @@ export function activate(context: vscode.ExtensionContext): void {
     return [...baseRoots, ...extra.map((dir) => vscode.Uri.file(dir))];
   };
 
-  // Post the current treatment to the webview, computing the asset-mount map
-  // (prefix → webview URI, for prefixes with a resolved dir) and the still-
-  // unmapped prefixes that drive the picker card.
+  // Post the current treatment to the webview: the asset-mount map (prefix →
+  // webview URI) and the still-unmapped prefixes that drive the picker card.
   const postTreatment = (panel: vscode.WebviewPanel): void => {
     if (!currentTreatment || !currentTreatmentDir) return;
-    const { mounted, unmapped } = splitAssetMounts(
-      collectAssetPrefixes(currentTreatment),
-      getAssetMountDirs(),
-    );
+    const mountDirs = getAssetMountDirs();
+    // Advertise EVERY configured/picked mount, not just the prefixes the
+    // treatment statically references — so a field-supplied `file: ${clipUrl}`
+    // bound to `asset://…`, or an `asset://` ref inside a loaded prompt body,
+    // also resolves when its prefix is configured. localResourceRoots already
+    // covers each of these dirs, so the webview URIs are loadable.
     const assetRoots: Record<string, string> = {};
-    for (const [prefix, dir] of Object.entries(mounted)) {
+    for (const [prefix, dir] of Object.entries(mountDirs)) {
       assetRoots[prefix] = panel.webview
         .asWebviewUri(vscode.Uri.file(dir))
         .toString();
     }
+    // The picker card lists prefixes the treatment STATICALLY references that
+    // aren't mounted yet. (A prefix appearing only in a field value or a prompt
+    // body can't be discovered host-side, but a configured mount still resolves
+    // it via the map above.)
+    const { unmapped } = splitAssetMounts(
+      collectAssetPrefixes(currentTreatment),
+      mountDirs,
+    );
     panel.webview.postMessage({
       type: "treatment",
       treatmentFile: currentTreatment,
@@ -1148,10 +1158,9 @@ export function activate(context: vscode.ExtensionContext): void {
   };
 
   // Ensure the panel's localResourceRoots cover every mount dir, then refresh
-  // the webview's asset map. Reassigning `options` (a whole new object — an
-  // in-place array mutation is ignored) reloads the webview, which re-sends
-  // "ready" → postTreatment; when the roots already cover the mounts we post
-  // directly, no reload.
+  // the webview's asset map. When the roots already cover the mounts, post
+  // directly — no reload. When they don't (a new out-of-workspace mount), the
+  // added root must take effect, which requires reloading the webview.
   const syncAssetRoots = (panel: vscode.WebviewPanel): void => {
     const desired = buildLocalResourceRoots(getAssetMountDirs());
     const currentKeys = new Set(
@@ -1165,11 +1174,16 @@ export function activate(context: vscode.ExtensionContext): void {
       postTreatment(panel);
       return;
     }
+    // Update localResourceRoots (a whole new options object — an in-place array
+    // mutation is ignored), then force the reload deterministically by
+    // re-setting the html rather than relying on the options reassignment alone
+    // to reload. The reloaded webview posts a fresh "ready" → postTreatment, so
+    // it picks up both the new CSP roots and the new assetRoots map.
     panel.webview.options = {
       ...panel.webview.options,
       localResourceRoots: desired,
     };
-    // The reload triggers a fresh "ready" → postTreatment.
+    panel.webview.html = getWebviewContent(panel.webview, context.extensionUri);
   };
 
   // Prompt for a folder to mount at `prefix`, persist it (workspace-scoped),
@@ -1294,15 +1308,64 @@ export function activate(context: vscode.ExtensionContext): void {
               currentTreatment = refreshResult.data;
               // Panel may have been disposed while we were awaiting above.
               if (!previewPanel) return;
-              postTreatment(panel);
+              // syncAssetRoots (not postTreatment) so a settings edit that
+              // added an out-of-workspace mount since the panel opened updates
+              // localResourceRoots too, not just the assetRoots map (#192).
+              syncAssetRoots(panel);
             } catch (err) {
               vscode.window.showErrorMessage(
                 `Refresh failed: ${err instanceof Error ? err.message : String(err)}`,
               );
             }
           } else if (msg.type === "readFile" && currentTreatmentDir) {
-            // Guard against path traversal
             const filePath = String(msg.path);
+            // #192: an asset:// prompt/text ref resolves against its local
+            // mount and is read from there — bounded by the mount dir, not the
+            // workspace (out-of-workspace is the point), mirroring the media
+            // path. Without this, a mounted asset:// prompt would still fail.
+            if (/^asset:\/\//i.test(filePath)) {
+              const resolved = parseMountedAsset(filePath, getAssetMountDirs());
+              if (!resolved) {
+                previewPanel?.webview.postMessage({
+                  type: "fileContent",
+                  requestId: msg.requestId,
+                  error: `Cannot resolve asset: ${filePath}`,
+                });
+                return;
+              }
+              try {
+                const assetUri = vscode.Uri.joinPath(
+                  vscode.Uri.file(resolved.dir),
+                  resolved.rest,
+                );
+                // Defense in depth: keep the resolved file within the mount dir
+                // (parseMountedAsset already rejects `..`). Does not resolve
+                // symlinks — same caveat as the workspace guard below.
+                if (!isWithinWorkspace(assetUri.fsPath, resolved.dir)) {
+                  previewPanel?.webview.postMessage({
+                    type: "fileContent",
+                    requestId: msg.requestId,
+                    error: `Path escapes mount: ${filePath}`,
+                  });
+                  return;
+                }
+                const assetContent =
+                  await vscode.workspace.fs.readFile(assetUri);
+                previewPanel?.webview.postMessage({
+                  type: "fileContent",
+                  requestId: msg.requestId,
+                  content: new TextDecoder().decode(assetContent),
+                });
+              } catch {
+                previewPanel?.webview.postMessage({
+                  type: "fileContent",
+                  requestId: msg.requestId,
+                  error: `Failed to read: ${filePath}`,
+                });
+              }
+              return;
+            }
+            // Guard against path traversal (workspace-relative reads)
             if (filePath.includes("..") || path.isAbsolute(filePath)) {
               previewPanel?.webview.postMessage({
                 type: "fileContent",

--- a/apps/vscode/src/lib/assetMounts.test.ts
+++ b/apps/vscode/src/lib/assetMounts.test.ts
@@ -4,6 +4,7 @@ import {
   mergeAssetMounts,
   splitAssetMounts,
   extraAssetRoots,
+  parseMountedAsset,
 } from "./assetMounts.js";
 
 // Build an OS-appropriate absolute path so these run on POSIX and Windows CI.
@@ -152,5 +153,45 @@ describe("extraAssetRoots (#192 — reload-free in-workspace mounts)", () => {
     expect(
       extraAssetRoots(["", good, undefined as unknown as string], [DIST, WS]),
     ).toEqual([good]);
+  });
+});
+
+describe("parseMountedAsset (#192 — asset:// prompt text via readFile)", () => {
+  const DIRS = { prompts: "/mnt/prompts", recordings: "/mnt/rec" };
+
+  it("resolves a mounted asset:// text ref to its dir + rest", () => {
+    expect(parseMountedAsset("asset://prompts/intro.prompt.md", DIRS)).toEqual({
+      dir: "/mnt/prompts",
+      rest: "intro.prompt.md",
+    });
+  });
+
+  it("resolves a nested rest path", () => {
+    expect(parseMountedAsset("asset://prompts/en/q.prompt.md", DIRS)).toEqual({
+      dir: "/mnt/prompts",
+      rest: "en/q.prompt.md",
+    });
+  });
+
+  it("matches the scheme case-insensitively, preserves prefix case", () => {
+    expect(parseMountedAsset("ASSET://prompts/x.md", DIRS)).toEqual({
+      dir: "/mnt/prompts",
+      rest: "x.md",
+    });
+    // A mixed-case prefix is a distinct mount key.
+    expect(parseMountedAsset("asset://Prompts/x.md", DIRS)).toBeNull();
+  });
+
+  it("returns null for an unmounted prefix", () => {
+    expect(parseMountedAsset("asset://unknown/x.md", DIRS)).toBeNull();
+  });
+
+  it("returns null for upward traversal (either separator)", () => {
+    expect(parseMountedAsset("asset://prompts/../../etc/x", DIRS)).toBeNull();
+    expect(parseMountedAsset("asset://prompts/..\\..\\x", DIRS)).toBeNull();
+  });
+
+  it("returns null for a non-asset path", () => {
+    expect(parseMountedAsset("prompts/intro.prompt.md", DIRS)).toBeNull();
   });
 });

--- a/apps/vscode/src/lib/assetMounts.test.ts
+++ b/apps/vscode/src/lib/assetMounts.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import * as path from "path";
+import {
+  mergeAssetMounts,
+  splitAssetMounts,
+  extraAssetRoots,
+} from "./assetMounts.js";
+
+// Build an OS-appropriate absolute path so these run on POSIX and Windows CI.
+const abs = (...segs: string[]) => path.join(path.sep, ...segs);
+
+describe("mergeAssetMounts (#192)", () => {
+  const WS = path.join(path.sep, "ws", "study");
+
+  it("resolves a relative setting path against the workspace root", () => {
+    expect(mergeAssetMounts({ diagrams: "media/diagrams" }, {}, WS)).toEqual({
+      diagrams: path.join(WS, "media/diagrams"),
+    });
+  });
+
+  it("passes an absolute setting path through unchanged", () => {
+    const abs = path.join(path.sep, "Users", "me", "videos");
+    expect(mergeAssetMounts({ recordings: abs }, {}, WS)).toEqual({
+      recordings: abs,
+    });
+  });
+
+  it("lets an interactive pick override the setting for the same prefix", () => {
+    const pick = path.join(path.sep, "Users", "me", "local_videos");
+    expect(
+      mergeAssetMounts({ recordings: "media/rec" }, { recordings: pick }, WS),
+    ).toEqual({ recordings: pick });
+  });
+
+  it("unions distinct prefixes from both sources", () => {
+    const pick = path.join(path.sep, "tmp", "clips");
+    expect(
+      mergeAssetMounts({ diagrams: "media/d" }, { clips: pick }, WS),
+    ).toEqual({
+      diagrams: path.join(WS, "media/d"),
+      clips: pick,
+    });
+  });
+
+  it("skips empty or non-string values in either source", () => {
+    expect(
+      mergeAssetMounts(
+        { a: "", b: 42 as unknown as string, c: "media/c" },
+        { d: null as unknown as string, e: path.join(path.sep, "e") },
+        WS,
+      ),
+    ).toEqual({ c: path.join(WS, "media/c"), e: path.join(path.sep, "e") });
+  });
+
+  it("passes a relative setting path through unchanged when there is no workspace root", () => {
+    // Can't resolve it; leave it as-is (the caller then fails to load it).
+    expect(mergeAssetMounts({ x: "media/x" }, {}, undefined)).toEqual({
+      x: "media/x",
+    });
+  });
+
+  it("still applies absolute picks with no workspace root", () => {
+    const pick = path.join(path.sep, "abs", "pick");
+    expect(mergeAssetMounts({}, { x: pick }, undefined)).toEqual({ x: pick });
+  });
+});
+
+describe("splitAssetMounts (#192)", () => {
+  it("routes mounted prefixes to `mounted` and the rest to `unmapped`", () => {
+    const dirs = {
+      recordings: "/a/rec",
+      diagrams: "/a/dia",
+    };
+    expect(splitAssetMounts(["recordings", "clips", "diagrams"], dirs)).toEqual(
+      {
+        mounted: { recordings: "/a/rec", diagrams: "/a/dia" },
+        unmapped: ["clips"],
+      },
+    );
+  });
+
+  it("preserves input order in `unmapped`", () => {
+    expect(splitAssetMounts(["z", "a", "m"], {})).toEqual({
+      mounted: {},
+      unmapped: ["z", "a", "m"],
+    });
+  });
+
+  it("treats an empty mount dir as unmapped", () => {
+    expect(splitAssetMounts(["x"], { x: "" })).toEqual({
+      mounted: {},
+      unmapped: ["x"],
+    });
+  });
+
+  it("returns empty results for no prefixes", () => {
+    expect(splitAssetMounts([], { x: "/a" })).toEqual({
+      mounted: {},
+      unmapped: [],
+    });
+  });
+});
+
+describe("extraAssetRoots (#192 — reload-free in-workspace mounts)", () => {
+  const WS = abs("ws", "study");
+  const DIST = abs("ext", "dist");
+
+  it("drops a mount INSIDE a covered root (already recursive → no new root)", () => {
+    // The key fix: an in-workspace pick adds no root, so the panel's root set
+    // is unchanged and the pick doesn't force a webview reload.
+    expect(extraAssetRoots([abs("ws", "study", "media")], [DIST, WS])).toEqual(
+      [],
+    );
+  });
+
+  it("keeps a mount OUTSIDE every covered root", () => {
+    const outside = abs("Users", "me", "videos");
+    expect(extraAssetRoots([outside], [DIST, WS])).toEqual([outside]);
+  });
+
+  it("treats the workspace root itself as covered", () => {
+    expect(extraAssetRoots([WS], [DIST, WS])).toEqual([]);
+  });
+
+  it("keeps a mount that is a PARENT of a covered root", () => {
+    // Mounting /Users/me when /Users/me/study is the workspace legitimately
+    // widens access — the parent is not covered by its child.
+    const parent = abs("Users", "me");
+    const child = abs("Users", "me", "study");
+    expect(extraAssetRoots([parent], [DIST, child])).toEqual([parent]);
+  });
+
+  it("dedupes nested mounts against each other", () => {
+    const outer = abs("data", "assets");
+    const inner = abs("data", "assets", "clips");
+    expect(extraAssetRoots([outer, inner], [DIST, WS])).toEqual([outer]);
+  });
+
+  it("dedupes identical mount dirs", () => {
+    const d = abs("data", "x");
+    expect(extraAssetRoots([d, d], [DIST, WS])).toEqual([d]);
+  });
+
+  it("preserves input order of the kept dirs", () => {
+    const a = abs("z", "a");
+    const b = abs("y", "b");
+    expect(extraAssetRoots([a, b], [DIST, WS])).toEqual([a, b]);
+  });
+
+  it("skips empty / non-string entries", () => {
+    const good = abs("data", "ok");
+    expect(
+      extraAssetRoots(["", good, undefined as unknown as string], [DIST, WS]),
+    ).toEqual([good]);
+  });
+});

--- a/apps/vscode/src/lib/assetMounts.ts
+++ b/apps/vscode/src/lib/assetMounts.ts
@@ -1,0 +1,101 @@
+import * as path from "path";
+import { isWithinWorkspace } from "./filePaths.js";
+
+/**
+ * workspaceState key under which the VS Code preview persists the user's
+ * interactive asset-folder picks (#192), as a prefix → absolute-fsPath map.
+ * Workspace-scoped and machine-local (a Memento, not a file) — never committed
+ * to the study, never Settings-Synced.
+ */
+export const ASSET_MOUNTS_STATE_KEY = "stagebook.assetMounts";
+
+/**
+ * Merge the two sources of asset mounts into one prefix → absolute-fsPath map.
+ *
+ * - `settingMounts` — the `stagebook.assetRoots` setting, a committable shared
+ *   convention. Relative paths resolve against the workspace root; absolute
+ *   paths are used as-is.
+ * - `pickedMounts` — the user's interactive folder picks from workspaceState
+ *   (always absolute). These WIN on conflict, so a local pick overrides a
+ *   committed default.
+ *
+ * Pure (no VS Code or filesystem access) so it's unit-testable. Non-string or
+ * empty values are skipped. A relative setting path with no workspace root is
+ * passed through unchanged — it can't be resolved, and the caller will simply
+ * fail to load it, which is the correct outcome.
+ */
+export function mergeAssetMounts(
+  settingMounts: Record<string, unknown>,
+  pickedMounts: Record<string, unknown>,
+  workspaceRootFsPath: string | undefined,
+): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const [prefix, raw] of Object.entries(settingMounts)) {
+    if (typeof raw !== "string" || raw.length === 0) continue;
+    merged[prefix] =
+      path.isAbsolute(raw) || !workspaceRootFsPath
+        ? raw
+        : path.join(workspaceRootFsPath, raw);
+  }
+  // Interactive picks override the committed setting.
+  for (const [prefix, raw] of Object.entries(pickedMounts)) {
+    if (typeof raw === "string" && raw.length > 0) merged[prefix] = raw;
+  }
+  return merged;
+}
+
+/**
+ * Reduce a set of mount directories to the minimal set that must be ADDED as
+ * extra webview `localResourceRoots`, given the roots the webview already
+ * covers (the extension dir + workspace folders).
+ *
+ * VS Code `localResourceRoots` are RECURSIVE, so a mount inside a workspace
+ * folder (or inside another retained mount) is already loadable — re-adding it
+ * as a distinct root is pointless AND makes the panel's root set change, which
+ * would force a spurious webview reload on every in-workspace pick. Dropping
+ * those keeps an in-workspace mount reload-free (#192 review).
+ *
+ * Pure — testable. Order-preserving and deterministic (so the caller's
+ * reload-vs-not root-set comparison is stable). Paths are compared via
+ * {@link isWithinWorkspace} (string-level `path.relative`; does not resolve
+ * symlinks — the same caveat the readFile guard carries).
+ */
+export function extraAssetRoots(
+  mountDirs: string[],
+  coveredRootFsPaths: string[],
+): string[] {
+  const kept: string[] = [];
+  for (const dir of mountDirs) {
+    if (typeof dir !== "string" || dir.length === 0) continue;
+    if (coveredRootFsPaths.some((root) => isWithinWorkspace(dir, root))) {
+      continue; // already covered by a base root (recursive)
+    }
+    if (kept.some((k) => isWithinWorkspace(dir, k))) {
+      continue; // already covered by a mount we're keeping
+    }
+    kept.push(dir);
+  }
+  return kept;
+}
+
+/**
+ * Split the asset prefixes a treatment references into those with a resolved
+ * mount directory and those without.
+ *
+ * `mounted` (prefix → dir) feeds the webview's resolver; `unmapped` drives the
+ * picker card. Pure — testable. Preserves the input order of `prefixes` in
+ * `unmapped`.
+ */
+export function splitAssetMounts(
+  prefixes: string[],
+  mountDirs: Record<string, string>,
+): { mounted: Record<string, string>; unmapped: string[] } {
+  const mounted: Record<string, string> = {};
+  const unmapped: string[] = [];
+  for (const prefix of prefixes) {
+    const dir = mountDirs[prefix];
+    if (typeof dir === "string" && dir.length > 0) mounted[prefix] = dir;
+    else unmapped.push(prefix);
+  }
+  return { mounted, unmapped };
+}

--- a/apps/vscode/src/lib/assetMounts.ts
+++ b/apps/vscode/src/lib/assetMounts.ts
@@ -45,6 +45,31 @@ export function mergeAssetMounts(
 }
 
 /**
+ * Resolve an `asset://<prefix>/<rest>` reference to its mounted directory and
+ * the relative rest path, for READING the file host-side (#192 — an
+ * `asset://…` prompt loads its markdown through the readFile bridge, not the
+ * webview `<img>/<video src>` path).
+ *
+ * Returns null when the prefix isn't mounted or `rest` traverses upward (`..`,
+ * either separator) — the caller then reports it unresolved so the #191
+ * placeholder fires. The rest is returned raw for the caller to join onto the
+ * mount dir (and re-check containment). Pure/testable; `asset:` scheme match is
+ * case-insensitive, prefix case preserved.
+ */
+export function parseMountedAsset(
+  assetPath: string,
+  mountDirs: Record<string, string>,
+): { dir: string; rest: string } | null {
+  const match = /^asset:\/\/([^/]+)(?:\/(.*))?$/i.exec(assetPath);
+  if (!match) return null;
+  const dir = mountDirs[match[1]];
+  if (typeof dir !== "string" || dir.length === 0) return null;
+  const rest = match[2] ?? "";
+  if (rest.split(/[/\\]/).some((seg) => seg === "..")) return null;
+  return { dir, rest };
+}
+
+/**
  * Reduce a set of mount directories to the minimal set that must be ADDED as
  * extra webview `localResourceRoots`, given the roots the webview already
  * covers (the extension dir + workspace folders).

--- a/apps/vscode/src/webview/index.tsx
+++ b/apps/vscode/src/webview/index.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useRef } from "react";
 import { createRoot } from "react-dom/client";
 import type { TreatmentFileType } from "stagebook";
 import { PreviewHost } from "stagebook/viewer";
+import { buildAssetURL } from "./resolveAsset.js";
 
 // Declare the VS Code API injected by the webview
 declare function acquireVsCodeApi(): {
@@ -40,7 +41,10 @@ window.addEventListener("message", (event) => {
   }
 });
 
-function createWebviewContentFns(webviewBaseUri: string) {
+function createWebviewContentFns(
+  webviewBaseUri: string,
+  assetRoots: Record<string, string>,
+) {
   const cache = new Map<string, Promise<string>>();
 
   return {
@@ -62,10 +66,10 @@ function createWebviewContentFns(webviewBaseUri: string) {
     },
 
     getAssetURL(assetPath: string): string {
-      const base = webviewBaseUri.endsWith("/")
-        ? webviewBaseUri
-        : webviewBaseUri + "/";
-      return base + assetPath.replace(/^\/+/, "");
+      // Platform asset:// references resolve against the configured local
+      // mounts (#192); an unmapped or unsafe one passes through unchanged so
+      // the renderer shows the #191 placeholder rather than a broken URL.
+      return buildAssetURL(assetPath, webviewBaseUri, assetRoots);
     },
   };
 }
@@ -79,6 +83,14 @@ function App() {
   const [introIndex, setIntroIndex] = useState(0);
   const [treatmentIndex, setTreatmentIndex] = useState(0);
   const [webviewBaseUri, setWebviewBaseUri] = useState("");
+  // #192: prefix → webview-URI base for each mounted asset root, plus the
+  // discovered prefixes that have no mount yet (drive the picker card).
+  // useState (not a fresh literal) keeps `assetRoots` referentially stable
+  // between treatment messages, which matters for the contentFns memo.
+  const [assetRoots, setAssetRoots] = useState<Record<string, string>>({});
+  const [unmappedAssetPrefixes, setUnmappedAssetPrefixes] = useState<string[]>(
+    [],
+  );
   const [error, setError] = useState<string | null>(null);
   // Bumped on each treatment message so that `contentFns` is recreated
   // with a fresh cache, forcing prompt files to re-fetch from disk.
@@ -126,6 +138,12 @@ function App() {
           );
         });
         setWebviewBaseUri(msg.webviewBaseUri ?? "");
+        setAssetRoots(
+          (msg.assetRoots as Record<string, string> | undefined) ?? {},
+        );
+        setUnmappedAssetPrefixes(
+          (msg.unmappedAssetPrefixes as string[] | undefined) ?? [],
+        );
         setContentVersion((v) => v + 1);
         setError(null);
       } else if (msg.type === "error") {
@@ -144,8 +162,8 @@ function App() {
   // `contentVersion` is deliberately part of the deps so a refresh creates
   // a fresh cache — forcing prompt files to re-fetch from disk.
   const contentFns = useMemo(
-    () => createWebviewContentFns(webviewBaseUri),
-    [webviewBaseUri, contentVersion],
+    () => createWebviewContentFns(webviewBaseUri, assetRoots),
+    [webviewBaseUri, assetRoots, contentVersion],
   );
 
   if (error) {
@@ -176,9 +194,121 @@ function App() {
       onIntroIndexChange={setIntroIndex}
       onRefresh={() => vscode.postMessage({ type: "refresh" })}
       contentVersion={contentVersion}
+      hostNotice={
+        unmappedAssetPrefixes.length > 0 ? (
+          <AssetMountCard
+            prefixes={unmappedAssetPrefixes}
+            onPick={(prefix) =>
+              vscode.postMessage({ type: "pickAssetFolder", prefix })
+            }
+          />
+        ) : undefined
+      }
     />
   );
 }
+
+// --- Asset-mount picker card (#192) ---
+//
+// A NON-BLOCKING notice rendered above the live preview (via PreviewHost's
+// `hostNotice` → Viewer's `notice` slot) listing every `asset://<prefix>/…`
+// reference with no local mount yet. Each row's button asks the extension to
+// open a folder picker for that prefix; the preview keeps rendering (unmapped
+// assets show the #191 placeholder) rather than gating on the pick.
+//
+// vscode-webview-only: local mounting is meaningless in the browser viewer or
+// TalkBench, so this lives here, not in the shared harness. Colors match the
+// preview's light chrome (cf. the locale-mismatch banner) rather than the
+// editor theme, since the preview emulates the participant experience.
+function AssetMountCard({
+  prefixes,
+  onPick,
+}: {
+  prefixes: string[];
+  onPick: (prefix: string) => void;
+}) {
+  return (
+    <div data-testid="asset-mount-card" role="region" style={cardWrapStyle}>
+      <strong style={cardTitleStyle}>
+        {prefixes.length === 1
+          ? "1 asset folder isn't mapped"
+          : `${prefixes.length} asset folders aren't mapped`}
+      </strong>
+      <p style={cardSubtitleStyle}>
+        These <code>asset://</code> references point at files on your machine.
+        Choose a local folder for each prefix to preview its media — until then
+        a placeholder is shown. Your choice is remembered for this workspace and
+        is never written to the study.
+      </p>
+      <ul style={cardListStyle}>
+        {prefixes.map((prefix) => (
+          <li key={prefix} style={cardRowStyle}>
+            <code style={cardPrefixStyle}>asset://{prefix}/</code>
+            <button
+              type="button"
+              style={cardButtonStyle}
+              onClick={() => onPick(prefix)}
+            >
+              Choose folder…
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+const cardWrapStyle: React.CSSProperties = {
+  padding: "0.75rem 1rem",
+  borderBottom: "1px solid #bfdbfe",
+  backgroundColor: "#eff6ff",
+  color: "#1e3a8a",
+  fontFamily: "system-ui, sans-serif",
+  fontSize: "0.875rem",
+};
+
+const cardTitleStyle: React.CSSProperties = {
+  fontWeight: 600,
+};
+
+const cardSubtitleStyle: React.CSSProperties = {
+  margin: "0.25rem 0 0.5rem",
+  color: "#1e40af",
+};
+
+const cardListStyle: React.CSSProperties = {
+  listStyle: "none",
+  margin: 0,
+  padding: 0,
+  display: "flex",
+  flexDirection: "column",
+  gap: "0.5rem",
+};
+
+const cardRowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  gap: "0.75rem",
+  flexWrap: "wrap",
+};
+
+const cardPrefixStyle: React.CSSProperties = {
+  fontFamily: "monospace",
+  fontSize: "0.8125rem",
+};
+
+const cardButtonStyle: React.CSSProperties = {
+  padding: "0.375rem 0.75rem",
+  borderRadius: "0.375rem",
+  border: "none",
+  backgroundColor: "#3b82f6",
+  color: "#ffffff",
+  cursor: "pointer",
+  fontSize: "0.8125rem",
+  fontWeight: 500,
+  whiteSpace: "nowrap",
+};
 
 // Mount
 const root = document.getElementById("root");

--- a/apps/vscode/src/webview/resolveAsset.test.ts
+++ b/apps/vscode/src/webview/resolveAsset.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "vitest";
+import { resolveAssetUrl, buildAssetURL } from "./resolveAsset.js";
+
+// #192: the webview resolves `asset://<prefix>/<rest>` against the mount map the
+// extension pre-computed (`{ prefix -> asWebviewUri(<local dir>) }`). A matched,
+// safe path becomes a loadable webview URL; anything unmatched or unsafe passes
+// through unchanged so the #191 placeholder fires instead of a broken load.
+const ROOTS = {
+  group_recordings: "https://file+.vscode-resource.example/Users/me/videos",
+  // A base WITHOUT a trailing slash — resolution must still join correctly.
+  diagrams: "https://file+.vscode-resource.example/repo/media/diagrams",
+};
+
+describe("resolveAssetUrl (#192)", () => {
+  it("resolves a mounted prefix to base + path", () => {
+    expect(
+      resolveAssetUrl("asset://group_recordings/session_01.mp4", ROOTS),
+    ).toBe(
+      "https://file+.vscode-resource.example/Users/me/videos/session_01.mp4",
+    );
+  });
+
+  it("joins correctly when the base has no trailing slash", () => {
+    expect(resolveAssetUrl("asset://diagrams/flow.png", ROOTS)).toBe(
+      "https://file+.vscode-resource.example/repo/media/diagrams/flow.png",
+    );
+  });
+
+  it("resolves nested subpaths under a mount", () => {
+    expect(resolveAssetUrl("asset://group_recordings/day1/a.mp4", ROOTS)).toBe(
+      "https://file+.vscode-resource.example/Users/me/videos/day1/a.mp4",
+    );
+  });
+
+  it("returns the bare base when there is no rest", () => {
+    expect(resolveAssetUrl("asset://group_recordings", ROOTS)).toBe(
+      "https://file+.vscode-resource.example/Users/me/videos",
+    );
+    expect(resolveAssetUrl("asset://group_recordings/", ROOTS)).toBe(
+      "https://file+.vscode-resource.example/Users/me/videos",
+    );
+  });
+
+  it("percent-encodes each path segment but preserves separators", () => {
+    expect(
+      resolveAssetUrl("asset://group_recordings/day 1/a&b.mp4", ROOTS),
+    ).toBe(
+      "https://file+.vscode-resource.example/Users/me/videos/day%201/a%26b.mp4",
+    );
+  });
+
+  it("ignores `.` and empty segments", () => {
+    expect(
+      resolveAssetUrl("asset://group_recordings/./sub//a.mp4", ROOTS),
+    ).toBe("https://file+.vscode-resource.example/Users/me/videos/sub/a.mp4");
+  });
+
+  it("matches the scheme case-insensitively (fileSchema accepts ASSET://)", () => {
+    expect(resolveAssetUrl("ASSET://group_recordings/a.mp4", ROOTS)).toBe(
+      "https://file+.vscode-resource.example/Users/me/videos/a.mp4",
+    );
+  });
+
+  it("passes an unmatched prefix through unchanged (→ #191 placeholder)", () => {
+    expect(resolveAssetUrl("asset://unknown/a.mp4", ROOTS)).toBe(
+      "asset://unknown/a.mp4",
+    );
+  });
+
+  it("passes through unchanged (no resolution) when the path traverses upward", () => {
+    // A treatment must not escape its mounted root; refuse to build the URL.
+    expect(
+      resolveAssetUrl("asset://group_recordings/../../etc/passwd", ROOTS),
+    ).toBe("asset://group_recordings/../../etc/passwd");
+    expect(
+      resolveAssetUrl("asset://group_recordings/sub/../../secret", ROOTS),
+    ).toBe("asset://group_recordings/sub/../../secret");
+  });
+
+  it("also rejects backslash-delimited traversal (cross-platform)", () => {
+    // The `..` check splits on both separators, so a `..\..` can't slip past.
+    expect(
+      resolveAssetUrl("asset://group_recordings/..\\..\\secret", ROOTS),
+    ).toBe("asset://group_recordings/..\\..\\secret");
+    expect(
+      resolveAssetUrl("asset://group_recordings/sub\\..\\..\\x", ROOTS),
+    ).toBe("asset://group_recordings/sub\\..\\..\\x");
+  });
+
+  it("passes a non-asset input through unchanged", () => {
+    expect(resolveAssetUrl("images/logo.png", ROOTS)).toBe("images/logo.png");
+    expect(resolveAssetUrl("https://cdn.test/x.png", ROOTS)).toBe(
+      "https://cdn.test/x.png",
+    );
+  });
+
+  it("returns passthrough for every prefix when the mount map is empty", () => {
+    expect(resolveAssetUrl("asset://group_recordings/a.mp4", {})).toBe(
+      "asset://group_recordings/a.mp4",
+    );
+  });
+});
+
+describe("buildAssetURL (#192 getAssetURL routing)", () => {
+  const BASE = "https://webview.example/study/";
+
+  it("routes a mounted asset:// URI through the resolver", () => {
+    expect(buildAssetURL("asset://group_recordings/s.mp4", BASE, ROOTS)).toBe(
+      "https://file+.vscode-resource.example/Users/me/videos/s.mp4",
+    );
+  });
+
+  it("returns an UNMAPPED asset:// URI unchanged (keeps #191 placeholder firing)", () => {
+    // Critical: the passthrough must still be an `asset:` URI so Element's
+    // isUnresolvedAsset detector fires — NOT base-joined into a broken URL.
+    const out = buildAssetURL("asset://unknown/x.mp4", BASE, ROOTS);
+    expect(out).toBe("asset://unknown/x.mp4");
+    expect(out.startsWith("asset:")).toBe(true);
+  });
+
+  it("returns a traversal asset:// URI unchanged (not base-joined)", () => {
+    const out = buildAssetURL("asset://group_recordings/../x", BASE, ROOTS);
+    expect(out).toBe("asset://group_recordings/../x");
+    expect(out.startsWith("asset:")).toBe(true);
+  });
+
+  it("base-joins a normal repo-relative path (leading slashes stripped)", () => {
+    expect(buildAssetURL("images/logo.png", BASE, ROOTS)).toBe(
+      "https://webview.example/study/images/logo.png",
+    );
+    expect(buildAssetURL("/images/logo.png", BASE, ROOTS)).toBe(
+      "https://webview.example/study/images/logo.png",
+    );
+  });
+
+  it("normalizes a base URI that lacks a trailing slash", () => {
+    expect(buildAssetURL("a.png", "https://webview.example/study", ROOTS)).toBe(
+      "https://webview.example/study/a.png",
+    );
+  });
+
+  it("matches the asset:// scheme case-insensitively when routing", () => {
+    // Same case-insensitivity as isUnresolvedAsset, so uppercase still routes.
+    expect(buildAssetURL("ASSET://unknown/x.mp4", BASE, ROOTS)).toBe(
+      "ASSET://unknown/x.mp4",
+    );
+  });
+});

--- a/apps/vscode/src/webview/resolveAsset.ts
+++ b/apps/vscode/src/webview/resolveAsset.ts
@@ -1,0 +1,67 @@
+/**
+ * Resolve an `asset://<prefix>/<rest>` URI against the configured local mounts
+ * (#192). The extension reads `stagebook.assetRoots` and pre-computes a
+ * `{ prefix -> webview-URI base }` map (each base is `asWebviewUri(<mount dir>)`);
+ * this runs in the webview and does the sync prefix lookup + path join, so the
+ * host resolver stays synchronous.
+ *
+ * Returns the loadable webview URL when the prefix is mounted and the path is
+ * safe; otherwise returns the `asset://` URI UNCHANGED so the renderer falls
+ * back to the labeled placeholder (#191) instead of loading a broken URL.
+ *
+ * `assetPath` is assumed to be an `asset://…` URI (the caller checks the
+ * scheme); a non-asset input is returned unchanged.
+ */
+export function resolveAssetUrl(
+  assetPath: string,
+  assetRoots: Record<string, string>,
+): string {
+  const match = /^asset:\/\/([^/]+)(?:\/(.*))?$/i.exec(assetPath);
+  if (!match) return assetPath; // not asset:// or malformed → passthrough
+
+  const prefix = match[1];
+  const rest = match[2] ?? "";
+
+  const base = assetRoots[prefix];
+  if (!base) return assetPath; // prefix not mounted → placeholder fallback
+
+  // Reject path traversal before building a URL — a treatment must not reach
+  // outside its mounted root (`localResourceRoots` is the second line of
+  // defense). Split on BOTH separators so a backslash-delimited `..\..`
+  // (crafted, or a stray Windows path) is caught too, not just `../..`.
+  if (rest.split(/[/\\]/).some((seg) => seg === "..")) return assetPath;
+
+  // `.` and empty segments are harmless noise; drop them before joining.
+  const segments = rest.split("/").filter((s) => s !== "" && s !== ".");
+  const encoded = segments.map(encodeURIComponent).join("/");
+  const normalizedBase = base.endsWith("/") ? base : base + "/";
+  return encoded ? normalizedBase + encoded : base;
+}
+
+/**
+ * Route a webview content path to a loadable URL (#192):
+ *
+ * - an `asset://…` URI resolves against the local mounts via
+ *   {@link resolveAssetUrl} — an unmapped or unsafe one is returned UNCHANGED
+ *   so the #191 placeholder fires. That passthrough MUST stay an `asset:` URI:
+ *   Element's `isUnresolvedAsset` detector (`/^asset:\/\//i`) keys off it, so
+ *   this routing gate has to match that scheme test.
+ * - any other path is joined onto the treatment-dir base URI (leading slashes
+ *   stripped) — the pre-#192 behavior for repo-relative assets.
+ *
+ * This is the exact `getAssetURL` contract the renderer calls; kept pure and
+ * separate from the postMessage bridge so it's unit-testable.
+ */
+export function buildAssetURL(
+  assetPath: string,
+  webviewBaseUri: string,
+  assetRoots: Record<string, string>,
+): string {
+  if (/^asset:\/\//i.test(assetPath)) {
+    return resolveAssetUrl(assetPath, assetRoots);
+  }
+  const base = webviewBaseUri.endsWith("/")
+    ? webviewBaseUri
+    : webviewBaseUri + "/";
+  return base + assetPath.replace(/^\/+/, "");
+}

--- a/packages/stagebook/src/utils/index.ts
+++ b/packages/stagebook/src/utils/index.ts
@@ -13,6 +13,7 @@ export {
 } from "./evaluateConditions.js";
 export {
   getReferencedAssets,
+  collectAssetPrefixes,
   type ReferencedAsset,
 } from "./referencedAssets.js";
 export { sanitizeName, deriveStorageKeyName } from "./deriveStorageKeyName.js";

--- a/packages/stagebook/src/utils/referencedAssets.test.ts
+++ b/packages/stagebook/src/utils/referencedAssets.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "vitest";
 import {
   getReferencedAssets,
+  collectAssetPrefixes,
   type ReferencedAsset,
 } from "./referencedAssets.js";
 
@@ -402,5 +403,116 @@ describe("getReferencedAssets — malformed input safety", () => {
     ]);
     expect(() => getReferencedAssets(tree)).not.toThrow();
     expect(getReferencedAssets(tree)).toEqual([]);
+  });
+});
+
+describe("collectAssetPrefixes (#192)", () => {
+  test("returns [] for non-object / empty input", () => {
+    expect(collectAssetPrefixes(null)).toEqual([]);
+    expect(collectAssetPrefixes(undefined)).toEqual([]);
+    expect(collectAssetPrefixes("asset://x/y.mp4")).toEqual([]);
+    expect(collectAssetPrefixes({})).toEqual([]);
+  });
+
+  test("collects the prefix from a single asset:// reference", () => {
+    const tree = treatmentWithElements([
+      { type: "mediaPlayer", file: "asset://group_recordings/session.mp4" },
+    ]);
+    expect(collectAssetPrefixes(tree)).toEqual(["group_recordings"]);
+  });
+
+  test("collects across every asset://-bearing field/element type", () => {
+    const tree = treatmentWithElements([
+      { type: "prompt", file: "asset://prompts/intro.prompt.md" },
+      { type: "image", file: "asset://diagrams/flow.png" },
+      { type: "audio", file: "asset://clips/intro.mp3" },
+      {
+        type: "mediaPlayer",
+        file: "asset://videos/a.mp4",
+        captionsFile: "asset://captions/a.vtt",
+      },
+    ]);
+    expect(collectAssetPrefixes(tree).sort()).toEqual([
+      "captions",
+      "clips",
+      "diagrams",
+      "prompts",
+      "videos",
+    ]);
+  });
+
+  test("dedupes a prefix used by multiple references", () => {
+    const tree = treatmentWithElements([
+      { type: "mediaPlayer", file: "asset://recordings/a.mp4" },
+      { type: "mediaPlayer", file: "asset://recordings/b.mp4" },
+      { type: "audio", file: "asset://recordings/c.mp3" },
+    ]);
+    expect(collectAssetPrefixes(tree)).toEqual(["recordings"]);
+  });
+
+  test("preserves prefix case (mount key is looked up exactly)", () => {
+    const tree = treatmentWithElements([
+      { type: "image", file: "ASSET://Group_Recordings/x.png" },
+    ]);
+    // Scheme match is case-insensitive; the prefix case is preserved.
+    expect(collectAssetPrefixes(tree)).toEqual(["Group_Recordings"]);
+  });
+
+  test("ignores relative paths and http(s) URLs (only asset://)", () => {
+    const tree = treatmentWithElements([
+      { type: "image", file: "images/logo.png" },
+      { type: "audio", file: "https://cdn.example/clip.mp3" },
+      { type: "mediaPlayer", file: "//cdn.example/v.mp4" },
+    ]);
+    expect(collectAssetPrefixes(tree)).toEqual([]);
+  });
+
+  test("ignores an opaque asset: URI with no //host (not mountable)", () => {
+    const tree = treatmentWithElements([
+      { type: "image", file: "asset:clip.png" },
+    ]);
+    expect(collectAssetPrefixes(tree)).toEqual([]);
+  });
+
+  test("skips a prefix that is still a ${…} placeholder", () => {
+    const tree = treatmentWithElements([
+      { type: "mediaPlayer", file: "asset://${clipset}/x.mp4" },
+    ]);
+    expect(collectAssetPrefixes(tree)).toEqual([]);
+  });
+
+  test("collects a concrete prefix even when the REST holds a ${…}", () => {
+    // Only the prefix must be concrete to mount; the path can bind later.
+    const tree = treatmentWithElements([
+      { type: "mediaPlayer", file: "asset://recordings/${clip}.mp4" },
+    ]);
+    expect(collectAssetPrefixes(tree)).toEqual(["recordings"]);
+  });
+
+  test("does not treat a name-reference field (timeline.source) as an asset", () => {
+    const tree = treatmentWithElements([
+      { type: "timeline", source: "asset://x/y.mp4" },
+    ]);
+    expect(collectAssetPrefixes(tree)).toEqual([]);
+  });
+
+  test("finds prefixes in introSequences, not just game stages", () => {
+    const tree = {
+      introSequences: [
+        {
+          name: "intro",
+          introSteps: [
+            {
+              name: "welcome",
+              elements: [
+                { type: "image", file: "asset://onboarding/welcome.png" },
+              ],
+            },
+          ],
+        },
+      ],
+      treatments: [],
+    };
+    expect(collectAssetPrefixes(tree)).toEqual(["onboarding"]);
   });
 });

--- a/packages/stagebook/src/utils/referencedAssets.ts
+++ b/packages/stagebook/src/utils/referencedAssets.ts
@@ -64,18 +64,83 @@ function isCollectableLocalPath(value: unknown): value is string {
  */
 export function getReferencedAssets(treatmentFile: unknown): ReferencedAsset[] {
   const results: ReferencedAsset[] = [];
-  walk(treatmentFile, [], results);
+  visitFileFields(treatmentFile, [], (info) => {
+    if (!isCollectableLocalPath(info.value)) return;
+    const asset: ReferencedAsset = {
+      path: info.value,
+      field: info.field,
+      elementType: info.elementType,
+      pathInTree: info.pathInTree,
+    };
+    if (info.elementName !== undefined) {
+      asset.elementName = info.elementName;
+    }
+    results.push(asset);
+  });
   return results;
 }
 
-function walk(
+// Matches the hierarchical `asset://<prefix>/…` form only (the mountable
+// shape). The scheme is case-insensitive because `fileSchema` accepts
+// `ASSET://`; `[^/]+` captures the prefix up to the first slash. An opaque
+// `asset:clip.mp4` (no `//host`) has no mount prefix and is intentionally not
+// matched.
+const ASSET_PREFIX_PATTERN = /^asset:\/\/([^/]+)/i;
+
+/**
+ * Collect the distinct mount prefixes referenced by `asset://<prefix>/…` URIs
+ * in a treatment (#192), using the same file-field allowlist as
+ * {@link getReferencedAssets}.
+ *
+ * The `asset:` scheme match is case-insensitive (fileSchema accepts
+ * `ASSET://`), but the prefix case is PRESERVED — it's a literal mount key a
+ * host looks up exactly, so lowercasing it would break a mixed-case mount.
+ * Prefixes that still contain a `${…}` template placeholder are skipped (they
+ * can't be mounted until the field binds).
+ *
+ * Pass the EXPANDED (template-filled) treatment so a `${field}` inside a
+ * prefix has already resolved to a concrete name. Non-object input yields
+ * `[]`. Order is stable tree-walk order.
+ */
+export function collectAssetPrefixes(treatmentFile: unknown): string[] {
+  const prefixes = new Set<string>();
+  visitFileFields(treatmentFile, [], (info) => {
+    if (typeof info.value !== "string") return;
+    const match = ASSET_PREFIX_PATTERN.exec(info.value);
+    if (!match) return;
+    const prefix = match[1];
+    // A prefix containing an unresolved `${…}` (or the start of one) isn't a
+    // concrete mount key — skip it rather than mount a literal placeholder.
+    if (prefix.includes("${")) return;
+    prefixes.add(prefix);
+  });
+  return [...prefixes];
+}
+
+/** Info passed to a {@link visitFileFields} callback for one file-like field. */
+interface FileFieldVisit {
+  /** The raw field value (may be any type; callers narrow to string). */
+  value: unknown;
+  field: string;
+  elementType: string;
+  elementName?: string;
+  pathInTree: (string | number)[];
+}
+
+/**
+ * Shared recursive walker behind {@link getReferencedAssets} and
+ * {@link collectAssetPrefixes}: invokes `visit` once for every file-like field
+ * (per {@link FILE_FIELDS_BY_ELEMENT_TYPE}) of every element in the tree, so
+ * both callers stay pinned to the same field source-of-truth.
+ */
+function visitFileFields(
   node: unknown,
   path: (string | number)[],
-  acc: ReferencedAsset[],
+  visit: (info: FileFieldVisit) => void,
 ): void {
   if (Array.isArray(node)) {
     node.forEach((item, i) => {
-      walk(item, [...path, i], acc);
+      visitFileFields(item, [...path, i], visit);
     });
     return;
   }
@@ -91,25 +156,20 @@ function walk(
     typeof type === "string" &&
     Object.hasOwn(FILE_FIELDS_BY_ELEMENT_TYPE, type)
   ) {
-    const fields = FILE_FIELDS_BY_ELEMENT_TYPE[type];
-    for (const field of fields) {
-      const value = record[field];
-      if (isCollectableLocalPath(value)) {
-        const asset: ReferencedAsset = {
-          path: value,
-          field,
-          elementType: type,
-          pathInTree: [...path, field],
-        };
-        if (typeof record.name === "string") {
-          asset.elementName = record.name;
-        }
-        acc.push(asset);
-      }
+    const elementName =
+      typeof record.name === "string" ? record.name : undefined;
+    for (const field of FILE_FIELDS_BY_ELEMENT_TYPE[type]) {
+      visit({
+        value: record[field],
+        field,
+        elementType: type,
+        elementName,
+        pathInTree: [...path, field],
+      });
     }
   }
 
   for (const [key, value] of Object.entries(record)) {
-    walk(value, [...path, key], acc);
+    visitFileFields(value, [...path, key], visit);
   }
 }

--- a/packages/stagebook/src/viewer/components/PreviewHost.test.tsx
+++ b/packages/stagebook/src/viewer/components/PreviewHost.test.tsx
@@ -256,3 +256,80 @@ describe("PreviewHost post-fill locale-consistency (#492)", () => {
     unmount();
   });
 });
+
+describe("PreviewHost hostNotice pass-through (#192)", () => {
+  const hostNotice = <div data-testid="host-notice">choose a folder</div>;
+  const findHostNotice = (c: HTMLElement) =>
+    c.querySelector('[data-testid="host-notice"]');
+
+  it("renders a host-supplied notice above the live preview", async () => {
+    // Locales agree → no built-in banner; the host notice must still show once
+    // the Viewer renders (the asset-mount card is non-blocking).
+    const getText = vi.fn(() => Promise.resolve(HE_PROMPT));
+    const { container, unmount } = render(
+      <PreviewHost
+        treatmentFile={fieldBoundLocaleTreatment()}
+        additionalFields={{ lang: "he" }}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        hostNotice={hostNotice}
+      />,
+    );
+    await flush();
+
+    expect(banner(container)).toBeNull();
+    expect(findHostNotice(container)).not.toBeNull();
+    unmount();
+  });
+
+  it("stacks the host notice ABOVE the built-in locale banner", async () => {
+    // Mismatch → banner shows; the host notice must precede it in document
+    // order (both are non-blocking notices in the Viewer's notice slot).
+    const getText = vi.fn(() => Promise.resolve(UNTAGGED_PROMPT));
+    const { container, unmount } = render(
+      <PreviewHost
+        treatmentFile={fieldBoundLocaleTreatment()}
+        additionalFields={{ lang: "he" }}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        hostNotice={hostNotice}
+      />,
+    );
+    await flush();
+
+    const host = findHostNotice(container);
+    const b = banner(container);
+    expect(host).not.toBeNull();
+    expect(b).not.toBeNull();
+    // DOCUMENT_POSITION_FOLLOWING is set when `b` comes after `host`.
+    expect(
+      host!.compareDocumentPosition(b!) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    unmount();
+  });
+
+  it("does not render the notice while the FieldForm gate is showing", async () => {
+    // An unresolved ${field} keeps PreviewHost in the blocking FieldForm branch
+    // (Viewer isn't mounted), so the host notice must not appear yet.
+    const getText = vi.fn(() => Promise.resolve(UNTAGGED_PROMPT));
+    const { container, unmount } = render(
+      <PreviewHost
+        treatmentFile={fieldBoundLocaleTreatment()}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        hostNotice={hostNotice}
+      />,
+    );
+    await flush();
+
+    // `lang` is unbound → FieldForm gate is up, Viewer (and its notice) is not.
+    expect(findHostNotice(container)).toBeNull();
+    unmount();
+  });
+});

--- a/packages/stagebook/src/viewer/components/PreviewHost.tsx
+++ b/packages/stagebook/src/viewer/components/PreviewHost.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { type TreatmentFileType } from "../../schemas/index.js";
 import { checkPromptLocaleConsistencyWithLoader } from "../../validate/localeConsistency.js";
 import {
@@ -43,6 +43,14 @@ export interface PreviewHostProps {
   onTreatmentIndexChange?: (index: number) => void;
   /** Forwarded to Viewer to drive its intro-sequence dropdown. */
   onIntroIndexChange?: (index: number) => void;
+  /**
+   * An optional host-supplied notice rendered above the live preview (below
+   * the Viewer header, non-blocking), stacked above any built-in banner. Used
+   * by the VS Code extension to surface its asset-mount picker (#192); other
+   * hosts (viewer app, TalkBench) omit it. Only shown once the Viewer renders
+   * — not during the FieldForm gate or an error screen.
+   */
+  hostNotice?: ReactNode;
 }
 
 /**
@@ -67,6 +75,7 @@ export function PreviewHost({
   contentVersion,
   onTreatmentIndexChange,
   onIntroIndexChange,
+  hostNotice,
 }: PreviewHostProps) {
   const [userValues, setUserValues] = useState<Record<string, string> | null>(
     null,
@@ -212,7 +221,14 @@ export function PreviewHost({
       contentVersion={contentVersion}
       onTreatmentIndexChange={onTreatmentIndexChange}
       onIntroIndexChange={onIntroIndexChange}
-      notice={localeBanner}
+      notice={
+        hostNotice || localeBanner ? (
+          <>
+            {hostNotice}
+            {localeBanner}
+          </>
+        ) : undefined
+      }
     />
   );
 }


### PR DESCRIPTION
Fixes #192.

Treatments reference platform media as `asset://<prefix>/<path>`. In production the platform resolves it; in the VS Code preview there is no platform, so #191 (merged) shows a labeled placeholder. This PR lets the author **mount each prefix to a local folder** so the real media loads while authoring — the placeholder remains the fallback for anything unmapped.

## Where the mount lives (per the issue discussion)
Nothing committed by default. When a preview references an unmapped prefix, a **non-blocking banner** offers **Choose folder…** per prefix (native picker). The pick is remembered **per-workspace** in `workspaceState` and is **never written to the study**, so `.stagebook.yaml` stays platform-agnostic. An optional, `resource`-scoped `stagebook.assetRoots` setting remains for teams that want a committable convention; **`Stagebook: Configure Asset Folders`** re-picks or clears mounts.

## How it works
- **`collectAssetPrefixes`** (library) — shares the file-field walk + allowlist with `getReferencedAssets`, inverting the filter to collect `asset://` prefixes from the expanded treatment.
- **`resolveAssetUrl` / `buildAssetURL`** (webview, pure) — map `asset://<prefix>/<rest>` to a mounted webview URI (traversal-rejected, segment-encoded), or pass the URI through unchanged so the #191 placeholder still fires.
- **`mergeAssetMounts` / `splitAssetMounts` / `extraAssetRoots`** (pure) — merge the setting with `workspaceState` picks, split mapped/unmapped, and compute the minimal `localResourceRoots` additions (in-workspace mounts are already covered recursively, so they add no root and don't force a reload).
- **`PreviewHost`** gains a generic `hostNotice` prop (stacked above the locale banner) so the vscode-only picker card renders without leaking into the shared viewer harness (also used by the viewer app + TalkBench).
- **Extension** — discovers prefixes, pre-seeds `localResourceRoots`, posts `{ assetRoots, unmappedAssetPrefixes }` in both treatment posts, and handles `pickAssetFolder`, reassigning `webview.options` only when the root set truly changes (the one case that reloads — out-of-workspace folders).

## Security
- Traversal rejected in `resolveAssetUrl` (both `/` and `\` separators) and bounded by `localResourceRoots`.
- The mount map is always **human-chosen** — a folder picked via `showOpenDialog` or a setting committed to one's own trusted workspace; a treatment file can never set it.
- The existing `readFile` `isWithinWorkspace` guard is untouched; assets load via `<img>/<video src>` gated by `localResourceRoots`, not through that handler.
- Gated by Workspace Trust and the existing strict CSP (script nonce-only, no `connect-src`).

## Review
Ran a 3-subagent review (correctness / test-coverage / security) with adversarial verification before opening. Five findings survived (all low/nit) and are folded in: containment-aware roots (fixes a spurious reload on in-workspace picks), resource-scoped setting read (multi-root workspaces), `getAssetURL` routing tests, and backslash-traversal hardening. Two security findings were verified as non-exploitable (CSP + Workspace Trust bound them) and are documented rather than "fixed."

## Test plan
- Library vitest: `getReferencedAssets` refactor preserved byte-for-byte; +11 `collectAssetPrefixes`, +3 `PreviewHost` hostNotice (full suite green).
- VS Code app vitest: 147 pass — pure helpers `resolveAssetUrl`/`buildAssetURL`/`mergeAssetMounts`/`splitAssetMounts`/`extraAssetRoots` covered (traversal, encoding, case, containment, multi-root merge).
- Playwright CT green (webkit Markdown flake retried green — untouched file).
- `tsc` clean for all touched files (one pre-existing `semanticTokens.ts` error, unrelated); `vsce package` validates the manifest + production build.

> **Note:** #192's placeholder fallback depends on #191 (#515), which is already merged — no ordering constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)