### PR TITLE
feat(vscode): derive the extension version from the stagebook version

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -33,6 +33,10 @@ Note: prior versions are not strictly sequential — `0.10.2` was skipped. Don't
 git checkout main && git pull origin main
 git checkout -b release/X.Y.Z
 # edit packages/stagebook/package.json: bump "version" field only
+# Mirror the version onto the VS Code extension so the installed extension
+# reports which stagebook it bundles (#562). This is derived, not typed:
+node scripts/sync-vscode-version.mjs   # sets apps/vscode/package.json to X.Y.Z
+npm install --package-lock-only        # reflect both bumps in the lockfile
 git commit -am "chore(release): bump stagebook to X.Y.Z
 
 <release notes — same shape as the PR body in step 3>
@@ -41,7 +45,7 @@ Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>"
 git push -u origin release/X.Y.Z
 ```
 
-The commit subject must follow the format `chore(release): bump stagebook to X.Y.Z` — the GitHub Action keys off this.
+The commit subject must follow the format `chore(release): bump stagebook to X.Y.Z` — the GitHub Action keys off this. The diff is version bumps only (stagebook + the derived extension version + the lockfile) — still no code to review.
 
 ## 3. Open the release PR
 
@@ -88,7 +92,7 @@ gh pr merge <PR#> --squash
 
 Run the `until` loop via Bash's `run_in_background: true` so the user isn't blocked.
 
-Auto-merge (when available) is safe **only** for release PRs (single-line version bump on a `release/X.Y.Z` branch, no other changes). If the PR diff touches anything else, do not auto-merge — wait for the user. The merge style is `--squash` to match the project convention (recent main has the squash-style `<message> (#N)` commits).
+Auto-merge (when available) is safe **only** for release PRs (version bumps on a `release/X.Y.Z` branch — `packages/stagebook/package.json`, the derived `apps/vscode/package.json` from `sync-vscode-version.mjs`, and the lockfile — with no other changes). If the PR diff touches anything beyond those version fields, do not auto-merge — wait for the user. The merge style is `--squash` to match the project convention (recent main has the squash-style `<message> (#N)` commits).
 
 If the user is around, you can either merge automatically (auto or poll-then-merge) and notify them, or wait for them to merge manually — their call. If they're away, proceed automatically.
 
@@ -141,4 +145,5 @@ gh issue close <NNN> --comment "Fixed in #<PR> (released as [v<X.Y.Z>](https://g
 - Don't run `npm publish` manually — the GH Action owns this. Manual publish would race with the Action and may use the wrong credentials.
 - Don't skip the `chore(release):` prefix on the bump commit — automation may rely on it.
 - Don't infer the version from `git tag` alone — check `packages/stagebook/package.json` since the tag sequence has gaps (0.10.2 skipped).
-- Don't use `gh pr merge --auto` for anything other than a release PR. Auto-merge is safe here because the diff is a single-line version bump with no code; for normal PRs the user reviews and merges.
+- Don't use `gh pr merge --auto` for anything other than a release PR. Auto-merge is safe here because the diff is version bumps only (stagebook + the derived extension version + lockfile) with no code; for normal PRs the user reviews and merges.
+- Don't hand-edit `apps/vscode/package.json`'s version — it's derived from stagebook by `scripts/sync-vscode-version.mjs` (#562). Run that script, don't type a number.

--- a/.github/workflows/release-vscode.yml
+++ b/.github/workflows/release-vscode.yml
@@ -7,9 +7,10 @@ name: Release VS Code Extension
 #
 # Two assets are uploaded per release:
 #   - stagebook-vscode-<tag>.vsix — named for the release tag, so each
-#     release has a distinct archival artifact (the extension's own
-#     package.json version is decoupled from the library release and does
-#     not advance, so the tag is what makes the name unique).
+#     release has a distinct archival artifact. The extension's own
+#     package.json version is derived from the stagebook version at package
+#     time (the `prepackage` → sync-vscode-version.mjs hook, #562), so it
+#     matches the tag; the tag-named copy is kept for a stable archival name.
 #   - stagebook-vscode.vsix — stable name, so
 #     https://github.com/talkbench/stagebook/releases/latest/download/stagebook-vscode.vsix
 #     always resolves to the newest release. Install with:

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "stagebook-vscode",
   "displayName": "Stagebook",
   "description": "Validation, syntax highlighting, and preview for Stagebook treatment and prompt files",
-  "version": "0.1.2",
+  "version": "0.24.0",
   "publisher": "talkbench",
   "private": true,
   "license": "MIT",
@@ -133,6 +133,7 @@
     "build:watch:extension": "npm run build:extension -- --watch",
     "build:watch:webview": "npm run build:webview -- --watch",
     "vscode:prepublish": "npm run build --prefix ../../packages/stagebook && npm run build:production",
+    "prepackage": "node ../../scripts/sync-vscode-version.mjs",
     "package": "vsce package --no-dependencies",
     "lint": "echo 'no linter configured yet'",
     "test": "vitest run"

--- a/apps/vscode/src/versionSync.test.ts
+++ b/apps/vscode/src/versionSync.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// The extension version mirrors the bundled stagebook version so the installed
+// extension reports which stagebook it previews against (#562). It's derived at
+// build time by scripts/sync-vscode-version.mjs (apps/vscode's `prepackage`
+// hook), so every built vsix is correct regardless of the committed value — but
+// this guards the committed values from drifting apart on a stagebook bump
+// (asserting major.minor, which is the compatibility-meaningful part; the sync
+// makes them exact).
+const root = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const version = (p: string): string =>
+  JSON.parse(readFileSync(join(root, p), "utf8")).version as string;
+const majorMinor = (v: string): string => v.split(".").slice(0, 2).join(".");
+
+describe("extension version tracks stagebook (#562)", () => {
+  it("mirrors the stagebook major.minor", () => {
+    const lib = version("packages/stagebook/package.json");
+    const ext = version("apps/vscode/package.json");
+    expect(majorMinor(ext)).toBe(majorMinor(lib));
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -297,7 +297,7 @@
     },
     "apps/vscode": {
       "name": "stagebook-vscode",
-      "version": "0.1.2",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "react": "^19.2.4",

--- a/scripts/sync-vscode-version.mjs
+++ b/scripts/sync-vscode-version.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// Derive the VS Code extension's version from the stagebook library version, so
+// the installed extension's version reflects the stagebook it bundles (#562).
+//
+// The extension only ships alongside a stagebook release (release-vscode.yml
+// fires on `release: published`), so its version should equal the library's —
+// then "which stagebook am I previewing against?" and "is my extension current?"
+// are answerable from the Extensions panel. A hand-maintained number is the same
+// drift trap the design-token copy was (#560), so this is derived, never typed.
+//
+// Runs as apps/vscode's `prepackage` hook (before `vsce package`), so every
+// built/released vsix carries the stagebook version. Idempotent: a no-op when
+// already in sync (so a local `npm run package` doesn't dirty the tree).
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const libPath = join(root, "packages", "stagebook", "package.json");
+const extPath = join(root, "apps", "vscode", "package.json");
+
+const libVersion = JSON.parse(readFileSync(libPath, "utf8")).version;
+const extRaw = readFileSync(extPath, "utf8");
+const extVersion = JSON.parse(extRaw).version;
+
+if (extVersion === libVersion) {
+  console.log(
+    `stagebook-vscode version already ${libVersion} (matches stagebook) — no change`,
+  );
+  process.exit(0);
+}
+
+// Replace only the first `"version": "…"` (the package version — `engines`
+// uses `"vscode":`, not `"version":`) so the file's formatting is preserved.
+const updated = extRaw.replace(/("version":\s*")[^"]*(")/, `$1${libVersion}$2`);
+if (updated === extRaw) {
+  console.error("sync-vscode-version: could not find the version field to update");
+  process.exit(1);
+}
+writeFileSync(extPath, updated);
+console.log(
+  `stagebook-vscode version ${extVersion} -> ${libVersion} (matched to stagebook)`,
+);


### PR DESCRIPTION
## Summary

Closes the "which build am I running?" tail of the #559/#560/#561 preview-drift saga. The VS Code extension previews against the stagebook it bundles, but its version was independent (`0.1.x`) — so "which stagebook is this?" and "is my extension current?" had no answer, and a frozen `0.1.0` is what let a stale build linger unnoticed.

`Fixes #562`

## What changed

**Derive the version, never type it** (a hand-maintained number is the same drift trap the design-token copy was in #560):

- **`scripts/sync-vscode-version.mjs`** — sets `apps/vscode/package.json`'s version to the `packages/stagebook` version. Idempotent (no-op when equal); fail-closed (aborts if it can't find the field).
- **`prepackage` hook** — runs it before every `vsce package`, so both a local `npm run package` and the `release-vscode.yml` CI job emit a vsix whose version mirrors stagebook.
- **`versionSync.test.ts`** — guards the committed values from drifting a minor.
- **`cut-release` skill** — the release bump now runs the sync + `npm install --package-lock-only`, kept as a version-only, auto-mergeable diff; "don't hand-edit the extension version" guard added.
- **`release-vscode.yml`** — corrected the now-false "version does not advance" comment.

Because the extension only ships alongside a stagebook release (`release-vscode.yml` fires on `release: published`), exact-match is the natural result; major/minor is the compatibility-meaningful part.

## Verified end-to-end
Forced the extension version to `0.1.2`, ran `npm run package` → `prepackage` re-synced to `0.24.0` and vsce emitted `stagebook-vscode-0.24.0.vsix`. So `vsce` reads the version **after** `prepackage`. Also confirmed: idempotent no-op leaves the tree clean; the drift-guard test fails on a minor mismatch; the release flow is a closed loop (`npm ci` + `versionSync` both fail-closed if the sync is skipped).

## Effect
Cutting stagebook `0.25.0` now automatically ships the extension as `0.25.0` — the Extensions panel answers "which stagebook / am I current?" at a glance. No chrome, no manual step. (Deliberately did **not** add an in-preview version stamp — the panel + version-tying covers it; see #562 for that decision.)

## Review
Pre-PR correctness review: sound, no defects (script regex/fail-path, cwd-independent path resolution, CI/release-flow interaction all verified empirically). Security surface is negligible — a build script that rewrites one version field, no runtime/participant/auth surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)