### PR TITLE
Bump stagebook to 0.24.1

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "stagebook-vscode",
   "displayName": "Stagebook",
   "description": "Validation, syntax highlighting, and preview for Stagebook treatment and prompt files",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "publisher": "talkbench",
   "private": true,
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -297,7 +297,7 @@
     },
     "apps/vscode": {
       "name": "stagebook-vscode",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "license": "MIT",
       "dependencies": {
         "react": "^19.2.4",
@@ -13415,7 +13415,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.24.0",
+      "version": "0.24.1",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Patch release picking up the color-system follow-through, preview fixes, and VS Code extension tooling since v0.24.0.

## What's in

- **#559** — Timeline selections no longer vanish on a stage reload (the saved-selection read was missing the `self.` reference prefix mandatory after #298). Also corrects the retired blue-500 that lingered in viewer chrome and the VS Code preview after the #535 palette bump, with drift guards.
- **#561** — The VS Code preview now renders from the library's real `styles.css` instead of a hand-copied token block, so it can't drift from what participants see. Markdown inline/block code gets an explicit `color: inherit` so it renders in the study's text color on any host (previously bare `<code>` could pick up a host's `code` color, e.g. the VS Code webview's theme tint); code used as link text keeps the link color.
- **#563** — The VS Code extension version is now derived from the stagebook version, so the installed extension reports which stagebook it bundles. This release is the first to exercise it — the extension bumps to 0.24.1 too.

## Compatibility

- No API changes.
- Markdown code now sets an explicit text color (`inherit`) for host-independent rendering — a fix for consumers whose host ships a `code { color }` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)