### PR TITLE
feat(image): authorable altText + missing-alt lint; accept width (#536, #537)

### DIFF
--- a/docs/researcher/elements.md
+++ b/docs/researcher/elements.md
@@ -145,8 +145,17 @@ Displays an image.
 ```yaml
 - type: image
   file: shared/diagram.png
+  altText: "Bar chart: 2020 vs 2024 turnout" # describe the image; "" = decorative
   width: 50 # optional — percentage of available width
 ```
+
+`altText` is the text screen readers announce in place of the image; it becomes
+the `<img alt>` attribute. Describe what the image conveys so a participant using
+assistive technology gets the same information a sighted participant does. Set
+`altText: ""` for a purely decorative image (a divider, a flourish) to hide it
+from screen readers — that's the correct choice only when the image carries no
+information. Omitting `altText` entirely raises a validation warning nudging you
+to make that choice explicitly.
 
 ## Media Player
 

--- a/packages/stagebook/src/cli/validate.test.ts
+++ b/packages/stagebook/src/cli/validate.test.ts
@@ -653,6 +653,18 @@ ${imageBody}
     expect(r.stdout).not.toContain("width");
   });
 
+  it("still warns under --no-expand (raw source path also runs the lint)", async () => {
+    await writeFile(
+      join(dir, "study.stagebook.yaml"),
+      studyYaml(`          - type: image
+            file: shared/diagram.png`),
+    );
+    const r = await runCli(["--no-expand", join(dir, "study.stagebook.yaml")]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("warning:");
+    expect(r.stdout).toContain("altText");
+  });
+
   it("lints a template-authored image once it expands into a concrete stage", async () => {
     // The image lives only in a template body — never scanned raw — but the
     // CLI validates the EXPANDED tree, so it surfaces once the invocation

--- a/packages/stagebook/src/cli/validate.test.ts
+++ b/packages/stagebook/src/cli/validate.test.ts
@@ -652,6 +652,36 @@ ${imageBody}
     expect(r.stdout).not.toContain("warning:");
     expect(r.stdout).not.toContain("width");
   });
+
+  it("lints a template-authored image once it expands into a concrete stage", async () => {
+    // The image lives only in a template body — never scanned raw — but the
+    // CLI validates the EXPANDED tree, so it surfaces once the invocation
+    // becomes a real element. This is the wiring path study-repo CI relies on.
+    await writeFile(
+      join(dir, "study.stagebook.yaml"),
+      `templates:
+  - name: imageStage
+    contentType: stage
+    content:
+      name: stage1
+      duration: 300
+      elements:
+        - type: image
+          file: shared/diagram.png
+        - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    compatibleIntroSequences: []
+    gameStages:
+      - template: imageStage
+`,
+    );
+    const r = await runCli([join(dir, "study.stagebook.yaml")]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("warning:");
+    expect(r.stdout).toContain("altText");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/stagebook/src/cli/validate.test.ts
+++ b/packages/stagebook/src/cli/validate.test.ts
@@ -583,6 +583,78 @@ describe("consent i18n-completeness rule", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Image missing-altText lint (#536): an `image` element with no `altText` key
+// is a WARNING (not an error). This exercises the CLI's default expand-and-
+// validate path (`expandAndValidateWithImports`) end-to-end, codifying that
+// the schema-level lint survives template expansion and reaches the CLI
+// surface — the other half of the "two wiring paths" guarantee.
+// ---------------------------------------------------------------------------
+
+describe("image missing-altText lint (#536)", () => {
+  let dir: string;
+
+  function studyYaml(imageBody: string): string {
+    return `treatments:
+  - name: t1
+    playerCount: 1
+    compatibleIntroSequences: []
+    gameStages:
+      - name: s1
+        duration: 10
+        elements:
+${imageBody}
+          - type: submitButton
+`;
+  }
+
+  beforeAll(async () => {
+    dir = await mkdtemp(join(tmpdir(), "stagebook-cli-image-"));
+  });
+
+  afterAll(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("warns (but does not error) when an image has no altText", async () => {
+    await writeFile(
+      join(dir, "study.stagebook.yaml"),
+      studyYaml(`          - type: image
+            file: shared/diagram.png`),
+    );
+    const r = await runCli([join(dir, "study.stagebook.yaml")]);
+    expect(r.code).toBe(0); // warning does not fail the build
+    expect(r.stdout).toContain("warning:");
+    expect(r.stdout).toContain("altText");
+  });
+
+  it("is clean when the image explicitly marks itself decorative", async () => {
+    await writeFile(
+      join(dir, "study.stagebook.yaml"),
+      studyYaml(`          - type: image
+            file: shared/divider.png
+            altText: ""`),
+    );
+    const r = await runCli([join(dir, "study.stagebook.yaml")]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).not.toContain("altText");
+  });
+
+  it("accepts an authored altText and a width (#537) with no diagnostics", async () => {
+    await writeFile(
+      join(dir, "study.stagebook.yaml"),
+      studyYaml(`          - type: image
+            file: shared/chart.png
+            altText: "A labeled bar chart"
+            width: 50`),
+    );
+    const r = await runCli([join(dir, "study.stagebook.yaml")]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).not.toContain("warning:");
+    expect(r.stdout).not.toContain("width");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Unsatisfiable-condition rule (#480): a condition reading a prompt's answer
 // whose comparator can never match any value the prompt produces (dead gate)
 // is flagged as an error, reading the referenced prompt's option domain from

--- a/packages/stagebook/src/cli/validate.ts
+++ b/packages/stagebook/src/cli/validate.ts
@@ -12,7 +12,10 @@ import {
   checkPromptLocaleConsistencyWithLoader,
   checkUnsatisfiableConditionsWithLoader,
 } from "../validate/index.js";
-import { checkConsentLocaleCoverage } from "../schemas/index.js";
+import {
+  checkConsentLocaleCoverage,
+  collectMissingImageAltText,
+} from "../schemas/index.js";
 import { load as loadYaml } from "js-yaml";
 
 export type Format = "text" | "json";
@@ -253,6 +256,7 @@ export async function run({
         ...(await checkLocaleConsistencyDiagnostics(result.fullYaml, dir)),
         ...(await checkUnsatisfiableConditionDiagnostics(result.fullYaml, dir)),
         ...checkConsentLocaleCoverageDiagnostics(result.fullYaml),
+        ...checkMissingImageAltTextDiagnostics(result.fullYaml),
       );
     }
     results.push({ path: displayPath, type: "treatment", diagnostics });
@@ -377,6 +381,39 @@ function checkConsentLocaleCoverageDiagnostics(fullYaml: string): Diagnostic[] {
     message: gap.message,
     range: null,
   }));
+}
+
+/**
+ * Run the missing-alt-text image lint (#536) over the expanded treatment: an
+ * `image` element with no `altText` key gets a WARNING (never an error —
+ * `altText: ""` is the valid decorative escape hatch, so the lint nudges rather
+ * than blocks). Runs on the *expanded* tree so template-provided images are
+ * linted once they land in a concrete stage; because expanded positions don't
+ * map to the source, diagnostics carry `range: null` (top of file) with the
+ * element path appended to the message as the locator.
+ */
+function checkMissingImageAltTextDiagnostics(fullYaml: string): Diagnostic[] {
+  let fileObj: unknown;
+  try {
+    fileObj = loadYaml(fullYaml);
+  } catch {
+    return []; // YAML errors are already reported by the schema pass
+  }
+
+  return collectMissingImageAltText(fileObj).map((issue) => ({
+    severity: "warning" as const,
+    message: `${issue.message} (${formatIssuePath(issue.path)})`,
+    range: null,
+  }));
+}
+
+function formatIssuePath(path: (string | number)[]): string {
+  let out = "";
+  for (const segment of path) {
+    if (typeof segment === "number") out += `[${segment}]`;
+    else out += out ? `.${segment}` : segment;
+  }
+  return out;
 }
 
 function hasGlobChars(s: string): boolean {

--- a/packages/stagebook/src/cli/validate.ts
+++ b/packages/stagebook/src/cli/validate.ts
@@ -12,10 +12,7 @@ import {
   checkPromptLocaleConsistencyWithLoader,
   checkUnsatisfiableConditionsWithLoader,
 } from "../validate/index.js";
-import {
-  checkConsentLocaleCoverage,
-  collectMissingImageAltText,
-} from "../schemas/index.js";
+import { checkConsentLocaleCoverage } from "../schemas/index.js";
 import { load as loadYaml } from "js-yaml";
 
 export type Format = "text" | "json";
@@ -252,11 +249,14 @@ export async function run({
     // treatment's `locale` (both default `en`). Cross-file by nature, so it
     // runs here where the referenced prompt files are readable from disk.
     if (!result.expandError) {
+      // NOTE: the missing-`altText` image lint (#536) is NOT run here — it's
+      // emitted by `validateTreatmentSource`, which `expandAndValidateWithImports`
+      // runs over the expanded YAML (and which the `--no-expand`/stdin branch
+      // above runs over the raw source). Adding it here would double-report.
       diagnostics.push(
         ...(await checkLocaleConsistencyDiagnostics(result.fullYaml, dir)),
         ...(await checkUnsatisfiableConditionDiagnostics(result.fullYaml, dir)),
         ...checkConsentLocaleCoverageDiagnostics(result.fullYaml),
-        ...checkMissingImageAltTextDiagnostics(result.fullYaml),
       );
     }
     results.push({ path: displayPath, type: "treatment", diagnostics });
@@ -381,39 +381,6 @@ function checkConsentLocaleCoverageDiagnostics(fullYaml: string): Diagnostic[] {
     message: gap.message,
     range: null,
   }));
-}
-
-/**
- * Run the missing-alt-text image lint (#536) over the expanded treatment: an
- * `image` element with no `altText` key gets a WARNING (never an error —
- * `altText: ""` is the valid decorative escape hatch, so the lint nudges rather
- * than blocks). Runs on the *expanded* tree so template-provided images are
- * linted once they land in a concrete stage; because expanded positions don't
- * map to the source, diagnostics carry `range: null` (top of file) with the
- * element path appended to the message as the locator.
- */
-function checkMissingImageAltTextDiagnostics(fullYaml: string): Diagnostic[] {
-  let fileObj: unknown;
-  try {
-    fileObj = loadYaml(fullYaml);
-  } catch {
-    return []; // YAML errors are already reported by the schema pass
-  }
-
-  return collectMissingImageAltText(fileObj).map((issue) => ({
-    severity: "warning" as const,
-    message: `${issue.message} (${formatIssuePath(issue.path)})`,
-    range: null,
-  }));
-}
-
-function formatIssuePath(path: (string | number)[]): string {
-  let out = "";
-  for (const segment of path) {
-    if (typeof segment === "number") out += `[${segment}]`;
-    else out += out ? `.${segment}` : segment;
-  }
-  return out;
 }
 
 function hasGlobChars(s: string): boolean {

--- a/packages/stagebook/src/components/Element.assetPlaceholder.test.tsx
+++ b/packages/stagebook/src/components/Element.assetPlaceholder.test.tsx
@@ -145,6 +145,22 @@ describe("Element asset:// placeholder (#191)", () => {
     expect(img?.getAttribute("src")).toBe("https://cdn.test/images/logo.png");
   });
 
+  test("the router forwards an image element's altText to the <img alt> (#536)", () => {
+    const c = renderElement({
+      type: "image",
+      file: "images/chart.png",
+      altText: "Bar chart: 2020 vs 2024 turnout",
+    });
+    const img = c.querySelector("img");
+    expect(img?.getAttribute("alt")).toBe("Bar chart: 2020 vs 2024 turnout");
+  });
+
+  test('an image with no altText renders alt="" (#536)', () => {
+    const c = renderElement({ type: "image", file: "images/logo.png" });
+    const img = c.querySelector("img");
+    expect(img?.getAttribute("alt")).toBe("");
+  });
+
   test("mediaPlayer with a resolvable url + asset:// captions plays the video (captions dropped, not fetched)", () => {
     // Only the captions are unresolvable — the video itself resolves, so it
     // must still play; the asset:// track is dropped, never fetched (#191).

--- a/packages/stagebook/src/components/Element.tsx
+++ b/packages/stagebook/src/components/Element.tsx
@@ -97,6 +97,7 @@ export interface ElementConfig {
     position?: string;
   }>;
   width?: number;
+  altText?: string;
   startTime?: number;
   endTime?: number;
   displayTime?: number;
@@ -228,7 +229,13 @@ export function Element({ element, onSubmit, stageDuration }: ElementProps) {
       if (isUnresolvedAsset(imageSrc)) {
         return <AssetPlaceholder uri={element.file ?? ""} kind="image" />;
       }
-      return <ImageElement src={imageSrc} width={element.width} />;
+      return (
+        <ImageElement
+          src={imageSrc}
+          width={element.width}
+          alt={element.altText}
+        />
+      );
     }
 
     case "prompt": {

--- a/packages/stagebook/src/components/elements/ImageElement.test.tsx
+++ b/packages/stagebook/src/components/elements/ImageElement.test.tsx
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+import { describe, test, expect, afterEach, beforeAll } from "vitest";
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ImageElement } from "./ImageElement.js";
+
+beforeAll(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  root = undefined;
+  container = undefined;
+});
+
+function render(node: React.ReactElement): HTMLDivElement {
+  container = document.createElement("div");
+  root = createRoot(container);
+  act(() => root!.render(node));
+  return container;
+}
+
+describe("ImageElement — alt text (#536)", () => {
+  test("renders the provided alt on the <img>", () => {
+    const el = render(
+      <ImageElement src="diagram.png" alt="A labeled bar chart" />,
+    );
+    const img = el.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute("alt")).toBe("A labeled bar chart");
+  });
+
+  test('renders alt="" (decorative) when alt is an explicit empty string', () => {
+    const el = render(<ImageElement src="divider.png" alt="" />);
+    const img = el.querySelector("img");
+    // Present-but-empty: the image is exposed to screen readers as decorative.
+    expect(img?.getAttribute("alt")).toBe("");
+  });
+
+  test('falls back to alt="" when no alt is supplied', () => {
+    const el = render(<ImageElement src="diagram.png" />);
+    const img = el.querySelector("img");
+    expect(img?.getAttribute("alt")).toBe("");
+  });
+
+  test("still honors width", () => {
+    const el = render(
+      <ImageElement src="diagram.png" alt="chart" width={50} />,
+    );
+    const img = el.querySelector("img");
+    expect(img?.style.width).toBe("50%");
+  });
+});

--- a/packages/stagebook/src/components/elements/ImageElement.tsx
+++ b/packages/stagebook/src/components/elements/ImageElement.tsx
@@ -3,16 +3,23 @@ import React from "react";
 export interface ImageElementProps {
   src: string;
   width?: number;
+  /**
+   * Alt text for the `<img>` (#536). Supplied by the author via the treatment
+   * `altText:` field. An explicit empty string (or omission) marks the image
+   * decorative — hidden from screen readers — which is correct only when the
+   * image carries no information.
+   */
+  alt?: string;
 }
 
-export function ImageElement({ src, width }: ImageElementProps) {
+export function ImageElement({ src, width, alt }: ImageElementProps) {
   if (!src) return null;
 
   return (
     <div style={{ display: "flex", justifyContent: "center" }}>
       <img
         src={src}
-        alt=""
+        alt={alt ?? ""}
         style={{
           width: width ? `${width}%` : "100%",
           maxWidth: "100%",

--- a/packages/stagebook/src/schemas/imageAltText.test.ts
+++ b/packages/stagebook/src/schemas/imageAltText.test.ts
@@ -134,13 +134,7 @@ describe("collectMissingImageAltText", () => {
   });
 });
 
-describe("a missing altText is NOT a schema failure (stays out of the schema)", () => {
-  // The lint is a warning, wired through a SEPARATE post-validation channel —
-  // deliberately not the schema superRefine, because any superRefine issue
-  // flips `safeParse` to `success: false`, which non-diagnostic consumers
-  // (VS Code preview, viewer example catalog, external manager/runner) read as
-  // a blocking failure. These guard that contract: an un-annotated image is a
-  // clean parse, so those consumers keep working.
+describe("missing altText is a WARNING, never a schema failure", () => {
   const src = `
 treatments:
   - name: t
@@ -155,8 +149,12 @@ treatments:
           - type: submitButton
 `;
 
-  it("safeParseTreatmentFile succeeds for a treatment whose image lacks altText", () => {
-    // js-yaml the source the way callers do, then parse.
+  it("safeParseTreatmentFile SUCCEEDS for a treatment whose image lacks altText", () => {
+    // The load-bearing regression guard: the lint lives OUTSIDE the schema, so
+    // it never flips `safeParse` to `success: false`. Consumers that gate on
+    // that boolean (VS Code preview via parseTreatmentSource, the viewer example
+    // catalog, external manager/runner/annotator) keep working on a common,
+    // harmless input — an un-annotated image.
     const parsed = safeParseTreatmentFile({
       treatments: [
         {
@@ -179,11 +177,20 @@ treatments:
     expect(parsed.success).toBe(true);
   });
 
-  it("validateTreatmentSource reports no error AND no altText warning (the schema pass is silent)", () => {
-    // The schema pass alone doesn't run the lint — only the two wired surfaces
-    // (CLI `cli/validate.ts` + editor `validateTreatmentDiff.ts`) do.
+  it("validateTreatmentSource surfaces it as a WARNING (the shared CLI / expanded-preview chokepoint)", () => {
     const { diagnostics } = validateTreatmentSource(src);
     expect(diagnostics.some((d) => d.severity === "error")).toBe(false);
+    const warn = diagnostics.find((d) => /altText/i.test(d.message));
+    expect(warn).toBeDefined();
+    expect(warn?.severity).toBe("warning");
+  });
+
+  it("validateTreatmentSource is silent when the image is explicitly decorative", () => {
+    const decorative = src.replace(
+      "            file: shared/diagram.png",
+      '            file: shared/diagram.png\n            altText: ""',
+    );
+    const { diagnostics } = validateTreatmentSource(decorative);
     expect(diagnostics.find((d) => /altText/i.test(d.message))).toBeUndefined();
   });
 });

--- a/packages/stagebook/src/schemas/imageAltText.test.ts
+++ b/packages/stagebook/src/schemas/imageAltText.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { collectMissingImageAltText } from "./imageAltText.js";
 import { validateTreatmentSource } from "../validate/validateTreatment.js";
+import { safeParseTreatmentFile } from "./safeParseTreatmentFile.js";
 
 describe("collectMissingImageAltText", () => {
   it("returns nothing for empty/invalid input", () => {
@@ -133,9 +134,14 @@ describe("collectMissingImageAltText", () => {
   });
 });
 
-describe("missing-altText lint through validateTreatmentSource", () => {
-  it("surfaces a WARNING (not an error) for an image without altText", () => {
-    const src = `
+describe("a missing altText is NOT a schema failure (stays out of the schema)", () => {
+  // The lint is a warning, wired through a SEPARATE post-validation channel —
+  // deliberately not the schema superRefine, because any superRefine issue
+  // flips `safeParse` to `success: false`, which non-diagnostic consumers
+  // (VS Code preview, viewer example catalog, external manager/runner) read as
+  // a blocking failure. These guard that contract: an un-annotated image is a
+  // clean parse, so those consumers keep working.
+  const src = `
 treatments:
   - name: t
     playerCount: 1
@@ -148,47 +154,34 @@ treatments:
             file: shared/diagram.png
           - type: submitButton
 `;
-    const { diagnostics } = validateTreatmentSource(src);
-    const alt = diagnostics.find((d) => /altText/i.test(d.message));
-    expect(alt).toBeDefined();
-    expect(alt?.severity).toBe("warning");
+
+  it("safeParseTreatmentFile succeeds for a treatment whose image lacks altText", () => {
+    // js-yaml the source the way callers do, then parse.
+    const parsed = safeParseTreatmentFile({
+      treatments: [
+        {
+          name: "t",
+          playerCount: 1,
+          compatibleIntroSequences: [],
+          gameStages: [
+            {
+              name: "s1",
+              duration: 60,
+              elements: [
+                { type: "image", file: "shared/diagram.png" },
+                { type: "submitButton" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    expect(parsed.success).toBe(true);
   });
 
-  it("does not warn when the image explicitly marks itself decorative", () => {
-    const src = `
-treatments:
-  - name: t
-    playerCount: 1
-    compatibleIntroSequences: []
-    gameStages:
-      - name: s1
-        duration: 60
-        elements:
-          - type: image
-            file: shared/divider.png
-            altText: ""
-          - type: submitButton
-`;
-    const { diagnostics } = validateTreatmentSource(src);
-    expect(diagnostics.find((d) => /altText/i.test(d.message))).toBeUndefined();
-  });
-
-  it("does not warn when altText is authored", () => {
-    const src = `
-treatments:
-  - name: t
-    playerCount: 1
-    compatibleIntroSequences: []
-    gameStages:
-      - name: s1
-        duration: 60
-        elements:
-          - type: image
-            file: shared/diagram.png
-            altText: "A labeled bar chart"
-            width: 50
-          - type: submitButton
-`;
+  it("validateTreatmentSource reports no error AND no altText warning (the schema pass is silent)", () => {
+    // The schema pass alone doesn't run the lint — only the two wired surfaces
+    // (CLI `cli/validate.ts` + editor `validateTreatmentDiff.ts`) do.
     const { diagnostics } = validateTreatmentSource(src);
     expect(diagnostics.some((d) => d.severity === "error")).toBe(false);
     expect(diagnostics.find((d) => /altText/i.test(d.message))).toBeUndefined();

--- a/packages/stagebook/src/schemas/imageAltText.test.ts
+++ b/packages/stagebook/src/schemas/imageAltText.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect } from "vitest";
+import { collectMissingImageAltText } from "./imageAltText.js";
+import { validateTreatmentSource } from "../validate/validateTreatment.js";
+
+describe("collectMissingImageAltText", () => {
+  it("returns nothing for empty/invalid input", () => {
+    expect(collectMissingImageAltText(undefined)).toEqual([]);
+    expect(collectMissingImageAltText(null)).toEqual([]);
+    expect(collectMissingImageAltText("not an object")).toEqual([]);
+    expect(collectMissingImageAltText({})).toEqual([]);
+  });
+
+  it("warns when an image element has no altText key", () => {
+    const data = {
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [
+            {
+              name: "s1",
+              elements: [{ type: "image", file: "shared/diagram.png" }],
+            },
+          ],
+        },
+      ],
+    };
+    const issues = collectMissingImageAltText(data);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toEqual([
+      "treatments",
+      0,
+      "gameStages",
+      0,
+      "elements",
+      0,
+    ]);
+    expect(issues[0].message).toMatch(/altText/);
+  });
+
+  it("does NOT warn when altText is a non-empty string", () => {
+    const data = {
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [
+            {
+              name: "s1",
+              elements: [
+                {
+                  type: "image",
+                  file: "shared/diagram.png",
+                  altText: "Bar chart: 2020 vs 2024 turnout",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(collectMissingImageAltText(data)).toEqual([]);
+  });
+
+  it("does NOT warn when altText is an explicit empty string (decorative)", () => {
+    const data = {
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [
+            {
+              name: "s1",
+              elements: [
+                { type: "image", file: "shared/divider.png", altText: "" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(collectMissingImageAltText(data)).toEqual([]);
+  });
+
+  it("ignores non-image elements", () => {
+    const data = {
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [
+            {
+              name: "s1",
+              elements: [
+                { type: "prompt", file: "q.prompt.md", name: "q" },
+                { type: "submitButton" },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+    expect(collectMissingImageAltText(data)).toEqual([]);
+  });
+
+  it("scans exit sequences, intro sequences, and consent arms", () => {
+    const data = {
+      introSequences: [
+        {
+          name: "i1",
+          introSteps: [
+            { name: "s", elements: [{ type: "image", file: "a.png" }] },
+          ],
+        },
+      ],
+      consent: [
+        {
+          name: "c1",
+          steps: [{ name: "s", elements: [{ type: "image", file: "b.png" }] }],
+        },
+      ],
+      treatments: [
+        {
+          name: "t1",
+          gameStages: [],
+          exitSequence: [
+            { name: "s", elements: [{ type: "image", file: "c.png" }] },
+          ],
+        },
+      ],
+    };
+    const issues = collectMissingImageAltText(data);
+    expect(issues).toHaveLength(3);
+    expect(issues.map((i) => i.path[0])).toEqual(
+      expect.arrayContaining(["introSequences", "consent", "treatments"]),
+    );
+  });
+});
+
+describe("missing-altText lint through validateTreatmentSource", () => {
+  it("surfaces a WARNING (not an error) for an image without altText", () => {
+    const src = `
+treatments:
+  - name: t
+    playerCount: 1
+    compatibleIntroSequences: []
+    gameStages:
+      - name: s1
+        duration: 60
+        elements:
+          - type: image
+            file: shared/diagram.png
+          - type: submitButton
+`;
+    const { diagnostics } = validateTreatmentSource(src);
+    const alt = diagnostics.find((d) => /altText/i.test(d.message));
+    expect(alt).toBeDefined();
+    expect(alt?.severity).toBe("warning");
+  });
+
+  it("does not warn when the image explicitly marks itself decorative", () => {
+    const src = `
+treatments:
+  - name: t
+    playerCount: 1
+    compatibleIntroSequences: []
+    gameStages:
+      - name: s1
+        duration: 60
+        elements:
+          - type: image
+            file: shared/divider.png
+            altText: ""
+          - type: submitButton
+`;
+    const { diagnostics } = validateTreatmentSource(src);
+    expect(diagnostics.find((d) => /altText/i.test(d.message))).toBeUndefined();
+  });
+
+  it("does not warn when altText is authored", () => {
+    const src = `
+treatments:
+  - name: t
+    playerCount: 1
+    compatibleIntroSequences: []
+    gameStages:
+      - name: s1
+        duration: 60
+        elements:
+          - type: image
+            file: shared/diagram.png
+            altText: "A labeled bar chart"
+            width: 50
+          - type: submitButton
+`;
+    const { diagnostics } = validateTreatmentSource(src);
+    expect(diagnostics.some((d) => d.severity === "error")).toBe(false);
+    expect(diagnostics.find((d) => /altText/i.test(d.message))).toBeUndefined();
+  });
+});

--- a/packages/stagebook/src/schemas/imageAltText.ts
+++ b/packages/stagebook/src/schemas/imageAltText.ts
@@ -20,12 +20,29 @@
  * `mediaPlayer`) — authoring-helped accessibility rather than a runtime
  * guarantee. See ADR docs/decisions/2026-07-accessibility.md (Decision 3).
  *
+ * This runs as a SEPARATE post-validation check (like the consent
+ * i18n-completeness warning, #529), NOT inside the `treatmentFileSchema`
+ * superRefine. That's deliberate: a superRefine issue — even a self-marked
+ * "warning" — makes `safeParse` return `success: false`, which non-diagnostic
+ * consumers (VS Code preview, the viewer example catalog, external
+ * manager/runner/annotator) read as a hard schema failure and use to BLOCK a
+ * common, harmless input. Keeping it out of the schema preserves the
+ * success/failure contract as "errors only." The caller wires it into both
+ * validate surfaces (CLI `cli/validate.ts` + editor `validateTreatmentDiff.ts`)
+ * and assigns `warning` severity there.
+ *
  * The walk mirrors `collectStorageKeyCollisions`: every element-bearing
  * container a participant can traverse (treatment game stages + exit
- * sequences, intro-sequence steps, consent-arm steps). Emitted as a
- * schema-level warning from the `treatmentFileSchema` superRefine, so it flows
- * through BOTH validate surfaces (CLI + editor diff) automatically — the two
- * paths share the schema, so neither can silently skip it.
+ * sequences, intro-sequence steps, consent-arm steps). Like that walker it
+ * deliberately does NOT scan `templates:` bodies — only the concrete
+ * containers above. An image authored inside a template body is still linted
+ * once it lands in a real stage: the CLI runs the check over the *expanded*
+ * tree, where the invocation has become a concrete element. The editor diff
+ * runs it over the un-expanded source object (for precise squiggle positions),
+ * so a template-provided image surfaces in the CLI / expanded preview rather
+ * than on the invocation line — the same treatment every post-hydration rule
+ * gets. Scanning raw template bodies would instead mis-position warnings at
+ * `${placeholder}`-bearing partial elements.
  */
 
 export interface MissingImageAltText {
@@ -33,8 +50,6 @@ export interface MissingImageAltText {
   path: (string | number)[];
   /** Human-readable warning. */
   message: string;
-  /** Self-marks the diagnostic as a warning across the zod round-trip. */
-  severity: "warning";
 }
 
 type Path = (string | number)[];
@@ -63,7 +78,6 @@ function scanElements(
     into.push({
       path: [...basePath, idx],
       message: MESSAGE,
-      severity: "warning",
     });
   });
 }

--- a/packages/stagebook/src/schemas/imageAltText.ts
+++ b/packages/stagebook/src/schemas/imageAltText.ts
@@ -24,22 +24,30 @@
  * i18n-completeness warning, #529), NOT inside the `treatmentFileSchema`
  * superRefine. That's deliberate: a superRefine issue — even a self-marked
  * "warning" — makes `safeParse` return `success: false`, which non-diagnostic
- * consumers (VS Code preview, the viewer example catalog, external
- * manager/runner/annotator) read as a hard schema failure and use to BLOCK a
- * common, harmless input. Keeping it out of the schema preserves the
- * success/failure contract as "errors only." The caller wires it into both
- * validate surfaces (CLI `cli/validate.ts` + editor `validateTreatmentDiff.ts`)
- * and assigns `warning` severity there.
+ * consumers (VS Code preview via `parseTreatmentSource`, the viewer example
+ * catalog, external manager/runner/annotator) read as a hard schema failure and
+ * use to BLOCK a common, harmless input. Keeping it out of the schema preserves
+ * the success/failure contract as "errors only."
+ *
+ * Wiring — two diagnostic surfaces, both of which return diagnostics (never a
+ * pass/fail boolean), so `warning` severity flows through without blocking:
+ *   - `validateTreatmentSource` appends it after the schema pass. That's the
+ *     shared chokepoint for the CLI (raw source AND the expanded YAML, via
+ *     `expandAndValidate`) and the VS Code expanded preview — one wiring point
+ *     covers all of them, positioned via the same mapper.
+ *   - `validateTreatmentDiff` runs it over the un-expanded source object for the
+ *     inline editor squiggle (that path doesn't go through
+ *     `validateTreatmentSource`).
  *
  * The walk mirrors `collectStorageKeyCollisions`: every element-bearing
  * container a participant can traverse (treatment game stages + exit
  * sequences, intro-sequence steps, consent-arm steps). Like that walker it
  * deliberately does NOT scan `templates:` bodies — only the concrete
  * containers above. An image authored inside a template body is still linted
- * once it lands in a real stage: the CLI runs the check over the *expanded*
- * tree, where the invocation has become a concrete element. The editor diff
- * runs it over the un-expanded source object (for precise squiggle positions),
- * so a template-provided image surfaces in the CLI / expanded preview rather
+ * once it lands in a real stage: `validateTreatmentSource` runs over the
+ * *expanded* tree in the CLI / expanded-preview paths, where the invocation has
+ * become a concrete element. The inline editor diff runs over the un-expanded
+ * source, so a template-provided image surfaces in the expanded preview rather
  * than on the invocation line — the same treatment every post-hydration rule
  * gets. Scanning raw template bodies would instead mis-position warnings at
  * `${placeholder}`-bearing partial elements.

--- a/packages/stagebook/src/schemas/imageAltText.ts
+++ b/packages/stagebook/src/schemas/imageAltText.ts
@@ -1,0 +1,129 @@
+/**
+ * Missing-alt-text lint for `image` elements (#536).
+ *
+ * `ImageElement` renders `<img alt={…}>`. When an author supplies no
+ * `altText:`, the runtime falls back to `alt=""`, which is *technically valid*
+ * — it marks the image decorative and hides it from screen readers. That's the
+ * right call for a genuine divider or flourish, but wrong for an image that
+ * carries information (a chart, a diagram, a stimulus). Because `alt=""` is
+ * valid HTML, automated a11y tooling (axe) can't tell the two apart, so the
+ * authoring layer has to nudge instead: warn when `altText` is *absent* and let
+ * the author either describe the image or opt into decorative with an explicit
+ * empty string.
+ *
+ * This is a lint (warning), never a hard error: some images really are
+ * decorative, and `altText: ""` is the correct, un-warned way to say so. The
+ * warning fires ONLY when the `altText` key is missing entirely — never when it
+ * is present-but-empty.
+ *
+ * Precedent: this mirrors video's authorable captions (`captionsFile` on
+ * `mediaPlayer`) — authoring-helped accessibility rather than a runtime
+ * guarantee. See ADR docs/decisions/2026-07-accessibility.md (Decision 3).
+ *
+ * The walk mirrors `collectStorageKeyCollisions`: every element-bearing
+ * container a participant can traverse (treatment game stages + exit
+ * sequences, intro-sequence steps, consent-arm steps). Emitted as a
+ * schema-level warning from the `treatmentFileSchema` superRefine, so it flows
+ * through BOTH validate surfaces (CLI + editor diff) automatically — the two
+ * paths share the schema, so neither can silently skip it.
+ */
+
+export interface MissingImageAltText {
+  /** Path to the offending image element within the treatment file. */
+  path: (string | number)[];
+  /** Human-readable warning. */
+  message: string;
+  /** Self-marks the diagnostic as a warning across the zod round-trip. */
+  severity: "warning";
+}
+
+type Path = (string | number)[];
+
+const MESSAGE =
+  "Image element has no `altText`. Add `altText:` describing the image for " +
+  'screen-reader users, or set `altText: ""` to mark it decorative.';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function scanElements(
+  elements: unknown,
+  basePath: Path,
+  into: MissingImageAltText[],
+): void {
+  if (!Array.isArray(elements)) return;
+  elements.forEach((el, idx) => {
+    if (!isRecord(el) || el.type !== "image") return;
+    // Warn ONLY when the key is absent. An explicit `altText: ""` is the
+    // decorative escape hatch and must never warn; a present-but-non-string
+    // value (e.g. `altText: null`) is a *schema* error reported elsewhere, so
+    // we don't double-report it here.
+    if ("altText" in el) return;
+    into.push({
+      path: [...basePath, idx],
+      message: MESSAGE,
+      severity: "warning",
+    });
+  });
+}
+
+function scanStageList(
+  stages: unknown,
+  basePath: Path,
+  into: MissingImageAltText[],
+): void {
+  if (!Array.isArray(stages)) return;
+  stages.forEach((stage, stageIdx) => {
+    if (!isRecord(stage)) return;
+    scanElements(stage.elements, [...basePath, stageIdx, "elements"], into);
+  });
+}
+
+/**
+ * Collect every `image` element that is missing an `altText` field, across all
+ * element-bearing containers in the treatment file. Defensive against
+ * malformed input (returns `[]`): the schema runs this on dirty parses.
+ */
+export function collectMissingImageAltText(
+  data: unknown,
+): MissingImageAltText[] {
+  if (!isRecord(data)) return [];
+  const out: MissingImageAltText[] = [];
+
+  if (Array.isArray(data.treatments)) {
+    data.treatments.forEach((treatment, tIdx) => {
+      if (!isRecord(treatment)) return;
+      scanStageList(
+        treatment.gameStages,
+        ["treatments", tIdx, "gameStages"],
+        out,
+      );
+      scanStageList(
+        treatment.exitSequence,
+        ["treatments", tIdx, "exitSequence"],
+        out,
+      );
+    });
+  }
+
+  if (Array.isArray(data.introSequences)) {
+    data.introSequences.forEach((seq, seqIdx) => {
+      if (!isRecord(seq)) return;
+      scanStageList(
+        seq.introSteps,
+        ["introSequences", seqIdx, "introSteps"],
+        out,
+      );
+    });
+  }
+
+  if (Array.isArray(data.consent)) {
+    data.consent.forEach((arm, armIdx) => {
+      if (!isRecord(arm)) return;
+      scanStageList(arm.steps, ["consent", armIdx, "steps"], out);
+    });
+  }
+
+  return out;
+}

--- a/packages/stagebook/src/schemas/index.ts
+++ b/packages/stagebook/src/schemas/index.ts
@@ -116,6 +116,11 @@ export {
 } from "./storageKeyCollisions.js";
 
 export {
+  collectMissingImageAltText,
+  type MissingImageAltText,
+} from "./imageAltText.js";
+
+export {
   collectReferencedPromptFiles,
   checkPromptLocaleConsistency,
   checkConsentLocaleCoverage,

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -148,6 +148,8 @@ const resolvedElementBaseSchema = z.object({
   warnTimeRemaining: z.number().optional(),
   style: z.enum(["thin", "regular", "thick", ""]).optional(),
   width: z.number().optional(),
+  // image alt text (#536) — the resolved (post-fill) form the runtime reads.
+  altText: z.string().optional(),
   urlParams: z
     .array(
       z.object({

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -708,7 +708,15 @@ test("image: accepts width (documented + honored at runtime, #537)", () => {
     file: "shared/diagram.png",
     width: 50,
   });
-  if (!result.success) console.log(result.error);
+  expect(result.success).toBe(true);
+});
+
+test("image: accepts width at the inclusive upper bound (100%)", () => {
+  const result = elementSchema.safeParse({
+    type: "image",
+    file: "shared/diagram.png",
+    width: 100,
+  });
   expect(result.success).toBe(true);
 });
 
@@ -728,6 +736,15 @@ test("image: rejects a non-positive width", () => {
     width: 0,
   });
   expect(result.success).toBe(false);
+});
+
+test("image: accepts a ${field} placeholder for width (templatable like siblings)", () => {
+  const result = elementSchema.safeParse({
+    type: "image",
+    file: "shared/diagram.png",
+    width: "${chartWidth}",
+  });
+  expect(result.success).toBe(true);
 });
 
 // --- qualtrics.url / trackedLink.url stricter (#249) ---

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -738,13 +738,17 @@ test("image: rejects a non-positive width", () => {
   expect(result.success).toBe(false);
 });
 
-test("image: accepts a ${field} placeholder for width (templatable like siblings)", () => {
+test("image: rejects a ${field} placeholder for width (literal only — see #549 review)", () => {
+  // Unlike the sibling numeric fields, image width is NOT templatable: the
+  // resolved schema types it as a plain number with no unresolved-placeholder
+  // deferral, so a surviving `${...}` would hard-error post-fill. Keep the
+  // authoring schema literal-only until that resolved-path gap is fixed.
   const result = elementSchema.safeParse({
     type: "image",
     file: "shared/diagram.png",
     width: "${chartWidth}",
   });
-  expect(result.success).toBe(true);
+  expect(result.success).toBe(false);
 });
 
 // --- qualtrics.url / trackedLink.url stricter (#249) ---

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -682,6 +682,54 @@ test("mediaPlayer: malformed captionsFile (asset: with no //) is rejected", () =
   expect(result.success).toBe(false);
 });
 
+// --- image altText + width (#536, #537) ---
+
+test("image: accepts authorable altText", () => {
+  const result = elementSchema.safeParse({
+    type: "image",
+    file: "shared/diagram.png",
+    altText: "Bar chart: 2020 vs 2024 turnout",
+  });
+  expect(result.success).toBe(true);
+});
+
+test("image: accepts an explicit empty altText (decorative)", () => {
+  const result = elementSchema.safeParse({
+    type: "image",
+    file: "shared/divider.png",
+    altText: "",
+  });
+  expect(result.success).toBe(true);
+});
+
+test("image: accepts width (documented + honored at runtime, #537)", () => {
+  const result = elementSchema.safeParse({
+    type: "image",
+    file: "shared/diagram.png",
+    width: 50,
+  });
+  if (!result.success) console.log(result.error);
+  expect(result.success).toBe(true);
+});
+
+test("image: rejects width above 100 (percentage of available width)", () => {
+  const result = elementSchema.safeParse({
+    type: "image",
+    file: "shared/diagram.png",
+    width: 150,
+  });
+  expect(result.success).toBe(false);
+});
+
+test("image: rejects a non-positive width", () => {
+  const result = elementSchema.safeParse({
+    type: "image",
+    file: "shared/diagram.png",
+    width: 0,
+  });
+  expect(result.success).toBe(false);
+});
+
 // --- qualtrics.url / trackedLink.url stricter (#249) ---
 
 test("qualtrics: asset:// url is rejected (browser-direct only)", () => {

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -1241,9 +1241,16 @@ const imageSchema = elementBaseSchema
     // docs/researcher/elements.md and honored at runtime (Element.tsx image
     // case → ImageElement, resolved.ts:width), but previously absent from the
     // strict authoring schema, so `stagebook validate` rejected a field the
-    // runtime actually uses (docs/schema/runtime drift). `.or(placeholder)`
-    // keeps it templatable via `${field}` like the other numeric element
-    // fields (displayTime/hideTime, mediaPlayer.startAt/stopAt).
+    // runtime actually uses (docs/schema/runtime drift). A literal number only:
+    // NOT `.or(fieldPlaceholderSchema)`, even though the sibling numeric fields
+    // (displayTime/hideTime, mediaPlayer.startAt/stopAt) accept `${field}`.
+    // Those siblings share a latent gap — the resolved schema (`resolved.ts`)
+    // types them as plain numbers with no `unresolved-placeholder` tag, so a
+    // placeholder that survives hydration hard-errors under
+    // `validateResolvedTreatmentFile({ skipUnresolved: true })` instead of being
+    // deferred. Templatable width would inherit that (see PR #549 review); keep
+    // width literal until the numeric-placeholder resolved path is fixed for all
+    // of them together.
     width: z
       .number()
       .positive(
@@ -1253,7 +1260,6 @@ const imageSchema = elementBaseSchema
         100,
         "`width` is a percentage of the available width, so it can't exceed 100.",
       )
-      .or(fieldPlaceholderSchema)
       .optional(),
     // Todo: check that file exists
   })

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument */
 import { z } from "zod";
 import { collectStorageKeyCollisions } from "./storageKeyCollisions.js";
-import { collectMissingImageAltText } from "./imageAltText.js";
 import { validateTreatmentFileReferences } from "./validateReferences.js";
 import { nameSchema, localeSchema, type NameType } from "./primitives.js";
 import {
@@ -1242,7 +1241,9 @@ const imageSchema = elementBaseSchema
     // docs/researcher/elements.md and honored at runtime (Element.tsx image
     // case → ImageElement, resolved.ts:width), but previously absent from the
     // strict authoring schema, so `stagebook validate` rejected a field the
-    // runtime actually uses (docs/schema/runtime drift).
+    // runtime actually uses (docs/schema/runtime drift). `.or(placeholder)`
+    // keeps it templatable via `${field}` like the other numeric element
+    // fields (displayTime/hideTime, mediaPlayer.startAt/stopAt).
     width: z
       .number()
       .positive(
@@ -1252,6 +1253,7 @@ const imageSchema = elementBaseSchema
         100,
         "`width` is a percentage of the available width, so it can't exceed 100.",
       )
+      .or(fieldPlaceholderSchema)
       .optional(),
     // Todo: check that file exists
   })
@@ -2573,19 +2575,14 @@ export const treatmentFileSchema = z
         });
       }
     }
-    // Missing-alt-text lint for `image` elements (#536). A warning, not an
-    // error: `alt=""` is valid for genuinely-decorative images, so the lint
-    // nudges ("describe it, or explicitly mark it decorative") rather than
-    // hard-failing. `params.severity` marks it a warning so the diagnostic
-    // layers read it back (same round-trip as #499). Baked into the schema so
-    // it flows through both validate surfaces without per-path wiring.
-    for (const issue of collectMissingImageAltText(data)) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: issue.path,
-        message: issue.message,
-        params: { severity: issue.severity },
-      });
-    }
+    // NOTE: the missing-`altText` image lint (#536) is deliberately NOT emitted
+    // here. It is a *warning*, and any issue added in a superRefine makes
+    // `safeParse` return `success: false` — which non-diagnostic consumers
+    // (VS Code preview via `parseTreatmentSource`, the viewer example catalog,
+    // external manager/runner/annotator) read as a hard schema failure, blocking
+    // a common, harmless input (an un-annotated image). Instead it rides the
+    // separate post-validation channel (`collectMissingImageAltText`) wired into
+    // both validate surfaces, exactly like the consent i18n-completeness warning
+    // (#529) — so the schema's success/failure contract stays "errors only."
   });
 export type TreatmentFileType = z.infer<typeof treatmentFileSchema>;

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-argument */
 import { z } from "zod";
 import { collectStorageKeyCollisions } from "./storageKeyCollisions.js";
+import { collectMissingImageAltText } from "./imageAltText.js";
 import { validateTreatmentFileReferences } from "./validateReferences.js";
 import { nameSchema, localeSchema, type NameType } from "./primitives.js";
 import {
@@ -1232,6 +1233,26 @@ const imageSchema = elementBaseSchema
   .extend({
     type: z.literal("image"),
     file: fileSchema,
+    // Author-facing alt text (#536). Maps to the component `alt` prop /
+    // `<img alt>`. An explicit empty string marks the image decorative; an
+    // absent field triggers the missing-altText lint (a warning, not an
+    // error — see `collectMissingImageAltText`).
+    altText: z.string().optional(),
+    // Percentage of the available width (#537). Documented in
+    // docs/researcher/elements.md and honored at runtime (Element.tsx image
+    // case → ImageElement, resolved.ts:width), but previously absent from the
+    // strict authoring schema, so `stagebook validate` rejected a field the
+    // runtime actually uses (docs/schema/runtime drift).
+    width: z
+      .number()
+      .positive(
+        "`width` is a percentage of the available width, so it must be positive.",
+      )
+      .max(
+        100,
+        "`width` is a percentage of the available width, so it can't exceed 100.",
+      )
+      .optional(),
     // Todo: check that file exists
   })
   .strict();
@@ -2551,6 +2572,20 @@ export const treatmentFileSchema = z
           message: collision.message,
         });
       }
+    }
+    // Missing-alt-text lint for `image` elements (#536). A warning, not an
+    // error: `alt=""` is valid for genuinely-decorative images, so the lint
+    // nudges ("describe it, or explicitly mark it decorative") rather than
+    // hard-failing. `params.severity` marks it a warning so the diagnostic
+    // layers read it back (same round-trip as #499). Baked into the schema so
+    // it flows through both validate surfaces without per-path wiring.
+    for (const issue of collectMissingImageAltText(data)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: issue.path,
+        message: issue.message,
+        params: { severity: issue.severity },
+      });
     }
   });
 export type TreatmentFileType = z.infer<typeof treatmentFileSchema>;

--- a/packages/stagebook/src/validate/expandAndValidate.test.ts
+++ b/packages/stagebook/src/validate/expandAndValidate.test.ts
@@ -31,6 +31,38 @@ treatments:
       );
       expect(result.yaml).toContain("name: stage1");
     });
+
+    it("warns on a template-authored image missing altText after expansion (#536)", () => {
+      // This is the path the VS Code expanded preview uses
+      // (expandAndValidateWithImports → finishExpandAndValidate →
+      // validateTreatmentSource(fullYaml)). The image lives only in a template
+      // body — never scanned raw — but once expanded into study1's game stage
+      // it's a concrete element, so the lint fires as a WARNING (not an error).
+      const src = `templates:
+  - name: imageStage
+    contentType: stage
+    content:
+      name: stage1
+      duration: 300
+      elements:
+        - type: image
+          file: shared/diagram.png
+        - type: submitButton
+treatments:
+  - name: study1
+    playerCount: 1
+    compatibleIntroSequences: []
+    gameStages:
+      - template: imageStage`;
+      const result = expandAndValidate(src);
+      expect(result.expandError).toBeNull();
+      expect(result.diagnostics.filter((d) => d.severity === "error")).toEqual(
+        [],
+      );
+      const warn = result.diagnostics.find((d) => /altText/i.test(d.message));
+      expect(warn).toBeDefined();
+      expect(warn!.severity).toBe("warning");
+    });
   });
 
   describe("invalid expanded output from valid-looking source", () => {

--- a/packages/stagebook/src/validate/validateTreatment.ts
+++ b/packages/stagebook/src/validate/validateTreatment.ts
@@ -1,4 +1,7 @@
-import { safeParseTreatmentFile } from "../index.js";
+import {
+  safeParseTreatmentFile,
+  collectMissingImageAltText,
+} from "../index.js";
 import { createPositionMapper, extractYamlErrors } from "./yamlPositionMap.js";
 import type { Diagnostic } from "./types.js";
 
@@ -97,6 +100,28 @@ export function validateTreatmentSource(source: string): ValidationResult {
         range,
       });
     }
+  }
+
+  // Step 4: Missing-alt-text image lint (#536). A WARNING (never a schema
+  // failure — see collectMissingImageAltText), appended here rather than inside
+  // the schema so it reaches every surface that runs validateTreatmentSource
+  // without flipping `safeParse` for consumers that gate on it: the CLI (raw
+  // source, and the expanded YAML via expandAndValidate) and the VS Code
+  // expanded preview. The inline editor diff runs its own copy over the
+  // un-expanded source (validateTreatmentDiff) for a precise squiggle. Uses the
+  // same mapper + walk-up as the schema issues above.
+  for (const issue of collectMissingImageAltText(parsedObj)) {
+    let range = mapper.resolve(issue.path);
+    let ancestorPath = issue.path;
+    while (!range && ancestorPath.length > 0) {
+      ancestorPath = ancestorPath.slice(0, -1);
+      range = mapper.resolve(ancestorPath);
+    }
+    diagnostics.push({
+      message: `${issue.message} (${formatPath(issue.path)})`,
+      severity: "warning",
+      range,
+    });
   }
 
   return { diagnostics, parsedObj };

--- a/packages/stagebook/src/validate/validateTreatmentDiff.test.ts
+++ b/packages/stagebook/src/validate/validateTreatmentDiff.test.ts
@@ -547,9 +547,10 @@ ${imageBody}
 `;
 
     it("warns (not errors) when an image element has no altText", async () => {
+      const source = study(`          - type: image
+            file: shared/diagram.png`);
       const result = await validateTreatmentWithDiff({
-        source: study(`          - type: image
-            file: shared/diagram.png`),
+        source,
         loadImport: noImports,
       });
       // Fixture is otherwise schema-valid, so no error masks the warning.
@@ -559,6 +560,12 @@ ${imageBody}
       const warn = result.diagnostics.find((d) => /altText/i.test(d.message));
       expect(warn).toBeDefined();
       expect(warn!.severity).toBe("warning");
+      // Editor path runs on the source object → the warning squiggles the
+      // image element itself, not a generic top-of-file range.
+      const imageLine = source
+        .split("\n")
+        .findIndex((l) => l.includes("- type: image"));
+      expect(warn!.range?.startLine).toBe(imageLine);
     });
 
     it("is clean when the image explicitly marks itself decorative", async () => {

--- a/packages/stagebook/src/validate/validateTreatmentDiff.test.ts
+++ b/packages/stagebook/src/validate/validateTreatmentDiff.test.ts
@@ -533,6 +533,56 @@ introSequences:
     });
   });
 
+  describe("image missing-altText lint (#536)", () => {
+    const study = (imageBody: string) => `treatments:
+  - name: t
+    playerCount: 1
+    compatibleIntroSequences: []
+    gameStages:
+      - name: g
+        duration: 10
+        elements:
+${imageBody}
+          - type: submitButton
+`;
+
+    it("warns (not errors) when an image element has no altText", async () => {
+      const result = await validateTreatmentWithDiff({
+        source: study(`          - type: image
+            file: shared/diagram.png`),
+        loadImport: noImports,
+      });
+      // Fixture is otherwise schema-valid, so no error masks the warning.
+      expect(result.diagnostics.filter((d) => d.severity === "error")).toEqual(
+        [],
+      );
+      const warn = result.diagnostics.find((d) => /altText/i.test(d.message));
+      expect(warn).toBeDefined();
+      expect(warn!.severity).toBe("warning");
+    });
+
+    it("is clean when the image explicitly marks itself decorative", async () => {
+      const result = await validateTreatmentWithDiff({
+        source: study(`          - type: image
+            file: shared/divider.png
+            altText: ""`),
+        loadImport: noImports,
+      });
+      expect(result.diagnostics).toEqual([]);
+    });
+
+    it("is clean when the image carries altText", async () => {
+      const result = await validateTreatmentWithDiff({
+        source: study(`          - type: image
+            file: shared/diagram.png
+            altText: "A labeled bar chart"
+            width: 50`),
+        loadImport: noImports,
+      });
+      expect(result.diagnostics).toEqual([]);
+    });
+  });
+
   describe("unsatisfiable conditions (#480)", () => {
     const withGate = (comparator: string, value: string) => `treatments:
   - name: t

--- a/packages/stagebook/src/validate/validateTreatmentDiff.ts
+++ b/packages/stagebook/src/validate/validateTreatmentDiff.ts
@@ -4,6 +4,7 @@ import {
   parseTreatmentYaml as parseStagebookYaml,
   validateResolvedTreatmentFile,
   checkConsentLocaleCoverage,
+  collectMissingImageAltText,
   type PreHydrationIssue,
 } from "../index.js";
 import type { ZodIssue } from "zod";
@@ -99,6 +100,21 @@ export async function validateTreatmentWithDiff({
   // downstream "couldn't expand" / "schema rejected" noise that's
   // already explained by the parse failure.
   if (hasYamlParseError) return { diagnostics, parsedObj };
+
+  // Missing-alt-text image lint (#536). A WARNING (never blocks): `altText: ""`
+  // is the valid decorative escape hatch, so the lint only fires when the key
+  // is absent. Runs directly on the un-expanded source object so it squiggles
+  // the exact image element; a template-provided image (which lives under
+  // `templates:` here, not in a concrete stage yet) surfaces instead through
+  // the CLI / expanded-preview pass. Kept OUT of the schema on purpose — see
+  // `collectMissingImageAltText` — so it never flips `safeParse` to failure.
+  for (const issue of collectMissingImageAltText(parsedObj)) {
+    diagnostics.push({
+      message: issue.message,
+      severity: "warning",
+      range: resolveOrWalkUp(mapper, issue.path),
+    });
+  }
 
   // Load imports asynchronously.
   const loadResult = await loadAndMergeImports({ source, loadImport });


### PR DESCRIPTION
## What & why

Gives researchers a way to supply **alt text** on `image` elements and warns
when they don't — Step 2 of the July 2026 accessibility audit (parent #20, ADR
`docs/decisions/2026-07-accessibility.md` Decision 3). axe can't catch this:
`ImageElement` hardcoded `alt=""`, which is *valid* HTML, so every image stimulus
was silently marked decorative and hidden from screen readers. The authoring
layer nudges instead — the "components conform / authoring is helped" case.

Also fixes **#537** (bundled because both touch `imageSchema`): the documented,
runtime-honored `width` field was rejected by the strict authoring validator.

## Changes

- **Schema** (`schemas/treatment.ts`): `imageSchema` gains `altText`
  (`z.string().optional()`) and `width`
  (`z.number().positive().max(100).optional()` — a `%`-of-available-width
  value). **Literal only, not `${field}`-templatable:** the sibling numeric
  fields (displayTime/startAt/…) accept placeholders in the authoring schema
  but share a latent gap — the *resolved* schema types them as plain numbers
  with no `unresolved-placeholder` tag, so a surviving placeholder hard-errors
  under `validateResolvedTreatmentFile({ skipUnresolved: true })` (thanks
  @codex). Rather than add `width` to that set, it stays literal until the
  numeric-placeholder resolved path is fixed for all of them together.
  `altText` also added to the resolved schema for the runtime.
- **Component / router**: `ImageElement` takes an `alt` prop and renders
  `<img alt={alt ?? ""}>`; `Element.tsx` forwards `element.altText`. An explicit
  `altText: ""` keeps `alt=""` (decorative).
- **Lint** (`schemas/imageAltText.ts`): `collectMissingImageAltText` warns when
  an `image` element has **no** `altText` key — never for an explicit `""` (the
  decorative escape hatch). It walks every element-bearing container (game
  stages, exit sequences, intro steps, consent steps), mirroring
  `collectStorageKeyCollisions`.
- **Docs**: `docs/researcher/elements.md` image example gains `altText` +
  decorative guidance.

## Design note — why the lint is *not* a schema `superRefine`

An earlier revision emitted the warning from the `treatmentFileSchema`
`superRefine`. That's wrong for a warning: **any** superRefine issue flips
`safeParse` to `success: false`, and consumers that gate on the success boolean
rather than reading `params.severity` — VS Code "Preview Stage" (via
`parseTreatmentSource`), the viewer example catalog, and the external
manager/runner/annotator — would treat a common, harmless input (an un-annotated
image) as a **blocking** schema failure.

So the lint stays out of the schema (success/failure contract remains "errors
only") and rides the **separate post-validation channel** instead — like the
consent i18n-completeness warning (#529). Both diagnostic surfaces return
*diagnostics* (never a pass/fail boolean), so a `warning` never blocks:

- **`validateTreatmentSource`** appends it after the schema pass. That's the one
  chokepoint the CLI (raw source *and* the expanded YAML via `expandAndValidate`)
  and the VS Code **expanded preview** all share — wiring it here covers every
  non-inline surface at once, positioned via the same mapper.
- **`validateTreatmentDiff`** runs it over the *un-expanded source* object for
  the **inline editor** squiggle (that path doesn't go through
  `validateTreatmentSource`).

A template-authored image is linted once it expands into a concrete stage (CLI /
expanded preview); the walker deliberately doesn't scan raw `templates:` bodies
(it would mis-position on `${placeholder}` partials), mirroring
`collectStorageKeyCollisions`.

## Testing (TDD)

- Walker unit tests (absent → warn; `""`/authored → silent; non-image ignored;
  all container types scanned).
- Schema: `altText` accepted, `width` accepted incl. the `100` boundary;
  `0`/`150` and a `${field}` placeholder rejected.
- **Regression guard for the correctness fix**: a missing-`altText` image is
  *not* a schema failure (`safeParseTreatmentFile` succeeds; the schema pass is
  silent).
- Lint asserted through **both** surfaces: CLI (incl. a template-expanded image;
  warning + exit 0) and the editor diff (incl. the precise element-line
  position).
- Component + router render `<img alt>`.

Full vitest (stagebook / viewer / vscode), lint, prettier, and
`validate:examples` are green. Reviewed by correctness / test-coverage /
security subagents before opening; the correctness HIGH finding above was found
and fixed pre-PR.

Fixes #536, fixes #537
Refs #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)
