### PR TITLE
test(a11y): axe per-component regression gate (#20)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "stagebook",
+  "name": "feat+20-a11y-gate",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -1103,6 +1103,19 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@azu/format-text": {
       "version": "1.0.2",
@@ -4263,6 +4276,16 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/azure-devops-node-api": {
       "version": "12.5.0",
@@ -13392,7 +13415,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.22.0",
+      "version": "0.23.0",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",
@@ -13406,6 +13429,7 @@
         "stagebook": "bin/stagebook.js"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@hello-pangea/dnd": "^18.0.1",
         "@playwright/experimental-ct-react": "^1.58.2",
         "@types/js-yaml": "^4.0.9",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -117,6 +117,7 @@
     }
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@hello-pangea/dnd": "^18.0.1",
     "@playwright/experimental-ct-react": "^1.58.2",
     "@types/js-yaml": "^4.0.9",

--- a/packages/stagebook/src/components/a11y.gate.ct.tsx
+++ b/packages/stagebook/src/components/a11y.gate.ct.tsx
@@ -1,0 +1,237 @@
+// Accessibility regression gate (issue #20).
+//
+// Mounts each participant-facing component in its correctly-used form and
+// asserts zero axe-core violations at the WCAG 2.2 AA ruleset the project
+// committed to (docs/decisions/2026-07-accessibility.md).
+//
+// This is the permanent successor to the one-off audit harness: it stays
+// GREEN, so a future regression — a contrast-token drift, a dropped
+// `aria-labelledby`, an unnamed control — turns it red. Co-locating a
+// per-component assertion inside each `*.ct.tsx` is a possible future
+// refinement; a single gate is the low-friction starting form.
+import { test, expect } from "@playwright/experimental-ct-react";
+import AxeBuilder from "@axe-core/playwright";
+import type { ReactNode } from "react";
+import type { MetadataType } from "../schemas/promptFile";
+
+import { RadioGroup } from "./form/RadioGroup";
+import { CheckboxGroup } from "./form/CheckboxGroup";
+import { Select } from "./form/Select";
+import { TextArea } from "./form/TextArea";
+import { Slider } from "./form/Slider";
+import { Button } from "./form/Button";
+import { Markdown } from "./form/Markdown";
+import { Separator } from "./form/Separator";
+import { MockListSorter } from "./testing/MockListSorter";
+import { MockKitchenTimer } from "./testing/MockKitchenTimer";
+import { Prompt } from "./elements/Prompt";
+import { Display } from "./elements/Display";
+import { SubmitButton } from "./elements/SubmitButton";
+import { ImageElement } from "./elements/ImageElement";
+import { TrackedLink } from "./elements/TrackedLink";
+import {
+  multipleChoiceSingle,
+  multipleChoiceMultiple,
+  openResponse,
+  slider as sliderPrompt,
+  listSorter as listSorterPrompt,
+} from "./elements/fixtures/prompts";
+
+// WCAG 2.2 AA = 2.0/2.1/2.2 at levels A and AA.
+const WCAG_22_AA = [
+  "wcag2a",
+  "wcag2aa",
+  "wcag21a",
+  "wcag21aa",
+  "wcag22a",
+  "wcag22aa",
+];
+
+const options = [
+  { key: "a", value: "Option A" },
+  { key: "b", value: "Option B" },
+  { key: "c", value: "Option C" },
+];
+
+// 1×1 transparent PNG.
+const testImage =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==";
+
+const promptProps = {
+  progressLabel: "game_0_gate",
+  save: () => {},
+  getElapsedTime: () => 0,
+};
+
+const dropdownPrompt = {
+  metadata: {
+    name: "projects/example/dropdown.md",
+    type: "dropdown",
+  } as MetadataType,
+  body: "# Choose your favorite\n\nPick one from the list.",
+  responseItems: ["Alpha", "Bravo", "Charlie"],
+  responsePoints: [],
+  sliderPoints: [],
+};
+
+// Each case is a participant-facing component in its correctly-used (named,
+// themed) form. The gate asserts none of them produce WCAG 2.2 AA violations.
+const cases: { name: string; node: ReactNode }[] = [
+  {
+    name: "RadioGroup",
+    node: <RadioGroup options={options} onChange={() => {}} label="Pick one" />,
+  },
+  {
+    name: "CheckboxGroup",
+    node: (
+      <CheckboxGroup
+        options={options}
+        value={["a"]}
+        onChange={() => {}}
+        label="Select all"
+      />
+    ),
+  },
+  {
+    name: "Select",
+    node: (
+      <Select options={options} onChange={() => {}} label="Choose an option" />
+    ),
+  },
+  {
+    name: "TextArea",
+    node: <TextArea value="Some typed response" ariaLabel="Your answer" />,
+  },
+  {
+    name: "Slider (anchored)",
+    node: <Slider min={0} max={100} interval={1} value={50} />,
+  },
+  {
+    name: "Slider (unanchored)",
+    node: <Slider min={0} max={100} interval={1} />,
+  },
+  { name: "Button", node: <Button>Continue</Button> },
+  {
+    name: "SubmitButton",
+    node: (
+      <SubmitButton
+        onSubmit={() => {}}
+        name="submit"
+        save={() => {}}
+        getElapsedTime={() => 0}
+      />
+    ),
+  },
+  {
+    name: "ImageElement",
+    node: <ImageElement src={testImage} alt="A small test image" />,
+  },
+  {
+    name: "TrackedLink",
+    node: (
+      <TrackedLink
+        name="link"
+        url="https://example.org/form"
+        displayText="Open the linked form"
+        save={() => {}}
+        getElapsedTime={() => 0}
+        progressLabel="game_0_gate"
+      />
+    ),
+  },
+  {
+    name: "KitchenTimer",
+    node: <MockKitchenTimer startTime={0} endTime={60} elapsedTime={0} />,
+  },
+  {
+    name: "ListSorter",
+    node: <MockListSorter items={["Alpha", "Bravo", "Charlie", "Delta"]} />,
+  },
+  {
+    name: "Markdown",
+    node: (
+      <Markdown
+        text={"Some **bold** text and a [link](https://example.org)."}
+      />
+    ),
+  },
+  { name: "Separator", node: <Separator /> },
+  {
+    name: "Display",
+    node: <Display reference="prompt.q1" values={["A displayed answer"]} />,
+  },
+  {
+    name: "Prompt: multiple choice (single)",
+    node: (
+      <Prompt
+        {...multipleChoiceSingle}
+        {...promptProps}
+        name="mcSingle"
+        value={undefined}
+      />
+    ),
+  },
+  {
+    name: "Prompt: multiple choice (multiple)",
+    node: (
+      <Prompt
+        {...multipleChoiceMultiple}
+        {...promptProps}
+        name="mcMulti"
+        value={[]}
+      />
+    ),
+  },
+  {
+    name: "Prompt: open response",
+    node: <Prompt {...openResponse} {...promptProps} name="open" value="" />,
+  },
+  {
+    name: "Prompt: slider",
+    node: (
+      <Prompt {...sliderPrompt} {...promptProps} name="slider" value={50} />
+    ),
+  },
+  {
+    name: "Prompt: list sorter",
+    node: (
+      <Prompt
+        {...listSorterPrompt}
+        {...promptProps}
+        name="sorter"
+        value={undefined}
+      />
+    ),
+  },
+  {
+    name: "Prompt: dropdown",
+    node: (
+      <Prompt
+        {...dropdownPrompt}
+        {...promptProps}
+        name="dropdown"
+        value={undefined}
+      />
+    ),
+  },
+];
+
+for (const c of cases) {
+  test(`a11y: ${c.name}`, async ({ mount, page }) => {
+    await mount(c.node);
+    const results = await new AxeBuilder({ page })
+      .include("#root")
+      .withTags(WCAG_22_AA)
+      .analyze();
+
+    expect(
+      results.violations.map(
+        (v) =>
+          `${v.id}(${v.impact}) @ ${v.nodes
+            .map((n) => n.target.join(" "))
+            .join(", ")}`,
+      ),
+      `${c.name} WCAG 2.2 AA violations`,
+    ).toEqual([]);
+  });
+}


### PR DESCRIPTION
Stands up the permanent accessibility **regression gate** — the ADR's
testing-strategy deliverable (#20).

## What

- `packages/stagebook/src/components/a11y.gate.ct.tsx` — mounts each
  participant-facing component in its correctly-used form and asserts **zero
  axe-core violations at WCAG 2.2 AA**. Runs in CI via the existing `test:ct`
  (all three browsers).
- Adds `@axe-core/playwright` (devDependency; **not shipped** — axe never loads
  in a participant session).

## Why now

The five component fixes have landed — #546 (dropdown `select-name`), #547
(TextArea labels), #548 (AA-by-construction colors), #549 (image `alt` + width).
Re-running the audit against `main` confirms **21/21 participant-facing cases now
pass** at 2.2 AA. This gate locks that in: a future contrast-token drift or a
dropped `aria-labelledby` turns it red.

## Scope

- Component library only (the audit's scope). `Timeline` / `MediaPlayer` and the
  viewer / VS Code surfaces remain deferred under #20.
- Co-locating a per-component assertion inside each `*.ct.tsx` is a possible
  future refinement; a single gate is the low-friction starting form.

Refs #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
