### PR TITLE
fix(a11y): name the dropdown Prompt's <select> (#545)

### DIFF
--- a/packages/stagebook/src/components/elements/Prompt.ct.tsx
+++ b/packages/stagebook/src/components/elements/Prompt.ct.tsx
@@ -373,6 +373,66 @@ test.describe("List Sorter", () => {
 });
 
 // ================================================================
+// Dropdown
+// ================================================================
+//
+// Inline fixture (mirrors the pattern used by the shuffle fixtures
+// below) so this file stays self-contained and doesn't touch the
+// shared fixtures module. The dropdown variant renders the prompt
+// body as a `<select>`.
+
+const dropdown = {
+  metadata: {
+    name: "projects/example/dropdownHouse.md",
+    type: "dropdown" as const,
+  },
+  body: `# Which Hogwarts house do you belong to?
+
+_Choose the house that fits you best._`,
+  responseItems: ["Gryffindor", "Hufflepuff", "Ravenclaw", "Slytherin"],
+  responsePoints: [],
+  sliderPoints: [],
+};
+
+test.describe("Dropdown", () => {
+  test("renders a select with each option", async ({ mount }) => {
+    const component = await mount(
+      <Prompt
+        {...dropdown}
+        name="testDropdown"
+        value={undefined}
+        save={() => {}}
+      />,
+    );
+    await expect(component.locator("select")).toHaveCount(1);
+    await expect(component).toContainText("Gryffindor");
+    await expect(component).toContainText("Slytherin");
+  });
+
+  // #545 — the dropdown `<select>` was rendered with no accessible name
+  // (axe `select-name`, WCAG 4.1.2 / 1.3.1). It must be named by the
+  // visible prompt body so screen-reader users know what the picker is
+  // for. `getByRole("combobox", { name })` resolves the accessible name
+  // (here via aria-labelledby → the rendered body text), so this pins
+  // the name to what the participant sees, not just any attribute.
+  test("select has an accessible name from the prompt body (#545)", async ({
+    mount,
+  }) => {
+    const component = await mount(
+      <Prompt
+        {...dropdown}
+        name="testDropdownName"
+        value={undefined}
+        save={() => {}}
+      />,
+    );
+    await expect(
+      component.getByRole("combobox", { name: /which hogwarts house/i }),
+    ).toBeVisible();
+  });
+});
+
+// ================================================================
 // Multiple Choice option order (shuffle vs source order)
 // ================================================================
 //

--- a/packages/stagebook/src/components/elements/Prompt.tsx
+++ b/packages/stagebook/src/components/elements/Prompt.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback, useRef } from "react";
+import React, { useEffect, useState, useCallback, useRef, useId } from "react";
 import { Markdown } from "../form/Markdown.js";
 import { RadioGroup } from "../form/RadioGroup.js";
 import { CheckboxGroup } from "../form/CheckboxGroup.js";
@@ -80,6 +80,13 @@ export function Prompt({
   const debounceInteractiveRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
+
+  // Stable id for the wrapper around the rendered prompt body. The
+  // dropdown's `<select>` points its `aria-labelledby` here so the
+  // control is named by the question the participant reads, rather
+  // than shipping a duplicate visible label (#545). `useId()` keeps
+  // it unique when multiple Prompts share a page.
+  const bodyId = useId();
 
   const promptType = metadata.type;
   // Per-type fields only exist on the discriminated-union branch where
@@ -228,7 +235,9 @@ export function Prompt({
 
   return (
     <>
-      <Markdown text={body} resolveURL={resolveURL} />
+      <div id={bodyId}>
+        <Markdown text={body} resolveURL={resolveURL} />
+      </div>
 
       {promptType === "multipleChoice" &&
         (metadata.select === "single" || metadata.select === undefined) &&
@@ -296,6 +305,11 @@ export function Prompt({
           }))}
           value={value as string | undefined}
           placeholder={metadata.placeholder}
+          // Name the <select> by the visible prompt body so it isn't an
+          // unnamed control (axe `select-name`, WCAG 4.1.2 / 1.3.1) — see
+          // #545. Preferred over a visible `label`, which would duplicate
+          // the body the participant already reads.
+          ariaLabelledBy={bodyId}
           onChange={(e) =>
             debouncedSaveInteractive(e.target.value, record, e.target.value)
           }

--- a/packages/stagebook/src/components/form/Select.ct.tsx
+++ b/packages/stagebook/src/components/form/Select.ct.tsx
@@ -33,6 +33,32 @@ test.describe("Select", () => {
     await expect(component).toContainText("Pick one");
   });
 
+  test("forwards ariaLabelledBy so the select is named by external content", async ({
+    mount,
+  }) => {
+    // Mirrors the RadioGroup/CheckboxGroup aria-labelledby tests: the
+    // accessible name can live in existing visible content (e.g. a
+    // prompt body) rather than a duplicate visible <label>. This is
+    // the path Prompt's dropdown variant uses (#545). Guards the
+    // component's own public API so a refactor dropping the forward
+    // fails here, not only in the Prompt integration test.
+    const component = await mount(
+      <div>
+        <div id="ext-label">Which Hogwarts house?</div>
+        <Select
+          options={options}
+          onChange={() => {}}
+          ariaLabelledBy="ext-label"
+        />
+      </div>,
+    );
+    // getByRole filters by accessible name — this only matches if
+    // aria-labelledby resolves to the visible text.
+    await expect(
+      component.getByRole("combobox", { name: "Which Hogwarts house?" }),
+    ).toBeVisible();
+  });
+
   test("renders placeholder as a leading disabled option", async ({
     mount,
   }) => {

--- a/packages/stagebook/src/components/form/Select.tsx
+++ b/packages/stagebook/src/components/form/Select.tsx
@@ -28,8 +28,10 @@ export interface SelectProps {
    * `aria-labelledby`. Use when the accessible name lives in existing
    * visible content (e.g. a prompt body) rather than the `label` prop —
    * naming the control without rendering a duplicate visible label.
-   * When set, no visible `<label>` is emitted for it; supply `label`
-   * instead if a visible caption is wanted. See #545.
+   * Pass this *instead of* `label`, not alongside it: the visible
+   * `<label>` is gated solely on `label`, so if both are set a caption
+   * still renders and `aria-labelledby` wins the accessible name. See
+   * #545.
    */
   ariaLabelledBy?: string;
   "data-testid"?: string;

--- a/packages/stagebook/src/components/form/Select.tsx
+++ b/packages/stagebook/src/components/form/Select.tsx
@@ -23,6 +23,15 @@ export interface SelectProps {
    */
   placeholder?: string;
   id?: string;
+  /**
+   * Space-separated id list forwarded to the `<select>`'s
+   * `aria-labelledby`. Use when the accessible name lives in existing
+   * visible content (e.g. a prompt body) rather than the `label` prop —
+   * naming the control without rendering a duplicate visible label.
+   * When set, no visible `<label>` is emitted for it; supply `label`
+   * instead if a visible caption is wanted. See #545.
+   */
+  ariaLabelledBy?: string;
   "data-testid"?: string;
 }
 
@@ -97,6 +106,7 @@ export function Select({
   label = "",
   placeholder,
   id,
+  ariaLabelledBy,
   "data-testid": dataTestId,
 }: SelectProps) {
   // Generate a unique id when the caller doesn't provide one — multiple
@@ -161,6 +171,7 @@ export function Select({
         className={triggerClass}
         value={currentValue}
         onChange={handleChange}
+        aria-labelledby={ariaLabelledBy}
         style={selectBaseStyle}
       >
         {placeholder !== undefined && (


### PR DESCRIPTION
## What

The `dropdown` Prompt variant rendered a `<select>` with **no accessible name** — a participant-facing WCAG 4.1.2 / 1.3.1 violation (axe `select-name`, critical) in authored studies. `Select` only wired an accessible name from its `label` prop, and the dropdown branch passed none.

## Approach

Name the control by the **visible prompt body** (the question the participant reads) rather than a duplicate visible label:

- Add an `ariaLabelledBy` pass-through prop to `Select`, forwarded to the `<select>`'s `aria-labelledby`.
- Wrap the rendered prompt body in a `<div id={bodyId}>` (stable `useId()`) and point the dropdown's `aria-labelledby` at it.

The `<style>` tag `Markdown` emits inside the wrapper is `display:none`, so the accessible-name algorithm excludes it — the name resolves to the visible body text. Only the **dropdown** variant is touched; the other Prompt variants already pass axe via option-level labels.

## Tests

- New CT test asserts the combobox has an accessible name via `getByRole("combobox", { name })` (TDD red→green confirmed). **No new axe dependency added** — a consolidated axe gate is a separate later task.
- `npm test` (1980 unit tests) ✅ · `npm run build` ✅ · lint/format ✅
- Full `npm run test:ct:all`: only the pre-existing webkit `:focus-visible` focus-ring flakes fail (verified identical on `main`; CI runs with `retries: 2`), unrelated to this change.

## Scope

Minimal — dropdown variant only. Touches `Prompt.tsx`, `Select.tsx`, `Prompt.ct.tsx`; no `package.json`/lockfile changes.

Fixes #545
Refs #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)