### PR TITLE
docs(a11y): component accessibility audit report + ListSorter keyboard test (#20)

### DIFF
--- a/docs/a11y-audit-2026-07.md
+++ b/docs/a11y-audit-2026-07.md
@@ -26,6 +26,9 @@ Target standard: **WCAG 2.2 AA** (per
 - axe catches roughly a third to a half of WCAG issues. **No full
   screen-reader manual pass** was done.
 - RTL rendering a11y not specifically exercised.
+- **2.4.11 Focus Not Obscured (Minimum)** — new AA in 2.2 — not verified this
+  pass: whether the sticky `ScrollIndicator` or the Timeline help popover can
+  fully obscure a keyboard-focused element still needs a manual check.
 - **Deferred (need deeper review):** `Timeline` (waveform — the ADR's
   acknowledged hard case, needs the provider), `MediaPlayer`, and `AudioElement`
   (renders no UI; audio captions/transcript is an authoring-side concern
@@ -158,8 +161,8 @@ slider, list-sorter).
 - **2.5.8 Target Size (≥24px):** existing tests assert ≥36px interactive rows
   (RadioGroup, Slider click strip, Select trigger) and ListSorter rows use a
   2.25rem (36px) min-height — comfortably above 24px.
-- **Focus visibility (2.4.7 / 2.4.11):** components deliver `:focus-visible`
-  rings (confirmed across the existing `.ct.tsx` suite).
+- **Focus visibility (2.4.7):** components deliver `:focus-visible` rings
+  (confirmed across the existing `.ct.tsx` suite).
 
 ## Next steps
 

--- a/docs/a11y-audit-2026-07.md
+++ b/docs/a11y-audit-2026-07.md
@@ -1,0 +1,172 @@
+# Accessibility audit — participant-facing component library (July 2026)
+
+Audit for issue [#20]. Scope: the `packages/stagebook` **participant-facing
+components** — the pieces consumer tools import to actually run studies. The
+viewer app and VS Code extension are **out of scope for this pass**.
+
+Target standard: **WCAG 2.2 AA** (per
+[docs/decisions/2026-07-accessibility.md](./decisions/2026-07-accessibility.md)).
+
+## Method
+
+- **Automated:** axe-core (`@axe-core/playwright`) run via the existing
+  Playwright Component Test harness, in real Chromium with `styles.css` loaded.
+  Each component mounted with realistic props, scan scoped to the mounted root,
+  ruleset restricted to WCAG 2.0/2.1/2.2 levels A + AA. Harness:
+  `packages/stagebook/src/components/a11y.audit.ct.tsx`.
+- **Manual / source review:** keyboard operability, focus visibility, WCAG 2.5.7
+  (dragging movements) and 2.5.8 (target size) — the criteria axe cannot check.
+
+**Coverage caveats (read before trusting a clean result):**
+
+- Default **light** theme and default token values only. Host token overrides
+  (incl. dark) not tested — those are a host concern.
+- Scans are **component-scoped**; document-level rules (landmarks, headings,
+  `lang`) are not exercised here (they belong to the host/viewer surface).
+- axe catches roughly a third to a half of WCAG issues. **No full
+  screen-reader manual pass** was done.
+- RTL rendering a11y not specifically exercised.
+- **Deferred (need deeper review):** `Timeline` (waveform — the ADR's
+  acknowledged hard case, needs the provider), `MediaPlayer`, and `AudioElement`
+  (renders no UI; audio captions/transcript is an authoring-side concern
+  analogous to Finding 2).
+
+## Summary
+
+21 participant-facing cases scanned. **17 clean**, **4 findings** (one of which
+axe structurally cannot see). Ordered below by priority for triage.
+
+| Step | Finding | Severity | WCAG | Detected by |
+| ---- | ------- | -------- | ---- | ----------- |
+| 1 | Interactive contrast (Button, SubmitButton, TrackedLink) → #535 | serious | 1.4.3 | axe |
+| 2 | ImageElement has no `alt` affordance → #536 | high | 1.1.1 | manual (axe passes it) |
+| 3 | Standalone TextArea has no accessible name → #538 | critical\* | 1.3.1 / 4.1.2 | axe |
+| 4 | ListSorter keyboard-drag — verified working ✓ (regression test added) | low | 2.5.7 | manual |
+
+\* axe labels it "critical," but real-world impact is bounded — see Step 3.
+
+---
+
+## Step 1 — Interactive elements fail color contrast
+
+> **Disposition (triaged 2026-07-10):** folded into **#535 — Deliberate color
+> system for Stagebook**. Not fixed by a narrow patch; the contrast fix becomes
+> acceptance criterion #1 of the color-system work, so the palette is
+> contrast-valid by construction rather than by nudging one token.
+
+- **Components:** `Button`, `SubmitButton` (wraps Button styling), `TrackedLink`.
+- **Severity:** serious · **WCAG 1.4.3 Contrast (Minimum)** · axe `color-contrast`.
+- **Evidence:** all three flagged by axe. Shared root cause — the default
+  interactive color (`--stagebook-primary`, `#3b82f6`) against its companion
+  surface is ≈3.7:1, below the 4.5:1 AA threshold for normal-size text. Button &
+  SubmitButton share the token; TrackedLink is the link-text color.
+- **Why it matters:** highest frequency of anything here — buttons and links
+  appear in essentially every study. Low-vision participants can't reliably read
+  the primary CTA.
+- **Fix direction:** one shared token change likely resolves all three — darken
+  the interactive color for text use (e.g. toward `--stagebook-primary-hover`
+  `#2563eb` / `-active` `#1d4ed8`), or guarantee button label text is large/bold
+  (which lowers the bar to 3:1). Verify the chosen token against every surface it
+  paints on.
+- **Proposed subtask:** _"Fix WCAG 1.4.3 contrast on Button / SubmitButton /
+  TrackedLink."_ Acceptance: all three pass axe `color-contrast` at AA in the
+  default theme; add the axe assertion to each component's `.ct.tsx`.
+
+## Step 2 — ImageElement gives authors no way to add alt text
+
+> **Disposition (triaged 2026-07-10):** filed as **#536** — one issue covering
+> schema `altText` field → router passthrough → component `alt` prop → validator
+> lint (with a decorative escape hatch). Scope confirmed: the YAML `image`
+> element, not markdown images (which carry alt via `![alt](src)` syntax).
+
+- **Component:** `ImageElement` (participant-facing stimulus images).
+- **Severity:** high · **WCAG 1.1.1 Non-text Content** · **not detectable by
+  axe** (empty `alt` is technically valid).
+- **Evidence:** `ImageElement.tsx` renders `<img src={src} alt="" />` — a
+  hardcoded empty alt — and its props are only `{ src, width }`. Every researcher
+  image is therefore marked *decorative* and hidden from screen readers, with no
+  author lever to describe it.
+- **Why it matters:** silently excludes screen-reader participants from **all**
+  image stimuli, and a purely-axe audit would report images as clean. This is
+  the exact case the ADR's Decision 3 anticipated (components conform / authoring
+  is helped).
+- **Fix direction — two surfaces:**
+  1. **Component:** add an optional `alt` prop; keep `alt=""` only when the
+     author explicitly marks the image decorative.
+  2. **Authoring:** validator lint (ADR Decision 3) that warns when an `Image`
+     element has no `alt` — wired into **both** validate paths
+     (`cli/validate.ts` and `validateTreatmentDiff.ts`).
+- **Proposed subtask(s):** split into a component change and a validator-lint
+  change (the lint depends on the prop existing). Acceptance: `ImageElement`
+  accepts `alt`; validator flags missing/empty alt on authored `Image` elements.
+
+## Step 3 — Standalone TextArea has no accessible name
+
+> **Disposition (triaged 2026-07-10):** filed as **#538**. Priority upgraded from
+> "defensive" to a real **public-API conformance gap** — `TextArea` is exported
+> via `stagebook/components`, so a host using it standalone gets an unnamed input
+> (it lacks the `label` affordance its siblings have). Not reached in authored
+> studies (always `Prompt`-wrapped), but the export is the deciding factor.
+
+- **Component:** `TextArea` used directly (not via `Prompt`).
+- **Severity:** axe "critical" · **WCAG 1.3.1 / 4.1.2** · axe `label`.
+- **Evidence:** the bare `<textarea>` has an `id` but no `aria-label` /
+  `aria-labelledby` affordance in its props, so standalone it has no
+  programmatic name. **Note:** used *through* `Prompt` (open-response) it is
+  named correctly and passes — so real impact depends on whether `TextArea` is
+  ever consumed directly participant-facing.
+- **Fix direction:** add an `aria-label` / `ariaLabelledBy` prop, or document
+  that `TextArea` must always be given a programmatic label by its consumer.
+- **Triage question to resolve first:** is `TextArea` used standalone by any
+  consumer tool, or always via `Prompt`? That sets the priority.
+- **Proposed subtask:** _"Give TextArea a built-in accessible-name affordance."_
+
+## Step 4 — Verify ListSorter keyboard reordering (2.5.7)
+
+> **Disposition (triaged 2026-07-10):** **verified working — no defect.** A CT
+> test drives the @hello-pangea/dnd keyboard sensor (focus row → Space → ArrowDown
+> → Space) and the list reorders correctly, so WCAG 2.5.7 is satisfied. The test
+> (`a11y.keyboard.ct.tsx`) is kept as the regression guard; no issue needed.
+
+- **Component:** `ListSorter` (drag-to-reorder).
+- **Severity:** low · **WCAG 2.5.7 Dragging Movements** (new AA in 2.2).
+- **Evidence:** `ListSorter` uses `@hello-pangea/dnd`, which ships a keyboard
+  sensor (Tab to a row → Space to lift → arrows to move → Space to drop), and the
+  component already has a `:focus-visible` ring on rows with a comment describing
+  keyboard grab. So a non-drag alternative **very likely already exists** — but
+  it is **not covered by any test**, and "the library supports it" ≠ "it works in
+  our config."
+- **Fix direction:** no code change expected; add a CT test that reorders the
+  list by keyboard alone to lock the behavior in (and catch regressions if the
+  dnd dep changes).
+- **Proposed subtask:** _"Add a keyboard-reorder CT test for ListSorter (2.5.7)."_
+
+---
+
+## Verified clean (17)
+
+RadioGroup (labelled + unlabelled), CheckboxGroup, Select, Slider (anchored +
+unanchored), ListSorter (axe), Display, KitchenTimer, Markdown, Separator, and
+all five `Prompt` variants (multiple-choice single/multiple, open-response,
+slider, list-sorter).
+
+**Manual checks that passed:**
+
+- **Keyboard operability:** form inputs are native elements (radio, checkbox,
+  select, textarea, range) → natively operable. The custom Slider wraps a native
+  range input; `rtl.ct.tsx` confirms arrow keys record the correct value.
+- **2.5.8 Target Size (≥24px):** existing tests assert ≥36px interactive rows
+  (RadioGroup, Slider click strip, Select trigger) and ListSorter rows use a
+  2.25rem (36px) min-height — comfortably above 24px.
+- **Focus visibility (2.4.7 / 2.4.11):** components deliver `:focus-visible`
+  rings (confirmed across the existing `.ct.tsx` suite).
+
+## Next steps
+
+1. Walk these four steps and file each as a subtask issue under [#20]
+   (prioritized), per the ADR's deliverable-6 breakdown.
+2. After fixes land, promote the audit assertions from the standalone harness
+   into each component's `.ct.tsx` as a permanent per-component gate (the ADR's
+   testing-strategy deliverable), and retire this scratch harness.
+
+[#20]: https://github.com/talkbench/stagebook/issues/20

--- a/docs/a11y-audit-2026-07.md
+++ b/docs/a11y-audit-2026-07.md
@@ -12,8 +12,10 @@ Target standard: **WCAG 2.2 AA** (per
 - **Automated:** axe-core (`@axe-core/playwright`) run via the existing
   Playwright Component Test harness, in real Chromium with `styles.css` loaded.
   Each component mounted with realistic props, scan scoped to the mounted root,
-  ruleset restricted to WCAG 2.0/2.1/2.2 levels A + AA. Harness:
-  `packages/stagebook/src/components/a11y.audit.ct.tsx`.
+  ruleset restricted to WCAG 2.0/2.1/2.2 levels A + AA. The harness
+  (`a11y.audit.ct.tsx`) is an **uncommitted scratch artifact** — red by design
+  (it documents the gaps), so it is kept out of the tree until the fixes land and
+  it becomes the permanent per-component gate.
 - **Manual / source review:** keyboard operability, focus visibility, WCAG 2.5.7
   (dragging movements) and 2.5.8 (target size) — the criteria axe cannot check.
 
@@ -36,7 +38,7 @@ Target standard: **WCAG 2.2 AA** (per
 
 ## Summary
 
-21 participant-facing cases scanned. **17 clean**, **4 findings** (one of which
+22 participant-facing cases scanned. **17 clean**, **5 findings** (one of which
 axe structurally cannot see). Ordered below by priority for triage.
 
 | Step | Finding | Severity | WCAG | Detected by |
@@ -45,6 +47,7 @@ axe structurally cannot see). Ordered below by priority for triage.
 | 2 | ImageElement has no `alt` affordance → #536 | high | 1.1.1 | manual (axe passes it) |
 | 3 | Standalone TextArea has no accessible name → #538 | critical\* | 1.3.1 / 4.1.2 | axe |
 | 4 | ListSorter keyboard-drag — verified working ✓ (regression test added) | low | 2.5.7 | manual |
+| 5 | Prompt **dropdown** renders an unnamed `<select>` → #545 | critical | 4.1.2 / 1.3.1 | axe |
 
 \* axe labels it "critical," but real-world impact is bounded — see Step 3.
 
@@ -144,14 +147,31 @@ axe structurally cannot see). Ordered below by priority for triage.
   dnd dep changes).
 - **Proposed subtask:** _"Add a keyboard-reorder CT test for ListSorter (2.5.7)."_
 
+## Step 5 — Prompt `dropdown` renders an unnamed `<select>`
+
+> **Disposition (triaged 2026-07-10):** filed as **#545**. Added after the Codex
+> review of #541 flagged the `dropdown` Prompt variant, which the initial pass
+> missed. Confirmed with axe (`select-name`, critical).
+
+- **Component:** `Prompt` (dropdown variant) → `Select`.
+- **Severity:** critical · **WCAG 4.1.2 / 1.3.1** · axe `select-name`.
+- **Evidence:** `Prompt.tsx` renders the dropdown's `<Select>` without a `label`;
+  `Select` only wires an accessible name when given one, so the `<select>` is
+  unnamed. Participant-facing — dropdown prompts appear in authored studies.
+- **Fix:** give the dropdown's `Select` an accessible name (a `label` from the
+  prompt, or `aria-labelledby` to the prompt body) plus an axe assertion.
+  Distinct from #538 — `Select` already _has_ the affordance; Prompt just doesn't
+  use it.
+
 ---
 
 ## Verified clean (17)
 
 RadioGroup (labelled + unlabelled), CheckboxGroup, Select, Slider (anchored +
 unanchored), ListSorter (axe), Display, KitchenTimer, Markdown, Separator, and
-all five `Prompt` variants (multiple-choice single/multiple, open-response,
-slider, list-sorter).
+five of the six `Prompt` variants (multiple-choice single/multiple,
+open-response, slider, list-sorter). The sixth, **dropdown**, is _not_ clean — it
+renders an unnamed `<select>` (→ #545, added after the Codex review of #541).
 
 **Manual checks that passed:**
 

--- a/packages/stagebook/src/components/a11y.keyboard.ct.tsx
+++ b/packages/stagebook/src/components/a11y.keyboard.ct.tsx
@@ -1,0 +1,30 @@
+// Step-4 verification for the a11y audit (#20): does ListSorter's drag-to-reorder
+// have a working keyboard alternative (WCAG 2.5.7 Dragging Movements)?
+// @hello-pangea/dnd ships a keyboard sensor (focus a row → Space to lift →
+// arrows to move → Space to drop); this proves it actually works in our config.
+import { test, expect } from "@playwright/experimental-ct-react";
+import { MockListSorter } from "./testing/MockListSorter";
+
+test("ListSorter is reorderable by keyboard alone (WCAG 2.5.7)", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(
+    <MockListSorter items={["Alpha", "Bravo", "Charlie", "Delta"]} />,
+  );
+  const order = component.locator('[data-testid="current-order"]');
+  await expect(order).toHaveText("Alpha|Bravo|Charlie|Delta");
+
+  // Focus the first draggable row and drive the @hello-pangea/dnd keyboard
+  // sensor: Space lifts, ArrowDown moves one slot, Space drops.
+  await component.getByTestId("draggable-0").focus();
+  await page.keyboard.press("Space");
+  await page.waitForTimeout(150);
+  await page.keyboard.press("ArrowDown");
+  await page.waitForTimeout(150);
+  await page.keyboard.press("Space");
+  await page.waitForTimeout(150);
+
+  // Alpha should have moved from slot 1 to slot 2.
+  await expect(order).toHaveText("Bravo|Alpha|Charlie|Delta");
+});


### PR DESCRIPTION
The July 2026 accessibility audit of the participant-facing component library
(#20), plus the first regression test it produced.

## Contents

- **`docs/a11y-audit-2026-07.md`** — the walkable audit report: 21 participant-
  facing components scanned at WCAG 2.2 AA (axe via Playwright CT) + a manual
  keyboard / focus / target-size review. 17 clean; findings triaged into #535
  (contrast → color system), #536 (ImageElement alt) + #537 (`width` schema
  drift), #538 (exported form-input labels); ListSorter keyboard reorder verified.
- **`packages/stagebook/src/components/a11y.keyboard.ct.tsx`** — a WCAG 2.5.7
  regression test proving `ListSorter` is reorderable without a mouse (green).

## Deliberately not included

- The axe audit **harness** + `@axe-core/playwright` dep stay as scratch until
  the fixes land; they then become the permanent per-component gate (the ADR's
  testing-strategy deliverable), folded into each component's `.ct.tsx`.
- Viewer + VS Code surfaces are out of scope for this pass.

Follows the accessibility ADR (#539). Refs #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
