### PR TITLE
fix(schema): reject non-self position selectors in groupComposition conditions

### DIFF
--- a/packages/stagebook/src/schemas/resolved.test.ts
+++ b/packages/stagebook/src/schemas/resolved.test.ts
@@ -519,3 +519,46 @@ describe("resolvedTreatmentFileSchema schema is exported", () => {
     expect(resolvedTreatmentFileSchema.safeParse({}).success).toBe(true);
   });
 });
+
+describe("resolved groupComposition enforces the self-only rule (#526)", () => {
+  // The pre-fill `playerSchema` skips a `${field}` groupComposition, so a
+  // host-supplied composition is first validated here post-fill. The
+  // self-only rule must fire on this surface too, or a cross-participant
+  // selector slips through on the resolved/preview path (#526 review).
+  const treatmentWith = (reference: string) => ({
+    name: "t",
+    playerCount: 2,
+    compatibleIntroSequences: [],
+    groupComposition: [
+      {
+        position: 0,
+        conditions: [{ reference, comparator: "equals", value: "buyer" }],
+      },
+      { position: 1 },
+    ],
+    gameStages: [
+      { name: "s", duration: 60, elements: [{ type: "submitButton" }] },
+    ],
+  });
+
+  test("rejects a non-self position in a resolved groupComposition condition", () => {
+    const result = resolvedTreatmentSchema.safeParse(
+      treatmentWith("0.prompt.role"),
+    );
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path.join(".") === "groupComposition.0.conditions.0.reference",
+      );
+      expect(issue?.message).toMatch(/must use the `self` position selector/);
+    }
+  });
+
+  test("accepts a `self` position in a resolved groupComposition condition", () => {
+    const result = resolvedTreatmentSchema.safeParse(
+      treatmentWith("self.prompt.role"),
+    );
+    if (!result.success) console.error(result.error.issues);
+    expect(result.success).toBe(true);
+  });
+});

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -22,6 +22,7 @@ import {
   discussionSchema,
   referenceSchema,
   promptFilePathSchema,
+  validateConditionRules,
 } from "./treatment.js";
 
 // Detects `${field}` placeholders that survived `fillTemplates` —
@@ -330,11 +331,27 @@ export const resolvedTreatmentSchema = z.object({
   locale: localeSchema.optional(),
   groupComposition: z
     .array(
-      z.object({
-        position: positionSchema,
-        title: z.string().max(25).optional(),
-        conditions: resolvedConditionsSchema,
-      }),
+      z
+        .object({
+          position: positionSchema,
+          title: z.string().max(25).optional(),
+          conditions: resolvedConditionsSchema,
+        })
+        .superRefine((data, ctx) => {
+          // Same `self`-only rule as the pre-fill `playerSchema` (#526).
+          // Unlike the cross-treatment checks this schema deliberately
+          // omits, this is a fillTemplates leak the resolved schema exists
+          // to catch: when `groupComposition` is a `${field}` placeholder,
+          // the pre-fill schema skips it entirely, so a host-supplied
+          // composition with a cross-participant selector (`shared`, a slot
+          // index, or `all`) is first seen post-fill — enforce it here too
+          // or it slips through on the resolved/preview path.
+          validateConditionRules(data.conditions, ["conditions"], ctx, {
+            contextLabel: "Group-composition",
+            forbidSelfPosition: false,
+            requireSelfPosition: true,
+          });
+        }),
     )
     .optional(),
   gameStages: z.array(resolvedStageSchema).nonempty(),

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -1668,6 +1668,32 @@ test("playerSchema require-self rule stays silent when the position is undetermi
   }
 });
 
+test("playerSchema require-self rule stays silent on an invalid/unresolved structured position (#526 review)", () => {
+  // Structured-object references whose `position` is not a valid selector
+  // (an unbound `${slot}` placeholder, or a `player` typo) must not draw a
+  // misleading cross-participant-selector error — the grammar error owns it,
+  // mirroring the dotted-string path.
+  for (const badPosition of ["${slot}", "player"]) {
+    const result = playerSchema.safeParse({
+      position: 0,
+      conditions: [
+        {
+          reference: { position: badPosition, source: "prompt", name: "role" },
+          comparator: "equals",
+          value: "buyer",
+        },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const selfIssue = result.error.issues.find((i) =>
+        i.message.includes("must use the `self` position selector"),
+      );
+      expect(selfIssue).toBeUndefined();
+    }
+  }
+});
+
 test("playerSchema require-self rule recurses into operator branches (#526)", () => {
   // A `shared.` leaf nested inside an `any:` operator is still rejected —
   // the walker applies the self-only rule to every leaf, mirroring the

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -11,6 +11,7 @@ import {
   introStepsSchema,
   exitStepsSchema,
   mediaPlayerSchema,
+  playerSchema,
   stageSchema,
   timelineSchema,
   promptSchema,
@@ -1575,6 +1576,166 @@ test("game-stage forbid-self error message points at the boolean-tree migration 
     );
     expect(issue?.message).toMatch(/cross-client position prefix/);
     expect(issue?.message).toMatch(/`all:` or `any:` operator/);
+  }
+});
+
+// ----------- Group-composition require-self rule (#526) ------------
+//
+// Player-block (`groupComposition`) conditions gate slot eligibility,
+// which is decided per candidate *before* any group exists — so only the
+// candidate's own responses (`self`) can resolve. A cross-participant
+// selector (`shared`, a numeric slot index, or `all`) would otherwise
+// validate clean but silently misbehave at dispatch, so it's a validation
+// error. Mirrors the game-stage `forbidSelfPosition` tests above.
+
+test("playerSchema accepts a groupComposition condition with a `self` position", () => {
+  const result = playerSchema.safeParse({
+    position: 0,
+    conditions: [
+      { reference: "self.prompt.role", comparator: "equals", value: "buyer" },
+    ],
+  });
+  if (!result.success) console.log(result.error.issues);
+  expect(result.success).toBe(true);
+});
+
+for (const [badReference, got] of [
+  ["0.prompt.role", "0"], // numeric slot index
+  ["shared.prompt.role", "shared"], // group-shared state
+  ["all.prompt.role", "all"], // cross-participant list
+] as const) {
+  test(`playerSchema rejects a groupComposition condition with a non-self position (${badReference})`, () => {
+    const result = playerSchema.safeParse({
+      position: 0,
+      conditions: [
+        { reference: badReference, comparator: "equals", value: "buyer" },
+      ],
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find(
+        (i) => i.path.join(".") === "conditions.0.reference",
+      );
+      expect(issue?.message).toMatch(/must use the `self` position selector/);
+      // The message echoes the offending selector, so the three cases are
+      // actually distinguished (not all matching a shared prefix).
+      expect(issue?.message).toContain(`Got \`${got}\`.`);
+    }
+  });
+}
+
+test("playerSchema rejects a non-self position in the structured-object reference form (#526)", () => {
+  // References can be authored as `{ position, source, name }` objects, not
+  // just dotted strings. `extractReferencePosition` reads `.position` off
+  // the object form, so this must be rejected too.
+  const result = playerSchema.safeParse({
+    position: 0,
+    conditions: [
+      {
+        reference: { position: 0, source: "prompt", name: "role" },
+        comparator: "equals",
+        value: "buyer",
+      },
+    ],
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find(
+      (i) => i.path.join(".") === "conditions.0.reference",
+    );
+    expect(issue?.message).toMatch(/must use the `self` position selector/);
+    expect(issue?.message).toContain("Got `0`.");
+  }
+});
+
+test("playerSchema require-self rule stays silent when the position is undetermined (#526)", () => {
+  // A reference with no determinable position (here: missing the required
+  // position prefix) is left to the reference validator — the require-self
+  // rule must NOT pile on a spurious position-selector error. The parse
+  // still fails on the reference grammar, but not for the self reason.
+  const result = playerSchema.safeParse({
+    position: 0,
+    conditions: [
+      { reference: "prompt.role", comparator: "equals", value: "buyer" },
+    ],
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const selfIssue = result.error.issues.find((i) =>
+      i.message.includes("must use the `self` position selector"),
+    );
+    expect(selfIssue).toBeUndefined();
+  }
+});
+
+test("playerSchema require-self rule recurses into operator branches (#526)", () => {
+  // A `shared.` leaf nested inside an `any:` operator is still rejected —
+  // the walker applies the self-only rule to every leaf, mirroring the
+  // game-stage forbid-self recursion test.
+  const result = playerSchema.safeParse({
+    position: 1,
+    conditions: {
+      any: [
+        { reference: "self.prompt.role", comparator: "equals", value: "buyer" },
+        {
+          reference: "shared.prompt.role",
+          comparator: "equals",
+          value: "seller",
+        },
+      ],
+    },
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find(
+      (i) => i.path.join(".") === "conditions.any.1.reference",
+    );
+    expect(issue?.message).toMatch(/must use the `self` position selector/);
+  }
+});
+
+test("groupComposition non-self condition errors through treatmentFileSchema (#526)", () => {
+  // Confirms the require-self rule fires on the full parse path shared by
+  // the CLI and diff validators (both go through `safeParseTreatmentFile`
+  // → `treatmentFileSchema` → `groupComposition: z.array(playerSchema)`),
+  // not only on a standalone `playerSchema.safeParse`.
+  const result = treatmentFileSchema.safeParse({
+    treatments: [
+      {
+        name: "t",
+        playerCount: 2,
+        compatibleIntroSequences: [],
+        groupComposition: [
+          {
+            position: 0,
+            conditions: [
+              {
+                reference: "0.prompt.role",
+                comparator: "equals",
+                value: "buyer",
+              },
+            ],
+          },
+          { position: 1 },
+        ],
+        gameStages: [
+          {
+            name: "stage1",
+            duration: 60,
+            elements: [{ type: "submitButton" }],
+          },
+        ],
+      },
+    ],
+  });
+  expect(result.success).toBe(false);
+  if (!result.success) {
+    const issue = result.error.issues.find(
+      (i) =>
+        i.path.join(".") ===
+        "treatments.0.groupComposition.0.conditions.0.reference",
+    );
+    expect(issue?.message).toMatch(/must use the `self` position selector/);
   }
 });
 

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -951,7 +951,7 @@ function validateTimelineSources(
  * are skipped — they're checked after expansion against the resolved
  * shape, not pre-expansion.
  */
-function validateConditionRules(
+export function validateConditionRules(
   conditions: unknown,
   pathPrefix: (string | number)[],
   ctx: z.RefinementCtx,
@@ -1061,7 +1061,16 @@ function extractReferencePosition(
     (typeof (reference as { position: unknown }).position === "string" ||
       typeof (reference as { position: unknown }).position === "number")
   ) {
-    return (reference as { position: number | string }).position;
+    // Mirror the dotted-string path: only surface a position the grammar
+    // actually accepts. An unresolved (`${slot}`) or malformed (`player`)
+    // structured position is left to `referenceSchema` to report, so the
+    // caller's rules don't pile a misleading position-selector message on
+    // top of the reference-grammar error (#526 review). Coercing here also
+    // canonicalizes a quoted `"1"` to the numeric `1`, matching the parser.
+    const parsed = positionSelectorSchema.safeParse(
+      (reference as { position: number | string }).position,
+    );
+    return parsed.success ? parsed.data : undefined;
   }
   return undefined;
 }

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -955,7 +955,14 @@ function validateConditionRules(
   conditions: unknown,
   pathPrefix: (string | number)[],
   ctx: z.RefinementCtx,
-  options: { contextLabel: string; forbidSelfPosition: boolean },
+  options: {
+    contextLabel: string;
+    // Game-stage rule: reject `self` (would desync across clients).
+    forbidSelfPosition: boolean;
+    // Group-composition rule: reject anything *but* `self` (#526).
+    // Mutually exclusive with `forbidSelfPosition`.
+    requireSelfPosition?: boolean;
+  },
 ): void {
   if (conditions === undefined || conditions === null) return;
 
@@ -1009,6 +1016,25 @@ function validateConditionRules(
         code: z.ZodIssueCode.custom,
         path: [...pathPrefix, "reference"],
         message: `${options.contextLabel} conditions must use a cross-client position prefix on the reference (\`shared\`, a numeric slot index, or \`all\`) — got \`self\`. Per-participant references would let one participant skip the stage while the other renders it. For per-participant aggregation, wrap leaves in an \`all:\` or \`any:\` operator with explicit slot-index references.`,
+      });
+    }
+  }
+
+  // Group-composition (player-block) eligibility is decided per candidate
+  // *before* any group exists, so only the candidate's own responses can
+  // resolve. A cross-participant selector (`shared`, a numeric slot index,
+  // or `all`) has nothing to resolve against and silently misbehaves at
+  // dispatch — the slot becomes either never-eligible or vacuously eligible
+  // with no error at authoring or launch (#526). Require `self`. An
+  // undetermined position (invalid reference or template placeholder) is
+  // left to the reference/expansion validators, same as the forbid path.
+  if (options.requireSelfPosition) {
+    const refPosition = extractReferencePosition(c.reference);
+    if (refPosition !== undefined && refPosition !== "self") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [...pathPrefix, "reference"],
+        message: `${options.contextLabel} conditions must use the \`self\` position selector — eligibility is decided per candidate before any group exists, so cross-participant selectors (\`shared\`, a numeric slot index, or \`all\`) have nothing to resolve against. Got \`${refPosition}\`.`,
       });
     }
   }
@@ -1128,7 +1154,7 @@ export type ConditionType = z.infer<typeof conditionSchema>;
 
 // ------------------ Players ------------------ //
 
-export const playerSchema = z
+const playerBaseSchema = z
   .object({
     position: positionSchema,
     title: z.string().max(25).optional(),
@@ -1140,6 +1166,20 @@ export const playerSchema = z
     conditions: conditionsSchema.optional(),
   })
   .strict();
+
+export const playerSchema = playerBaseSchema.superRefine((data, ctx) => {
+  // Group-composition (player-block) conditions gate who is eligible for
+  // this slot. Eligibility is evaluated per candidate before any group is
+  // formed, so a cross-participant selector (`shared`, a numeric slot
+  // index, or `all`) resolves to nothing and silently misbehaves at
+  // dispatch. Enforce the documented `self`-only rule at validation time
+  // (#526) — the docs already describe it; this makes the validator match.
+  validateConditionRules(data.conditions, ["conditions"], ctx, {
+    contextLabel: "Group-composition",
+    forbidSelfPosition: false,
+    requireSelfPosition: true,
+  });
+});
 export type PlayerType = z.infer<typeof playerSchema>;
 
 // ------------------ Elements ------------------ //
@@ -1597,11 +1637,11 @@ export function getValidKeysForDiscussion(): string[] {
 
 /**
  * Return the list of valid keys allowed on a player block (an item in
- * a treatment's `groupComposition`). `playerSchema` is a plain
- * `ZodObject`, so we read `.shape` directly.
+ * a treatment's `groupComposition`). `playerSchema` wraps a refine, so
+ * we read `.shape` off the underlying `playerBaseSchema` object.
  */
 export function getValidKeysForPlayer(): string[] {
-  return Object.keys(playerSchema.shape);
+  return Object.keys(playerBaseSchema.shape);
 }
 
 export const elementSchema = altTemplateContext(


### PR DESCRIPTION
## Summary

`groupComposition` (player-block) eligibility `conditions` are **documented** as `self`-only but were **never validated**. A researcher could write a cross-participant selector (`shared.`, `all.`, or a numeric slot index like `0.`) in a group-assignment condition; it passed validation and then **silently misbehaved at dispatch** — the slot became either **never-eligible** (positive comparators like `equals`/`isAtLeast`) or **vacuously eligible** (negative family like `doesNotEqual`), with **no error at authoring or launch**. Group assignment is exactly where a silent wrong answer is most costly.

This makes the validator match the docs (`docs/researcher/conditions.md:400`): group-assignment conditions can only reference the participant's own responses via `self`.

Fixes #526. Surfaced while documenting the dispatch algorithms (#525).

## What changed

- **`validateConditionRules`** gains a `requireSelfPosition` counterpart to the existing `forbidSelfPosition` refine — it rejects any non-`self` position selector with a clear, actionable message:
  > Group-composition conditions must use the `self` position selector — eligibility is decided per candidate before any group exists, so cross-participant selectors (`shared`, a numeric slot index, or `all`) have nothing to resolve against. Got `<selector>`.
- **`playerSchema`** is refactored into `playerBaseSchema` (the plain `.strict()` object, still read by `getValidKeysForPlayer` via `.shape`) plus a `superRefine` that runs the walker with `requireSelfPosition: true`.
- An undetermined position (invalid reference or template placeholder) is left to the reference/expansion validators — the rule doesn't pile on a spurious error, mirroring the `forbidSelfPosition` path.

Because the rule lives **inside the zod schema**, it fires on every validation path automatically — the CLI (`validateTreatment` → `safeParseTreatmentFile`) and the diff validator (`runValidationDiff`, pre- **and** post-expansion) both parse through `treatmentFileSchema` → `groupComposition: z.array(playerSchema)`. No manual per-surface wiring, so it can't skip one validator (see [the two-wiring-paths trap]). Confirmed by running the built CLI on a sample file and by an end-to-end `treatmentFileSchema` test.

## Tests

Mirror the existing game-stage `forbidSelfPosition` tests:
- `0.`, `shared.`, `all.` selectors each → error (message echoes the offending selector); `self.` → clean.
- Structured-object reference form (`{ position, source, name }`) → error.
- Rule recurses into `all`/`any`/`none` operator branches.
- Stays silent when the position is undetermined (no spurious error).
- Fires end-to-end through `treatmentFileSchema` (the CLI + diff shared path).

## Review

Ran correctness / test-coverage / security subagents over the diff before opening. Correctness and security came back clean; test-coverage findings (structured-object form, message-specificity, undetermined-position skip) were folded in. No doc change needed — `conditions.md` already describes the `self`-only rule; this makes the validator enforce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[the two-wiring-paths trap]: this rule lives in the schema refine, not in a manually-wired cross-file validator, so both surfaces are covered by construction.