### PR TITLE
feat(vscode): discover asset:// prefixes in prompt bodies & field values (#524)

### DIFF
--- a/apps/vscode/src/webview/index.tsx
+++ b/apps/vscode/src/webview/index.tsx
@@ -2,7 +2,8 @@ import React, { useState, useEffect, useMemo, useRef } from "react";
 import { createRoot } from "react-dom/client";
 import type { TreatmentFileType } from "stagebook";
 import { PreviewHost } from "stagebook/viewer";
-import { buildAssetURL } from "./resolveAsset.js";
+import { resolveAssetForRender } from "./resolveAsset.js";
+import { useAssetBanner } from "./useAssetBanner.js";
 
 // Declare the VS Code API injected by the webview
 declare function acquireVsCodeApi(): {
@@ -44,6 +45,7 @@ window.addEventListener("message", (event) => {
 function createWebviewContentFns(
   webviewBaseUri: string,
   assetRoots: Record<string, string>,
+  onUnresolvedAsset: (prefix: string) => void,
 ) {
   const cache = new Map<string, Promise<string>>();
 
@@ -66,10 +68,17 @@ function createWebviewContentFns(
     },
 
     getAssetURL(assetPath: string): string {
-      // Platform asset:// references resolve against the configured local
-      // mounts (#192); an unmapped or unsafe one passes through unchanged so
-      // the renderer shows the #191 placeholder rather than a broken URL.
-      return buildAssetURL(assetPath, webviewBaseUri, assetRoots);
+      // #524: report an asset:// ref whose prefix isn't mounted (including one
+      // that appears only in a prompt body or field value the host-side scan
+      // can't see) so the picker banner can offer it — then resolve/passthrough
+      // the URL (#192). onUnresolvedAsset is a ref write promoted to state after
+      // render (see App/useAssetBanner).
+      return resolveAssetForRender(
+        assetPath,
+        webviewBaseUri,
+        assetRoots,
+        onUnresolvedAsset,
+      );
     },
   };
 }
@@ -95,6 +104,16 @@ function App() {
   // Bumped on each treatment message so that `contentFns` is recreated
   // with a fresh cache, forcing prompt files to re-fetch from disk.
   const [contentVersion, setContentVersion] = useState(0);
+
+  // #524: the banner offers the host-side scan (`unmappedAssetPrefixes`, all
+  // arms) unioned with prefixes the webview saw unresolved at render time
+  // (prompt bodies, field values). `collectUnresolved` is what getAssetURL
+  // reports into.
+  const { bannerPrefixes, collectUnresolved } = useAssetBanner(
+    unmappedAssetPrefixes,
+    assetRoots,
+    contentVersion,
+  );
 
   // Tracks whether we've received any `treatment` message yet. On the
   // first load we honor `msg.{treatment,intro}Index` (today always 0;
@@ -162,8 +181,9 @@ function App() {
   // `contentVersion` is deliberately part of the deps so a refresh creates
   // a fresh cache — forcing prompt files to re-fetch from disk.
   const contentFns = useMemo(
-    () => createWebviewContentFns(webviewBaseUri, assetRoots),
-    [webviewBaseUri, assetRoots, contentVersion],
+    () =>
+      createWebviewContentFns(webviewBaseUri, assetRoots, collectUnresolved),
+    [webviewBaseUri, assetRoots, contentVersion, collectUnresolved],
   );
 
   if (error) {
@@ -195,9 +215,9 @@ function App() {
       onRefresh={() => vscode.postMessage({ type: "refresh" })}
       contentVersion={contentVersion}
       hostNotice={
-        unmappedAssetPrefixes.length > 0 ? (
+        bannerPrefixes.length > 0 ? (
           <AssetMountCard
-            prefixes={unmappedAssetPrefixes}
+            prefixes={bannerPrefixes}
             onPick={(prefix) =>
               vscode.postMessage({ type: "pickAssetFolder", prefix })
             }

--- a/apps/vscode/src/webview/resolveAsset.test.ts
+++ b/apps/vscode/src/webview/resolveAsset.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from "vitest";
-import { resolveAssetUrl, buildAssetURL } from "./resolveAsset.js";
+import { describe, it, expect, vi } from "vitest";
+import {
+  resolveAssetUrl,
+  buildAssetURL,
+  assetPrefixOf,
+  reportUnresolvedAsset,
+  resolveAssetForRender,
+  mergeBannerPrefixes,
+} from "./resolveAsset.js";
 
 // #192: the webview resolves `asset://<prefix>/<rest>` against the mount map the
 // extension pre-computed (`{ prefix -> asWebviewUri(<local dir>) }`). A matched,
@@ -144,5 +151,130 @@ describe("buildAssetURL (#192 getAssetURL routing)", () => {
     expect(buildAssetURL("ASSET://unknown/x.mp4", BASE, ROOTS)).toBe(
       "ASSET://unknown/x.mp4",
     );
+  });
+});
+
+describe("assetPrefixOf (#524)", () => {
+  it("extracts the prefix from an asset:// URI", () => {
+    expect(assetPrefixOf("asset://diagrams/flow.png")).toBe("diagrams");
+    expect(assetPrefixOf("asset://recordings/a/b.mp4")).toBe("recordings");
+  });
+
+  it("matches case-insensitively but preserves prefix case", () => {
+    expect(assetPrefixOf("ASSET://Diagrams/x.png")).toBe("Diagrams");
+  });
+
+  it("handles a bare prefix with no rest", () => {
+    expect(assetPrefixOf("asset://diagrams")).toBe("diagrams");
+  });
+
+  it("returns null for a non-asset path", () => {
+    expect(assetPrefixOf("images/logo.png")).toBeNull();
+    expect(assetPrefixOf("https://cdn/x.png")).toBeNull();
+    expect(assetPrefixOf("asset:opaque.png")).toBeNull(); // no //host
+  });
+});
+
+describe("reportUnresolvedAsset (#524)", () => {
+  it("reports the prefix of an UNMOUNTED asset:// ref", () => {
+    const onUnresolved = vi.fn();
+    reportUnresolvedAsset("asset://diagrams/x.png", {}, onUnresolved);
+    expect(onUnresolved).toHaveBeenCalledWith("diagrams");
+  });
+
+  it("does NOT report a mounted prefix", () => {
+    const onUnresolved = vi.fn();
+    reportUnresolvedAsset(
+      "asset://diagrams/x.png",
+      { diagrams: "https://webview/x" },
+      onUnresolved,
+    );
+    expect(onUnresolved).not.toHaveBeenCalled();
+  });
+
+  it("does NOT report a non-asset path", () => {
+    const onUnresolved = vi.fn();
+    reportUnresolvedAsset("images/logo.png", {}, onUnresolved);
+    expect(onUnresolved).not.toHaveBeenCalled();
+  });
+
+  it("reports an unmounted prefix even for a traversal ref (prefix is still real)", () => {
+    const onUnresolved = vi.fn();
+    reportUnresolvedAsset("asset://clips/../../x", {}, onUnresolved);
+    expect(onUnresolved).toHaveBeenCalledWith("clips");
+  });
+});
+
+describe("mergeBannerPrefixes (#524)", () => {
+  it("unions the static scan with the render-collected set, sorted + deduped", () => {
+    expect(
+      mergeBannerPrefixes(
+        ["recordings", "diagrams"],
+        ["diagrams", "clips"],
+        {},
+      ),
+    ).toEqual(["clips", "diagrams", "recordings"]);
+  });
+
+  it("drops any prefix that is now mounted (from either source)", () => {
+    expect(
+      mergeBannerPrefixes(["recordings"], ["diagrams", "clips"], {
+        diagrams: "https://webview/d",
+      }),
+    ).toEqual(["clips", "recordings"]);
+  });
+
+  it("returns [] when everything is mounted or nothing is referenced", () => {
+    expect(mergeBannerPrefixes([], [], {})).toEqual([]);
+    expect(
+      mergeBannerPrefixes(["x"], ["x"], { x: "https://webview/x" }),
+    ).toEqual([]);
+  });
+
+  it("is order-independent (stable for change-detection)", () => {
+    const a = mergeBannerPrefixes(["b", "a"], ["c"], {});
+    const b = mergeBannerPrefixes(["a"], ["c", "b"], {});
+    expect(a).toEqual(b);
+    expect(a).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("resolveAssetForRender (#524 getAssetURL seam)", () => {
+  const BASE = "https://webview.example/study/";
+
+  it("returns the resolved URL AND reports an unmounted asset:// prefix", () => {
+    const onUnresolved = vi.fn();
+    const url = resolveAssetForRender(
+      "asset://diagrams/x.png",
+      BASE,
+      {},
+      onUnresolved,
+    );
+    // Passthrough (unmounted) so #191 placeholder fires...
+    expect(url).toBe("asset://diagrams/x.png");
+    // ...and the prefix is reported for the banner.
+    expect(onUnresolved).toHaveBeenCalledWith("diagrams");
+  });
+
+  it("resolves a mounted prefix and does NOT report it", () => {
+    const onUnresolved = vi.fn();
+    const url = resolveAssetForRender(
+      "asset://group_recordings/s.mp4",
+      BASE,
+      ROOTS,
+      onUnresolved,
+    );
+    expect(url).toBe(
+      "https://file+.vscode-resource.example/Users/me/videos/s.mp4",
+    );
+    expect(onUnresolved).not.toHaveBeenCalled();
+  });
+
+  it("base-joins a normal path and reports nothing", () => {
+    const onUnresolved = vi.fn();
+    expect(
+      resolveAssetForRender("images/logo.png", BASE, ROOTS, onUnresolved),
+    ).toBe("https://webview.example/study/images/logo.png");
+    expect(onUnresolved).not.toHaveBeenCalled();
   });
 });

--- a/apps/vscode/src/webview/resolveAsset.ts
+++ b/apps/vscode/src/webview/resolveAsset.ts
@@ -65,3 +65,64 @@ export function buildAssetURL(
     : webviewBaseUri + "/";
   return base + assetPath.replace(/^\/+/, "");
 }
+
+/**
+ * The mount prefix of an `asset://<prefix>/…` URI (case-insensitive scheme,
+ * prefix case preserved), or null if `path` isn't such a URI. Lets the webview
+ * notice asset refs it couldn't resolve — including those in prompt bodies or
+ * field values that the host-side scan never sees (#524).
+ */
+export function assetPrefixOf(path: string): string | null {
+  const match = /^asset:\/\/([^/]+)/i.exec(path);
+  return match ? match[1] : null;
+}
+
+/**
+ * If `assetPath` is an `asset://` ref whose prefix isn't mounted, report that
+ * prefix via `onUnresolved` so the picker banner can offer it (#524). No-op for
+ * a non-asset path or an already-mounted prefix. Kept separate from
+ * {@link buildAssetURL} so the collection is unit-testable without React.
+ */
+export function reportUnresolvedAsset(
+  assetPath: string,
+  assetRoots: Record<string, string>,
+  onUnresolved: (prefix: string) => void,
+): void {
+  const prefix = assetPrefixOf(assetPath);
+  if (prefix && !assetRoots[prefix]) onUnresolved(prefix);
+}
+
+/**
+ * The full `getAssetURL` contract: report an unresolved `asset://` prefix for
+ * the picker banner (#524) AND return the loadable/passthrough URL (#192). Kept
+ * as one testable function so the report-and-build seam getAssetURL relies on
+ * is covered without the postMessage bridge.
+ */
+export function resolveAssetForRender(
+  assetPath: string,
+  webviewBaseUri: string,
+  assetRoots: Record<string, string>,
+  onUnresolved: (prefix: string) => void,
+): string {
+  reportUnresolvedAsset(assetPath, assetRoots, onUnresolved);
+  return buildAssetURL(assetPath, webviewBaseUri, assetRoots);
+}
+
+/**
+ * The prefixes the picker banner should offer (#524): the host-side static
+ * scan (all treatment arms) unioned with the prefixes the webview saw
+ * unresolved at render time (prompt bodies, field values), minus any that are
+ * now mounted. Sorted + deduped so the result is stable across renders and the
+ * caller's change-detection converges.
+ */
+export function mergeBannerPrefixes(
+  staticUnmapped: string[],
+  seenUnresolved: string[],
+  assetRoots: Record<string, string>,
+): string[] {
+  const out = new Set<string>();
+  for (const prefix of [...staticUnmapped, ...seenUnresolved]) {
+    if (!assetRoots[prefix]) out.add(prefix);
+  }
+  return [...out].sort();
+}

--- a/apps/vscode/src/webview/useAssetBanner.test.tsx
+++ b/apps/vscode/src/webview/useAssetBanner.test.tsx
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+// (jsdom is a workspace-hoisted devDependency, provided by the library package.)
+//
+// #524: the picker banner must also offer asset:// prefixes the host-side scan
+// can't see (prompt bodies, field values). useAssetBanner collects the prefixes
+// getAssetURL reports unresolved at render time and unions them with the scan.
+// These tests exercise the render-phase collection + reconcile loop (its
+// convergence is load-bearing — a non-converging effect would hang act()).
+import { describe, it, expect, beforeAll } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useAssetBanner } from "./useAssetBanner.js";
+
+beforeAll(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+interface HarnessProps {
+  unmapped: string[];
+  assetRoots: Record<string, string>;
+  contentVersion: number;
+  /** Prefixes the "child tree" references this render (simulates getAssetURL). */
+  refsToRender: string[];
+  onBanner: (banner: string[]) => void;
+  onCollector?: (collect: (prefix: string) => void) => void;
+}
+
+/** Drives the hook and simulates getAssetURL collecting during render. */
+function Harness({
+  unmapped,
+  assetRoots,
+  contentVersion,
+  refsToRender,
+  onBanner,
+  onCollector,
+}: HarnessProps) {
+  const { bannerPrefixes, collectUnresolved } = useAssetBanner(
+    unmapped,
+    assetRoots,
+    contentVersion,
+  );
+  // Mirror getAssetURL: report any referenced asset:// prefix that isn't mounted.
+  for (const prefix of refsToRender) {
+    if (!assetRoots[prefix]) collectUnresolved(prefix);
+  }
+  onBanner(bannerPrefixes);
+  onCollector?.(collectUnresolved);
+  return null;
+}
+
+function renderHarness(props: Omit<HarnessProps, "onBanner">) {
+  const container = document.createElement("div");
+  let latest: string[] = [];
+  let root: Root;
+  const render = (p: Omit<HarnessProps, "onBanner">) =>
+    root.render(<Harness {...p} onBanner={(b) => (latest = b)} />);
+  act(() => {
+    root = createRoot(container);
+    render(props);
+  });
+  return {
+    banner: () => latest,
+    rerender: (p: Omit<HarnessProps, "onBanner">) => act(() => render(p)),
+    unmount: () => act(() => root.unmount()),
+  };
+}
+
+describe("useAssetBanner (#524)", () => {
+  it("surfaces a render-collected prefix the host-side scan missed", () => {
+    // Host scan found nothing (ref lives only in a prompt body / field value),
+    // but getAssetURL saw asset://diagrams/ unresolved.
+    const h = renderHarness({
+      unmapped: [],
+      assetRoots: {},
+      contentVersion: 1,
+      refsToRender: ["diagrams"],
+    });
+    expect(h.banner()).toEqual(["diagrams"]);
+    h.unmount();
+  });
+
+  it("unions the host-side scan with render-collected prefixes (sorted)", () => {
+    const h = renderHarness({
+      unmapped: ["recordings"],
+      assetRoots: {},
+      contentVersion: 1,
+      refsToRender: ["diagrams"],
+    });
+    expect(h.banner()).toEqual(["diagrams", "recordings"]);
+    h.unmount();
+  });
+
+  it("does not collect a mounted prefix", () => {
+    const h = renderHarness({
+      unmapped: [],
+      assetRoots: { diagrams: "https://webview/d" },
+      contentVersion: 1,
+      refsToRender: ["diagrams"],
+    });
+    expect(h.banner()).toEqual([]);
+    h.unmount();
+  });
+
+  it("converges (a redundant re-render produces the same banner, no loop)", () => {
+    const props = {
+      unmapped: [] as string[],
+      assetRoots: {},
+      contentVersion: 1,
+      refsToRender: ["a", "b"],
+    };
+    const h = renderHarness(props);
+    expect(h.banner()).toEqual(["a", "b"]);
+    // A no-op re-render must not thrash — same banner (act would hang on a loop).
+    h.rerender(props);
+    expect(h.banner()).toEqual(["a", "b"]);
+    h.unmount();
+  });
+
+  it("accumulates prefixes seen across renders within the same treatment", () => {
+    const h = renderHarness({
+      unmapped: [],
+      assetRoots: {},
+      contentVersion: 1,
+      refsToRender: ["a"],
+    });
+    expect(h.banner()).toEqual(["a"]);
+    // Same treatment, a different stage now references `b` — `a` persists.
+    h.rerender({
+      unmapped: [],
+      assetRoots: {},
+      contentVersion: 1,
+      refsToRender: ["b"],
+    });
+    expect(h.banner()).toEqual(["a", "b"]);
+    h.unmount();
+  });
+
+  it("resets the accumulation on a new treatment (contentVersion change)", () => {
+    const h = renderHarness({
+      unmapped: [],
+      assetRoots: {},
+      contentVersion: 1,
+      refsToRender: ["a"],
+    });
+    expect(h.banner()).toEqual(["a"]);
+    h.rerender({
+      unmapped: [],
+      assetRoots: {},
+      contentVersion: 2,
+      refsToRender: ["b"],
+    });
+    expect(h.banner()).toEqual(["b"]); // 'a' dropped — fresh treatment
+    h.unmount();
+  });
+
+  it("drops a prefix once it becomes mounted (pick → new roots + version)", () => {
+    const h = renderHarness({
+      unmapped: [],
+      assetRoots: {},
+      contentVersion: 1,
+      refsToRender: ["diagrams"],
+    });
+    expect(h.banner()).toEqual(["diagrams"]);
+    // Simulate a pick: diagrams mounted, treatment re-posted (version bump).
+    h.rerender({
+      unmapped: [],
+      assetRoots: { diagrams: "https://webview/d" },
+      contentVersion: 2,
+      refsToRender: ["diagrams"],
+    });
+    expect(h.banner()).toEqual([]);
+    h.unmount();
+  });
+
+  it("drops a prefix via the mounted-filter alone (assetRoots change, same version)", () => {
+    const h = renderHarness({
+      unmapped: [],
+      assetRoots: {},
+      contentVersion: 1,
+      refsToRender: ["diagrams"],
+    });
+    expect(h.banner()).toEqual(["diagrams"]);
+    // Same treatment (version unchanged), so the accumulated ref still holds
+    // 'diagrams' — but it's now mounted, so mergeBannerPrefixes filters it out.
+    // Exercises the mounted-filter path independent of the version reset.
+    h.rerender({
+      unmapped: [],
+      assetRoots: { diagrams: "https://webview/d" },
+      contentVersion: 1,
+      refsToRender: ["diagrams"],
+    });
+    expect(h.banner()).toEqual([]);
+    h.unmount();
+  });
+
+  it("keeps collectUnresolved referentially stable across renders (getAssetURL contract)", () => {
+    const collectors: Array<(p: string) => void> = [];
+    const base = {
+      unmapped: [] as string[],
+      assetRoots: {},
+      contentVersion: 1,
+      refsToRender: [] as string[],
+      onCollector: (c: (p: string) => void) => collectors.push(c),
+    };
+    const h = renderHarness(base);
+    h.rerender({ ...base, refsToRender: ["a"] });
+    h.rerender({ ...base, contentVersion: 2 });
+    // A fresh identity each render would recreate contentFns → getAssetURL →
+    // PreviewHost re-fetch loop. Every render must hand back the same collector.
+    expect(collectors.length).toBeGreaterThan(1);
+    expect(collectors.every((c) => c === collectors[0])).toBe(true);
+    h.unmount();
+  });
+});

--- a/apps/vscode/src/webview/useAssetBanner.ts
+++ b/apps/vscode/src/webview/useAssetBanner.ts
@@ -1,0 +1,73 @@
+import { useState, useRef, useEffect, useMemo, useCallback } from "react";
+import { mergeBannerPrefixes } from "./resolveAsset.js";
+
+/**
+ * Drives the asset-mount picker banner (#524).
+ *
+ * The host-side scan (`unmappedAssetPrefixes`) only sees `asset://` refs in the
+ * treatment YAML. The webview is the one place that sees EVERY ref at render
+ * time — including those in prompt bodies (`![](asset://…)`) and field-supplied
+ * values (`file: ${clipUrl}`) — because `getAssetURL` is called for each. This
+ * hook collects the unresolved prefixes `getAssetURL` reports (via
+ * `collectUnresolved`) and unions them with the host-side scan.
+ *
+ * Collection is a ref write during render (safe; not state), promoted to state
+ * by an effect after commit. `setState` bails when the sorted set is unchanged,
+ * so it converges: a re-render collects the same prefixes and produces no
+ * further update. The accumulation resets whenever `contentVersion` changes (a
+ * new treatment), during render, so a treatment whose refs live only in prompt
+ * bodies still re-collects from scratch.
+ *
+ * @param unmappedAssetPrefixes host-side static scan (all treatment arms)
+ * @param assetRoots            prefix → mounted webview URI (to drop mounted)
+ * @param contentVersion        bumped per treatment message; resets collection
+ * @returns `bannerPrefixes` (sorted, deduped, mounted-filtered) and
+ *          `collectUnresolved` for `getAssetURL` to report into
+ */
+export function useAssetBanner(
+  unmappedAssetPrefixes: string[],
+  assetRoots: Record<string, string>,
+  contentVersion: number,
+): { bannerPrefixes: string[]; collectUnresolved: (prefix: string) => void } {
+  const [seenUnresolved, setSeenUnresolved] = useState<string[]>([]);
+  const unresolvedRef = useRef<Set<string>>(new Set());
+  const lastContentVersionRef = useRef(contentVersion);
+
+  // Reset DURING render (before the child tree calls getAssetURL) so this pass
+  // re-collects from scratch. An effect would clear the just-collected set and
+  // then never re-run for a treatment whose refs are all in prompt bodies.
+  // Resetting `seenUnresolved` here too (React's set-state-during-render, which
+  // re-renders before paint) avoids a one-frame flash of the previous
+  // treatment's accumulated prefixes on a bump render.
+  if (lastContentVersionRef.current !== contentVersion) {
+    lastContentVersionRef.current = contentVersion;
+    unresolvedRef.current = new Set();
+    setSeenUnresolved((prev) => (prev.length === 0 ? prev : []));
+  }
+
+  // Stable, so it doesn't churn a getAssetURL/contentFns memo; reads the ref
+  // dynamically.
+  const collectUnresolved = useCallback((prefix: string) => {
+    unresolvedRef.current.add(prefix);
+  }, []);
+
+  // Promote the render-collected set to state after each render. Bails when
+  // unchanged → converges.
+  useEffect(() => {
+    const collected = [...unresolvedRef.current].sort();
+    setSeenUnresolved((prev) =>
+      prev.length === collected.length &&
+      prev.every((p, i) => p === collected[i])
+        ? prev
+        : collected,
+    );
+  });
+
+  const bannerPrefixes = useMemo(
+    () =>
+      mergeBannerPrefixes(unmappedAssetPrefixes, seenUnresolved, assetRoots),
+    [unmappedAssetPrefixes, seenUnresolved, assetRoots],
+  );
+
+  return { bannerPrefixes, collectUnresolved };
+}


### PR DESCRIPTION
Fixes #524. Follow-up to #192 (#522).

## Problem
The #192 asset-mount picker banner listed only prefixes found by a **host-side static scan** of the treatment YAML. An `asset://` ref that appears only inside a loaded **prompt body** (`![](asset://diagrams/flow.png)`) or a **field-supplied value** (`file: ${clipUrl}` bound to `asset://…`) wasn't in the YAML tree, so it never got a "Choose folder…" row. (A *configured* mount still resolved it — this is only about interactive discovery.)

## Approach
The webview is the one place that sees **every** asset ref at render time, because `getAssetURL` is called for each. So:

- **`getAssetURL`** now calls `resolveAssetForRender`, which reports any ref whose prefix isn't mounted (`reportUnresolvedAsset`) and returns the resolved/passthrough URL (#192, unchanged).
- **`useAssetBanner(unmappedAssetPrefixes, assetRoots, contentVersion)`** hook:
  - collects reported prefixes into a ref **during render** (a ref write, not state), promoted to `seenUnresolved` state by a reconcile effect that **bails when unchanged** — so it **converges** (a re-render collects the same set → no further update);
  - resets the accumulation **per treatment** (`contentVersion`), during render — and resets `seenUnresolved` synchronously in the same block to avoid a one-frame stale flash;
  - returns `bannerPrefixes = mergeBannerPrefixes(...)` = union of host scan + render-collected, minus anything now mounted, sorted + deduped (stable for change-detection);
  - returns a **referentially stable** `collectUnresolved` so `getAssetURL`/`contentFns` stay stable (PreviewHost's re-fetch contract).
- The banner (`AssetMountCard`) is driven by `bannerPrefixes`; the pick flow (`pickAssetFolder`) is unchanged.

The banner still lists only prefixes seen in the *current view* plus the host scan's all-arms set; a prefix in a non-current arm's prompt body surfaces when you navigate to it.

## Testing
- **Pure helpers** unit-tested: `assetPrefixOf`, `reportUnresolvedAsset`, `resolveAssetForRender` (the getAssetURL seam), `mergeBannerPrefixes`.
- **`useAssetBanner` jsdom test** covers the load-bearing wiring: reconcile-loop **convergence** (a runaway loop would hang `act()`), discovery of a scan-missed prefix, union with the host scan, mounted-drop (both via version-reset and via the filter alone), accumulate-within-treatment, reset-on-new-treatment, and `collectUnresolved` referential stability.
- 177 vscode tests green; tsc clean (one pre-existing `semanticTokens.ts` error, unrelated); esbuild build clean.

## Review
Ran a 3-subagent review (correctness-of-React-wiring / coverage / security) with adversarial verification before opening; 4 low/nit findings folded in (stale-flash fix, getAssetURL-seam test, stability + filter-only-drop tests), 1 rejected. No new security surface — collection is render-time only; mounting/reading is the unchanged, human-gated #192 path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)