### PR TITLE
feat(viewer): researcher keyboard shortcuts (Alt/Option namespace) (#534)

### DIFF
--- a/docs/decisions/2026-07-viewer-hotkeys.md
+++ b/docs/decisions/2026-07-viewer-hotkeys.md
@@ -1,0 +1,102 @@
+# Viewer researcher keyboard shortcuts (July 2026)
+
+Status: **accepted** — design settled in [#534] (see its thread for the full
+compatibility research and citations). Implemented by the PR that links here.
+
+[#534]: https://github.com/talkbench/stagebook/issues/534
+
+## Motivation
+
+The viewer (`stagebook/viewer` harness — the standalone app, the VS Code
+webview preview, and external hosts) is how a researcher drives a study while
+authoring it: switch treatment, step through stages, jump to a player
+position, scrub the timeline. All of that was mouse-only. The common
+inner-loop actions deserve keyboard shortcuts.
+
+The constraint that shapes the whole design: the viewer renders **real study
+content**, and that content has its own keyboard behavior (move a radio, type
+in a Prompt, drag a Slider, Space to play a Timeline). Any chrome shortcut has
+to coexist with participant input without a focus-sniffing heuristic.
+
+## Decision
+
+**The modifier is a namespace.** Every viewer shortcut is `Alt`/`Option` +
+key, and the modifier separates the two roles unambiguously:
+
+> **Bare keys → the study content** (participant actions).
+> **Alt/Option + key → the viewer chrome** (researcher actions).
+
+Because unmodified keys always pass through and modified keys always drive the
+chrome, there is no `document.activeElement` sniffing and no special-casing of
+the element-level key handlers — a chrome shortcut works even while the caret
+sits in a textarea (that is the point: it is *focus-independent*).
+
+### Keymap
+
+| Keys | Action |
+|---|---|
+| `Alt+←` / `Alt+→` | previous / next step (clamped, no wrap) |
+| `Alt+↑` / `Alt+↓` | previous / next treatment (cycle the unit list) |
+| `Alt+P` | focus the "part to preview" picker |
+| `Alt+0` … `Alt+9` | select player position N (ignored if `N ≥ playerCount`) |
+| `Alt+K` | timer play/pause (only when the step has a `duration`) |
+| `Alt+/` | toggle the shortcut cheatsheet |
+
+Two points where the implementation refined the #534 sketch:
+
+- **`Alt+P` to focus the picker.** `Alt+↑/↓` cycles *adjacent* treatments,
+  which is right for A/B toggling but poor for browsing: treatments are a
+  flat, name-keyed set with no meaningful order (alphabetical by group), so
+  blind cycling can never show the whole list. `Alt+P` focuses the native
+  `<select>`, which gives typeahead-by-name (the fast way into an alphabetical
+  list) and the OS dropdown for a full view — mirroring an existing focusable
+  control, per the "every shortcut mirrors a control" rule below.
+- **Cheatsheet is `Alt+/`, not bare `?`.** #534 sketched a bare `?`; keeping
+  it inside the `Alt` namespace holds the "bare keys belong to the study" line
+  with no exception.
+
+### Load-bearing implementation rules
+
+- **Key off `event.code`, never `event.key`.** On macOS, `Option` composes the
+  character (`Option+K` → `˚`, `Option+3` → `£`), so `event.key` is unreliable;
+  `event.code` (`"KeyK"`, `"Digit3"`, `"ArrowLeft"`) is physical and
+  layout-independent. Gate on `e.altKey && !e.ctrlKey && !e.metaKey` so Windows
+  AltGr (reported as Ctrl+Alt) and Cmd/Ctrl accelerators still pass through.
+- **Scope the listener to the focused viewer**, not `window`: it lives on the
+  viewer root (`tabIndex=-1`, focus-on-click), so several embedded viewers and
+  the host page never cross-fire.
+- **Every shortcut mirrors an existing focusable control** (button or
+  `<select>`) — never a keyboard-only action. Mirrored controls carry
+  `aria-keyshortcuts` and key hints in their tooltips.
+- **`preventDefault()` only on handled keys** — suppresses the macOS
+  Option-symbol insertion and the one native overlap (see below).
+
+## Cross-OS / cross-host caveats
+
+Verified across Chrome / Firefox / Safari and the VS Code (Chromium) webview on
+macOS / Windows / Linux (full citations in #534). Residual, accepted gaps:
+
+- **`Alt+←/→` overlaps two native behaviors, both narrow.** (1) *Browser
+  history* back/forward — but only for the viewer running as a plain web page
+  on **Windows/Linux** desktop browsers; macOS browsers bind Back to `⌘←`, and
+  the VS Code webview has no history stack. The `keydown` is cancelable, so
+  `preventDefault()` suppresses it. Documented fallback if a real leak is ever
+  reported: `Alt+[` / `Alt+]`. (2) **macOS in-field word-navigation** —
+  `Option+←/→` is the standard word-jump (and `Option+Shift+←/→` word-select)
+  inside any text field. This corrects #534's finding #3, which considered only
+  browser history and concluded "macOS unaffected": inside a focused study
+  Prompt/TextArea in the preview, `Option+←` steps the *stage* instead of the
+  caret. This is consistent with the namespace design (Alt = chrome, even in a
+  textarea) and is working-as-intended, but researchers lose in-preview word
+  nav — an accepted trade, noted here so the claim isn't repeated uncorrected.
+- **`Alt+digit`** switches tabs in Firefox-on-Linux (likely not preventable) —
+  accepted minor gap.
+- **Windows VS Code** captures `Alt` + a menu-mnemonic letter (F/E/S/V/G/R/T/H).
+  The keymap avoids all of them; `Alt+P` and `Alt+K` are safe.
+
+## Non-goals
+
+- Participant-facing accessibility — that lives in the runner and its a11y
+  work, not this researcher-only chrome. (These modifier-plus-single-key
+  shortcuts are exempt from WCAG 2.1.4 Character Key Shortcuts anyway.)
+- A user-configurable keybinding UI.

--- a/docs/decisions/2026-07-viewer-hotkeys.md
+++ b/docs/decisions/2026-07-viewer-hotkeys.md
@@ -108,7 +108,17 @@ macOS / Windows / Linux (full citations in #534). Residual, accepted gaps:
 
 ## Non-goals
 
-- Participant-facing accessibility — that lives in the runner and its a11y
-  work, not this researcher-only chrome. (These modifier-plus-single-key
-  shortcuts are exempt from WCAG 2.1.4 Character Key Shortcuts anyway.)
+- **Full accessibility semantics are not the goal of the _shortcuts_** — they
+  are researcher ergonomics, additive to (never a replacement for) the mouse
+  and focus controls they mirror, and exempt from WCAG 2.1.4 Character Key
+  Shortcuts because they require a non-text modifier. Note that the viewer
+  chrome these live in _is_ committed to WCAG 2.2 AA per the
+  [accessibility ADR](2026-07-accessibility.md); the one known gap introduced
+  here is that the `Alt+/` cheatsheet dialog does not yet move focus into
+  itself on open or trap Tab (Escape-to-close works via a capture-phase
+  listener). That is a researcher-facing item to close under the [#20] audit,
+  which the accessibility ADR prioritises by facing × fix-cost rather than
+  fixing inline.
 - A user-configurable keybinding UI.
+
+[#20]: https://github.com/talkbench/stagebook/issues/20

--- a/docs/decisions/2026-07-viewer-hotkeys.md
+++ b/docs/decisions/2026-07-viewer-hotkeys.md
@@ -63,13 +63,25 @@ Two points where the implementation refined the #534 sketch:
   layout-independent. Gate on `e.altKey && !e.ctrlKey && !e.metaKey` so Windows
   AltGr (reported as Ctrl+Alt) and Cmd/Ctrl accelerators still pass through.
 - **Scope the listener to the focused viewer**, not `window`: it lives on the
-  viewer root (`tabIndex=-1`, focus-on-click), so several embedded viewers and
-  the host page never cross-fire.
+  viewer root (`tabIndex=-1`), so several embedded viewers and the host page
+  never cross-fire. A `tabIndex=-1` root isn't reliably focused when a click
+  lands on non-focusable stage content, so a `mousedown` handler nudges focus
+  onto the root (skipping clicks on interactive controls, whose focus the study
+  needs) — otherwise the "click anywhere activates the hotkeys" promise breaks.
 - **Every shortcut mirrors an existing focusable control** (button or
   `<select>`) — never a keyboard-only action. Mirrored controls carry
   `aria-keyshortcuts` and key hints in their tooltips.
-- **`preventDefault()` only on handled keys** — suppresses the macOS
-  Option-symbol insertion and the one native overlap (see below).
+- **Consume handled keys in the capture phase** — the keydown listener is
+  attached with `capture: true`, and a handled shortcut is `preventDefault()`d
+  *and* `stopPropagation()`d, so it is routed before it reaches a focused study
+  widget deeper in the tree. Without this, `Alt+K` / `Alt+→` would drive both
+  the chrome *and* a focused MediaPlayer / Timeline (which act on bare `K` /
+  arrows without checking `altKey`) — the namespace only holds if Alt keys
+  never reach the content. `preventDefault` also suppresses the macOS
+  Option-symbol insertion and the one native overlap (below); bare and unmapped
+  keys are left untouched so participant input still flows. The cheatsheet's
+  Escape listener is likewise capture-phase, so it closes even when a focused
+  Timeline would otherwise swallow Escape first.
 
 ## Cross-OS / cross-host caveats
 

--- a/packages/stagebook/src/viewer/components/HotkeyHelp.tsx
+++ b/packages/stagebook/src/viewer/components/HotkeyHelp.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef } from "react";
+
+interface HotkeyHelpProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+// Researcher hotkeys, shown in the cheatsheet. Kept in sync with the routing
+// in ../lib/hotkeys.ts. `⌥` renders as the Option glyph; on Windows/Linux it
+// is the Alt key (noted in the footnote).
+const SHORTCUTS: { keys: string; action: string }[] = [
+  { keys: "⌥ ← / ⌥ →", action: "Previous / next step" },
+  { keys: "⌥ ↑ / ⌥ ↓", action: "Previous / next treatment" },
+  { keys: "⌥ P", action: "Focus the part picker (type to jump)" },
+  { keys: "⌥ 0 – ⌥ 9", action: "Jump to player position" },
+  { keys: "⌥ K", action: "Play / pause the timer" },
+  { keys: "⌥ /", action: "Toggle this cheatsheet" },
+];
+
+/**
+ * The `Alt+/` shortcut cheatsheet. Rendered inside the viewer root; the
+ * backdrop is `position: absolute`, so it dims only this viewer (the root is a
+ * containing block), not the whole host page when embedded. Escape or a
+ * backdrop click dismisses it.
+ */
+export function HotkeyHelp({ open, onClose }: HotkeyHelpProps) {
+  // Read onClose through a ref so the Escape listener subscribes once per open
+  // (not on every parent re-render — the viewer re-renders ~20×/s during timer
+  // playback, and onClose is typically a fresh inline closure each time).
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCloseRef.current();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div style={backdropStyle} onClick={onClose} data-testid="hotkey-help">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Keyboard shortcuts"
+        style={panelStyle}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={titleRowStyle}>
+          <span style={titleStyle}>Keyboard shortcuts</span>
+          <button aria-label="Close" onClick={onClose} style={closeStyle}>
+            &times;
+          </button>
+        </div>
+        <table style={tableStyle}>
+          <tbody>
+            {SHORTCUTS.map((s) => (
+              <tr key={s.keys}>
+                <td style={keysCellStyle}>{s.keys}</td>
+                <td style={actionCellStyle}>{s.action}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <p style={footnoteStyle}>
+          Hold <kbd style={kbdStyle}>⌥ Option</kbd> with each key — on
+          Windows/Linux that&rsquo;s the <kbd style={kbdStyle}>Alt</kbd> key.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// --- Styles (match the viewer's light chrome) ---
+
+const backdropStyle: React.CSSProperties = {
+  // Absolute (not fixed) so it's scoped to the positioned viewer root — dims
+  // this viewer only, staying polite when embedded in a larger host page.
+  position: "absolute",
+  inset: 0,
+  backgroundColor: "rgba(17, 24, 39, 0.35)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 50,
+};
+
+const panelStyle: React.CSSProperties = {
+  backgroundColor: "white",
+  borderRadius: "0.5rem",
+  boxShadow: "0 10px 30px rgba(0, 0, 0, 0.25)",
+  padding: "1rem 1.25rem",
+  minWidth: "20rem",
+  maxWidth: "26rem",
+};
+
+const titleRowStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  marginBottom: "0.75rem",
+};
+
+const titleStyle: React.CSSProperties = {
+  fontSize: "0.875rem",
+  fontWeight: 600,
+  color: "#1f2937",
+};
+
+const closeStyle: React.CSSProperties = {
+  background: "none",
+  border: "none",
+  cursor: "pointer",
+  fontSize: "1.25rem",
+  lineHeight: 1,
+  color: "#6b7280",
+  padding: "0 0.25rem",
+};
+
+const tableStyle: React.CSSProperties = {
+  width: "100%",
+  borderCollapse: "collapse",
+  fontSize: "0.8125rem",
+};
+
+const keysCellStyle: React.CSSProperties = {
+  padding: "0.25rem 0.75rem 0.25rem 0",
+  whiteSpace: "nowrap",
+  fontVariantNumeric: "tabular-nums",
+  color: "#111827",
+  fontWeight: 600,
+};
+
+const actionCellStyle: React.CSSProperties = {
+  padding: "0.25rem 0",
+  color: "#4b5563",
+  width: "100%",
+};
+
+const footnoteStyle: React.CSSProperties = {
+  marginTop: "0.75rem",
+  fontSize: "0.6875rem",
+  color: "#6b7280",
+  lineHeight: 1.5,
+};
+
+const kbdStyle: React.CSSProperties = {
+  fontFamily: "inherit",
+  fontSize: "0.625rem",
+  fontWeight: 600,
+  border: "1px solid #d1d5db",
+  borderRadius: "0.1875rem",
+  padding: "0.0625rem 0.25rem",
+  backgroundColor: "#f9fafb",
+  color: "#374151",
+};

--- a/packages/stagebook/src/viewer/components/HotkeyHelp.tsx
+++ b/packages/stagebook/src/viewer/components/HotkeyHelp.tsx
@@ -35,11 +35,18 @@ export function HotkeyHelp({ open, onClose }: HotkeyHelpProps) {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
         e.preventDefault();
+        // Consume it: without focus moved into the dialog, Escape would also
+        // reach the previously focused study widget (e.g. a Timeline with an
+        // active selection deselects on Escape) if we let it propagate.
+        e.stopPropagation();
         onCloseRef.current();
       }
     };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
+    // Capture phase so this runs before a focused study widget's own Escape
+    // handler, which may stopPropagation() and otherwise leave the cheatsheet
+    // stuck open.
+    document.addEventListener("keydown", onKey, true);
+    return () => document.removeEventListener("keydown", onKey, true);
   }, [open]);
 
   if (!open) return null;

--- a/packages/stagebook/src/viewer/components/StageNav.tsx
+++ b/packages/stagebook/src/viewer/components/StageNav.tsx
@@ -17,6 +17,8 @@ export function StageNav({ steps, currentIndex, onSelect }: StageNavProps) {
         disabled={!hasPrev}
         style={arrowStyle}
         aria-label="Previous stage"
+        aria-keyshortcuts="Alt+ArrowLeft"
+        title="Previous step (⌥←)"
       >
         &#9664;
       </button>
@@ -38,6 +40,8 @@ export function StageNav({ steps, currentIndex, onSelect }: StageNavProps) {
         disabled={!hasNext}
         style={arrowStyle}
         aria-label="Next stage"
+        aria-keyshortcuts="Alt+ArrowRight"
+        title="Next step (⌥→)"
       >
         &#9654;
       </button>

--- a/packages/stagebook/src/viewer/components/TimeScrubber.test.tsx
+++ b/packages/stagebook/src/viewer/components/TimeScrubber.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { describe, test, expect, vi, beforeAll } from "vitest";
+import { act, createRef } from "react";
+import { createRoot } from "react-dom/client";
+import { TimeScrubber, type TimeScrubberHandle } from "./TimeScrubber.js";
+import type { ViewerStep } from "../lib/steps.js";
+
+// Unit coverage for the `Alt+K` imperative path added in the hotkeys work: the
+// viewer drives play/pause through the ref, and `toggle()` restarts from 0 when
+// the scrubber is already at the end. Playwright CT (Viewer.hotkeys.ct.tsx)
+// covers the play↔pause round-trip; here we exercise the branch that needs the
+// timeline parked at its end, which is awkward to reach through the UI.
+//
+// jsdom (dev React) also gives this refactored, hook-churned component a
+// rules-of-hooks smoke net that prod-React CT can't provide.
+
+beforeAll(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+// TimeScrubber reads only `.duration` and `.elements`; cast the rest away.
+function step(fields: Partial<ViewerStep>): ViewerStep {
+  return { elements: [], ...fields } as unknown as ViewerStep;
+}
+
+function mount(currentStep: ViewerStep, elapsedTime: number) {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const ref = createRef<TimeScrubberHandle>();
+  const onTimeChange = vi.fn();
+  act(() =>
+    root.render(
+      <TimeScrubber
+        ref={ref}
+        currentStep={currentStep}
+        elapsedTime={elapsedTime}
+        onTimeChange={onTimeChange}
+      />,
+    ),
+  );
+  return {
+    ref,
+    onTimeChange,
+    unmount: () => act(() => root.unmount()),
+    cleanup: () => container.remove(),
+  };
+}
+
+describe("TimeScrubber imperative toggle (Alt+K)", () => {
+  test("restarts from 0 when toggled at the end of the timeline", () => {
+    const { ref, onTimeChange, unmount, cleanup } = mount(
+      step({ duration: 60 }),
+      60,
+    );
+    const handle = ref.current;
+    if (!handle) throw new Error("expected a TimeScrubber handle");
+
+    act(() => handle.toggle());
+    expect(onTimeChange).toHaveBeenCalledWith(0);
+
+    unmount();
+    cleanup();
+  });
+
+  test("does not reset when toggled mid-timeline", () => {
+    const { ref, onTimeChange, unmount, cleanup } = mount(
+      step({ duration: 60 }),
+      10,
+    );
+    const handle = ref.current;
+    if (!handle) throw new Error("expected a TimeScrubber handle");
+
+    act(() => handle.toggle());
+    expect(onTimeChange).not.toHaveBeenCalled();
+
+    unmount();
+    cleanup();
+  });
+
+  test("exposes no handle for an untimed step, so Alt+K safely no-ops", () => {
+    const { ref, unmount, cleanup } = mount(step({ duration: undefined }), 0);
+    expect(ref.current).toBeNull();
+
+    unmount();
+    cleanup();
+  });
+});

--- a/packages/stagebook/src/viewer/components/TimeScrubber.tsx
+++ b/packages/stagebook/src/viewer/components/TimeScrubber.tsx
@@ -1,4 +1,11 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
 import { extractTimeBreakpoints } from "../lib/timeBreakpoints.js";
 import type { ViewerStep } from "../lib/steps.js";
 
@@ -6,6 +13,12 @@ interface TimeScrubberProps {
   currentStep: ViewerStep;
   elapsedTime: number;
   onTimeChange: (seconds: number) => void;
+}
+
+/** Imperative handle so the viewer's `Alt+K` hotkey can drive playback. */
+export interface TimeScrubberHandle {
+  /** Play/pause; restarts from 0 if at the end. Mirrors the ▶/⏸ button. */
+  toggle: () => void;
 }
 
 const SPEEDS = [1, 2, 5, 10];
@@ -16,40 +29,50 @@ function formatTime(seconds: number): string {
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 
-export function TimeScrubber({
-  currentStep,
-  elapsedTime,
-  onTimeChange,
-}: TimeScrubberProps) {
-  const duration = currentStep.duration;
-  if (duration === undefined) return null;
+export const TimeScrubber = forwardRef<TimeScrubberHandle, TimeScrubberProps>(
+  function TimeScrubber({ currentStep, elapsedTime, onTimeChange }, ref) {
+    const duration = currentStep.duration;
+    if (duration === undefined) return null;
 
-  return (
-    <TimeScrubberInner
-      duration={duration}
-      elements={currentStep.elements as Record<string, unknown>[]}
-      elapsedTime={elapsedTime}
-      onTimeChange={onTimeChange}
-    />
-  );
-}
+    return (
+      <TimeScrubberInner
+        ref={ref}
+        duration={duration}
+        elements={currentStep.elements as Record<string, unknown>[]}
+        elapsedTime={elapsedTime}
+        onTimeChange={onTimeChange}
+      />
+    );
+  },
+);
 
-function TimeScrubberInner({
-  duration,
-  elements,
-  elapsedTime,
-  onTimeChange,
-}: {
-  duration: number;
-  elements: Record<string, unknown>[];
-  elapsedTime: number;
-  onTimeChange: (seconds: number) => void;
-}) {
+const TimeScrubberInner = forwardRef<
+  TimeScrubberHandle,
+  {
+    duration: number;
+    elements: Record<string, unknown>[];
+    elapsedTime: number;
+    onTimeChange: (seconds: number) => void;
+  }
+>(function TimeScrubberInner(
+  { duration, elements, elapsedTime, onTimeChange },
+  ref,
+) {
   const [playing, setPlaying] = useState(false);
   const [speed, setSpeed] = useState(1);
   const trackRef = useRef<HTMLDivElement>(null);
   const elapsedRef = useRef(elapsedTime);
   elapsedRef.current = elapsedTime;
+
+  // Play/pause, shared by the ▶/⏸ button and the viewer's Alt+K hotkey (via the
+  // imperative handle). Reads elapsed from a ref + a functional setState so it
+  // stays correct without re-binding on every tick.
+  const toggle = useCallback(() => {
+    if (elapsedRef.current >= duration) onTimeChange(0);
+    setPlaying((p) => !p);
+  }, [duration, onTimeChange]);
+
+  useImperativeHandle(ref, () => ({ toggle }), [toggle]);
 
   // Playback — interval reads elapsed from ref to avoid teardown every tick
   useEffect(() => {
@@ -87,12 +110,11 @@ function TimeScrubberInner({
   return (
     <div style={containerStyle}>
       <button
-        onClick={() => {
-          if (elapsedTime >= duration) onTimeChange(0);
-          setPlaying(!playing);
-        }}
+        onClick={toggle}
         style={playButtonStyle}
         aria-label={playing ? "Pause" : "Play"}
+        aria-keyshortcuts="Alt+K"
+        title="Play/pause (⌥K)"
       >
         {playing ? "⏸" : "▶"}
       </button>
@@ -146,7 +168,7 @@ function TimeScrubberInner({
       <span style={timeStyle}>{formatTime(duration)}</span>
     </div>
   );
-}
+});
 
 // --- Styles ---
 

--- a/packages/stagebook/src/viewer/components/Viewer.hotkeys.ct.tsx
+++ b/packages/stagebook/src/viewer/components/Viewer.hotkeys.ct.tsx
@@ -1,0 +1,132 @@
+import { test, expect } from "@playwright/experimental-ct-react";
+import { MockViewer } from "./testing/MockViewer.js";
+
+// End-to-end coverage for the researcher hotkeys (issue #534) in a real
+// browser: unit tests in ../lib/hotkeys.test.tsx cover the pure dispatcher with
+// synthetic events; here we drive REAL key presses through the mounted Viewer
+// and assert the chrome actually navigates. Key chords are code-form
+// ("Alt+ArrowLeft", "Alt+Digit1", "Alt+KeyK", "Alt+Slash") because the
+// dispatcher matches event.code — Playwright synthesizes the physical key, so
+// this holds across chromium/webkit/firefox even though macOS Option would
+// otherwise compose a character.
+//
+// The listener is scoped to the Viewer's root node (not window), so every
+// press must land with focus inside it — locator.press() focuses first.
+
+test("⌥→ / ⌥← advance and rewind the step", async ({ mount }) => {
+  const component = await mount(<MockViewer />);
+  const counter = component.getByText(/^\d+ \/ 3$/);
+  await expect(counter).toHaveText("1 / 3");
+
+  await component.press("Alt+ArrowRight");
+  await expect(counter).toHaveText("2 / 3");
+
+  await component.press("Alt+ArrowLeft");
+  await expect(counter).toHaveText("1 / 3");
+});
+
+test("⌥↓ / ⌥↑ switch the previewed treatment", async ({ mount }) => {
+  const component = await mount(<MockViewer />);
+  const picker = component.getByRole("combobox", { name: "Part to preview" });
+  await expect(picker).toHaveValue("treatment:0");
+
+  await component.press("Alt+ArrowDown");
+  await expect(picker).toHaveValue("treatment:1");
+
+  await component.press("Alt+ArrowUp");
+  await expect(picker).toHaveValue("treatment:0");
+});
+
+test("⌥<digit> selects a player position and ignores out-of-range digits", async ({
+  mount,
+}) => {
+  const component = await mount(<MockViewer />);
+  const position = component.locator("#position-select");
+  await expect(position).toHaveValue("0");
+
+  await component.press("Alt+Digit1");
+  await expect(position).toHaveValue("1");
+
+  // playerCount is 2, so ⌥5 is out of range and must be a no-op.
+  await component.press("Alt+Digit5");
+  await expect(position).toHaveValue("1");
+
+  await component.press("Alt+Digit0");
+  await expect(position).toHaveValue("0");
+});
+
+test("⌥K plays and pauses the timeline scrubber", async ({ mount }) => {
+  const component = await mount(<MockViewer />);
+  // Stage 1 (A1) has a duration, so the scrubber's play button is present.
+  await expect(component.getByRole("button", { name: "Play" })).toBeVisible();
+
+  await component.press("Alt+KeyK");
+  await expect(component.getByRole("button", { name: "Pause" })).toBeVisible();
+
+  await component.press("Alt+KeyK");
+  await expect(component.getByRole("button", { name: "Play" })).toBeVisible();
+});
+
+test("⌥/ toggles the shortcut cheatsheet", async ({ mount }) => {
+  const component = await mount(<MockViewer />);
+  const help = component.locator('[data-testid="hotkey-help"]');
+  await expect(help).toHaveCount(0);
+
+  await component.press("Alt+Slash");
+  await expect(help).toBeVisible();
+
+  await component.press("Alt+Slash");
+  await expect(help).toHaveCount(0);
+});
+
+test("Escape closes the cheatsheet", async ({ mount }) => {
+  const component = await mount(<MockViewer />);
+  const help = component.locator('[data-testid="hotkey-help"]');
+
+  await component.press("Alt+Slash");
+  await expect(help).toBeVisible();
+
+  await component.press("Escape");
+  await expect(help).toHaveCount(0);
+});
+
+test("⌥P focuses the part picker so the whole list is reachable", async ({
+  mount,
+}) => {
+  const component = await mount(<MockViewer />);
+  const picker = component.getByRole("combobox", { name: "Part to preview" });
+  await expect(picker).not.toBeFocused();
+
+  await component.press("Alt+KeyP");
+  await expect(picker).toBeFocused();
+});
+
+test("step and treatment nav clamp at the bounds (no wrap-around)", async ({
+  mount,
+}) => {
+  const component = await mount(<MockViewer />);
+  const counter = component.getByText(/^\d+ \/ 3$/);
+  const picker = component.getByRole("combobox", { name: "Part to preview" });
+  // MockViewer starts on the first step of the first treatment.
+  await expect(counter).toHaveText("1 / 3");
+  await expect(picker).toHaveValue("treatment:0");
+
+  // Prev at the first step / first treatment is a no-op — must not wrap to the
+  // last one.
+  await component.press("Alt+ArrowLeft");
+  await expect(counter).toHaveText("1 / 3");
+  await component.press("Alt+ArrowUp");
+  await expect(picker).toHaveValue("treatment:0");
+});
+
+test("bare keys pass through — no modifier means no chrome navigation", async ({
+  mount,
+}) => {
+  const component = await mount(<MockViewer />);
+  const counter = component.getByText(/^\d+ \/ 3$/);
+  await expect(counter).toHaveText("1 / 3");
+
+  // Bare ArrowRight belongs to the study content, not the researcher chrome.
+  await component.press("ArrowRight");
+  await expect(counter).toHaveText("1 / 3");
+});

--- a/packages/stagebook/src/viewer/components/Viewer.hotkeys.ct.tsx
+++ b/packages/stagebook/src/viewer/components/Viewer.hotkeys.ct.tsx
@@ -90,6 +90,27 @@ test("Escape closes the cheatsheet", async ({ mount }) => {
   await expect(help).toHaveCount(0);
 });
 
+test("shortcuts stay live while the cheatsheet is open; Escape always clears it", async ({
+  mount,
+}) => {
+  const component = await mount(<MockViewer />);
+  const help = component.locator('[data-testid="hotkey-help"]');
+  const counter = component.getByText(/^\d+ \/ 3$/);
+
+  await component.press("Alt+Slash");
+  await expect(help).toBeVisible();
+
+  // The cheatsheet deliberately doesn't trap focus, so a researcher can try a
+  // shortcut with it still open — the step advances and the sheet stays up.
+  await component.press("Alt+ArrowRight");
+  await expect(counter).toHaveText("2 / 3");
+  await expect(help).toBeVisible();
+
+  // ...and Escape still clears it regardless of what's been pressed.
+  await component.press("Escape");
+  await expect(help).toHaveCount(0);
+});
+
 test("⌥P focuses the part picker so the whole list is reachable", async ({
   mount,
 }) => {

--- a/packages/stagebook/src/viewer/components/Viewer.hotkeys.ct.tsx
+++ b/packages/stagebook/src/viewer/components/Viewer.hotkeys.ct.tsx
@@ -119,6 +119,22 @@ test("step and treatment nav clamp at the bounds (no wrap-around)", async ({
   await expect(picker).toHaveValue("treatment:0");
 });
 
+test("a click on non-focusable content activates the hotkeys", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(<MockViewer />);
+  const counter = component.getByText(/^\d+ \/ 3$/);
+  await expect(counter).toHaveText("1 / 3");
+
+  // Click a non-interactive element (the locale badge span), NOT via a hotkey
+  // helper that would auto-focus the root. Focus must land in the viewer so the
+  // next Alt shortcut — pressed through the page, with no explicit focus — works.
+  await component.locator('[data-testid="viewer-locale-badge"]').click();
+  await page.keyboard.press("Alt+ArrowRight");
+  await expect(counter).toHaveText("2 / 3");
+});
+
 test("bare keys pass through — no modifier means no chrome navigation", async ({
   mount,
 }) => {

--- a/packages/stagebook/src/viewer/components/Viewer.tsx
+++ b/packages/stagebook/src/viewer/components/Viewer.tsx
@@ -18,9 +18,11 @@ import {
 import { buildUnits, initialUnitKey, type ViewerUnit } from "../lib/steps.js";
 import { ViewerStateStore } from "../lib/store.js";
 import { createViewerContext } from "../lib/context.js";
+import { useViewerHotkeys } from "../lib/hotkeys.js";
 import { StageNav } from "./StageNav.js";
 import { StateInspector } from "./StateInspector.js";
-import { TimeScrubber } from "./TimeScrubber.js";
+import { TimeScrubber, type TimeScrubberHandle } from "./TimeScrubber.js";
+import { HotkeyHelp } from "./HotkeyHelp.js";
 import { NotesIconsOverlay } from "./NotesIconsOverlay.js";
 import { createSkeletonRenderers } from "./SkeletonPlaceholder.js";
 
@@ -196,6 +198,67 @@ export function Viewer({
     [store, stageIndex],
   );
 
+  // --- Researcher hotkeys (Alt/Option namespace) — see issue #534 ---
+  // Selecting a unit also syncs the host's persisted index (so the VS Code
+  // preview restores the right unit after a refresh). Extracted so the header
+  // <select> and the Alt+↑/↓ hotkey share one path.
+  const selectUnit = useCallback(
+    (key: string) => {
+      setSelectedUnitKey(key);
+      if (key.startsWith("treatment:")) {
+        onTreatmentIndexChange?.(Number(key.slice("treatment:".length)));
+      } else if (key.startsWith("intro:")) {
+        onIntroIndexChange?.(Number(key.slice("intro:".length)));
+      }
+    },
+    [onTreatmentIndexChange, onIntroIndexChange],
+  );
+
+  // Unit keys in the order the <optgroup> picker shows them, so Alt+↑/↓ walks
+  // the visible list (Consent → Intro → Treatments), not internal array order.
+  const orderedUnitKeys = useMemo(() => {
+    const keysOf = (kind: ViewerUnit["kind"]) =>
+      units.filter((u) => u.kind === kind).map((u) => u.key);
+    return [...keysOf("consent"), ...keysOf("intro"), ...keysOf("treatment")];
+  }, [units]);
+
+  const cycleUnit = useCallback(
+    (delta: number) => {
+      const i = orderedUnitKeys.indexOf(selectedUnitKey);
+      if (i === -1) return;
+      const clamped = Math.min(
+        orderedUnitKeys.length - 1,
+        Math.max(0, i + delta),
+      );
+      const nextKey = orderedUnitKeys[clamped];
+      if (nextKey && nextKey !== selectedUnitKey) selectUnit(nextKey);
+    },
+    [orderedUnitKeys, selectedUnitKey, selectUnit],
+  );
+
+  const [showHelp, setShowHelp] = useState(false);
+  const scrubberRef = useRef<TimeScrubberHandle>(null);
+  const treatmentSelectRef = useRef<HTMLSelectElement>(null);
+
+  // Plain inline handlers: the hook reads the latest set on each keystroke via
+  // a ref, so these don't need memoizing (and aren't passed to memoized
+  // children). Step nav uses functional setState to stay correct at the bounds.
+  const hotkeyRootRef = useViewerHotkeys({
+    onPrevStep: () => setStageIndex((i) => Math.max(0, i - 1)),
+    onNextStep: () => setStageIndex((i) => Math.min(steps.length - 1, i + 1)),
+    onPrevTreatment: () => cycleUnit(-1),
+    onNextTreatment: () => cycleUnit(1),
+    onSelectPosition: (n) => {
+      if (n >= 0 && n < playerCount) setPosition(n);
+    },
+    onToggleTimer: () => scrubberRef.current?.toggle(),
+    onToggleHelp: () => setShowHelp((s) => !s),
+    // Alt+↑/↓ cycles adjacent treatments (good for A/B toggling); Alt+P focuses
+    // the picker so the researcher can see the whole list and jump by name —
+    // treatments are unordered, so cycling alone can't surface all options.
+    onFocusPicker: () => treatmentSelectRef.current?.focus(),
+  });
+
   const ctx = useMemo(
     () =>
       createViewerContext({
@@ -281,32 +344,22 @@ export function Viewer({
   };
 
   return (
-    <div style={layoutStyle}>
+    // tabIndex makes the viewer root focusable so a click anywhere in it
+    // activates the researcher hotkeys, which are scoped to this element (not
+    // window) — polite when the viewer is embedded among other page content.
+    <div style={layoutStyle} ref={hotkeyRootRef} tabIndex={-1}>
       {/* Header */}
       <header style={headerStyle}>
         <div style={headerLeftStyle}>
           {hostControls}
           {units.length > 1 ? (
             <select
+              ref={treatmentSelectRef}
               aria-label="Part to preview"
-              title="Part of the study to preview"
+              title="Part of the study to preview (⌥↑ / ⌥↓; ⌥P to focus)"
+              aria-keyshortcuts="Alt+ArrowUp Alt+ArrowDown Alt+P"
               value={unit.key}
-              onChange={(e) => {
-                const key = e.target.value;
-                setSelectedUnitKey(key);
-                // Keep the host's persisted selection in sync so the VS Code
-                // preview restores this unit (not the previous treatment) after
-                // a refresh (#485 review).
-                if (key.startsWith("treatment:")) {
-                  onTreatmentIndexChange?.(
-                    Number(key.slice("treatment:".length)),
-                  );
-                } else if (key.startsWith("intro:")) {
-                  onIntroIndexChange?.(Number(key.slice("intro:".length)));
-                }
-                // Consent keys have no host-persisted index (yet) — the
-                // local selection alone drives the preview.
-              }}
+              onChange={(e) => selectUnit(e.target.value)}
               style={treatmentSelectStyle}
             >
               {consentUnits.length > 0 && (
@@ -348,6 +401,7 @@ export function Viewer({
           />
         </div>
         <TimeScrubber
+          ref={scrubberRef}
           currentStep={currentStep}
           elapsedTime={store.getElapsedTime(stageIndex)}
           onTimeChange={handleTimeChange}
@@ -374,6 +428,8 @@ export function Viewer({
           </label>
           <select
             id="position-select"
+            title="Player position (⌥0–⌥9)"
+            aria-keyshortcuts="Alt+0 Alt+1 Alt+2 Alt+3 Alt+4 Alt+5 Alt+6 Alt+7 Alt+8 Alt+9"
             value={clampedPosition}
             onChange={(e) => setPosition(Number(e.target.value))}
             style={positionSelectStyle}
@@ -453,6 +509,8 @@ export function Viewer({
           )}
         </main>
       </div>
+
+      <HotkeyHelp open={showHelp} onClose={() => setShowHelp(false)} />
     </div>
   );
 }
@@ -483,6 +541,14 @@ const layoutStyle: React.CSSProperties = {
   display: "flex",
   flexDirection: "column",
   height: "100vh",
+  // Focusable for hotkey scoping (tabIndex -1); it's a container, not a
+  // tab-stop, so suppress the focus ring a click would otherwise draw.
+  outline: "none",
+  // Containing block for the HotkeyHelp backdrop (position: absolute), so the
+  // cheatsheet dims only this viewer, not the whole host page when embedded.
+  // Safe: no descendant currently positions against the viewport (TimeScrubber
+  // scopes to its track, NotesIconsOverlay to <main>).
+  position: "relative",
 };
 
 const headerStyle: React.CSSProperties = {

--- a/packages/stagebook/src/viewer/components/testing/MockViewer.tsx
+++ b/packages/stagebook/src/viewer/components/testing/MockViewer.tsx
@@ -1,0 +1,46 @@
+import type { TreatmentFileType } from "../../../schemas/index.js";
+import { Viewer } from "../Viewer.js";
+
+// Playwright CT can't serialize the Viewer's function props (getTextContent /
+// getAssetURL) across the mount boundary, so this fixture closes over them and
+// bakes in a small treatment that exercises every researcher hotkey:
+//   - 2 treatments        → the "Part to preview" picker renders (⌥↑ / ⌥↓)
+//   - 2 game stages each   → step nav has somewhere to go (⌥← / ⌥→)
+//   - first stage timed    → TimeScrubber renders, so ⌥K has a target
+//   - playerCount 2        → the position <select> has ≥2 options (⌥0 / ⌥1)
+// buildUnits appends one synthetic transition step per unit, so each 2-stage
+// treatment reads "1 / 3" in the stage counter.
+const TREATMENT_FILE = {
+  treatments: [
+    {
+      name: "Treatment A",
+      playerCount: 2,
+      compatibleIntroSequences: [],
+      gameStages: [
+        { name: "A1", duration: 60, elements: [] },
+        { name: "A2", elements: [] },
+      ],
+    },
+    {
+      name: "Treatment B",
+      playerCount: 2,
+      compatibleIntroSequences: [],
+      gameStages: [
+        { name: "B1", duration: 30, elements: [] },
+        { name: "B2", elements: [] },
+      ],
+    },
+  ],
+} as unknown as TreatmentFileType;
+
+export function MockViewer() {
+  return (
+    <Viewer
+      treatmentFile={TREATMENT_FILE}
+      getTextContent={() => Promise.resolve("")}
+      getAssetURL={(path) => path}
+      selectedIntroIndex={0}
+      selectedTreatmentIndex={0}
+    />
+  );
+}

--- a/packages/stagebook/src/viewer/lib/hotkeys.test.tsx
+++ b/packages/stagebook/src/viewer/lib/hotkeys.test.tsx
@@ -82,11 +82,15 @@ describe("dispatchViewerHotkey", () => {
     expect(h.onSelectPosition).toHaveBeenCalledWith(3);
   });
 
-  test("returns true and prevents default on a handled key", () => {
+  test("consumes a handled key: preventDefault + stopPropagation", () => {
     const h = makeHandlers();
     const e = key({ altKey: true, code: "ArrowRight" });
+    const stop = vi.spyOn(e, "stopPropagation");
     expect(dispatchViewerHotkey(e, h)).toBe(true);
     expect(e.defaultPrevented).toBe(true);
+    // stopPropagation keeps the same keydown from also reaching a focused study
+    // widget (which might act on the bare key without checking altKey).
+    expect(stop).toHaveBeenCalledTimes(1);
   });
 
   test("ignores bare keys (no modifier) — they pass through to the study", () => {
@@ -107,11 +111,15 @@ describe("dispatchViewerHotkey", () => {
     expect(h.onNextStep).not.toHaveBeenCalled();
   });
 
-  test("ignores an unmapped Alt+<key> without preventing default", () => {
+  test("ignores an unmapped Alt+<key> without consuming the event", () => {
     const h = makeHandlers();
     const e = key({ altKey: true, code: "KeyG" });
+    const stop = vi.spyOn(e, "stopPropagation");
     expect(dispatchViewerHotkey(e, h)).toBe(false);
     expect(e.defaultPrevented).toBe(false);
+    // Unhandled keys must keep flowing to the study content, so we neither
+    // preventDefault nor stopPropagation.
+    expect(stop).not.toHaveBeenCalled();
   });
 });
 
@@ -175,6 +183,89 @@ describe("useViewerHotkeys", () => {
     );
     expect(h.onNextStep).not.toHaveBeenCalled();
     cleanup();
+  });
+
+  // A handled Alt shortcut must be consumed before a focused study widget
+  // deeper in the tree sees the bare key. The capture-phase listener + the
+  // dispatcher's stopPropagation() enforce that.
+  test("consumes a handled key before a focused child handler runs", () => {
+    const h = makeHandlers();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    let child!: HTMLButtonElement;
+    function Probe() {
+      const setRef = useViewerHotkeys(h);
+      return (
+        <div ref={setRef}>
+          <button
+            ref={(el) => {
+              if (el) child = el;
+            }}
+          />
+        </div>
+      );
+    }
+    act(() => root.render(<Probe />));
+
+    // Stands in for a study widget's own keydown handler (e.g. MediaPlayer).
+    const childHandler = vi.fn();
+    child.addEventListener("keydown", childHandler);
+    act(() => {
+      child.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          altKey: true,
+          code: "ArrowRight",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+    expect(h.onNextStep).toHaveBeenCalledTimes(1); // viewer routed it
+    expect(childHandler).not.toHaveBeenCalled(); // ...and the child never saw it
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  // A bare key must still reach the focused child — the namespace only consumes
+  // Alt-modified chrome keys.
+  test("lets a bare key reach a focused child handler", () => {
+    const h = makeHandlers();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    let child!: HTMLButtonElement;
+    function Probe() {
+      const setRef = useViewerHotkeys(h);
+      return (
+        <div ref={setRef}>
+          <button
+            ref={(el) => {
+              if (el) child = el;
+            }}
+          />
+        </div>
+      );
+    }
+    act(() => root.render(<Probe />));
+
+    const childHandler = vi.fn();
+    child.addEventListener("keydown", childHandler);
+    act(() => {
+      child.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          code: "ArrowRight", // no altKey — belongs to the study content
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+    expect(childHandler).toHaveBeenCalledTimes(1);
+    expect(h.onNextStep).not.toHaveBeenCalled();
+
+    act(() => root.unmount());
+    container.remove();
   });
 
   // The hook tracks its node in state (not a plain ref) specifically so the

--- a/packages/stagebook/src/viewer/lib/hotkeys.test.tsx
+++ b/packages/stagebook/src/viewer/lib/hotkeys.test.tsx
@@ -1,0 +1,277 @@
+// @vitest-environment jsdom
+import { describe, test, expect, vi, beforeAll } from "vitest";
+import React, { useRef } from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import {
+  dispatchViewerHotkey,
+  useViewerHotkeys,
+  type ViewerHotkeyHandlers,
+} from "./hotkeys.js";
+
+beforeAll(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+function makeHandlers(): ViewerHotkeyHandlers & {
+  [K in keyof ViewerHotkeyHandlers]: ReturnType<typeof vi.fn>;
+} {
+  return {
+    onPrevStep: vi.fn(),
+    onNextStep: vi.fn(),
+    onPrevTreatment: vi.fn(),
+    onNextTreatment: vi.fn(),
+    onSelectPosition: vi.fn(),
+    onToggleTimer: vi.fn(),
+    onToggleHelp: vi.fn(),
+    onFocusPicker: vi.fn(),
+  };
+}
+
+/** Build a cancelable keydown so `defaultPrevented` reflects preventDefault(). */
+function key(init: KeyboardEventInit): KeyboardEvent {
+  return new KeyboardEvent("keydown", { cancelable: true, ...init });
+}
+
+describe("dispatchViewerHotkey", () => {
+  test("Alt+Arrows drive step (←/→) and treatment (↑/↓) navigation", () => {
+    const h = makeHandlers();
+    dispatchViewerHotkey(key({ altKey: true, code: "ArrowLeft" }), h);
+    dispatchViewerHotkey(key({ altKey: true, code: "ArrowRight" }), h);
+    dispatchViewerHotkey(key({ altKey: true, code: "ArrowUp" }), h);
+    dispatchViewerHotkey(key({ altKey: true, code: "ArrowDown" }), h);
+    expect(h.onPrevStep).toHaveBeenCalledTimes(1);
+    expect(h.onNextStep).toHaveBeenCalledTimes(1);
+    expect(h.onPrevTreatment).toHaveBeenCalledTimes(1);
+    expect(h.onNextTreatment).toHaveBeenCalledTimes(1);
+  });
+
+  test("Alt+digit selects that player position; 0 maps to position 0", () => {
+    const h = makeHandlers();
+    dispatchViewerHotkey(key({ altKey: true, code: "Digit3" }), h);
+    dispatchViewerHotkey(key({ altKey: true, code: "Digit0" }), h);
+    expect(h.onSelectPosition).toHaveBeenNthCalledWith(1, 3);
+    expect(h.onSelectPosition).toHaveBeenNthCalledWith(2, 0);
+  });
+
+  test("Alt+K toggles the timer, Alt+/ toggles help", () => {
+    const h = makeHandlers();
+    dispatchViewerHotkey(key({ altKey: true, code: "KeyK" }), h);
+    dispatchViewerHotkey(key({ altKey: true, code: "Slash" }), h);
+    expect(h.onToggleTimer).toHaveBeenCalledTimes(1);
+    expect(h.onToggleHelp).toHaveBeenCalledTimes(1);
+  });
+
+  test("Alt+P focuses the part picker", () => {
+    const h = makeHandlers();
+    const e = key({ altKey: true, code: "KeyP" });
+    expect(dispatchViewerHotkey(e, h)).toBe(true);
+    expect(e.defaultPrevented).toBe(true);
+    expect(h.onFocusPicker).toHaveBeenCalledTimes(1);
+  });
+
+  test("keys off event.code, so macOS Option-composed event.key is irrelevant", () => {
+    const h = makeHandlers();
+    // On macOS, Option+K yields event.key "˚" and Option+3 yields "£".
+    // Keying off `code` must still route correctly.
+    dispatchViewerHotkey(key({ altKey: true, code: "KeyK", key: "˚" }), h);
+    dispatchViewerHotkey(key({ altKey: true, code: "Digit3", key: "£" }), h);
+    expect(h.onToggleTimer).toHaveBeenCalledTimes(1);
+    expect(h.onSelectPosition).toHaveBeenCalledWith(3);
+  });
+
+  test("returns true and prevents default on a handled key", () => {
+    const h = makeHandlers();
+    const e = key({ altKey: true, code: "ArrowRight" });
+    expect(dispatchViewerHotkey(e, h)).toBe(true);
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  test("ignores bare keys (no modifier) — they pass through to the study", () => {
+    const h = makeHandlers();
+    const e = key({ code: "ArrowRight" });
+    expect(dispatchViewerHotkey(e, h)).toBe(false);
+    expect(e.defaultPrevented).toBe(false);
+    expect(h.onNextStep).not.toHaveBeenCalled();
+  });
+
+  test("ignores Ctrl+Alt (AltGr) and Cmd+Alt so native/i18n input is untouched", () => {
+    const h = makeHandlers();
+    const altGr = key({ altKey: true, ctrlKey: true, code: "Digit3" });
+    const cmdAlt = key({ altKey: true, metaKey: true, code: "ArrowRight" });
+    expect(dispatchViewerHotkey(altGr, h)).toBe(false);
+    expect(dispatchViewerHotkey(cmdAlt, h)).toBe(false);
+    expect(h.onSelectPosition).not.toHaveBeenCalled();
+    expect(h.onNextStep).not.toHaveBeenCalled();
+  });
+
+  test("ignores an unmapped Alt+<key> without preventing default", () => {
+    const h = makeHandlers();
+    const e = key({ altKey: true, code: "KeyG" });
+    expect(dispatchViewerHotkey(e, h)).toBe(false);
+    expect(e.defaultPrevented).toBe(false);
+  });
+});
+
+describe("useViewerHotkeys", () => {
+  function mount(handlers: ViewerHotkeyHandlers) {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    let node!: HTMLDivElement;
+    function Probe() {
+      const localRef = useRef<HTMLDivElement>(null);
+      const setRef = useViewerHotkeys(handlers);
+      return (
+        <div
+          data-testid="root"
+          ref={(el) => {
+            localRef.current = el;
+            setRef(el);
+            if (el) node = el;
+          }}
+        />
+      );
+    }
+    act(() => root.render(<Probe />));
+    return {
+      node,
+      unmount: () => act(() => root.unmount()),
+      cleanup: () => container.remove(),
+    };
+  }
+
+  test("dispatches hotkeys from keydown events within the scoped node", () => {
+    const h = makeHandlers();
+    const { node, unmount, cleanup } = mount(h);
+    act(() => {
+      node.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          altKey: true,
+          code: "ArrowRight",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+    expect(h.onNextStep).toHaveBeenCalledTimes(1);
+    unmount();
+    cleanup();
+  });
+
+  test("detaches the listener on unmount", () => {
+    const h = makeHandlers();
+    const { node, unmount, cleanup } = mount(h);
+    unmount();
+    node.dispatchEvent(
+      new KeyboardEvent("keydown", {
+        altKey: true,
+        code: "ArrowRight",
+        bubbles: true,
+        cancelable: true,
+      }),
+    );
+    expect(h.onNextStep).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  // The hook tracks its node in state (not a plain ref) specifically so the
+  // listener follows when the viewer swaps its root element (the empty-state ↔
+  // normal-render transition). A regression to a plain ref would pass every
+  // other test here yet silently break hotkeys after such a swap.
+  test("follows a node swap — old node goes quiet, new node fires", () => {
+    const h = makeHandlers();
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    let nodeA!: HTMLDivElement;
+    let nodeB!: HTMLDivElement;
+    // Distinct keys force React to unmount the old div and mount a new one, so
+    // the ref receives a genuinely different DOM node (not a reconciled reuse).
+    function Probe({ which }: { which: "a" | "b" }) {
+      const setRef = useViewerHotkeys(h);
+      return which === "a" ? (
+        <div
+          key="a"
+          ref={(el) => {
+            setRef(el);
+            if (el) nodeA = el;
+          }}
+        />
+      ) : (
+        <div
+          key="b"
+          ref={(el) => {
+            setRef(el);
+            if (el) nodeB = el;
+          }}
+        />
+      );
+    }
+    act(() => root.render(<Probe which="a" />));
+    act(() => root.render(<Probe which="b" />));
+    expect(nodeA).not.toBe(nodeB);
+
+    const fire = (n: HTMLElement) =>
+      act(() => {
+        n.dispatchEvent(
+          new KeyboardEvent("keydown", {
+            altKey: true,
+            code: "ArrowRight",
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+    fire(nodeA);
+    expect(h.onNextStep).not.toHaveBeenCalled();
+    fire(nodeB);
+    expect(h.onNextStep).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  // Handlers may be a fresh object each render; the hook reads the latest set
+  // via a ref, so a re-render with new handlers must route to the new ones
+  // (a closure captured at subscribe time would fire the stale set).
+  test("uses the latest handlers after a re-render (no stale closure)", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    let node!: HTMLDivElement;
+    function Probe({ handlers }: { handlers: ViewerHotkeyHandlers }) {
+      const setRef = useViewerHotkeys(handlers);
+      return (
+        <div
+          ref={(el) => {
+            setRef(el);
+            if (el) node = el;
+          }}
+        />
+      );
+    }
+    const first = makeHandlers();
+    act(() => root.render(<Probe handlers={first} />));
+    const second = makeHandlers();
+    act(() => root.render(<Probe handlers={second} />));
+
+    act(() => {
+      node.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          altKey: true,
+          code: "ArrowRight",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+    expect(first.onNextStep).not.toHaveBeenCalled();
+    expect(second.onNextStep).toHaveBeenCalledTimes(1);
+
+    act(() => root.unmount());
+    container.remove();
+  });
+});

--- a/packages/stagebook/src/viewer/lib/hotkeys.ts
+++ b/packages/stagebook/src/viewer/lib/hotkeys.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Researcher-facing keyboard shortcuts for the viewer chrome. See the design in
+ * https://github.com/talkbench/stagebook/issues/534.
+ *
+ * The Alt/Option modifier is a **namespace separator**: bare keys pass through
+ * to the study content (the participant experience — move a radio, type into a
+ * Prompt, drag a Slider), while `Alt+<key>` drives the researcher chrome
+ * (switch treatment, advance step, jump position, timer). This keeps the two
+ * roles unambiguous and focus-independent, so we need no "am I focused in a
+ * text field?" heuristics.
+ */
+export interface ViewerHotkeyHandlers {
+  /** Alt+ArrowLeft — previous step. */
+  onPrevStep: () => void;
+  /** Alt+ArrowRight — next step. */
+  onNextStep: () => void;
+  /** Alt+ArrowUp — previous treatment/unit. */
+  onPrevTreatment: () => void;
+  /** Alt+ArrowDown — next treatment/unit. */
+  onNextTreatment: () => void;
+  /** Alt+0..9 — select that player position (ignored if out of range). */
+  onSelectPosition: (index: number) => void;
+  /** Alt+K — play/pause the timeline scrubber. */
+  onToggleTimer: () => void;
+  /** Alt+/ (or Alt+?) — toggle the shortcut cheatsheet. */
+  onToggleHelp: () => void;
+  /**
+   * Alt+P — focus the "part to preview" picker. Treatments are a flat,
+   * name-keyed set (no meaningful order), so blind Alt+↑/↓ cycling can't show
+   * the whole list; focusing the native <select> gives typeahead-by-name and
+   * the OS dropdown for browsing. See issue #534.
+   */
+  onFocusPicker: () => void;
+}
+
+/** "Digit0".."Digit9" → 0..9; anything else → null. */
+function digitFromCode(code: string): number | null {
+  const m = /^Digit([0-9])$/.exec(code);
+  return m ? Number(m[1]) : null;
+}
+
+/**
+ * Route one keydown to the matching researcher action. Returns `true` (and
+ * calls `preventDefault`) when the event was one of ours, `false` otherwise.
+ *
+ * Keying off `event.code` (the physical key) rather than `event.key` is
+ * deliberate and load-bearing: on macOS, holding Option composes the character
+ * (`Option+K` → `"˚"`, `Option+3` → `"£"`), so `event.key` is unreliable while
+ * `event.code` ("KeyK", "Digit3") stays stable and layout-independent.
+ */
+export function dispatchViewerHotkey(
+  e: KeyboardEvent,
+  handlers: ViewerHotkeyHandlers,
+): boolean {
+  // Only Alt-modified keys are ours. Bail on Ctrl/Meta so we never shadow a
+  // native accelerator (Cmd/Ctrl+R reload, Cmd/Ctrl+digit tab switch) and so
+  // Windows AltGr (which reports as Ctrl+Alt) still types characters.
+  if (!e.altKey || e.ctrlKey || e.metaKey) return false;
+
+  let handled = true;
+  switch (e.code) {
+    case "ArrowLeft":
+      handlers.onPrevStep();
+      break;
+    case "ArrowRight":
+      handlers.onNextStep();
+      break;
+    case "ArrowUp":
+      handlers.onPrevTreatment();
+      break;
+    case "ArrowDown":
+      handlers.onNextTreatment();
+      break;
+    case "KeyK":
+      handlers.onToggleTimer();
+      break;
+    case "KeyP":
+      handlers.onFocusPicker();
+      break;
+    case "Slash":
+      // Alt+/ and Alt+? (Shift+Slash) both land here.
+      handlers.onToggleHelp();
+      break;
+    default: {
+      const digit = digitFromCode(e.code);
+      if (digit !== null) {
+        handlers.onSelectPosition(digit);
+      } else {
+        handled = false;
+      }
+    }
+  }
+
+  if (handled) e.preventDefault();
+  return handled;
+}
+
+/**
+ * Attach the researcher hotkeys to a viewer instance. Returns a callback ref to
+ * put on the viewer's root element; the listener lives on that node (not
+ * `window`), so shortcuts only fire when focus is within this viewer — polite
+ * when several viewers, or other page content, share the document.
+ *
+ * `handlers` may be recreated every render; the latest set is always used
+ * without re-subscribing.
+ */
+export function useViewerHotkeys(
+  handlers: ViewerHotkeyHandlers,
+  enabled = true,
+): (node: HTMLElement | null) => void {
+  const handlersRef = useRef(handlers);
+  handlersRef.current = handlers;
+
+  // Track the mounted node in state (not a plain ref) so the effect re-runs if
+  // the viewer swaps its root element (e.g. empty-state ↔ normal render).
+  const [node, setNode] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !node) return;
+    const onKeyDown = (e: KeyboardEvent) =>
+      dispatchViewerHotkey(e, handlersRef.current);
+    node.addEventListener("keydown", onKeyDown);
+    return () => node.removeEventListener("keydown", onKeyDown);
+  }, [node, enabled]);
+
+  return useCallback((n: HTMLElement | null) => setNode(n), []);
+}

--- a/packages/stagebook/src/viewer/lib/hotkeys.ts
+++ b/packages/stagebook/src/viewer/lib/hotkeys.ts
@@ -42,6 +42,18 @@ function digitFromCode(code: string): number | null {
 }
 
 /**
+ * Interactive controls whose click should keep focus (so we don't steal it
+ * from a study widget the researcher is operating). Everything else — plain
+ * Markdown, a Display, empty stage space — is non-focusable, and a click there
+ * should land focus on the viewer root so the scoped hotkeys still fire.
+ */
+const INTERACTIVE_SELECTOR =
+  'a[href],button,input,select,textarea,[contenteditable="true"],' +
+  '[tabindex]:not([tabindex="-1"]),' +
+  '[role="button"],[role="slider"],[role="radio"],[role="checkbox"],' +
+  '[role="textbox"],[role="link"],[role="menuitem"]';
+
+/**
  * Route one keydown to the matching researcher action. Returns `true` (and
  * calls `preventDefault`) when the event was one of ours, `false` otherwise.
  *
@@ -93,7 +105,14 @@ export function dispatchViewerHotkey(
     }
   }
 
-  if (handled) e.preventDefault();
+  if (handled) {
+    e.preventDefault();
+    // Consume the event so a focused study widget doesn't also act on the bare
+    // key — e.g. MediaPlayer treats `K` as play/pause and Timeline treats the
+    // arrows as nudge, neither filtering `altKey`. The namespace only holds if
+    // Alt keys never reach the content.
+    e.stopPropagation();
+  }
   return handled;
 }
 
@@ -121,8 +140,23 @@ export function useViewerHotkeys(
     if (!enabled || !node) return;
     const onKeyDown = (e: KeyboardEvent) =>
       dispatchViewerHotkey(e, handlersRef.current);
-    node.addEventListener("keydown", onKeyDown);
-    return () => node.removeEventListener("keydown", onKeyDown);
+    // A click anywhere in the viewer should land focus inside it, so the scoped
+    // hotkeys fire on the next keypress. A `tabIndex=-1` root isn't reliably
+    // focused when the click hits non-focusable stage content, so nudge it —
+    // but skip clicks on interactive controls, whose own focus the study needs.
+    const onMouseDown = (e: MouseEvent) => {
+      const target = e.target as Element | null;
+      if (target && !target.closest(INTERACTIVE_SELECTOR)) node.focus();
+    };
+    // Capture phase: a handled Alt shortcut is routed (and stopPropagation()d)
+    // before it can reach a focused study widget deeper in the tree. Unhandled
+    // and bare keys are left untouched, so participant input still flows.
+    node.addEventListener("keydown", onKeyDown, true);
+    node.addEventListener("mousedown", onMouseDown);
+    return () => {
+      node.removeEventListener("keydown", onKeyDown, true);
+      node.removeEventListener("mousedown", onMouseDown);
+    };
   }, [node, enabled]);
 
   return useCallback((n: HTMLElement | null) => setNode(n), []);


### PR DESCRIPTION
## Summary

Adds researcher-facing keyboard shortcuts to the viewer chrome (`stagebook/viewer` harness — standalone app, VS Code webview, external hosts). The **modifier is a namespace**: bare keys pass through to the study content (participant actions — move a radio, type in a Prompt, drag a Slider), and `Alt`/`Option`+key drives the chrome (researcher actions). This is focus-independent and needs no `activeElement` sniffing.

Fixes #534.

### Keymap

| Keys | Action |
|---|---|
| `⌥←` / `⌥→` | previous / next step (clamped, no wrap) |
| `⌥↑` / `⌥↓` | previous / next treatment (cycle the unit list) |
| `⌥P` | focus the "part to preview" picker (type to jump) |
| `⌥0` … `⌥9` | select player position N (ignored if `N ≥ playerCount`) |
| `⌥K` | timer play/pause (only when the step has a `duration`) |
| `⌥/` | toggle the shortcut cheatsheet |

### Design notes

- **Keys off `event.code`, not `event.key`** — macOS Option composes the character (`Option+K` → `˚`), so `code` is the only stable, layout-independent signal. Gated on `altKey && !ctrlKey && !metaKey` so Windows AltGr and Cmd/Ctrl accelerators pass through.
- **Listener scoped to the focused viewer root** (`tabIndex=-1`), never `window`, so multiple embedded viewers / the host page don't cross-fire.
- **Every shortcut mirrors an existing focusable control**; mirrored controls carry `aria-keyshortcuts` + tooltip hints.
- **`TimeScrubber`** lifts play/pause behind an imperative handle for `⌥K`; the handle only exists when the step has a `duration` (so `⌥K` safely no-ops on an untimed stage).

### Two refinements to the #534 sketch

- **`⌥P` focuses the picker** instead of relying only on `⌥↑/↓` cycling. Treatments are a flat, name-keyed set (alphabetical by group, no meaningful order), so blind adjacent-cycling can't surface the whole list. Focusing the native `<select>` gives typeahead-by-name and the OS dropdown. (`⌥↑/↓` stays — it's good for A/B toggling.)
- **Cheatsheet is `⌥/`, not bare `?`** — keeps everything inside the `Alt` namespace so "bare keys belong to the study" has no exception.

### ADR

`docs/decisions/2026-07-viewer-hotkeys.md` records the design and **corrects #534's "macOS unaffected for `Alt+Arrow`" claim**: it considered only browser history and overlooked macOS in-field **word-navigation** (`Option+←/→` moves the caret by word). Inside a focused Prompt/TextArea in the preview, `⌥←` steps the stage instead — consistent with the namespace design and working-as-intended, but noted so the claim isn't repeated uncorrected.

## Testing

- **Unit (vitest/jsdom):** pure dispatcher (every keymap entry + all ignore paths — bare keys, AltGr, Cmd+Alt, unmapped `Alt+key`, macOS Option-composed `event.key`); hook lifecycle (attach/detach, **node-swap**, **handler-freshness**); `TimeScrubber` imperative toggle including **restart-from-end** and the no-handle-when-untimed case.
- **Component (Playwright CT, chromium + webkit + firefox):** real key presses through the mounted `Viewer` for every shortcut, Escape-closes-cheatsheet, `⌥P` focuses the picker, bounds-clamp (no wrap), and bare-key pass-through.
- Full local suite green: vitest 1978/1978, hotkeys CT 27/27 across all three browsers, ESLint clean, `tsc` clean.

## Review

Ran a 3-subagent review (correctness / test-coverage / security) over the branch diff before opening. Findings folded in:
- **Correctness:** fixed `HotkeyHelp` re-subscribing its Escape listener on every render; corrected the macOS `Alt+Arrow` claim in the ADR.
- **Coverage:** added the missing `TimeScrubber` restart-from-end, Escape-close, node-swap, handler-freshness, and bounds-clamp tests.
- **Security:** scoped the cheatsheet backdrop to the viewer (`position: absolute` against the now-positioned root) so it dims only this viewer, not the whole host page when embedded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)