### PR TITLE
feat(schemas): accept ${field} placeholders for discussion showTitle/showNickname

### DIFF
--- a/packages/stagebook/src/schemas/resolved.test.ts
+++ b/packages/stagebook/src/schemas/resolved.test.ts
@@ -252,6 +252,68 @@ describe("resolved schemas reject unresolved ${field} placeholders (#284)", () =
     }
   });
 
+  test("resolvedStageSchema rejects discussion.showTitle as a placeholder string (#565)", () => {
+    const stage = {
+      name: "stage1",
+      duration: 60,
+      discussion: {
+        chatType: "video",
+        showNickname: true,
+        showTitle: "${unboundShowTitle}",
+        rooms: [{ includePositions: [0, 1] }],
+      },
+      elements: [{ type: "submitButton" }],
+    };
+    const result = resolvedStageSchema.safeParse(stage);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.message.includes("unresolved"),
+      );
+      expect(issue).toBeDefined();
+      expect(issue?.path).toEqual(["discussion", "showTitle"]);
+    }
+  });
+
+  test("resolvedStageSchema rejects discussion.showNickname as a placeholder string (#565)", () => {
+    const stage = {
+      name: "stage1",
+      duration: 60,
+      discussion: {
+        chatType: "video",
+        showNickname: "${unboundShowNickname}",
+        showTitle: true,
+        rooms: [{ includePositions: [0, 1] }],
+      },
+      elements: [{ type: "submitButton" }],
+    };
+    const result = resolvedStageSchema.safeParse(stage);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues.find((i) =>
+        i.message.includes("unresolved"),
+      );
+      expect(issue).toBeDefined();
+      expect(issue?.path).toEqual(["discussion", "showNickname"]);
+    }
+  });
+
+  test("resolvedStageSchema accepts discussion.showTitle as a literal boolean (no regression)", () => {
+    const stage = {
+      name: "stage1",
+      duration: 60,
+      discussion: {
+        chatType: "video",
+        showNickname: false,
+        showTitle: true,
+        rooms: [{ includePositions: [0, 1] }],
+      },
+      elements: [{ type: "submitButton" }],
+    };
+    const result = resolvedStageSchema.safeParse(stage);
+    expect(result.success).toBe(true);
+  });
+
   test("resolvedStageSchema accepts discussion.rooms as a literal array (no regression)", () => {
     const stage = {
       name: "stage1",

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -243,6 +243,20 @@ const resolvedDiscussionSchema = discussionSchema.superRefine((data, ctx) => {
       params: { reason: "unresolved-placeholder" },
     });
   }
+  // `showNickname` / `showTitle` accept a `${field}` placeholder pre-fill
+  // (#565). A string reaching the resolved shape means the template field was
+  // never bound — flag it instead of letting the widened `boolean | string`
+  // type carry a placeholder into a runtime component.
+  for (const flag of ["showNickname", "showTitle"] as const) {
+    if (typeof data[flag] === "string") {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [flag],
+        message: `discussion.${flag} is an unresolved \`${data[flag]}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
+        params: { reason: "unresolved-placeholder" },
+      });
+    }
+  }
   if (data.layout && typeof data.layout === "object") {
     for (const [seat, layoutDef] of Object.entries(data.layout)) {
       if (

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -2424,6 +2424,64 @@ test("discussion.layout.feeds accepts a ${field} placeholder (#284)", () => {
   expect(result.success).toBe(true);
 });
 
+test("discussion.showTitle accepts a ${field} placeholder pre-fill (#565)", () => {
+  // A single `treatment` template can vary the per-arm title-visibility
+  // manipulation by binding showTitle to a broadcast-row field. The pre-fill
+  // schema accepts the placeholder string; the boolean arrives at fill time.
+  const result = discussionSchema.safeParse({
+    chatType: "video",
+    showNickname: true,
+    showTitle: "${showTitle}",
+    rooms: [{ includePositions: [0, 1] }],
+  });
+  expect(result.success).toBe(true);
+});
+
+test("discussion.showNickname accepts a ${field} placeholder pre-fill (#565)", () => {
+  const result = discussionSchema.safeParse({
+    chatType: "video",
+    showNickname: "${showNickname}",
+    showTitle: true,
+    rooms: [{ includePositions: [0, 1] }],
+  });
+  expect(result.success).toBe(true);
+});
+
+test("discussion.showTitle still accepts a literal boolean (no regression)", () => {
+  const result = discussionSchema.safeParse({
+    chatType: "video",
+    showNickname: true,
+    showTitle: false,
+    rooms: [{ includePositions: [0, 1] }],
+  });
+  expect(result.success).toBe(true);
+});
+
+test("discussion.showTitle rejects a non-placeholder string (#565)", () => {
+  // A plain string that doesn't match the ${...} pattern must be rejected —
+  // accepting it would let typos like `showTitle: "yes"` (or a stringified
+  // "true") slip through pre-fill validation.
+  const result = discussionSchema.safeParse({
+    chatType: "video",
+    showNickname: true,
+    showTitle: "yes",
+    rooms: [{ includePositions: [0, 1] }],
+  });
+  expect(result.success).toBe(false);
+});
+
+test("discussion.showNickname rejects a non-placeholder string (#565)", () => {
+  // Same typo protection as showTitle — the two flags share the placeholder
+  // escape hatch, so both must reject a bare non-placeholder string.
+  const result = discussionSchema.safeParse({
+    chatType: "video",
+    showNickname: "yes",
+    showTitle: true,
+    rooms: [{ includePositions: [0, 1] }],
+  });
+  expect(result.success).toBe(false);
+});
+
 test("conditions.all accepts a ${field} placeholder (#284)", () => {
   const result = conditionsSchema.safeParse({
     all: "${ruleSet}",
@@ -2573,6 +2631,89 @@ test("end-to-end: rooms placeholder resolves through fillTemplates and re-valida
   // produced strict, placeholder-free values.
   const filledTreatments = (result as { treatments: unknown[] }).treatments;
   for (const t of filledTreatments) {
+    const resolved = resolvedTreatmentSchema.safeParse(t);
+    expect(resolved.success).toBe(true);
+  }
+});
+
+test("end-to-end: showTitle boolean placeholder resolves through fillTemplates to a real boolean and re-validates (#565)", () => {
+  const templates = [
+    {
+      name: "sessionTreatment",
+      contentType: "treatment",
+      content: {
+        name: "session_${sessionType}",
+        playerCount: 2,
+        compatibleIntroSequences: [],
+        gameStages: [
+          {
+            name: "discuss_${sessionType}",
+            duration: 180,
+            discussion: {
+              chatType: "video",
+              showNickname: "${showNickname}",
+              showTitle: "${showTitle}",
+              rooms: [{ includePositions: [0, 1] }],
+            },
+            elements: [{ type: "submitButton" }],
+          },
+        ],
+      },
+    },
+  ];
+
+  // Bind the two flags to OPPOSITE values per arm so the test proves each
+  // resolves independently and in both directions — and, critically, that a
+  // `false` binding lands as boolean `false` (a naive string substitution
+  // would leave the truthy string "false", inverting the manipulation).
+  const obj = {
+    treatments: [
+      {
+        template: "sessionTreatment",
+        broadcast: {
+          d0: [
+            { sessionType: "A", showTitle: true, showNickname: false },
+            { sessionType: "C", showTitle: false, showNickname: true },
+          ],
+        },
+      },
+    ],
+  };
+
+  // Pre-fill validation passes (placeholders accepted in both boolean slots).
+  const preFill = treatmentFileSchema.safeParse(obj);
+  expect(preFill.success).toBe(true);
+
+  // fillTemplates substitutes each broadcast row's boolean into the slot — the
+  // quoted placeholder `"${showTitle}"` becomes an unquoted JSON boolean, so
+  // it round-trips to a *real* boolean, not the string "true"/"false".
+  const filled = fillTemplates({ obj, templates });
+  const result: unknown = filled.result;
+  const treatments = (
+    result as {
+      treatments: {
+        gameStages: {
+          discussion: { showTitle: unknown; showNickname: unknown };
+        }[];
+      }[];
+    }
+  ).treatments;
+  expect(treatments).toHaveLength(2);
+
+  const d0 = treatments[0].gameStages[0].discussion;
+  const d1 = treatments[1].gameStages[0].discussion;
+  // Strict identity (`.toBe` is Object.is) — a stringified "true"/"false"
+  // would fail these, and the explicit typeof guards the intent.
+  expect(typeof d0.showTitle).toBe("boolean");
+  expect(typeof d0.showNickname).toBe("boolean");
+  expect(d0.showTitle).toBe(true);
+  expect(d0.showNickname).toBe(false);
+  expect(d1.showTitle).toBe(false);
+  expect(d1.showNickname).toBe(true);
+
+  // The resolved-shape schema is the safety net: each filled treatment must
+  // carry placeholder-free booleans.
+  for (const t of treatments) {
     const resolved = resolvedTreatmentSchema.safeParse(t);
     expect(resolved.success).toBe(true);
   }

--- a/packages/stagebook/src/schemas/treatment.test.ts
+++ b/packages/stagebook/src/schemas/treatment.test.ts
@@ -2482,6 +2482,39 @@ test("discussion.showNickname rejects a non-placeholder string (#565)", () => {
   expect(result.success).toBe(false);
 });
 
+// A boolean slot may ONLY carry a whole-field placeholder — the entire value
+// is `${field}` with nothing around it. A partial/embedded placeholder can
+// never resolve to a boolean and, worse, would silently fill to a truthy
+// string (`"${showTitle} "` bound to `false` → `"false "`), so it must be
+// rejected at pre-fill rather than caught downstream (#566 review).
+test.each([
+  ["trailing space", "${showTitle} "],
+  ["leading text", "show ${showTitle}"],
+  ["adjacent prefix", "pre${showTitle}"],
+  ["two placeholders", "${a}${b}"],
+])(
+  "discussion.showTitle rejects an embedded/partial placeholder (%s) (#566)",
+  (_label, value) => {
+    const result = discussionSchema.safeParse({
+      chatType: "video",
+      showNickname: true,
+      showTitle: value,
+      rooms: [{ includePositions: [0, 1] }],
+    });
+    expect(result.success).toBe(false);
+  },
+);
+
+test("discussion.showNickname rejects an embedded/partial placeholder (#566)", () => {
+  const result = discussionSchema.safeParse({
+    chatType: "video",
+    showNickname: "${showNickname} ",
+    showTitle: true,
+    rooms: [{ includePositions: [0, 1] }],
+  });
+  expect(result.success).toBe(false);
+});
+
 test("conditions.all accepts a ${field} placeholder (#284)", () => {
   const result = conditionsSchema.safeParse({
     all: "${ruleSet}",

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -460,8 +460,16 @@ const discussionRoomSchema = z
 export const discussionSchema = z
   .object({
     chatType: z.enum(["text", "audio", "video"]),
-    showNickname: z.boolean(),
-    showTitle: z.boolean(),
+    // `showNickname` / `showTitle` accept a `${field}` placeholder (#565) so a
+    // single `treatment` template can vary the per-arm nickname/title
+    // visibility manipulation via a broadcast-row field. Unlike the numeric
+    // slots (displayTime/startAt/width), booleans round-trip cleanly through
+    // fillTemplates — a quoted `"${field}"` is replaced by an unquoted JSON
+    // boolean, so the resolved value is a real boolean, not the string
+    // "true". `resolvedDiscussionSchema` in resolved.ts flags any placeholder
+    // that survives substitution (unbound field), matching `rooms`/`feeds`.
+    showNickname: z.boolean().or(fieldPlaceholderSchema),
+    showTitle: z.boolean().or(fieldPlaceholderSchema),
     showSelfView: z.boolean().optional().default(true),
     showReportMissing: z.boolean().optional().default(true),
     showAudioMute: z.boolean().optional().default(true),

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -59,6 +59,26 @@ const fieldPlaceholderSchema = z.string().regex(FIELD_PLACEHOLDER_PATTERN, {
     "Field placeholder must be in the format `${fieldKey}` (alphanumeric and underscores only)",
 });
 
+// Anchored variant: the ENTIRE value must be a single `${field}` placeholder,
+// with no surrounding text. Required by *scalar* slots whose bound value is a
+// boolean/number — where a substring placeholder can never resolve to the
+// target type and, worse, partially substitutes at fill time into a
+// plausible-but-wrong value. e.g. `showTitle: "${showTitle} "` bound to
+// `false` becomes the truthy string `"false "` with no surviving `${}` marker,
+// so `fillTemplates` reports nothing unresolved and only the resolved-shape
+// guard could catch it. Rejecting at pre-fill is stricter and fail-fast. The
+// *structured* slots (rooms/feeds/conditions) don't need this: their bound
+// value is an array, which the fill's scalar pass never touches, so an
+// embedded placeholder survives verbatim and is always flagged. (#566 review)
+const WHOLE_FIELD_PLACEHOLDER_PATTERN = /^\$\{[a-zA-Z0-9_]+\}$/;
+
+const wholeFieldPlaceholderSchema = z
+  .string()
+  .regex(WHOLE_FIELD_PLACEHOLDER_PATTERN, {
+    message:
+      "Field placeholder must be exactly `${fieldKey}` as the whole value (no surrounding text), with alphanumeric and underscores only",
+  });
+
 /**
  * True if `value` contains any `${field}` placeholder. Used by cross-field
  * refinements that should skip validation until templates are filled.
@@ -460,16 +480,20 @@ const discussionRoomSchema = z
 export const discussionSchema = z
   .object({
     chatType: z.enum(["text", "audio", "video"]),
-    // `showNickname` / `showTitle` accept a `${field}` placeholder (#565) so a
-    // single `treatment` template can vary the per-arm nickname/title
-    // visibility manipulation via a broadcast-row field. Unlike the numeric
-    // slots (displayTime/startAt/width), booleans round-trip cleanly through
-    // fillTemplates — a quoted `"${field}"` is replaced by an unquoted JSON
-    // boolean, so the resolved value is a real boolean, not the string
-    // "true". `resolvedDiscussionSchema` in resolved.ts flags any placeholder
-    // that survives substitution (unbound field), matching `rooms`/`feeds`.
-    showNickname: z.boolean().or(fieldPlaceholderSchema),
-    showTitle: z.boolean().or(fieldPlaceholderSchema),
+    // `showNickname` / `showTitle` accept a whole-field `${field}` placeholder
+    // (#565) so a single `treatment` template can vary the per-arm
+    // nickname/title visibility manipulation via a broadcast-row field. A bound
+    // boolean round-trips cleanly through fillTemplates — a quoted `"${field}"`
+    // is whole-value-replaced with an unquoted JSON boolean, so the resolved
+    // value is a real boolean, not the string "true"/"false". We use the
+    // *anchored* `wholeFieldPlaceholderSchema` (not the substring matcher) so a
+    // partial placeholder like `"${showTitle} "` — which would silently
+    // fill to the truthy string `"false "` — is rejected up front (#566
+    // review). `resolvedDiscussionSchema` in resolved.ts is the defense-in-depth
+    // guard for a whole-field placeholder that survives unbound, matching
+    // `rooms`/`feeds`.
+    showNickname: z.boolean().or(wholeFieldPlaceholderSchema),
+    showTitle: z.boolean().or(wholeFieldPlaceholderSchema),
     showSelfView: z.boolean().optional().default(true),
     showReportMissing: z.boolean().optional().default(true),
     showAudioMute: z.boolean().optional().default(true),


### PR DESCRIPTION
Fixes #565

## Problem

Binding a discussion display flag to a broadcast-row field failed validation:

```yaml
discussion:
  chatType: video
  showNickname: true
  showTitle: ${showTitle}   # ← Expected boolean, received string
```

```
Invalid content for contentType 'treatment': Expected boolean, received string
(templates[N].content.gameStages[0].discussion.showTitle)
```

Template definitions are validated against their declared `contentType` **before** expansion, so `showTitle`'s value is still the literal string `"${showTitle}"` at that point. `discussionSchema` declared `showTitle`/`showNickname` as bare `z.boolean()` with no `${field}` escape hatch — unlike `rooms`, `layout.feeds`, `conditions`, `displayTime`, etc., which opted into placeholders in #284.

This blocked the natural per-arm "show partner titles" / "show nicknames" manipulation from a single broadcast template (came up authoring a cross-partisan multiple-conversations study — arms A/B disclose party, arm C is blind).

## Fix

Mirrors the `rooms`/`layout.feeds` treatment exactly:

1. **`discussionSchema`** — `showTitle` / `showNickname` → `z.boolean().or(wholeFieldPlaceholderSchema)`. The placeholder schema is **anchored** (`/^${field}$/`), so only a whole-value placeholder is accepted; any embedded/partial form (`"${x} "`, `"pre${x}"`) is rejected at pre-fill (see Codex review below).
2. **`resolvedDiscussionSchema`** — defense-in-depth: flags a *surviving* whole-field `${…}` string (unbound field) with the friendly `unresolved-placeholder` error, matching the existing `rooms`/`feeds` guards.

**Why booleans are safe (and this isn't the numeric-placeholder gap):** booleans round-trip cleanly through `fillTemplates` — a quoted `"${showTitle}"` is whole-value-replaced with an unquoted JSON boolean, so a bound value resolves to a real `true`/`false`, **not** the truthy string `"true"`/`"false"`. The e2e test binds both flags to opposite values per arm (including a `false`) and asserts strict boolean identity to pin exactly this.

## Verification

- Full workspace **vitest** (`npm test`) — pass; **Playwright CT** (`test:ct:all`, 1872 across chromium/firefox/webkit) — pass; **lint** — clean.
- Local CLI (`stagebook validate`) against a realistic full study file: templated `showTitle` bound per-arm validates clean; unbound / non-placeholder string still errors (typo protection intact).

## Pre-PR review (3 subagents: correctness, coverage, security)

- **Correctness** — no blocking bug; round-trip confirmed for the standalone `"${field}"` case. Noted one **pre-existing, shared** quirk (below).
- **Test coverage** — safety nets present; added the missing showNickname typo-rejection test and folded showNickname into the e2e round-trip.
- **Security** — no auth/tenant/workspace-isolation surface touched; guard is reachable through the real `validateResolvedTreatmentFile` chain and gates the viewer render path.

## Codex review (both addressed)

1. **P2 — embedded placeholders in boolean slots** → **fixed** in `253c499`. The boolean slots are scalars, so `fillTemplates`' scalar pass would partially-substitute `showTitle: "${showTitle} "` (bound to `false`) into the truthy string `"false "` with no surviving `${}` marker. Introduced the anchored `wholeFieldPlaceholderSchema` so any partial form is rejected at pre-fill; verified at the CLI seam; regression tests added.
2. **P2 — runtime discussion type widened to `boolean | string`** → **tracked as #567** (not folded in). The runtime seam (`renderDiscussion` / `StageConfig` / viewer step model) reuses the authoring `DiscussionType`; the correct fix is an authoring-vs-resolved **type split** applied consistently (booleans **and** the pre-existing `rooms`/`feeds` widening), which cascades through the viewer and requires splitting `discussionSchema` into a base + `.strict().superRefine()` wrapper. Runtime is already guarded in-repo (the resolved-schema pass gates the viewer render path); #567 adds the compile-time guarantee for external hosts.

### Known limitation (pre-existing, not introduced here)

- **Blinding-integrity contract:** enforcement of "no surviving placeholder at runtime" depends on each external host running `validateResolvedTreatmentFile(filled)` **without** `skipUnresolved` before showing a study — the same contract the `rooms` field already relies on. #567 makes the *type* enforce it; until then, worth confirming the production runner/annotator invokes that check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
