### PR TITLE
feat(styles): deliberate, AA-by-construction color system (#535)

### DIFF
--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -240,7 +240,12 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
           return <AssetPlaceholder uri={promptFile ?? ""} kind="prompt" />;
         }
         return (
-          <p style={{ color: "#dc2626", fontSize: "0.875rem" }}>
+          <p
+            style={{
+              color: "var(--stagebook-danger, #b91c1c)",
+              fontSize: "0.875rem",
+            }}
+          >
             Error loading prompt{element.file ? ` "${element.file}"` : ""}:{" "}
             {promptError.message}
           </p>
@@ -254,7 +259,7 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
         return (
           <p
             style={{
-              color: "var(--stagebook-danger, #dc2626)",
+              color: "var(--stagebook-danger, #b91c1c)",
               fontSize: "0.875rem",
             }}
           >

--- a/packages/stagebook/src/components/ElementErrorBoundary.tsx
+++ b/packages/stagebook/src/components/ElementErrorBoundary.tsx
@@ -82,9 +82,9 @@ class ElementErrorBoundaryInner extends React.Component<
           data-testid="element-error-fallback"
           style={{
             padding: "0.75rem 1rem",
-            border: "1px solid var(--stagebook-danger, #dc2626)",
+            border: "1px solid var(--stagebook-danger, #b91c1c)",
             borderRadius: "0.375rem",
-            color: "var(--stagebook-danger, #dc2626)",
+            color: "var(--stagebook-danger, #b91c1c)",
             backgroundColor: "var(--stagebook-danger-bg, #fef2f2)",
             fontSize: "0.875rem",
           }}

--- a/packages/stagebook/src/components/elements/AssetPlaceholder.tsx
+++ b/packages/stagebook/src/components/elements/AssetPlaceholder.tsx
@@ -50,13 +50,13 @@ const container: React.CSSProperties = {
 
 const icon: React.CSSProperties = {
   fontSize: "1.75rem",
-  color: "var(--stagebook-text-faint, #9ca3af)",
+  color: "var(--stagebook-decoration, #9ca3af)",
 };
 
 const label: React.CSSProperties = {
   fontSize: "0.8125rem",
   fontWeight: 600,
-  color: "var(--stagebook-text-secondary, #4b5563)",
+  color: "var(--stagebook-text-secondary, #374151)",
   margin: 0,
   textAlign: "center",
 };
@@ -67,14 +67,14 @@ const uriText: React.CSSProperties = {
   backgroundColor: "var(--stagebook-surface, #fff)",
   padding: "0.2rem 0.45rem",
   borderRadius: "0.25rem",
-  border: "1px solid var(--stagebook-border, #e5e7eb)",
+  border: "1px solid var(--stagebook-border, #d1d5db)",
   wordBreak: "break-all",
   maxWidth: "100%",
 };
 
 const hint: React.CSSProperties = {
   fontSize: "0.75rem",
-  color: "var(--stagebook-text-faint, #9ca3af)",
+  color: "var(--stagebook-decoration, #9ca3af)",
   margin: 0,
   textAlign: "center",
 };

--- a/packages/stagebook/src/components/elements/KitchenTimer.ct.tsx
+++ b/packages/stagebook/src/components/elements/KitchenTimer.ct.tsx
@@ -98,7 +98,7 @@ test("red fill when in warning zone", async ({ mount }) => {
   // remaining = 10, which is <= 15
   await expect(component).toHaveAttribute("data-state", "warning");
   const fill = component.locator('[data-testid="timer-fill"]');
-  await expect(fill).toHaveCSS("background-color", "rgb(239, 68, 68)");
+  await expect(fill).toHaveCSS("background-color", "rgb(185, 28, 28)");
 });
 
 test("transition from blue to red at warning boundary", async ({ mount }) => {

--- a/packages/stagebook/src/components/elements/KitchenTimer.tsx
+++ b/packages/stagebook/src/components/elements/KitchenTimer.tsx
@@ -70,7 +70,7 @@ export function KitchenTimer({
 
   const isWarning = timerRemaining <= warnTimeRemaining;
   const barColor = isWarning
-    ? "var(--stagebook-danger, #ef4444)"
+    ? "var(--stagebook-danger, #b91c1c)"
     : "var(--stagebook-timer-fill, #60a5fa)"; // red-500 / blue-400
 
   return (

--- a/packages/stagebook/src/components/elements/KitchenTimer.tsx
+++ b/packages/stagebook/src/components/elements/KitchenTimer.tsx
@@ -71,7 +71,7 @@ export function KitchenTimer({
   const isWarning = timerRemaining <= warnTimeRemaining;
   const barColor = isWarning
     ? "var(--stagebook-danger, #b91c1c)"
-    : "var(--stagebook-timer-fill, #60a5fa)"; // red-500 / blue-400
+    : "var(--stagebook-timer-fill, #60a5fa)"; // danger red-700 / blue-400
 
   return (
     <div

--- a/packages/stagebook/src/components/elements/MediaPlayer.tsx
+++ b/packages/stagebook/src/components/elements/MediaPlayer.tsx
@@ -1175,7 +1175,7 @@ export function MediaPlayer({
           .${containerClass}:focus-within {
             box-shadow:
               0 0 0 2px var(--stagebook-bg, #fff),
-              0 0 0 5px var(--stagebook-primary, #3b82f6);
+              0 0 0 5px var(--stagebook-primary, #2563eb);
           }
         `}</style>
         <div data-testid="mediaPlayer-viewport" style={VIEWPORT_STYLE}>
@@ -1279,7 +1279,7 @@ export function MediaPlayer({
         .${containerClass}:focus-within {
           box-shadow:
             0 0 0 2px var(--stagebook-bg, #fff),
-            0 0 0 5px var(--stagebook-primary, #3b82f6);
+            0 0 0 5px var(--stagebook-primary, #2563eb);
         }
       `}</style>
       {/* Audio-only: hidden video element (no viewport div) */}

--- a/packages/stagebook/src/components/elements/Prompt.ct.tsx
+++ b/packages/stagebook/src/components/elements/Prompt.ct.tsx
@@ -248,7 +248,7 @@ test.describe("Open Response", () => {
       />,
     );
     const counter = component.locator('[data-testid="char-counter"]');
-    await expect(counter).toHaveCSS("color", "rgb(22, 163, 74)");
+    await expect(counter).toHaveCSS("color", "rgb(21, 128, 61)");
   });
 
   test("counter is green at maximum (#333 — upper bound is valid, not error)", async ({
@@ -266,7 +266,7 @@ test.describe("Open Response", () => {
       />,
     );
     const counter = component.locator('[data-testid="char-counter"]');
-    await expect(counter).toHaveCSS("color", "rgb(22, 163, 74)");
+    await expect(counter).toHaveCSS("color", "rgb(21, 128, 61)");
   });
 
   test("shared mode hides textarea (notepad slot)", async ({ mount }) => {

--- a/packages/stagebook/src/components/elements/Timeline.tsx
+++ b/packages/stagebook/src/components/elements/Timeline.tsx
@@ -785,7 +785,7 @@ export function Timeline({
       <p
         data-testid="timeline-error"
         style={{
-          color: "var(--stagebook-danger, #dc2626)",
+          color: "var(--stagebook-danger, #b91c1c)",
           fontSize: "0.875rem",
         }}
       >
@@ -861,7 +861,7 @@ export function Timeline({
       }}
       className={containerClass}
       style={{
-        border: "1px solid var(--stagebook-border, #e5e7eb)",
+        border: "1px solid var(--stagebook-border, #d1d5db)",
         borderRadius: "0.5rem",
         overflow: "hidden",
         // `outline: none` removes the browser default; the scoped
@@ -893,7 +893,7 @@ export function Timeline({
            only fire on Space/Enter and most users don't expect a
            click-then-spacebar pattern on a button. */
         .${containerClass}:focus {
-          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25));
         }
       `}</style>
       {/* Header: zoom controls (always) + minimap (when zoomed in) — puts

--- a/packages/stagebook/src/components/elements/TrackedLink.tsx
+++ b/packages/stagebook/src/components/elements/TrackedLink.tsx
@@ -186,7 +186,7 @@ export function TrackedLink({
           transition: color 120ms ease-out;
         }
         .${linkClass}:hover {
-          color: var(--stagebook-primary-hover, #2563eb);
+          color: var(--stagebook-primary-hover, #1d4ed8);
         }
         /* :focus-visible (keyboard-only) ring. Mouse clicks don't
            leave a lingering ring around the link after release. */

--- a/packages/stagebook/src/components/elements/TrackedLink.tsx
+++ b/packages/stagebook/src/components/elements/TrackedLink.tsx
@@ -182,7 +182,7 @@ export function TrackedLink({
            outrank the :hover class selector on specificity (same
            trap as Slider / Button / TextArea). */
         .${linkClass} {
-          color: var(--stagebook-primary, #3b82f6);
+          color: var(--stagebook-primary, #2563eb);
           transition: color 120ms ease-out;
         }
         .${linkClass}:hover {
@@ -192,7 +192,7 @@ export function TrackedLink({
            leave a lingering ring around the link after release. */
         .${linkClass}:focus-visible {
           outline: none;
-          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25));
           border-radius: 0.125rem;
         }
         @media (prefers-reduced-motion: reduce) {

--- a/packages/stagebook/src/components/elements/timeline/HelpPopover.tsx
+++ b/packages/stagebook/src/components/elements/timeline/HelpPopover.tsx
@@ -128,7 +128,7 @@ export function HelpPopover({
         right: `${String(position.right)}px`,
         zIndex: 1000,
         background: "var(--stagebook-bg, #ffffff)",
-        border: "1px solid var(--stagebook-border, #e5e7eb)",
+        border: "1px solid var(--stagebook-border, #d1d5db)",
         borderRadius: "0.375rem",
         padding: "0.5rem 0.75rem",
         fontSize: "0.75rem",
@@ -140,7 +140,7 @@ export function HelpPopover({
         style={{
           fontWeight: 600,
           marginBottom: "0.375rem",
-          color: "var(--stagebook-text, #111827)",
+          color: "var(--stagebook-text, #1f2937)",
         }}
       >
         {messages.timelineShortcutsTitle}
@@ -158,7 +158,7 @@ export function HelpPopover({
                 style={{
                   paddingRight: "0.75rem",
                   fontFamily: "monospace",
-                  color: "var(--stagebook-text, #111827)",
+                  color: "var(--stagebook-text, #1f2937)",
                   whiteSpace: "nowrap",
                   verticalAlign: "top",
                 }}

--- a/packages/stagebook/src/components/elements/timeline/Minimap.tsx
+++ b/packages/stagebook/src/components/elements/timeline/Minimap.tsx
@@ -279,7 +279,8 @@ export function Minimap({
           height: "100%",
           border: VIEWPORT_RECT_BORDER,
           boxSizing: "border-box",
-          background: "rgba(37, 99, 235, 0.06)",
+          background:
+            "var(--stagebook-timeline-minimap-viewport-bg, rgba(37, 99, 235, 0.06))",
           pointerEvents: "none",
         }}
       />

--- a/packages/stagebook/src/components/elements/timeline/Minimap.tsx
+++ b/packages/stagebook/src/components/elements/timeline/Minimap.tsx
@@ -36,7 +36,7 @@ export interface MinimapProps {
 
 const HEIGHT = 32;
 const VIEWPORT_RECT_BORDER =
-  "1.5px solid var(--stagebook-timeline-minimap-viewport-border, rgba(59, 130, 246, 0.9))";
+  "1.5px solid var(--stagebook-timeline-minimap-viewport-border, rgba(37, 99, 235, 0.9))";
 
 function isRangeArray(
   s: TimelineValue,
@@ -169,7 +169,7 @@ export function Minimap({
             width: `${String(Math.max(x2 - x1, 1))}px`,
             height: HEIGHT - 8,
             background:
-              "var(--stagebook-timeline-minimap-range, rgba(59, 130, 246, 0.4))",
+              "var(--stagebook-timeline-minimap-range, rgba(37, 99, 235, 0.4))",
             borderRadius: "1px",
             pointerEvents: "none",
           }}
@@ -190,7 +190,7 @@ export function Minimap({
             width: 2,
             height: HEIGHT - 8,
             background:
-              "var(--stagebook-timeline-minimap-point, rgba(59, 130, 246, 0.7))",
+              "var(--stagebook-timeline-minimap-point, rgba(37, 99, 235, 0.7))",
             pointerEvents: "none",
           }}
         />,
@@ -279,7 +279,7 @@ export function Minimap({
           height: "100%",
           border: VIEWPORT_RECT_BORDER,
           boxSizing: "border-box",
-          background: "rgba(59, 130, 246, 0.06)",
+          background: "rgba(37, 99, 235, 0.06)",
           pointerEvents: "none",
         }}
       />

--- a/packages/stagebook/src/components/elements/timeline/Playhead.tsx
+++ b/packages/stagebook/src/components/elements/timeline/Playhead.tsx
@@ -172,7 +172,7 @@ export function Playhead({
           left: "50%",
           transform: "translateX(-50%)",
           pointerEvents: "auto",
-          background: "var(--stagebook-playhead, #e11d48)",
+          background: "var(--stagebook-playhead, #be123c)",
           cursor: "ew-resize",
           userSelect: "none",
         }}
@@ -190,7 +190,7 @@ export function Playhead({
             height: 0,
             borderLeft: "5px solid transparent",
             borderRight: "5px solid transparent",
-            borderTop: "5px solid var(--stagebook-playhead, #e11d48)",
+            borderTop: "5px solid var(--stagebook-playhead, #be123c)",
             // Inherit auto pointer events so clicks bubble up to the box.
             pointerEvents: "auto",
             cursor: "ew-resize",
@@ -207,7 +207,7 @@ export function Playhead({
           transform: "translateX(-50%)",
           width: "2px",
           height: "100%",
-          background: "var(--stagebook-playhead, #e11d48)",
+          background: "var(--stagebook-playhead, #be123c)",
           pointerEvents: "none",
         }}
       />

--- a/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
+++ b/packages/stagebook/src/components/elements/timeline/SelectionOverlay.tsx
@@ -627,11 +627,11 @@ export function SelectionOverlay({
             width: `${String(rangeWidth)}px`,
             height: `${String(rangeHeight)}px`,
             background: isActive
-              ? "var(--stagebook-timeline-range-active, rgba(59, 130, 246, 0.35))"
-              : "var(--stagebook-timeline-range-inactive, rgba(59, 130, 246, 0.18))",
+              ? "var(--stagebook-timeline-range-active, rgba(37, 99, 235, 0.35))"
+              : "var(--stagebook-timeline-range-inactive, rgba(37, 99, 235, 0.18))",
             border: isActive
               ? "1px solid var(--stagebook-timeline-range-active-border, rgba(37, 99, 235, 1))"
-              : "1px solid var(--stagebook-timeline-range-inactive-border, rgba(59, 130, 246, 0.6))",
+              : "1px solid var(--stagebook-timeline-range-inactive-border, rgba(37, 99, 235, 0.6))",
             boxSizing: "border-box",
             cursor: "pointer",
             pointerEvents: "auto",
@@ -677,7 +677,7 @@ export function SelectionOverlay({
               color={
                 isActive && activeHandle === "start"
                   ? "var(--stagebook-timeline-handle-active, rgba(37, 99, 235, 1))"
-                  : "var(--stagebook-timeline-handle-inactive, rgba(59, 130, 246, 0.7))"
+                  : "var(--stagebook-timeline-handle-inactive, rgba(37, 99, 235, 0.7))"
               }
             />
             {hoveredHandle?.index === i &&
@@ -719,7 +719,7 @@ export function SelectionOverlay({
               color={
                 isActive && activeHandle === "end"
                   ? "var(--stagebook-timeline-handle-active, rgba(37, 99, 235, 1))"
-                  : "var(--stagebook-timeline-handle-inactive, rgba(59, 130, 246, 0.7))"
+                  : "var(--stagebook-timeline-handle-inactive, rgba(37, 99, 235, 0.7))"
               }
             />
             {hoveredHandle?.index === i && hoveredHandle?.handle === "end" && (
@@ -777,7 +777,7 @@ export function SelectionOverlay({
               height: "100%",
               background: isActive
                 ? "var(--stagebook-timeline-handle-active, rgba(37, 99, 235, 1))"
-                : "var(--stagebook-timeline-handle-inactive, rgba(59, 130, 246, 0.7))",
+                : "var(--stagebook-timeline-handle-inactive, rgba(37, 99, 235, 0.7))",
             }}
           />
           <div
@@ -790,7 +790,7 @@ export function SelectionOverlay({
               borderRadius: "50%",
               background: isActive
                 ? "var(--stagebook-timeline-handle-active, rgba(37, 99, 235, 1))"
-                : "var(--stagebook-timeline-handle-inactive, rgba(59, 130, 246, 0.7))",
+                : "var(--stagebook-timeline-handle-inactive, rgba(37, 99, 235, 0.7))",
             }}
           />
         </div>
@@ -845,9 +845,9 @@ export function SelectionOverlay({
           width: `${String(previewWidth)}px`,
           height: `${String(previewHeight)}px`,
           background:
-            "var(--stagebook-timeline-preview-bg, rgba(59, 130, 246, 0.25))",
+            "var(--stagebook-timeline-preview-bg, rgba(37, 99, 235, 0.25))",
           border:
-            "1px dashed var(--stagebook-timeline-preview-border, rgba(59, 130, 246, 0.6))",
+            "1px dashed var(--stagebook-timeline-preview-border, rgba(37, 99, 235, 0.6))",
           boxSizing: "border-box",
           pointerEvents: "none",
         }}
@@ -946,9 +946,9 @@ export function SelectionOverlay({
           width: `${String(previewWidth)}px`,
           height: `${String(previewHeight)}px`,
           background:
-            "var(--stagebook-timeline-preview-bg, rgba(59, 130, 246, 0.25))",
+            "var(--stagebook-timeline-preview-bg, rgba(37, 99, 235, 0.25))",
           border:
-            "1px dashed var(--stagebook-timeline-preview-border, rgba(59, 130, 246, 0.6))",
+            "1px dashed var(--stagebook-timeline-preview-border, rgba(37, 99, 235, 0.6))",
           boxSizing: "border-box",
           pointerEvents: "none",
         }}
@@ -998,9 +998,9 @@ export function SelectionOverlay({
     >
       <style>{`
         @keyframes stagebookRangeBlockedPulse {
-          0% { box-shadow: 0 0 0 0 rgba(220, 38, 38, 0); }
-          30% { box-shadow: 0 0 0 4px rgba(220, 38, 38, 0.55); }
-          100% { box-shadow: 0 0 0 8px rgba(220, 38, 38, 0); }
+          0% { box-shadow: 0 0 0 0 transparent; }
+          30% { box-shadow: 0 0 0 4px color-mix(in srgb, var(--stagebook-danger, #b91c1c) 55%, transparent); }
+          100% { box-shadow: 0 0 0 8px transparent; }
         }
         .stagebook-range-blocked-pulse {
           animation: stagebookRangeBlockedPulse 600ms ease-out;

--- a/packages/stagebook/src/components/elements/timeline/TimeRuler.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimeRuler.tsx
@@ -155,7 +155,7 @@ export function TimeRuler({
         width: `${String(width)}px`,
         overflow: "visible",
         fontSize: "0.72rem",
-        color: "var(--stagebook-text-faint, #9ca3af)",
+        color: "var(--stagebook-decoration, #9ca3af)",
         userSelect: "none",
         cursor: onSeek ? "pointer" : "default",
       }}

--- a/packages/stagebook/src/components/elements/timeline/TimelineFooter.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineFooter.tsx
@@ -57,7 +57,7 @@ const buttonStyle: React.CSSProperties = {
   display: "inline-flex",
   alignItems: "center",
   justifyContent: "center",
-  border: "1px solid var(--stagebook-border, #e5e7eb)",
+  border: "1px solid var(--stagebook-border, #d1d5db)",
   borderRadius: "0.25rem",
   background: "var(--stagebook-bg, #ffffff)",
   cursor: "pointer",
@@ -92,7 +92,7 @@ export function TimelineFooter({
         alignItems: "center",
         justifyContent: "space-between",
         padding: "0.25rem 0.5rem",
-        borderTop: "1px solid var(--stagebook-border, #e5e7eb)",
+        borderTop: "1px solid var(--stagebook-border, #d1d5db)",
         fontSize: "0.75rem",
         color: "var(--stagebook-text-muted, #6b7280)",
         userSelect: "none",
@@ -101,7 +101,7 @@ export function TimelineFooter({
       <style>{`
         .${btnClass}:focus-visible {
           outline: none;
-          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25));
         }
         .${btnClass}:hover {
           background: var(--stagebook-hover-bg, #f3f4f6);

--- a/packages/stagebook/src/components/elements/timeline/TimelineHeader.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineHeader.tsx
@@ -21,7 +21,7 @@ const buttonStyle: React.CSSProperties = {
   display: "inline-flex",
   alignItems: "center",
   justifyContent: "center",
-  border: "1px solid var(--stagebook-border, #e5e7eb)",
+  border: "1px solid var(--stagebook-border, #d1d5db)",
   borderRadius: "0.25rem",
   background: "var(--stagebook-bg, #ffffff)",
   cursor: "pointer",
@@ -58,14 +58,14 @@ export function TimelineHeader({
       style={{
         display: "flex",
         alignItems: "center",
-        borderBottom: "1px solid var(--stagebook-border, #e5e7eb)",
+        borderBottom: "1px solid var(--stagebook-border, #d1d5db)",
         userSelect: "none",
       }}
     >
       <style>{`
         .${btnClass}:focus-visible {
           outline: none;
-          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25));
         }
         .${btnClass}:not(:disabled):hover {
           background: var(--stagebook-hover-bg, #f3f4f6);

--- a/packages/stagebook/src/components/elements/timeline/TimelineTrack.tsx
+++ b/packages/stagebook/src/components/elements/timeline/TimelineTrack.tsx
@@ -63,7 +63,7 @@ export function TimelineTrack({
       <style>{`
         .${muteClass}:focus-visible {
           outline: none;
-          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25));
         }
         .${muteClass}:hover {
           background: var(--stagebook-hover-bg, #f3f4f6);
@@ -78,7 +78,7 @@ export function TimelineTrack({
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          borderRight: "1px solid var(--stagebook-border, #e5e7eb)",
+          borderRight: "1px solid var(--stagebook-border, #d1d5db)",
         }}
       >
         <button
@@ -108,8 +108,8 @@ export function TimelineTrack({
             borderRadius: "0.25rem",
             cursor: "pointer",
             color: muted
-              ? "var(--stagebook-danger, #dc2626)"
-              : "var(--stagebook-text-faint, #9ca3af)",
+              ? "var(--stagebook-danger, #b91c1c)"
+              : "var(--stagebook-decoration, #9ca3af)",
           }}
         >
           {muted ? <SpeakerMutedIcon /> : <SpeakerIcon />}
@@ -135,10 +135,10 @@ export function TimelineTrack({
             padding: "1px 6px",
             fontSize: "0.7rem",
             lineHeight: 1.4,
-            color: "var(--stagebook-text-faint, #6b7280)",
+            color: "var(--stagebook-text-muted, #6b7280)",
             background:
               "var(--stagebook-timeline-track-label-bg, rgba(255, 255, 255, 0.85))",
-            border: "1px solid var(--stagebook-border, #e5e7eb)",
+            border: "1px solid var(--stagebook-border, #d1d5db)",
             borderRadius: "0.25rem",
             userSelect: "none",
             pointerEvents: "none",

--- a/packages/stagebook/src/components/form/Button.tsx
+++ b/packages/stagebook/src/components/form/Button.tsx
@@ -89,7 +89,7 @@ export function Button({
            background-color and box-shadow. */
         .${buttonClass} {
           color: #fff;
-          background-color: var(--stagebook-primary, #3b82f6);
+          background-color: var(--stagebook-primary, #2563eb);
           border-color: transparent;
           box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
         }
@@ -124,7 +124,7 @@ export function Button({
         .${buttonClass}:focus-visible {
           outline: none;
           box-shadow:
-            0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25)),
+            0 0 0 2px var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25)),
             0 1px 2px 0 rgba(0, 0, 0, 0.05);
         }
         @media (prefers-reduced-motion: reduce) {

--- a/packages/stagebook/src/components/form/Button.tsx
+++ b/packages/stagebook/src/components/form/Button.tsx
@@ -104,7 +104,7 @@ export function Button({
            with --stagebook-hover-bg, the same token Radio /
            Checkbox rows use for their hover. */
         .${buttonClass}[data-variant="primary"]:hover {
-          background-color: var(--stagebook-primary-hover, #2563eb);
+          background-color: var(--stagebook-primary-hover, #1d4ed8);
         }
         .${buttonClass}[data-variant="secondary"]:hover {
           background-color: var(--stagebook-hover-bg, #f3f4f6);
@@ -113,7 +113,7 @@ export function Button({
            tactile feedback during the click; without it the button
            feels unresponsive on slow clicks. */
         .${buttonClass}[data-variant="primary"]:active {
-          background-color: var(--stagebook-primary-active, #1d4ed8);
+          background-color: var(--stagebook-primary-active, #1e40af);
         }
         .${buttonClass}[data-variant="secondary"]:active {
           background-color: var(--stagebook-bg-track, #e5e7eb);

--- a/packages/stagebook/src/components/form/CheckboxGroup.tsx
+++ b/packages/stagebook/src/components/form/CheckboxGroup.tsx
@@ -61,8 +61,8 @@ const CHECKBOX_CHECK_SVG =
   "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e\")";
 
 const checkboxCheckedStyle: React.CSSProperties = {
-  backgroundColor: "var(--stagebook-primary, #3b82f6)",
-  borderColor: "var(--stagebook-primary, #3b82f6)",
+  backgroundColor: "var(--stagebook-primary, #2563eb)",
+  borderColor: "var(--stagebook-primary, #2563eb)",
   backgroundImage: CHECKBOX_CHECK_SVG,
 };
 
@@ -133,7 +133,7 @@ export function CheckboxGroup({
         }
         .${inputClass}:focus-visible {
           outline: none;
-          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25));
         }
         @media (prefers-reduced-motion: reduce) {
           .${rowClass} {

--- a/packages/stagebook/src/components/form/ListSorter.tsx
+++ b/packages/stagebook/src/components/form/ListSorter.tsx
@@ -253,7 +253,7 @@ export function ListSorter({ items, onChange }: ListSorterProps) {
         .${itemClass}[data-dragging="false"]:focus-visible {
           outline: none;
           box-shadow:
-            0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25)),
+            0 0 0 2px var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25)),
             0 1px 2px 0 rgba(0, 0, 0, 0.05);
         }
         @media (prefers-reduced-motion: reduce) {

--- a/packages/stagebook/src/components/form/Markdown.tsx
+++ b/packages/stagebook/src/components/form/Markdown.tsx
@@ -273,14 +273,14 @@ const tableCellBase: React.CSSProperties = {
   padding: "0.5rem 0.75rem",
   textAlign: "start",
   fontSize: "0.875rem",
-  color: "var(--stagebook-table-text, #4a5568)",
+  color: "var(--stagebook-table-text, #374151)",
 };
 
 const thStyle: React.CSSProperties = {
   ...tableCellBase,
   backgroundColor: "var(--stagebook-bg-muted, #f9fafb)",
   fontWeight: 500,
-  color: "var(--stagebook-table-header-text, #1a202c)",
+  color: "var(--stagebook-table-header-text, #1f2937)",
 };
 
 const tdStyle: React.CSSProperties = tableCellBase;
@@ -312,8 +312,8 @@ const TASKLIST_CHECK_SVG =
   "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e\")";
 
 const taskListCheckboxCheckedStyle: React.CSSProperties = {
-  backgroundColor: "var(--stagebook-primary, #3b82f6)",
-  borderColor: "var(--stagebook-primary, #3b82f6)",
+  backgroundColor: "var(--stagebook-primary, #2563eb)",
+  borderColor: "var(--stagebook-primary, #2563eb)",
   backgroundImage: TASKLIST_CHECK_SVG,
 };
 
@@ -377,7 +377,7 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
           color: var(--stagebook-link-visited, #7c3aed);
         }
         .${rootClass} a:focus-visible {
-          outline: 2px solid var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+          outline: 2px solid var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25));
           outline-offset: 2px;
           border-radius: 0.125rem;
         }
@@ -386,7 +386,7 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
            long lines (WCAG 2.1.1); the focus-visible ring tells
            them it's selected. */
         .${rootClass} pre:focus-visible {
-          outline: 2px solid var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+          outline: 2px solid var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25));
           outline-offset: 2px;
         }
         /* List markers — muted so the bullet/number reads as

--- a/packages/stagebook/src/components/form/RadioGroup.tsx
+++ b/packages/stagebook/src/components/form/RadioGroup.tsx
@@ -61,8 +61,8 @@ const RADIO_DOT_SVG =
   "url(\"data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='8' cy='8' r='3'/%3e%3c/svg%3e\")";
 
 const radioCheckedStyle: React.CSSProperties = {
-  backgroundColor: "var(--stagebook-primary, #3b82f6)",
-  borderColor: "var(--stagebook-primary, #3b82f6)",
+  backgroundColor: "var(--stagebook-primary, #2563eb)",
+  borderColor: "var(--stagebook-primary, #2563eb)",
   backgroundImage: RADIO_DOT_SVG,
 };
 
@@ -133,7 +133,7 @@ export function RadioGroup({
         }
         .${inputClass}:focus-visible {
           outline: none;
-          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25));
         }
         @media (prefers-reduced-motion: reduce) {
           .${rowClass} {

--- a/packages/stagebook/src/components/form/Select.tsx
+++ b/packages/stagebook/src/components/form/Select.tsx
@@ -134,7 +134,7 @@ export function Select({
       <style>{`
         .${triggerClass}:focus-visible {
           outline: none;
-          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25));
         }
         @media (prefers-reduced-motion: reduce) {
           .${triggerClass} {

--- a/packages/stagebook/src/components/form/Separator.tsx
+++ b/packages/stagebook/src/components/form/Separator.tsx
@@ -23,7 +23,7 @@ const baseStyle: React.CSSProperties = {
 };
 
 // Three sizes, three colors. Thin and regular share the gray-400
-// `--stagebook-text-faint` token; thick steps up to the heavier
+// `--stagebook-decoration` token; thick steps up to the heavier
 // `--stagebook-text-muted` to read as a strong separator. Researchers
 // pick the style via the prompt-file frontmatter; the default ("")
 // resolves to regular.
@@ -34,12 +34,12 @@ const VARIANT_STYLES: Record<
   thin: {
     ...baseStyle,
     height: "1px",
-    backgroundColor: "var(--stagebook-text-faint, #9ca3af)",
+    backgroundColor: "var(--stagebook-decoration, #9ca3af)",
   },
   regular: {
     ...baseStyle,
     height: "3px",
-    backgroundColor: "var(--stagebook-text-faint, #9ca3af)",
+    backgroundColor: "var(--stagebook-decoration, #9ca3af)",
   },
   thick: {
     ...baseStyle,

--- a/packages/stagebook/src/components/form/Slider.tsx
+++ b/packages/stagebook/src/components/form/Slider.tsx
@@ -175,7 +175,7 @@ export function Slider({
            this. The primary-tint reads as "interactive / selected"
            and keeps the gray ticks visible against it. */
         .${trackClass}-wrapper:hover .${trackClass} {
-          background-color: var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+          background-color: var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25));
         }
         /* Base thumb elevation. Kept in CSS (not inline) so the
            focus-ring rule below can stack on top of it — inline
@@ -189,7 +189,7 @@ export function Slider({
            sibling selector — the actual focused element is the
            invisible range input, but the user sees the thumb. */
         .${inputClass}:focus-visible ~ [data-testid="slider-thumb"] {
-          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25)), 0 2px 4px rgba(0, 0, 0, 0.2);
+          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25)), 0 2px 4px rgba(0, 0, 0, 0.2);
         }
         @media (prefers-reduced-motion: reduce) {
           .${trackClass},
@@ -342,7 +342,7 @@ export function Slider({
                     transform: `translate(${isRTL ? "50%" : "-50%"}, -50%)`,
                     width: "2px",
                     height: `${TRACK_HEIGHT - 2}px`,
-                    backgroundColor: "var(--stagebook-text-faint, #9ca3af)",
+                    backgroundColor: "var(--stagebook-decoration, #9ca3af)",
                     opacity: 0.4,
                     pointerEvents: "none",
                   }}
@@ -437,7 +437,7 @@ export function Slider({
                   width: THUMB_SIZE,
                   height: THUMB_SIZE,
                   borderRadius: "50%",
-                  background: "var(--stagebook-primary, #3b82f6)",
+                  background: "var(--stagebook-primary, #2563eb)",
                   borderWidth: "2px",
                   borderStyle: "solid",
                   borderColor: "white",

--- a/packages/stagebook/src/components/form/TextArea.ct.tsx
+++ b/packages/stagebook/src/components/form/TextArea.ct.tsx
@@ -46,7 +46,7 @@ test("min only: shows green when at minimum", async ({ mount }) => {
   );
   await expect(component).toContainText("50+ characters required");
   const counter = component.locator('[data-testid="char-counter"]');
-  await expect(counter).toHaveCSS("color", "rgb(22, 163, 74)");
+  await expect(counter).toHaveCSS("color", "rgb(21, 128, 61)");
 });
 
 // -- Character counter: max only --
@@ -102,7 +102,7 @@ test("min+max: green when in range", async ({ mount }) => {
   );
   await expect(component).toContainText("(13 / 10-50 characters)");
   const counter = component.locator('[data-testid="char-counter"]');
-  await expect(counter).toHaveCSS("color", "rgb(22, 163, 74)");
+  await expect(counter).toHaveCSS("color", "rgb(21, 128, 61)");
 });
 
 test("min+max: at maximum is valid green (#333)", async ({ mount }) => {
@@ -118,7 +118,7 @@ test("min+max: at maximum is valid green (#333)", async ({ mount }) => {
   );
   await expect(component).toContainText("(10 / 5-10 characters)");
   const counter = component.locator('[data-testid="char-counter"]');
-  await expect(counter).toHaveCSS("color", "rgb(22, 163, 74)");
+  await expect(counter).toHaveCSS("color", "rgb(21, 128, 61)");
   await expect(counter).toHaveAttribute("data-state", "valid");
 });
 
@@ -135,7 +135,7 @@ test("min+max: exact-length input (e.g. birth year 4/4-4) is valid (#333)", asyn
   );
   await expect(component).toContainText("(4 / 4-4 characters)");
   const counter = component.locator('[data-testid="char-counter"]');
-  await expect(counter).toHaveCSS("color", "rgb(22, 163, 74)");
+  await expect(counter).toHaveCSS("color", "rgb(21, 128, 61)");
   await expect(counter).toHaveAttribute("data-state", "valid");
 });
 

--- a/packages/stagebook/src/components/form/TextArea.tsx
+++ b/packages/stagebook/src/components/form/TextArea.tsx
@@ -327,13 +327,13 @@ export function TextArea({
       // Hitting maxLength is "you're at the upper limit" — a fact, not an
       // error. Attempts to type past it pulse red via isOverflowing (#333).
       if (currentLength >= minLength && currentLength <= maxLength) {
-        countColor = "var(--stagebook-success, #16a34a)";
+        countColor = "var(--stagebook-success, #15803d)";
         countState = "valid";
       }
     } else if (minLength) {
       countText = messages.charCount(currentLength, minLength);
       if (currentLength >= minLength) {
-        countColor = "var(--stagebook-success, #16a34a)";
+        countColor = "var(--stagebook-success, #15803d)";
         countState = "valid";
       }
     } else if (maxLength) {
@@ -352,7 +352,7 @@ export function TextArea({
     const animationStyle = !isOverflowing
       ? {}
       : prefersReducedMotion
-        ? { boxShadow: "0 0 0 4px var(--stagebook-warning, #dc2626)" }
+        ? { boxShadow: "0 0 0 4px var(--stagebook-warning, #b45309)" }
         : { animation: "stagebook-char-counter-pulse 300ms ease-out" };
     const overflowState = isOverflowing ? "overflow" : countState;
 
@@ -445,7 +445,7 @@ export function TextArea({
            under the ring. */
         .${textareaClass}:focus-visible {
           outline: none;
-          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25)), 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+          box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25)), 0 1px 2px 0 rgba(0, 0, 0, 0.05);
         }
 
         /* Animate a box-shadow glow instead of the text color, so the
@@ -457,13 +457,13 @@ export function TextArea({
            orange (etc.) propagates through the pulse. */
         @keyframes stagebook-char-counter-pulse {
           0% {
-            box-shadow: 0 0 0 0 var(--stagebook-warning, #dc2626);
+            box-shadow: 0 0 0 0 var(--stagebook-warning, #b45309);
           }
           30% {
-            box-shadow: 0 0 0 4px var(--stagebook-warning, #dc2626);
+            box-shadow: 0 0 0 4px var(--stagebook-warning, #b45309);
           }
           100% {
-            box-shadow: 0 0 0 0 var(--stagebook-warning, #dc2626);
+            box-shadow: 0 0 0 0 var(--stagebook-warning, #b45309);
           }
         }
 

--- a/packages/stagebook/src/components/scroll/ScrollIndicator.tsx
+++ b/packages/stagebook/src/components/scroll/ScrollIndicator.tsx
@@ -90,7 +90,7 @@ export function ScrollIndicator({ visible }: ScrollIndicatorProps) {
           style={{
             backgroundColor:
               "var(--stagebook-scroll-indicator-bg, rgba(229, 231, 235, 0.8))",
-            color: "var(--stagebook-scroll-indicator-fg, #4b5563)",
+            color: "var(--stagebook-scroll-indicator-fg, #374151)",
             borderRadius: "9999px",
             padding: "0.5rem",
             boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",

--- a/packages/stagebook/src/components/testing/MockSurveyStage.tsx
+++ b/packages/stagebook/src/components/testing/MockSurveyStage.tsx
@@ -116,7 +116,7 @@ export function MockSurveyStage() {
           onClick={() => onComplete(mockSurveyResults)}
           style={{
             padding: "0.5rem 1rem",
-            backgroundColor: "var(--stagebook-primary, #3b82f6)",
+            backgroundColor: "var(--stagebook-primary, #2563eb)",
             color: "#fff",
             border: "none",
             borderRadius: "0.375rem",

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -149,12 +149,14 @@
   --stagebook-text-secondary: var(--sb-gray-700);
   --stagebook-text-muted: var(--sb-gray-500);
   /* Non-text decoration (slider ticks, placeholder, spinner arc, quote
-   * rail). NOT readable text — it intentionally doesn't meet text
-   * contrast. Renamed from --stagebook-text-faint, which mislabeled it as
-   * text; the old name is kept just below as a deprecated alias. */
-  --stagebook-decoration: var(--sb-gray-400);
-  /* @deprecated — alias for --stagebook-decoration; remove next release. */
-  --stagebook-text-faint: var(--stagebook-decoration);
+   * rail). NOT readable text — it intentionally doesn't meet text contrast.
+   * Renamed from --stagebook-text-faint, which mislabeled it as text.
+   * @deprecated back-compat: decoration falls THROUGH a host's old
+   * --stagebook-text-faint override first (components read --decoration, so
+   * without this an existing text-faint override would silently stop
+   * working), then the gray-400 default. Drop the text-faint fallthrough
+   * next release. */
+  --stagebook-decoration: var(--stagebook-text-faint, var(--sb-gray-400));
 
   /* Borders and backgrounds */
   --stagebook-border: var(--sb-gray-300);
@@ -197,67 +199,33 @@
   --stagebook-scroll-indicator-bg: rgba(229, 231, 235, 0.8);
   --stagebook-scroll-indicator-fg: var(--stagebook-text-secondary);
 
-  /* Timeline (#382): selection overlay + minimap chrome. All derived from
-   * the accent so overriding --stagebook-primary retints the whole
-   * timeline. Alpha variants use color-mix; on browsers without color-mix
-   * the declaration drops and each component's inline rgba fallback
-   * applies. Ranges have two intensities — `active` (keyboard shortcuts
-   * act on it) and `inactive` (saved-but-not-focused); `preview` is the
-   * click-drag / press-and-hold creation state; handles are the grab
-   * indicators. Tooltip is the deeper blue-800 for the time boxes. */
-  --stagebook-timeline-range-active: color-mix(
-    in srgb,
-    var(--stagebook-primary) 35%,
-    transparent
-  );
+  /* Timeline (#382): selection overlay + minimap chrome. These are STATIC
+   * rgba defaults (blue-600 based) so browsers without color-mix still
+   * render the selection; the @supports block below upgrades the alpha
+   * tokens to live mixes of --stagebook-primary, so a root-level accent
+   * override retints the whole timeline. color-mix() can't be the
+   * unconditional value: on an unsupported browser the custom property is
+   * still *defined* (as an invalid token stream), so the component's var()
+   * fallback is skipped and the fill/border would vanish — the same trap
+   * the focus ring avoids. The solid border/handle tokens are plain
+   * var(--primary), which is valid everywhere. Ranges: `active` (keyboard
+   * target) vs `inactive` (saved-but-unfocused); `preview` is the drag /
+   * press-hold creation state; handles are the grab indicators; tooltip is
+   * the deeper time-box background. */
+  --stagebook-timeline-range-active: rgba(37, 99, 235, 0.35);
   --stagebook-timeline-range-active-border: var(--stagebook-primary);
-  --stagebook-timeline-range-inactive: color-mix(
-    in srgb,
-    var(--stagebook-primary) 18%,
-    transparent
-  );
-  --stagebook-timeline-range-inactive-border: color-mix(
-    in srgb,
-    var(--stagebook-primary) 60%,
-    transparent
-  );
+  --stagebook-timeline-range-inactive: rgba(37, 99, 235, 0.18);
+  --stagebook-timeline-range-inactive-border: rgba(37, 99, 235, 0.6);
   --stagebook-timeline-handle-active: var(--stagebook-primary);
-  --stagebook-timeline-handle-inactive: color-mix(
-    in srgb,
-    var(--stagebook-primary) 70%,
-    transparent
-  );
-  --stagebook-timeline-preview-bg: color-mix(
-    in srgb,
-    var(--stagebook-primary) 25%,
-    transparent
-  );
-  --stagebook-timeline-preview-border: color-mix(
-    in srgb,
-    var(--stagebook-primary) 60%,
-    transparent
-  );
-  --stagebook-timeline-tooltip-bg: color-mix(
-    in srgb,
-    var(--sb-blue-800) 90%,
-    transparent
-  );
+  --stagebook-timeline-handle-inactive: rgba(37, 99, 235, 0.7);
+  --stagebook-timeline-preview-bg: rgba(37, 99, 235, 0.25);
+  --stagebook-timeline-preview-border: rgba(37, 99, 235, 0.6);
+  --stagebook-timeline-tooltip-bg: rgba(30, 64, 175, 0.9);
   --stagebook-timeline-track-label-bg: rgba(255, 255, 255, 0.85);
-  --stagebook-timeline-minimap-viewport-border: color-mix(
-    in srgb,
-    var(--stagebook-primary) 90%,
-    transparent
-  );
-  --stagebook-timeline-minimap-range: color-mix(
-    in srgb,
-    var(--stagebook-primary) 40%,
-    transparent
-  );
-  --stagebook-timeline-minimap-point: color-mix(
-    in srgb,
-    var(--stagebook-primary) 70%,
-    transparent
-  );
+  --stagebook-timeline-minimap-viewport-border: rgba(37, 99, 235, 0.9);
+  --stagebook-timeline-minimap-viewport-bg: rgba(37, 99, 235, 0.06);
+  --stagebook-timeline-minimap-range: rgba(37, 99, 235, 0.4);
+  --stagebook-timeline-minimap-point: rgba(37, 99, 235, 0.7);
 
   /* Markdown / prompt typography (used by the Markdown component) */
   --stagebook-prompt-max-width: 36rem;
@@ -312,6 +280,66 @@
     --stagebook-focus-ring: color-mix(
       in srgb,
       var(--stagebook-primary) 25%,
+      transparent
+    );
+
+    /* Timeline: live mixes of the accent (see the static defaults above).
+     * The tooltip derives from --primary too — a darker, opaque accent —
+     * so a themed timeline's time boxes follow the brand instead of staying
+     * blue. */
+    --stagebook-timeline-range-active: color-mix(
+      in srgb,
+      var(--stagebook-primary) 35%,
+      transparent
+    );
+    --stagebook-timeline-range-inactive: color-mix(
+      in srgb,
+      var(--stagebook-primary) 18%,
+      transparent
+    );
+    --stagebook-timeline-range-inactive-border: color-mix(
+      in srgb,
+      var(--stagebook-primary) 60%,
+      transparent
+    );
+    --stagebook-timeline-handle-inactive: color-mix(
+      in srgb,
+      var(--stagebook-primary) 70%,
+      transparent
+    );
+    --stagebook-timeline-preview-bg: color-mix(
+      in srgb,
+      var(--stagebook-primary) 25%,
+      transparent
+    );
+    --stagebook-timeline-preview-border: color-mix(
+      in srgb,
+      var(--stagebook-primary) 60%,
+      transparent
+    );
+    --stagebook-timeline-tooltip-bg: color-mix(
+      in srgb,
+      var(--stagebook-primary) 80%,
+      #000
+    );
+    --stagebook-timeline-minimap-viewport-border: color-mix(
+      in srgb,
+      var(--stagebook-primary) 90%,
+      transparent
+    );
+    --stagebook-timeline-minimap-viewport-bg: color-mix(
+      in srgb,
+      var(--stagebook-primary) 6%,
+      transparent
+    );
+    --stagebook-timeline-minimap-range: color-mix(
+      in srgb,
+      var(--stagebook-primary) 40%,
+      transparent
+    );
+    --stagebook-timeline-minimap-point: color-mix(
+      in srgb,
+      var(--stagebook-primary) 70%,
       transparent
     );
   }

--- a/packages/stagebook/src/styles.css
+++ b/packages/stagebook/src/styles.css
@@ -12,11 +12,6 @@
  * become available at :root for the host to override in one place, and
  * the Inter webfont is registered.
  *
- * Provides:
- * - Inter font
- * - Stagebook CSS custom properties at :root (default values)
- * - Form input resets
- *
  * Customizing typography / colors: override the --stagebook-* variables on
  * any parent element (or :root). For example, to scale headings down on
  * a particular platform:
@@ -29,6 +24,12 @@
  *   }
  *
  * No selector-based CSS, no specificity battles.
+ *
+ * Color architecture (two tiers): a PRIVATE primitive ramp (`--sb-*`) holds
+ * the raw color values; the PUBLIC semantic tokens (`--stagebook-*`) alias
+ * those primitives. Theme by overriding the semantic tokens — never the
+ * `--sb-*` primitives, which are an internal implementation detail. See
+ * issue #535 and docs/decisions for the "why these colors" rationale.
  */
 
 /* ------------------------------------------------------------------ */
@@ -60,121 +61,203 @@
 /* ------------------------------------------------------------------ */
 
 :root {
-  /* Primary action color (buttons, slider thumb, focus rings) */
-  --stagebook-primary: #3b82f6;
-  --stagebook-primary-hover: #2563eb;
-  /* One step darker than --stagebook-primary-hover for the
-   * `:active` (pressed) state on primary buttons. The
-   * hover→active progression telegraphs "the click registered"
-   * during slow clicks. */
-  --stagebook-primary-active: #1d4ed8;
+  /* Pin the color scheme so a participant's OS dark mode can't re-tint
+   * native controls (select, range, textarea, scrollbars) out from under
+   * the study. Stagebook is a measurement instrument: every participant
+   * must see the same stimulus (#535). An explicit OS accessibility
+   * override (forced-colors / high-contrast) is deliberately NOT
+   * suppressed — that's the participant's need, not a theme preference. */
+  color-scheme: light;
 
-  /* Status colors */
-  --stagebook-success: #16a34a;
-  --stagebook-danger: #ef4444;
-  --stagebook-danger-bg: #fef2f2;
-  --stagebook-warning: #dc2626;
+  /* ---------------------------------------------------------------- */
+  /* Primitives — the raw color ramp (PRIVATE).                        */
+  /* Not part of the public override API. Theme via the semantic        */
+  /* --stagebook-* tokens below, which alias these. Steps are named     */
+  /* points on a widely used, perceptually even scale — the color       */
+  /* analog of choosing Inter: robust and standard, not bespoke.        */
+  /* ---------------------------------------------------------------- */
 
-  /* Timeline playhead */
-  --stagebook-playhead: #e11d48;
+  /* Accent — one blue scale */
+  --sb-blue-400: #60a5fa;
+  --sb-blue-600: #2563eb;
+  --sb-blue-700: #1d4ed8;
+  --sb-blue-800: #1e40af;
+
+  /* Neutrals — one gray ramp */
+  --sb-white: #ffffff;
+  --sb-gray-50: #f9fafb;
+  --sb-gray-100: #f3f4f6;
+  --sb-gray-200: #e5e7eb;
+  --sb-gray-300: #d1d5db;
+  --sb-gray-400: #9ca3af;
+  --sb-gray-500: #6b7280;
+  --sb-gray-700: #374151;
+  --sb-gray-800: #1f2937;
+
+  /* Semantic hues */
+  --sb-green-700: #15803d;
+  --sb-green-50: #f0fdf4;
+  /* red-700, not red-600: red-600 (#dc2626) on red-50 is only 4.41:1 —
+   * below AA for the danger pill/callout text. red-700 passes on both
+   * white and the red-50 tint. */
+  --sb-red-700: #b91c1c;
+  --sb-red-50: #fef2f2;
+  --sb-amber-700: #b45309;
+  --sb-amber-50: #fffbeb;
+  --sb-rose-700: #be123c;
+  --sb-violet-600: #7c3aed;
+
+  /* ---------------------------------------------------------------- */
+  /* Semantic tokens — the PUBLIC override surface. Each aliases a      */
+  /* primitive (or another semantic token). Override these to retheme.  */
+  /* ---------------------------------------------------------------- */
+
+  /* Primary action (buttons, links, focus ring, slider thumb).
+   * blue-600 passes WCAG 2.2 AA as both button fill (white-on-it) and as
+   * link text on white (#535). The hover → active progression telegraphs
+   * "the click registered" during slow clicks. */
+  --stagebook-primary: var(--sb-blue-600);
+  --stagebook-primary-hover: var(--sb-blue-700);
+  --stagebook-primary-active: var(--sb-blue-800);
+
+  /* Status — each ships as a {fg, bg} pair so status messages render as
+   * dark text on a soft tint (comfortably AA) rather than small colored
+   * text. The fg is the ramp step that passes AA as text on its own bg
+   * (perceptual, so the step differs by hue: red-600, green-700,
+   * amber-700). Warning is amber — a distinct hue from danger so
+   * "caution" never blurs into "error". */
+  --stagebook-success: var(--sb-green-700);
+  --stagebook-success-bg: var(--sb-green-50);
+  --stagebook-danger: var(--sb-red-700);
+  --stagebook-danger-bg: var(--sb-red-50);
+  --stagebook-warning: var(--sb-amber-700);
+  --stagebook-warning-bg: var(--sb-amber-50);
+
+  /* Timeline playhead — a deliberately distinct marker hue: it must stay
+   * distinct from the blue selection ranges AND must not read as
+   * "danger", so it is neither the accent nor the danger color and never
+   * aliases them (a host rebranding errors shouldn't move the playhead). */
+  --stagebook-playhead: var(--sb-rose-700);
 
   /* Timer */
-  --stagebook-timer-fill: #60a5fa;
-  --stagebook-timer-warn: #ef4444;
-  --stagebook-timer-track: #e5e7eb;
+  --stagebook-timer-fill: var(--sb-blue-400);
+  --stagebook-timer-warn: var(--stagebook-danger);
+  --stagebook-timer-track: var(--sb-gray-200);
 
   /* Text */
-  --stagebook-text: #1f2937;
-  --stagebook-text-secondary: #374151;
-  --stagebook-text-muted: #6b7280;
-  --stagebook-text-faint: #9ca3af;
+  --stagebook-text: var(--sb-gray-800);
+  --stagebook-text-secondary: var(--sb-gray-700);
+  --stagebook-text-muted: var(--sb-gray-500);
+  /* Non-text decoration (slider ticks, placeholder, spinner arc, quote
+   * rail). NOT readable text — it intentionally doesn't meet text
+   * contrast. Renamed from --stagebook-text-faint, which mislabeled it as
+   * text; the old name is kept just below as a deprecated alias. */
+  --stagebook-decoration: var(--sb-gray-400);
+  /* @deprecated — alias for --stagebook-decoration; remove next release. */
+  --stagebook-text-faint: var(--stagebook-decoration);
 
   /* Borders and backgrounds */
-  --stagebook-border: #d1d5db;
-  --stagebook-bg: #ffffff;
-  --stagebook-bg-muted: #f9fafb;
-  --stagebook-bg-track: #e5e7eb;
-  /* Hover-state background fill for interactive rows (radio /
-   * checkbox option labels, sortable items, etc.). Sits between
-   * --stagebook-bg-muted (page-level subdued surface) and the
-   * primary-tinted focus ring so the hover affordance reads as
-   * "this row is interactive" without competing with selection
-   * indicators. */
-  --stagebook-hover-bg: #f3f4f6;
-  /* Minimum height for interactive rows (radio / checkbox option
-   * labels). Default 2.25rem (36px) balances HIG's 44px touch-target
-   * recommendation against vertical density on long Likert-style
-   * scales. Mobile-first deployments can override to "2.75rem" to
-   * hit 44px without forking. */
+  --stagebook-border: var(--sb-gray-300);
+  --stagebook-bg: var(--sb-white);
+  --stagebook-bg-muted: var(--sb-gray-50);
+  --stagebook-bg-track: var(--sb-gray-200);
+  /* Hover-state background fill for interactive rows (radio / checkbox
+   * labels, sortable items). Sits between --stagebook-bg-muted and the
+   * primary-tinted focus ring so hover reads as "interactive" without
+   * competing with selection indicators. */
+  --stagebook-hover-bg: var(--sb-gray-100);
+  /* Minimum height for interactive rows. 2.25rem (36px) balances HIG's
+   * 44px touch target against vertical density on long Likert scales;
+   * mobile-first deployments can override to "2.75rem". */
   --stagebook-row-min-height: 2.25rem;
 
-  /* Form control surface (input, textarea, select, checkbox, radio). Kept
-   * distinct from --stagebook-bg so hosts can tint form controls separately
-   * from the page background (e.g., darker cards on a white page). */
-  --stagebook-surface: #fff;
+  /* Form control surface — kept distinct from --stagebook-bg so hosts can
+   * tint controls separately from the page (e.g. darker cards on white). */
+  --stagebook-surface: var(--sb-white);
 
-  /* Focus ring. Default is a static rgba tint of the primary color so
-   * browsers without color-mix support still get a visible focus ring.
-   * In browsers that support color-mix, the @supports block below upgrades
-   * the token to a live 25% mix of --stagebook-primary, so overriding the
-   * primary token automatically retunes the focus ring. Hosts can always
-   * override this token directly for a fully custom ring color.
-   *
-   * Why not define it as color-mix() unconditionally: custom-property
-   * substitution is validated at computed-value time, so if color-mix()
-   * isn't supported the whole box-shadow declaration becomes invalid and
-   * the var() fallback at the usage site does NOT apply — the focus ring
-   * would just disappear. */
-  --stagebook-focus-ring: rgba(59, 130, 246, 0.25);
+  /* Focus ring. Static rgba default (blue-600 @25%) so browsers without
+   * color-mix still get a visible ring; the @supports block below
+   * upgrades it to a live mix of --stagebook-primary so overriding the
+   * accent retunes the ring automatically. color-mix can't be the
+   * unconditional value: it's validated at computed-value time, so on an
+   * unsupported browser the whole declaration (and the var fallback at
+   * the usage site) would be dropped and the ring would vanish. */
+  --stagebook-focus-ring: rgba(37, 99, 235, 0.25);
 
-  /* Timeline waveform bars */
-  --stagebook-waveform-color: #6b7280;
-  /* Track-lane background behind the waveform — subtle so the waveform
-     remains visually dominant, but enough to frame the track area. */
+  /* Timeline waveform bars + subtle track lane behind them. The track is
+   * a neutral translucent so the waveform stays visually dominant. */
+  --stagebook-waveform-color: var(--sb-gray-500);
   --stagebook-waveform-track-bg: rgba(128, 128, 128, 0.15);
 
   /* Loading spinner */
-  --stagebook-spinner-track: #e5e7eb;
-  --stagebook-spinner-arc: #9ca3af;
+  --stagebook-spinner-track: var(--sb-gray-200);
+  --stagebook-spinner-arc: var(--stagebook-decoration);
 
-  /* Scroll-indicator pill (the "more content below" chevron at the
-   * bottom of an internally-scrolling Stage column). Lives behind a
-   * `pointer-events: none` div so it never intercepts clicks; the
-   * pill itself is a rounded button-like background with a chevron
-   * icon. Defaults are tuned to read on white backgrounds. */
+  /* Scroll-indicator pill (the "more content below" chevron). */
   --stagebook-scroll-indicator-bg: rgba(229, 231, 235, 0.8);
-  --stagebook-scroll-indicator-fg: #4b5563;
+  --stagebook-scroll-indicator-fg: var(--stagebook-text-secondary);
 
-  /* Timeline (#382): selection overlay + minimap chrome. Defaults are
-   * all primary-blue-derived; hosts can override per-token if their
-   * brand wants a different accent for annotations.
-   *
-   * Ranges have two intensities — `active` (the range the keyboard
-   * shortcuts will act on) and `inactive` (saved-but-not-focused). The
-   * `preview` pair is used during click-drag and keyboard press-and-
-   * hold range creation. Handles are the small grab indicators at the
-   * start/end of an active range.
-   *
-   * Tooltip background lives here too so the playhead time box and
-   * range-handle hover tooltips theme together. */
-  --stagebook-timeline-range-active: rgba(59, 130, 246, 0.35);
-  --stagebook-timeline-range-active-border: rgba(37, 99, 235, 1);
-  --stagebook-timeline-range-inactive: rgba(59, 130, 246, 0.18);
-  --stagebook-timeline-range-inactive-border: rgba(59, 130, 246, 0.6);
-  --stagebook-timeline-handle-active: rgba(37, 99, 235, 1);
-  --stagebook-timeline-handle-inactive: rgba(59, 130, 246, 0.7);
-  --stagebook-timeline-preview-bg: rgba(59, 130, 246, 0.25);
-  --stagebook-timeline-preview-border: rgba(59, 130, 246, 0.6);
-  --stagebook-timeline-tooltip-bg: rgba(30, 64, 175, 0.9);
+  /* Timeline (#382): selection overlay + minimap chrome. All derived from
+   * the accent so overriding --stagebook-primary retints the whole
+   * timeline. Alpha variants use color-mix; on browsers without color-mix
+   * the declaration drops and each component's inline rgba fallback
+   * applies. Ranges have two intensities — `active` (keyboard shortcuts
+   * act on it) and `inactive` (saved-but-not-focused); `preview` is the
+   * click-drag / press-and-hold creation state; handles are the grab
+   * indicators. Tooltip is the deeper blue-800 for the time boxes. */
+  --stagebook-timeline-range-active: color-mix(
+    in srgb,
+    var(--stagebook-primary) 35%,
+    transparent
+  );
+  --stagebook-timeline-range-active-border: var(--stagebook-primary);
+  --stagebook-timeline-range-inactive: color-mix(
+    in srgb,
+    var(--stagebook-primary) 18%,
+    transparent
+  );
+  --stagebook-timeline-range-inactive-border: color-mix(
+    in srgb,
+    var(--stagebook-primary) 60%,
+    transparent
+  );
+  --stagebook-timeline-handle-active: var(--stagebook-primary);
+  --stagebook-timeline-handle-inactive: color-mix(
+    in srgb,
+    var(--stagebook-primary) 70%,
+    transparent
+  );
+  --stagebook-timeline-preview-bg: color-mix(
+    in srgb,
+    var(--stagebook-primary) 25%,
+    transparent
+  );
+  --stagebook-timeline-preview-border: color-mix(
+    in srgb,
+    var(--stagebook-primary) 60%,
+    transparent
+  );
+  --stagebook-timeline-tooltip-bg: color-mix(
+    in srgb,
+    var(--sb-blue-800) 90%,
+    transparent
+  );
   --stagebook-timeline-track-label-bg: rgba(255, 255, 255, 0.85);
-  /* Minimap chrome — viewport rect (the draggable indicator of where
-   * the main timeline window sits in the full duration) plus the
-   * miniaturized range / point marks. Tuned a touch brighter than the
-   * main-timeline range tokens because the minimap is small and needs
-   * its marks to pop. */
-  --stagebook-timeline-minimap-viewport-border: rgba(59, 130, 246, 0.9);
-  --stagebook-timeline-minimap-range: rgba(59, 130, 246, 0.4);
-  --stagebook-timeline-minimap-point: rgba(59, 130, 246, 0.7);
+  --stagebook-timeline-minimap-viewport-border: color-mix(
+    in srgb,
+    var(--stagebook-primary) 90%,
+    transparent
+  );
+  --stagebook-timeline-minimap-range: color-mix(
+    in srgb,
+    var(--stagebook-primary) 40%,
+    transparent
+  );
+  --stagebook-timeline-minimap-point: color-mix(
+    in srgb,
+    var(--stagebook-primary) 70%,
+    transparent
+  );
 
   /* Markdown / prompt typography (used by the Markdown component) */
   --stagebook-prompt-max-width: 36rem;
@@ -192,40 +275,33 @@
   --stagebook-prompt-h4-weight: 600;
   --stagebook-prompt-h5-weight: 600;
   --stagebook-prompt-h6-weight: 600;
-  --stagebook-link: #2563eb;
-  /* One step darker than --stagebook-link for the `:hover` state on
-   * markdown links. The hover → base progression telegraphs "I'm
-   * hovering this" without inventing a new hue. */
-  --stagebook-link-hover: #1d4ed8;
-  /* Purple for `:visited`, the established convention since 1993.
-   * Researcher prompts sometimes link back to consent / instructions
-   * pages — distinguishing visited tells participants they've already
-   * been there. */
-  --stagebook-link-visited: #7c3aed;
+  /* Links default to the accent; override --stagebook-link to make prose
+   * links differ from buttons. Visited is a distinct violet — the
+   * established convention — so participants can tell they've already
+   * visited a linked consent / instructions page. */
+  --stagebook-link: var(--stagebook-primary);
+  --stagebook-link-hover: var(--stagebook-primary-hover);
+  --stagebook-link-visited: var(--sb-violet-600);
   --stagebook-code-bg: rgba(0, 0, 0, 0.06);
   --stagebook-code-font:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  /* Body font stack. Baked into all stagebook form components so a
+  /* Body font stack — baked into all stagebook form components so a
    * <textarea> / <select> / <input> never picks up the browser UA
    * default (Chrome's textarea default is monospace, Safari's is
-   * sans-serif — without this token the same TextArea would render
-   * different fonts cross-browser, drifting from the measurement-
-   * instrument goal). Hosts override at :root to opt into a different
-   * font; the fallback inside each var() call lets the component
-   * render correctly even when styles.css isn't loaded. */
+   * sans-serif). Hosts override at :root to opt into a different font. */
   --stagebook-font: "Inter", ui-sans-serif, system-ui, sans-serif;
 
-  /* Markdown GFM tables (used by the Markdown component, issue #214) */
-  --stagebook-table-text: #4a5568;
-  --stagebook-table-header-text: #1a202c;
+  /* Markdown GFM tables (#214). Snapped onto the gray ramp — previously
+   * Tailwind-v1 grays (#4a5568 / #1a202c) that didn't sit on the rest of
+   * the palette's scale. */
+  --stagebook-table-text: var(--stagebook-text-secondary);
+  --stagebook-table-header-text: var(--stagebook-text);
 
-  /* Blockquote (used by Display element and markdown blockquotes).
-   * Border bumped from #d1d5db (gray-300) → #9ca3af (gray-400) so the
-   * quote rail actually reads against the page background — at #d1d5db
-   * the rail and the body text contrast was indistinguishable from
-   * "softly highlighted box" rather than "quote." */
-  --stagebook-blockquote-border: #9ca3af;
-  --stagebook-blockquote-bg: #f9fafb;
+  /* Blockquote (Display element + markdown blockquotes). The rail is the
+   * decoration gray — enough weight to read as a quote rail without
+   * becoming a distinct UI element. */
+  --stagebook-blockquote-border: var(--stagebook-decoration);
+  --stagebook-blockquote-bg: var(--stagebook-bg-muted);
 }
 
 /* Upgrade the focus ring to a live mix of --stagebook-primary only on
@@ -321,8 +397,8 @@ input[type="tel"]:focus,
 textarea:focus,
 select:focus {
   outline: none;
-  border-color: var(--stagebook-primary, #3b82f6);
-  box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(59, 130, 246, 0.25));
+  border-color: var(--stagebook-primary, #2563eb);
+  box-shadow: 0 0 0 2px var(--stagebook-focus-ring, rgba(37, 99, 235, 0.25));
 }
 
 /* Checkbox + radio styling (base, :checked, :focus) moved to inline

--- a/packages/stagebook/src/styles.test.ts
+++ b/packages/stagebook/src/styles.test.ts
@@ -138,12 +138,12 @@ describe("styles.css uses theme variables for hardcoded values (#116)", () => {
     ],
     [
       "--stagebook-table-text",
-      "var(--stagebook-table-text, #4a5568)",
+      "var(--stagebook-table-text, #374151)",
       "table cell text color",
     ],
     [
       "--stagebook-table-header-text",
-      "var(--stagebook-table-header-text, #1a202c)",
+      "var(--stagebook-table-header-text, #1f2937)",
       "table header text color",
     ],
   ])("Markdown.tsx references %s via %s (%s)", (name, needle) => {
@@ -239,5 +239,98 @@ describe("styles.css uses theme variables for hardcoded values (#116)", () => {
     expect(stripVarCalls(outsideRoot)).not.toMatch(
       /rgba\(\s*59\s*,\s*130\s*,\s*246/,
     );
+  });
+});
+
+// Issue #535: the palette is accessible *by construction* — every documented
+// foreground/background pairing meets WCAG 2.2 AA. These tests resolve each
+// --stagebook-* token through the two-tier alias graph (semantic → primitive)
+// to a hex and assert the contrast ratio, so a future value edit that breaks
+// contrast fails CI instead of shipping.
+describe("styles.css palette meets WCAG 2.2 AA by construction (#535)", () => {
+  const css = readFileSync(stylesPath, "utf8");
+  const noComments = css.replace(/\/\*[\s\S]*?\*\//g, "");
+
+  // The main :root block (custom-property values use parens, never braces,
+  // so the first close-brace ends the block).
+  const rootBody = /:root\s*\{([\s\S]*?)\}/.exec(noComments)?.[1] ?? "";
+  const vars = new Map<string, string>();
+  for (const m of rootBody.matchAll(/(--[\w-]+)\s*:\s*([^;]+);/g)) {
+    vars.set(m[1], m[2].trim());
+  }
+
+  /** Resolve a token through var() aliases to a solid hex, or null. */
+  function resolveHex(name: string, seen = new Set<string>()): string | null {
+    if (seen.has(name)) return null;
+    seen.add(name);
+    const v = vars.get(name);
+    if (!v) return null;
+    if (/^#[0-9a-f]{3,8}$/i.test(v)) return v;
+    const ref = /var\(\s*(--[\w-]+)/.exec(v);
+    return ref ? resolveHex(ref[1], seen) : null; // color-mix/rgba → null
+  }
+
+  function relLum(hex: string): number {
+    const h = hex.replace("#", "");
+    const n =
+      h.length === 3
+        ? h
+            .split("")
+            .map((c) => c + c)
+            .join("")
+        : h;
+    const ch = [0, 2, 4].map((i) => parseInt(n.slice(i, i + 2), 16) / 255);
+    const lin = ch.map((c) =>
+      c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4),
+    );
+    return 0.2126 * lin[0] + 0.7152 * lin[1] + 0.0722 * lin[2];
+  }
+
+  function contrast(a: string, b: string): number {
+    const la = relLum(a);
+    const lb = relLum(b);
+    return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+  }
+
+  // [foreground token, background token, min ratio, label]
+  const AA = 4.5; // normal text
+  const UI = 3.0; // UI components / large text
+  const pairings: [string, string, number, string][] = [
+    ["--stagebook-text", "--stagebook-bg", AA, "body text on page"],
+    ["--stagebook-text-secondary", "--stagebook-bg", AA, "secondary text"],
+    ["--stagebook-text-muted", "--stagebook-bg", AA, "muted text"],
+    ["--stagebook-primary", "--stagebook-bg", AA, "link text / TrackedLink"],
+    ["--stagebook-bg", "--stagebook-primary", AA, "button label on primary"],
+    ["--stagebook-link", "--stagebook-bg", AA, "markdown link text"],
+    ["--stagebook-danger", "--stagebook-danger-bg", AA, "danger pill/callout"],
+    ["--stagebook-success", "--stagebook-success-bg", AA, "success pill"],
+    ["--stagebook-warning", "--stagebook-warning-bg", AA, "warning pill"],
+    ["--stagebook-danger", "--stagebook-bg", AA, "danger text on white"],
+    // NOTE: --stagebook-border (gray-300, 1.47:1 on white) is a deliberately
+    // subtle input border and predates #535 — the WCAG 1.4.11 question for
+    // form-control boundaries is a separate a11y decision, not asserted here.
+    ["--stagebook-playhead", "--stagebook-bg", UI, "playhead marker (UI)"],
+  ];
+
+  it.each(pairings)("%s on %s meets its contrast floor (%s)", (fg, bg, min) => {
+    const fgHex = resolveHex(fg);
+    const bgHex = resolveHex(bg);
+    expect(fgHex, `${fg} should resolve to a hex`).not.toBeNull();
+    expect(bgHex, `${bg} should resolve to a hex`).not.toBeNull();
+    const ratio = contrast(fgHex as string, bgHex as string);
+    expect(
+      ratio,
+      `${fg} (${String(fgHex)}) on ${bg} (${String(bgHex)}) = ${ratio.toFixed(2)}:1, need ${String(min)}`,
+    ).toBeGreaterThanOrEqual(min);
+  });
+
+  it("keeps --stagebook-text-faint as a deprecated alias of --stagebook-decoration", () => {
+    expect(vars.get("--stagebook-text-faint")).toContain(
+      "var(--stagebook-decoration)",
+    );
+  });
+
+  it("pins color-scheme: light so participant OS dark mode can't re-tint native controls", () => {
+    expect(rootBody).toMatch(/color-scheme:\s*light/);
   });
 });

--- a/packages/stagebook/src/styles.test.ts
+++ b/packages/stagebook/src/styles.test.ts
@@ -65,6 +65,17 @@ describe("styles.css custom property coverage", () => {
 
     expect(offenders).toEqual([]);
   });
+
+  it("no component references a private --sb-* primitive (theme via --stagebook-* only)", () => {
+    // Primitives are an internal implementation detail; components must only
+    // reference the public --stagebook-* semantic tokens so host overrides on
+    // those tokens are honored everywhere (#535).
+    const leaks: string[] = [];
+    for (const file of collectFiles(componentsDir)) {
+      if (/var\(\s*--sb-/.test(readFileSync(file, "utf8"))) leaks.push(file);
+    }
+    expect(leaks).toEqual([]);
+  });
 });
 
 // Issue #116: form resets, focus rings, and table styles previously
@@ -266,8 +277,15 @@ describe("styles.css palette meets WCAG 2.2 AA by construction (#535)", () => {
     const v = vars.get(name);
     if (!v) return null;
     if (/^#[0-9a-f]{3,8}$/i.test(v)) return v;
-    const ref = /var\(\s*(--[\w-]+)/.exec(v);
-    return ref ? resolveHex(ref[1], seen) : null; // color-mix/rgba → null
+    // Only follow a plain `var(--x)` alias to a solid hex. A color-mix()/rgba()
+    // value is a translucent/blended color with no single opaque hex, so a
+    // contrast assertion against it would be meaningless — return null (the
+    // caller asserts the token resolved) rather than the inner var's opaque hex.
+    if (/^var\(\s*--[\w-]+\s*\)$/.test(v)) {
+      const ref = /var\(\s*(--[\w-]+)/.exec(v);
+      return ref ? resolveHex(ref[1], seen) : null;
+    }
+    return null;
   }
 
   function relLum(hex: string): number {
@@ -302,6 +320,7 @@ describe("styles.css palette meets WCAG 2.2 AA by construction (#535)", () => {
     ["--stagebook-primary", "--stagebook-bg", AA, "link text / TrackedLink"],
     ["--stagebook-bg", "--stagebook-primary", AA, "button label on primary"],
     ["--stagebook-link", "--stagebook-bg", AA, "markdown link text"],
+    ["--stagebook-link-visited", "--stagebook-bg", AA, "visited link text"],
     ["--stagebook-danger", "--stagebook-danger-bg", AA, "danger pill/callout"],
     ["--stagebook-success", "--stagebook-success-bg", AA, "success pill"],
     ["--stagebook-warning", "--stagebook-warning-bg", AA, "warning pill"],
@@ -332,5 +351,14 @@ describe("styles.css palette meets WCAG 2.2 AA by construction (#535)", () => {
 
   it("pins color-scheme: light so participant OS dark mode can't re-tint native controls", () => {
     expect(rootBody).toMatch(/color-scheme:\s*light/);
+  });
+
+  it("keeps --stagebook-playhead independent of --stagebook-primary (rose, not the accent)", () => {
+    // The playhead is deliberately its own hue — a host rebranding the accent
+    // (or danger) must not move the playhead marker (#535).
+    const playhead = resolveHex("--stagebook-playhead");
+    expect(playhead).toBe("#be123c"); // rose-700
+    expect(playhead).not.toBe(resolveHex("--stagebook-primary"));
+    expect(playhead).not.toBe(resolveHex("--stagebook-danger"));
   });
 });

--- a/packages/stagebook/src/styles.test.ts
+++ b/packages/stagebook/src/styles.test.ts
@@ -343,9 +343,12 @@ describe("styles.css palette meets WCAG 2.2 AA by construction (#535)", () => {
     ).toBeGreaterThanOrEqual(min);
   });
 
-  it("keeps --stagebook-text-faint as a deprecated alias of --stagebook-decoration", () => {
-    expect(vars.get("--stagebook-text-faint")).toContain(
-      "var(--stagebook-decoration)",
+  it("honors a deprecated --stagebook-text-faint override through --stagebook-decoration", () => {
+    // Back-compat: components read --stagebook-decoration, so it must fall
+    // through the old --stagebook-text-faint token first (a host that still
+    // overrides the old name must keep working).
+    expect(vars.get("--stagebook-decoration")).toMatch(
+      /var\(\s*--stagebook-text-faint\b/,
     );
   });
 


### PR DESCRIPTION
## What & why

Turns Stagebook's ad-hoc palette (de facto Tailwind v3) into a **deliberate,
documented, accessible token system** — the color analog of the Inter font
decision. Addresses #535.

Public `--stagebook-*` token names are unchanged (one rename, with a deprecated
alias), so existing host overrides keep working. Their defaults now resolve
through a private primitive ramp, and every documented pairing is **WCAG 2.2 AA
by construction**, enforced by a test.

## Architecture — two tiers

- **Private `--sb-*` primitives** (one blue accent scale, one gray ramp, semantic
  hues) hold the raw values.
- **Public `--stagebook-*` semantic tokens** alias the primitives. Hosts override
  the semantic tokens; primitives are internal.
- **Timeline** selection/minimap tokens collapse to `color-mix(--primary …)`
  derivations, so overriding the accent retints the whole timeline.

## Value changes (contrast + intentionality)

| Token | Was | Now | Why |
|---|---|---|---|
| `--primary` | blue-500 `#3b82f6` | blue-600 `#2563eb` | 3.68:1 as button/link text → **passes AA** (hover→700, active→800; `--link` aliases it) |
| `--danger` | red-500 `#ef4444` | red-700 `#b91c1c` | red-600 measured **4.41:1** on `--danger-bg` (below AA); red-700 passes on white and the tint |
| `--warning` | red-600 `#dc2626` | amber-700 `#b45309` | distinct hue from danger |
| `--playhead` | rose-600 `#e11d48` | rose-700 `#be123c` | matched to the palette's weight; stays independent of the accent/danger |
| semantic `{fg,bg}` | danger only | + `--success-bg`, `--warning-bg` | completes the pairs for pills/callouts (consumed by #543) |
| `--text-faint` | — | → `--stagebook-decoration` | it's decoration, not text; old name kept as a **deprecated alias** |

Plus: **`color-scheme: light` pinned** so a participant's OS dark mode can't
re-tint native controls; inline `var()` fallbacks that had drifted from `:root`
fixed so the no-stylesheet render path matches; the last bare hardcodes
tokenized (`Element.tsx` error text, SelectionOverlay blocked-pulse → derives
from `--danger`).

## Tests

`styles.test.ts` resolves each token through the alias graph and asserts WCAG AA
on every documented pairing (a contrast-breaking edit fails CI), plus guards:
playhead independence, no component leaking a `--sb-*` primitive, `color-scheme`
pinned, and the deprecated alias. `.ct.tsx` assertions updated to the new
resolved colors; `ThemeOverride.ct.tsx` confirms host override still works
through the new two-tier scheme.

- vitest: **1993** (stagebook) + 78 (viewer) + 153 (vscode) pass
- contrast + style guards: **31** pass
- Playwright CT: full matrix green

## Pre-merge review

Ran correctness / test-coverage / security reviews before opening. Findings
folded in (commit `fix(styles): address pre-PR review`): the primary-hover/-active
fallback drift, stale `.ct.tsx` color assertions, and the added coverage
(link-visited, `--sb-*` leak guard, playhead independence). Security: clean —
purely presentational, no untrusted interpolation, override surface unchanged.

## Deferred (not in this PR)

- **#543** — `StatusMessage` component (chip + callout) that consumes the new
  `{fg,bg}` pairs; the TextArea counter's colored text already passes AA via the
  `--success` bump in the meantime.
- **#544** — researcher-facing color/theming doc (the "rationale doc"
  deliverable), deferred to the planned docs overhaul.
- Optional follow-ups: inline `color-scheme: light` on native form controls for
  the no-stylesheet path; axe `color-contrast` assertions in CT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
