### PR TITLE
Bump stagebook to 0.23.0

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Minor release folding per-treatment debrief into `exitSequence`, tightening schema validation, and adding viewer/vscode asset-resolution features.

## What's in

- **#520** — `retire per-treatment debrief; fold into exitSequence` — the per-treatment `debrief` field is removed; debrief content now lives in `exitSequence`. **Breaking** for treatments/consumers that referenced the old field.
- **#530** — `groupComposition` conditions now reject non-self position selectors — cross-client selectors that previously slipped through are flagged as errors.
- **#531** — validate now warns when a treatment locale has no matching consent arm.
- **#517** — repaired the `openResponse` example prompts and wired `examples/` into CI validation so they can't drift again.
- **#513** — viewer re-runs prompt locale-consistency checks after field binding.
- **#515** — viewer shows a labeled placeholder for unresolved `asset://` references instead of a broken ref.
- **#522** — the VS Code preview resolves `asset://` media against local folders.
- **#511** — the `stagebook validate` GitHub Action is now published for use in study repos with no JS toolchain.
- **#527**, **#521** — new docs: dispatcher assignment model, and imported treatment-authoring (DSL) reference from the runner RTD.
- **#519**, **#523**, **#518** — internal: CI now runs in the merge queue, dropped the `viewer/**` eslint override, and repointed the annotator comment ref.

## Compatibility

- **Breaking (#520):** per-treatment `debrief` is retired — move debrief content into `exitSequence`.
- **Stricter validation (#530):** `groupComposition` conditions using non-self position selectors now produce a parse error rather than silently passing.
- New validate warning (#531) is non-fatal and does not block existing treatments.
