### PR TITLE
Bump stagebook to 0.24.0

### DIFF
--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Minor release: an end-to-end accessibility pass on the participant-facing component library, targeting WCAG 2.2 AA.

## What's in

- **#548** — Deliberate, **AA-by-construction color system**. Default theme tokens are now contrast-validated at WCAG 2.2 AA (fixes low-contrast Button / SubmitButton / TrackedLink). Deployments on the default palette pick up the updated colors automatically.
- **#549** — Images are now **describable by authors**: the `image` element accepts an `altText` field (rendered as `<img alt>`), with a validator warning when it's missing on a non-decorative image. Also fixes a schema bug where the documented `width` field was erroneously rejected by the validator.
- **#547** — Exported `TextArea` gains `label` / `ariaLabel` / `ariaLabelledBy` props, so hosts embedding it standalone can give it an accessible name.
- **#546** — The dropdown `Prompt` variant now gives its `<select>` an accessible name (`aria-labelledby` to the prompt body).
- **#551** — New **axe per-component regression gate** in CI — every participant-facing component is asserted clean at WCAG 2.2 AA across chromium / firefox / webkit.
- **#540** — Researcher keyboard shortcuts in the viewer (Alt/Option namespace).
- **#539 / #541 / #555** — Accessibility ADR (WCAG 2.2 AA target + integrity boundary), the component audit report, and a "how to ship an accessible component" checklist.

## Compatibility

- **No API breaks.** All changes are additive: a new optional `image.altText` field, new optional `TextArea` props, and `image.width` now validates (it was previously rejected in error).
- **Visual:** default theme colors shifted slightly to meet AA contrast. Deployments relying on the exact prior default token values will see the updated (more accessible) colors — override the `--stagebook-*` tokens to pin your own palette.
