### PR TITLE
feat(a11y): standalone accessible-name affordance for exported TextArea (#538)

### DIFF
--- a/packages/stagebook/src/components/form/TextArea.ct.tsx
+++ b/packages/stagebook/src/components/form/TextArea.ct.tsx
@@ -2,6 +2,61 @@ import { test, expect } from "@playwright/experimental-ct-react";
 import { TextArea } from "./TextArea";
 import { MockTextArea } from "../testing/MockTextArea";
 
+// -- Standalone accessible name (#538) --
+// TextArea is a public export (stagebook/components) that hosts drop into
+// their own participant UI, outside Prompt (which otherwise names the
+// textarea). A bare <textarea> carries only an `id` — no aria-label /
+// <label> / aria-labelledby — so standalone it has no programmatic
+// accessible name, a WCAG 1.3.1 / 4.1.2 gap axe flags as `label`
+// (critical). These cover the three affordances that close it.
+
+test("standalone baseline: a bare textarea has no accessible name (the gap #538 closes)", async ({
+  mount,
+}) => {
+  // Pins the defect: with no label/aria affordance and no placeholder,
+  // the textarea's accessible name is empty. Also guards against a
+  // regression that hands it some unintended name.
+  const component = await mount(<TextArea />);
+  await expect(component.locator("textarea")).toHaveAccessibleName("");
+});
+
+test("standalone: ariaLabel gives the textarea an accessible name (#538)", async ({
+  mount,
+}) => {
+  const component = await mount(<TextArea ariaLabel="Your answer" />);
+  await expect(
+    component.getByRole("textbox", { name: "Your answer" }),
+  ).toBeVisible();
+});
+
+test("standalone: visible label prop names the textarea and associates via htmlFor (#538)", async ({
+  mount,
+}) => {
+  const component = await mount(<TextArea id="essay" label="Your answer" />);
+  // Accessible name resolves from the <label htmlFor> association.
+  await expect(
+    component.getByRole("textbox", { name: "Your answer" }),
+  ).toBeVisible();
+  // The visible <label> is rendered and points at the textarea's id.
+  const label = component.locator("label");
+  await expect(label).toHaveText("Your answer");
+  await expect(label).toHaveAttribute("for", "essay");
+});
+
+test("standalone: ariaLabelledBy names the textarea from an external element (#538)", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <div>
+      <span id="q1">Describe your reasoning</span>
+      <TextArea ariaLabelledBy="q1" />
+    </div>,
+  );
+  await expect(
+    component.getByRole("textbox", { name: "Describe your reasoning" }),
+  ).toBeVisible();
+});
+
 // -- Basic rendering --
 
 test("renders with placeholder text", async ({ mount }) => {

--- a/packages/stagebook/src/components/form/TextArea.tsx
+++ b/packages/stagebook/src/components/form/TextArea.tsx
@@ -44,6 +44,21 @@ export interface TextAreaProps {
   maxLength?: number;
   debounceDelay?: number;
   id?: string;
+  // Accessible-name affordances for standalone use (#538). Inside a
+  // Prompt the surrounding markup names the field, but TextArea is a
+  // public export (`stagebook/components`) that hosts drop in on their
+  // own — a bare <textarea> carries only an `id`, so without one of
+  // these it has no programmatic accessible name (WCAG 1.3.1 / 4.1.2).
+  // Mirrors the `label` prop on RadioGroup / CheckboxGroup / Select.
+  //
+  // `label` renders a visible <label htmlFor={id}>. `ariaLabel` /
+  // `ariaLabelledBy` pass through to the textarea for the invisible-
+  // label / external-element cases. If more than one is supplied the
+  // accessible-name spec resolves it deterministically
+  // (aria-labelledby > aria-label > <label for>).
+  label?: string;
+  ariaLabel?: string;
+  ariaLabelledBy?: string;
 }
 
 const CURSOR_KEYS = new Set([
@@ -70,6 +85,9 @@ export function TextArea({
   maxLength,
   debounceDelay = 500,
   id,
+  label = "",
+  ariaLabel,
+  ariaLabelledBy,
 }: TextAreaProps) {
   const messages = useMessages();
   const isRTL = useIsRTL();
@@ -382,9 +400,32 @@ export function TextArea({
       dir={isRTL ? "rtl" : "ltr"}
       style={{ position: "relative", width: "100%", boxSizing: "border-box" }}
     >
+      {label && (
+        // Visible label, associated via htmlFor. Styling matches the
+        // `label` on Select / RadioGroup / CheckboxGroup so a host mixing
+        // form components gets a consistent look (#538).
+        <label
+          htmlFor={textAreaId}
+          style={{
+            display: "block",
+            fontSize: "1rem",
+            fontWeight: 500,
+            color: "var(--stagebook-text, #1f2937)",
+            marginBottom: "0.5rem",
+          }}
+        >
+          {label}
+        </label>
+      )}
       <textarea
         id={textAreaId}
         className={textareaClass}
+        // Pass-throughs for the invisible-label / external-element cases.
+        // Undefined renders no attribute, so the Prompt-wrapped path is
+        // unchanged; when a visible `label` is used its htmlFor link
+        // supplies the name and these stay absent (#538).
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
         autoComplete="off"
         rows={rows}
         placeholder={defaultText}


### PR DESCRIPTION
## What & why

`TextArea` is a **public export** (`stagebook/components`) that hosts import to build their own participant-facing UI, outside `Prompt`. A bare `<textarea>` carried only an `id` — no `aria-label` / `<label>` / `aria-labelledby` — so used standalone it had **no programmatic accessible name**. axe flagged this for WCAG `label` (critical); it's a 1.3.1 / 4.1.2 gap and a public-API conformance gap against **ADR Decision 1** (components conform to WCAG 2.2 AA self-sufficiently, not by relying on always being `Prompt`-wrapped, which external hosts won't do).

Its siblings `RadioGroup`, `CheckboxGroup`, and `Select` all already take a `label` prop and passed the audit. `TextArea` was the odd one out.

## Change

Add three optional props to `TextArea`, mirroring the `label` prop on the siblings:

- **`label`** — renders a visible `<label htmlFor={id}>` (styled byte-for-byte like `Select`/`RadioGroup`/`CheckboxGroup`).
- **`ariaLabel` / `ariaLabelledBy`** — pass through to `aria-label` / `aria-labelledby` for the invisible-label / external-element cases.

`ariaLabel`/`ariaLabelledBy` have no default, so `undefined` renders no attribute; `label` defaults to `""` and renders no element. **The `Prompt`-wrapped path and every other existing call site are unchanged.** If more than one is supplied, the accessible-name spec resolves it deterministically (`aria-labelledby` > `aria-label` > `<label for>`).

Left untouched by design: `Prompt.tsx` / `Select` dropdown naming (that's #545).

## Sweep of the exported form inputs

Confirmed each can be given an accessible name standalone (issue's second acceptance criterion):

| Component | Affordance | Status |
|---|---|---|
| **TextArea** | `label` / `ariaLabel` / `ariaLabelledBy` | **fixed here** |
| RadioGroup | `label` → `<label htmlFor>` + `role="radiogroup"` `aria-labelledby` | already OK |
| CheckboxGroup | `label` → `<label htmlFor>` + `role="group"` `aria-labelledby` | already OK |
| Select | `label` → `<label htmlFor>` | already OK |
| Slider | range input always carries `aria-label={messages.sliderLabel}` | already OK¹ |

¹ Slider's name comes from provider messages (localizable), not a per-instance prop — it's never nameless, so no axe `label` gap. Per-instance customization would be a separate enhancement, out of scope here.

## Tests (Playwright CT — no `@axe-core/playwright`, per the issue)

`getByRole("textbox", { name })` / `toHaveAccessibleName`:

- **baseline** — a bare `<TextArea/>` has *no* accessible name (pins the exact defect + regression guard)
- `ariaLabel` names the textarea
- visible `label` prop names it **and** associates via `htmlFor`
- `ariaLabelledBy` names it from an external element

Full TextArea CT file green across chromium / firefox / webkit; `npm test` (vitest, 1980) and the build (dts) green.

## Reviews

Pre-PR correctness / test-coverage / security subagent reviews — all clean; the coverage review's one suggestion (baseline no-name test) is folded in.

Fixes #538
Refs #20