### PR TITLE
feat(validate): warn when a treatment locale has no matching consent arm (#529)

### DIFF
--- a/packages/stagebook/src/cli/validate.test.ts
+++ b/packages/stagebook/src/cli/validate.test.ts
@@ -501,6 +501,88 @@ describe("locale-consistency rule", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Consent i18n-completeness rule (#529): a treatment locale with no matching
+// consent arm is a WARNING (not an error — consent is not paired to
+// treatments). Runs on the expanded YAML, no prompt loading needed.
+// ---------------------------------------------------------------------------
+
+describe("consent i18n-completeness rule", () => {
+  let dir: string;
+
+  function studyYaml(opts: {
+    treatmentLocale?: string;
+    consentLocales?: (string | undefined)[] | null;
+  }): string {
+    const lines: string[] = [
+      "treatments:",
+      "  - name: t1",
+      ...(opts.treatmentLocale ? [`    locale: ${opts.treatmentLocale}`] : []),
+      "    playerCount: 1",
+      "    compatibleIntroSequences: []",
+      "    gameStages:",
+      "      - name: s1",
+      "        duration: 10",
+      "        elements:",
+      "          - type: submitButton",
+    ];
+    // `null` → no consent block at all (opt-in negative case).
+    if (opts.consentLocales != null) {
+      lines.push("consent:");
+      opts.consentLocales.forEach((loc, i) => {
+        lines.push(`  - name: arm${i}`);
+        if (loc) lines.push(`    locale: ${loc}`);
+        lines.push("    steps:");
+        lines.push("      - name: c1");
+        lines.push("        elements:");
+        lines.push("          - type: submitButton");
+      });
+    }
+    lines.push("");
+    return lines.join("\n");
+  }
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), "stagebook-cli-consent-"));
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("warns (but does not error) when a treatment locale has no consent arm", async () => {
+    await writeFile(
+      join(dir, "study.stagebook.yaml"),
+      studyYaml({ treatmentLocale: "he", consentLocales: ["en"] }),
+    );
+    const r = await runCli([join(dir, "study.stagebook.yaml")]);
+    expect(r.code).toBe(0); // warning does not fail the build
+    expect(r.stdout).toContain("warning:");
+    expect(r.stdout).toContain('locale "he"');
+    expect(r.stdout).toContain("no consent arm is authored");
+  });
+
+  it("is clean when a matching consent arm exists", async () => {
+    await writeFile(
+      join(dir, "study.stagebook.yaml"),
+      studyYaml({ treatmentLocale: "he", consentLocales: ["en", "he"] }),
+    );
+    const r = await runCli([join(dir, "study.stagebook.yaml")]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).not.toContain("no consent arm is authored");
+  });
+
+  it("does not warn when the study declares no consent (feature is opt-in)", async () => {
+    await writeFile(
+      join(dir, "study.stagebook.yaml"),
+      studyYaml({ treatmentLocale: "he", consentLocales: null }),
+    );
+    const r = await runCli([join(dir, "study.stagebook.yaml")]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).not.toContain("no consent arm is authored");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Unsatisfiable-condition rule (#480): a condition reading a prompt's answer
 // whose comparator can never match any value the prompt produces (dead gate)
 // is flagged as an error, reading the referenced prompt's option domain from

--- a/packages/stagebook/src/cli/validate.ts
+++ b/packages/stagebook/src/cli/validate.ts
@@ -12,6 +12,7 @@ import {
   checkPromptLocaleConsistencyWithLoader,
   checkUnsatisfiableConditionsWithLoader,
 } from "../validate/index.js";
+import { checkConsentLocaleCoverage } from "../schemas/index.js";
 import { load as loadYaml } from "js-yaml";
 
 export type Format = "text" | "json";
@@ -251,6 +252,7 @@ export async function run({
       diagnostics.push(
         ...(await checkLocaleConsistencyDiagnostics(result.fullYaml, dir)),
         ...(await checkUnsatisfiableConditionDiagnostics(result.fullYaml, dir)),
+        ...checkConsentLocaleCoverageDiagnostics(result.fullYaml),
       );
     }
     results.push({ path: displayPath, type: "treatment", diagnostics });
@@ -348,6 +350,31 @@ async function checkUnsatisfiableConditionDiagnostics(
   return issues.map((issue) => ({
     severity: "error" as const,
     message: issue.message,
+    range: null,
+  }));
+}
+
+/**
+ * Run the consent i18n-completeness rule (#529) over the expanded treatment: a
+ * treatment locale with no matching consent arm gets a WARNING (never an error
+ * — consent is deliberately not paired to treatments; see ADR
+ * docs/decisions/2026-07-consent-debrief.md decision #4). Pure over the
+ * hydrated tree — no file I/O — since both treatment and consent-arm locales
+ * live in the treatment file itself. Diagnostics carry `range: null` (top of
+ * file): the check runs on the *expanded* YAML, whose positions don't map to
+ * the source, and the message names the treatment and locale as the locator.
+ */
+function checkConsentLocaleCoverageDiagnostics(fullYaml: string): Diagnostic[] {
+  let fileObj: unknown;
+  try {
+    fileObj = loadYaml(fullYaml);
+  } catch {
+    return []; // YAML errors are already reported by the schema pass
+  }
+
+  return checkConsentLocaleCoverage(fileObj).map((gap) => ({
+    severity: "warning" as const,
+    message: gap.message,
     range: null,
   }));
 }

--- a/packages/stagebook/src/schemas/index.ts
+++ b/packages/stagebook/src/schemas/index.ts
@@ -118,7 +118,9 @@ export {
 export {
   collectReferencedPromptFiles,
   checkPromptLocaleConsistency,
+  checkConsentLocaleCoverage,
   type PromptLocaleMismatch,
+  type ConsentLocaleGap,
 } from "./localeConsistency.js";
 
 export {

--- a/packages/stagebook/src/schemas/localeConsistency.test.ts
+++ b/packages/stagebook/src/schemas/localeConsistency.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "vitest";
 import {
   collectReferencedPromptFiles,
   checkPromptLocaleConsistency,
+  checkConsentLocaleCoverage,
 } from "./localeConsistency.js";
 
 function treatmentFile(
@@ -287,5 +288,213 @@ describe("intro sequences (pre-assignment phase)", () => {
       ["prompts/he/q.prompt.md", "he"],
     ]);
     expect(checkPromptLocaleConsistency(file, locales)).toEqual([]);
+  });
+});
+
+describe("checkConsentLocaleCoverage (#529, i18n-completeness)", () => {
+  function fileWithConsent(spec: {
+    treatments?: { name: string; locale?: string }[];
+    consent?: { name: string; locale?: string }[];
+  }): Record<string, unknown> {
+    const obj: Record<string, unknown> = {
+      treatments: (spec.treatments ?? []).map((t) => ({
+        name: t.name,
+        playerCount: 1,
+        ...(t.locale !== undefined ? { locale: t.locale } : {}),
+        gameStages: [{ name: "g", duration: 5, elements: [] }],
+      })),
+    };
+    if (spec.consent !== undefined) {
+      obj.consent = spec.consent.map((a) => ({
+        name: a.name,
+        ...(a.locale !== undefined ? { locale: a.locale } : {}),
+        steps: [{ name: "s", elements: [] }],
+      }));
+    }
+    return obj;
+  }
+
+  test("treatment locale with no matching consent arm: warns", () => {
+    const file = fileWithConsent({
+      treatments: [{ name: "t-he", locale: "he" }],
+      consent: [{ name: "gdpr", locale: "en" }],
+    });
+    const gaps = checkConsentLocaleCoverage(file);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0]).toMatchObject({ locale: "he", treatments: ["t-he"] });
+    expect(gaps[0]?.message).toContain('locale "he"');
+    expect(gaps[0]?.message).toContain("`locale: he`");
+    expect(gaps[0]?.message).toContain("warning, not an error");
+  });
+
+  test("matching consent arm present: clean", () => {
+    const file = fileWithConsent({
+      treatments: [{ name: "t-he", locale: "he" }],
+      consent: [
+        { name: "gdpr-en", locale: "en" },
+        { name: "gdpr-he", locale: "he" },
+      ],
+    });
+    expect(checkConsentLocaleCoverage(file)).toEqual([]);
+  });
+
+  test("omitted locales both default to en: clean", () => {
+    const file = fileWithConsent({
+      treatments: [{ name: "t" }],
+      consent: [{ name: "gdpr" }],
+    });
+    expect(checkConsentLocaleCoverage(file)).toEqual([]);
+  });
+
+  test("en treatment (locale omitted) uncovered by an he-only consent: warns for en", () => {
+    const file = fileWithConsent({
+      treatments: [{ name: "t" }],
+      consent: [{ name: "gdpr-he", locale: "he" }],
+    });
+    const gaps = checkConsentLocaleCoverage(file);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0]).toMatchObject({ locale: "en", treatments: ["t"] });
+  });
+
+  test("repeated consent-arm locale is handled (arm locale may repeat)", () => {
+    const file = fileWithConsent({
+      treatments: [{ name: "t-he", locale: "he" }],
+      consent: [
+        { name: "gdpr-he", locale: "he" },
+        { name: "irb-he", locale: "he" },
+      ],
+    });
+    expect(checkConsentLocaleCoverage(file)).toEqual([]);
+  });
+
+  test("consent absent entirely: no warning (feature is opt-in)", () => {
+    const file = fileWithConsent({
+      treatments: [{ name: "t-he", locale: "he" }],
+    });
+    expect(checkConsentLocaleCoverage(file)).toEqual([]);
+  });
+
+  test("consent present but empty: no warning (feature is opt-in)", () => {
+    const file = fileWithConsent({
+      treatments: [{ name: "t-he", locale: "he" }],
+      consent: [],
+    });
+    expect(checkConsentLocaleCoverage(file)).toEqual([]);
+  });
+
+  test("per-locale dedup: two treatments share the missing locale, one warning", () => {
+    const file = fileWithConsent({
+      treatments: [
+        { name: "t-he-a", locale: "he" },
+        { name: "t-he-b", locale: "he" },
+      ],
+      consent: [{ name: "gdpr", locale: "en" }],
+    });
+    const gaps = checkConsentLocaleCoverage(file);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0]?.locale).toBe("he");
+    expect(gaps[0]?.treatments).toEqual(["t-he-a", "t-he-b"]);
+    // Plural noun AND verb agreement pinned together (guards the plural branch
+    // against regressing to the singular "declares").
+    expect(gaps[0]?.message).toContain(
+      'Treatments "t-he-a", "t-he-b" declare locale "he"',
+    );
+  });
+
+  test("multiple uncovered locales each warn once, in first-seen order", () => {
+    const file = fileWithConsent({
+      treatments: [
+        { name: "t-he", locale: "he" },
+        { name: "t-ar", locale: "ar" },
+      ],
+      consent: [{ name: "gdpr", locale: "en" }],
+    });
+    const gaps = checkConsentLocaleCoverage(file);
+    // Not sorted: the gaps array preserves the order locales are first seen
+    // among the treatments (he before ar), for stable diagnostic output.
+    expect(gaps.map((g) => g.locale)).toEqual(["he", "ar"]);
+  });
+
+  test("compares by primary subtag: he-IL treatment covered by he arm", () => {
+    const file = fileWithConsent({
+      treatments: [{ name: "t", locale: "he-IL" }],
+      consent: [{ name: "gdpr", locale: "he" }],
+    });
+    expect(checkConsentLocaleCoverage(file)).toEqual([]);
+  });
+
+  test("compares by primary subtag: he treatment covered by he-IL arm", () => {
+    const file = fileWithConsent({
+      treatments: [{ name: "t", locale: "he" }],
+      consent: [{ name: "gdpr", locale: "he-IL" }],
+    });
+    expect(checkConsentLocaleCoverage(file)).toEqual([]);
+  });
+
+  test("a leaked ${...} treatment locale is skipped (schema reports the leak)", () => {
+    const file = fileWithConsent({
+      treatments: [{ name: "t", locale: "${locale}" }],
+      consent: [{ name: "gdpr", locale: "en" }],
+    });
+    expect(checkConsentLocaleCoverage(file)).toEqual([]);
+  });
+
+  test("a leaked ${...} consent-arm locale does not count as coverage", () => {
+    const file = fileWithConsent({
+      treatments: [{ name: "t-he", locale: "he" }],
+      consent: [{ name: "gdpr", locale: "${locale}" }],
+    });
+    const gaps = checkConsentLocaleCoverage(file);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0]?.locale).toBe("he");
+  });
+
+  test("locale match is case-insensitive (HE arm covers he treatment)", () => {
+    const file = fileWithConsent({
+      treatments: [{ name: "t", locale: "he" }],
+      consent: [{ name: "gdpr", locale: "HE" }],
+    });
+    expect(checkConsentLocaleCoverage(file)).toEqual([]);
+  });
+
+  test("a malformed arm in a non-empty consent does not suppress a real gap", () => {
+    // consent is non-empty (opt-in fires), but the only arm is a non-record.
+    // It contributes no coverage, so the he treatment still warns — and the
+    // walk stays defensive (no throw) over the garbage arm.
+    const file = {
+      treatments: [
+        {
+          name: "t-he",
+          playerCount: 1,
+          locale: "he",
+          gameStages: [{ name: "g", duration: 5, elements: [] }],
+        },
+      ],
+      consent: [null],
+    };
+    const gaps = checkConsentLocaleCoverage(file);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0]?.locale).toBe("he");
+  });
+
+  test("singular vs plural phrasing in the message", () => {
+    const file = fileWithConsent({
+      treatments: [{ name: "solo", locale: "he" }],
+      consent: [{ name: "gdpr", locale: "en" }],
+    });
+    const gaps = checkConsentLocaleCoverage(file);
+    expect(gaps[0]?.message).toContain('Treatment "solo" declares');
+  });
+
+  test("is defensive over malformed input", () => {
+    expect(checkConsentLocaleCoverage(null)).toEqual([]);
+    expect(checkConsentLocaleCoverage("nope")).toEqual([]);
+    expect(checkConsentLocaleCoverage({ consent: "nope" })).toEqual([]);
+    expect(
+      checkConsentLocaleCoverage({ treatments: "nope", consent: [null] }),
+    ).toEqual([]);
+    expect(
+      checkConsentLocaleCoverage({ treatments: [null], consent: [{}] }),
+    ).toEqual([]);
   });
 });

--- a/packages/stagebook/src/schemas/localeConsistency.ts
+++ b/packages/stagebook/src/schemas/localeConsistency.ts
@@ -199,3 +199,108 @@ export function checkPromptLocaleConsistency(
   }
   return mismatches;
 }
+
+/**
+ * One treatment locale for which the study declares NO matching consent arm.
+ * The cross-collection (treatments × consent arms) counterpart to the
+ * per-prompt locale-consistency rule above.
+ */
+export interface ConsentLocaleGap {
+  /** Effective treatment locale (primary subtag, defaulted to `en`) that no
+   *  consent arm covers. */
+  locale: string;
+  /** Names of the treatments declaring that locale, in first-seen order. */
+  treatments: string[];
+  message: string;
+}
+
+/**
+ * i18n-completeness check (#529, ADR docs/decisions/2026-07-consent-debrief.md
+ * "Phase 3"): warn when a treatment declares a `locale` for which the study has
+ * no consent arm — a participant assigned that treatment would have no consent
+ * content in their language.
+ *
+ * **Warning, not error, by design.** Consent has no treatment-level pairing
+ * (ADR decision #4): a study may legitimately run a single-locale consent while
+ * treatments span locales, or handle a locale's consent out-of-band. This is a
+ * completeness nudge, not a hard constraint — the caller renders it at warning
+ * severity.
+ *
+ * Semantics mirror `checkPromptLocaleConsistency`: locales compare by BCP-47
+ * primary subtag (`he-IL` ≡ `he`), both consent-arm and treatment `locale`
+ * default to `en` when absent, and a leaked `${…}` placeholder (in either) is
+ * skipped — that leak is a different problem with its own schema diagnostic.
+ *
+ * **Opt-in.** A file with no consent arms (absent or empty) is not using the
+ * feature, so nothing is flagged. Findings are deduplicated per locale: three
+ * `he` treatments with no `he` arm produce one gap naming all three.
+ *
+ * Pure function over the hydrated (post-fillTemplates) treatment file — no I/O.
+ * `consentArm` templates have already fanned out to concrete per-locale arms by
+ * the time this runs, which is why it belongs with the post-hydration rules.
+ */
+export function checkConsentLocaleCoverage(
+  fileObj: unknown,
+): ConsentLocaleGap[] {
+  if (!isRecord(fileObj)) return [];
+
+  const consent = fileObj.consent;
+  // Opt-in: no consent collection (absent or empty) means the feature isn't in
+  // use, so there is nothing to be complete about.
+  if (!Array.isArray(consent) || consent.length === 0) return [];
+
+  // Locales the study's consent arms cover. A leaked `${…}` arm locale is
+  // dropped (it covers nothing and is reported elsewhere).
+  const coveredLocales = new Set<string>();
+  for (const arm of consent) {
+    if (!isRecord(arm)) continue;
+    const raw = typeof arm.locale === "string" ? arm.locale : undefined;
+    if (raw?.includes("${")) continue;
+    coveredLocales.add(primarySubtag(raw));
+  }
+
+  const treatments = fileObj.treatments;
+  if (!Array.isArray(treatments)) return [];
+
+  // Uncovered locale → treatment names declaring it. Both the Map (keyed by
+  // locale) and each name Set preserve first-seen order for stable output while
+  // deduplicating in O(1) — the Set-based dedup `checkPromptLocaleConsistency`
+  // uses for its per-(container, file) reports.
+  const gaps = new Map<string, Set<string>>();
+  for (const t of treatments) {
+    if (!isRecord(t)) continue;
+    const raw = typeof t.locale === "string" ? t.locale : undefined;
+    // A leaked `${…}` placeholder in the treatment locale is a different
+    // problem with its own schema diagnostic — skip rather than double-report.
+    if (raw?.includes("${")) continue;
+    const locale = primarySubtag(raw);
+    if (coveredLocales.has(locale)) continue;
+    const name = typeof t.name === "string" ? t.name : "(unnamed)";
+    const names = gaps.get(locale);
+    if (names === undefined) {
+      gaps.set(locale, new Set([name]));
+    } else {
+      names.add(name);
+    }
+  }
+
+  return [...gaps].map(([locale, nameSet]) => {
+    const names = [...nameSet];
+    const nameList = names.map((n) => `"${n}"`).join(", ");
+    const clause =
+      names.length > 1
+        ? `Treatments ${nameList} declare`
+        : `Treatment ${nameList} declares`;
+    return {
+      locale,
+      treatments: names,
+      message:
+        `${clause} locale "${locale}", but no consent arm is authored in ` +
+        `that locale. Add a consent arm with \`locale: ${locale}\` so ` +
+        `participants assigned this treatment see consent in their language, ` +
+        `or run a single-locale consent deliberately — consent is not paired ` +
+        `to treatments, so this is a warning, not an error. A consent arm ` +
+        `with no \`locale\` counts as "en".`,
+    };
+  });
+}

--- a/packages/stagebook/src/validate/validateTreatmentDiff.test.ts
+++ b/packages/stagebook/src/validate/validateTreatmentDiff.test.ts
@@ -462,6 +462,77 @@ introSequences:
     });
   });
 
+  describe("consent i18n-completeness (#529)", () => {
+    const study = (opts: {
+      treatmentLocale?: string;
+      consentLocales?: string[] | null;
+    }): string => {
+      const lines: string[] = [
+        "treatments:",
+        "  - name: t",
+        "    playerCount: 1",
+        "    compatibleIntroSequences: []",
+        ...(opts.treatmentLocale
+          ? [`    locale: ${opts.treatmentLocale}`]
+          : []),
+        "    gameStages:",
+        "      - name: g",
+        "        duration: 10",
+        "        elements:",
+        "          - type: submitButton",
+      ];
+      if (opts.consentLocales != null) {
+        lines.push("consent:");
+        opts.consentLocales.forEach((loc, i) => {
+          lines.push(`  - name: arm${i}`);
+          lines.push(`    locale: ${loc}`);
+          lines.push("    steps:");
+          lines.push("      - name: c1");
+          lines.push("        elements:");
+          lines.push("          - type: submitButton");
+        });
+      }
+      return lines.join("\n") + "\n";
+    };
+
+    it("warns when a treatment locale has no matching consent arm", async () => {
+      const result = await validateTreatmentWithDiff({
+        source: study({ treatmentLocale: "he", consentLocales: ["en"] }),
+        loadImport: noImports,
+      });
+      // Fixture is otherwise schema-valid, so the warning is the ONLY
+      // diagnostic — no incidental errors masking or padding the result.
+      expect(result.diagnostics.filter((d) => d.severity === "error")).toEqual(
+        [],
+      );
+      const gap = result.diagnostics.find((d) =>
+        d.message.includes("no consent arm is authored"),
+      );
+      expect(gap).toBeDefined();
+      expect(gap!.severity).toBe("warning");
+      expect(gap!.message).toContain('locale "he"');
+    });
+
+    it("is clean when a matching consent arm exists", async () => {
+      const result = await validateTreatmentWithDiff({
+        source: study({ treatmentLocale: "he", consentLocales: ["en", "he"] }),
+        loadImport: noImports,
+      });
+      // A fully valid, fully covered study produces no diagnostics at all —
+      // anchoring that the absence below isn't a vacuous pass over a fixture
+      // that errored out before the rule ran.
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("stays silent when the study declares no consent (opt-in)", async () => {
+      const result = await validateTreatmentWithDiff({
+        source: study({ treatmentLocale: "he", consentLocales: null }),
+        loadImport: noImports,
+      });
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+
   describe("unsatisfiable conditions (#480)", () => {
     const withGate = (comparator: string, value: string) => `treatments:
   - name: t

--- a/packages/stagebook/src/validate/validateTreatmentDiff.ts
+++ b/packages/stagebook/src/validate/validateTreatmentDiff.ts
@@ -3,6 +3,7 @@ import {
   collectPreHydrationIssues,
   parseTreatmentYaml as parseStagebookYaml,
   validateResolvedTreatmentFile,
+  checkConsentLocaleCoverage,
   type PreHydrationIssue,
 } from "../index.js";
 import type { ZodIssue } from "zod";
@@ -251,6 +252,21 @@ export async function validateTreatmentWithDiff({
       diagnostics.push({
         message: mismatch.message,
         severity: "error",
+        range: null,
+      });
+    }
+
+    // Post-hydration consent i18n-completeness rule (#529): a treatment locale
+    // with no matching consent arm is a WARNING, not an error — consent is
+    // deliberately not paired to treatments (ADR 2026-07-consent-debrief #4),
+    // so a single-locale consent alongside multi-locale treatments is a
+    // legitimate choice, not a bug. Pure over the hydrated tree (both locales
+    // live in-file, no prompt loading). Top-of-file range (null): the rule
+    // reports per missing locale and the message names the treatment(s).
+    for (const gap of checkConsentLocaleCoverage(diff.hydrated)) {
+      diagnostics.push({
+        message: gap.message,
+        severity: "warning",
         range: null,
       });
     }


### PR DESCRIPTION
## Summary

Adds the **i18n-completeness warning** from #529 (Phase 3 of #481): when a
treatment declares a `locale` for which no `consent:` arm exists, validation
emits a **warning** — never an error. A participant assigned that treatment
would otherwise have no consent content in their language, and nothing flagged
it.

Warning, not error, is deliberate: consent has no treatment-level pairing (ADR
[`2026-07-consent-debrief.md`](docs/decisions/2026-07-consent-debrief.md)
decision #4). A study may legitimately run a single-locale consent while
treatments span locales, or handle a locale's consent out-of-band. This is a
completeness nudge, not a hard constraint.

## What it does

- New pure function `checkConsentLocaleCoverage(fileObj)` in
  `schemas/localeConsistency.ts`, alongside the existing
  `checkPromptLocaleConsistency`. No I/O — both treatment and consent-arm
  locales live in the hydrated file, so unlike the per-prompt rule it needs no
  loader.
- Semantics mirror the existing locale rule: compare by BCP-47 primary subtag
  (`he-IL` ≡ `he`), both sides default to `en` when absent, and a leaked
  `${…}` placeholder (on either side) is skipped (it has its own schema
  diagnostic).
- **Opt-in:** a file with no consent arms (absent or empty) is not using the
  feature, so nothing is flagged.
- **Per-locale dedup:** three `he` treatments with no `he` arm produce one
  warning naming all three.
- Wired into **both** validate surfaces — the CLI (`cli/validate.ts`) and the
  editor diff (`validate/validateTreatmentDiff.ts`) — so neither silently
  skips it.

Runs on the post-hydration tree, so `consentArm` templates with `${locale}`
have already fanned out to concrete per-locale arms. Confirmed against the
`i18n-gallery` example (en+he treatments and en+he consent arms via template
fan-out): validates clean.

## Tests

- Unit tests for the pure function (missing arm → warning; present → clean;
  repeated/omitted `locale`; consent absent/empty → no warning; primary-subtag
  equivalence both directions; leaked `${…}` on each side; per-locale dedup;
  multiple uncovered locales; singular/plural phrasing; defensive over
  malformed input).
- CLI end-to-end: warns without flipping the exit code; clean when covered;
  silent when opt-in.
- Editor diff: warning severity, `range: null`, clean/opt-in cases.

Fixes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)
