### PR TITLE
feat(schemas): sweep resolved string slots for surviving ${field} placeholders

### DIFF
--- a/packages/stagebook/src/schemas/resolved.test.ts
+++ b/packages/stagebook/src/schemas/resolved.test.ts
@@ -569,6 +569,262 @@ describe("validateResolvedTreatmentFile (#398)", () => {
   });
 });
 
+// =====================================================================
+// #568 — resolved placeholder-leak sweep. Before this, a surviving
+// `${field}` in a *string-typed* slot (condition `value`, `buttonText`,
+// `url`, `displayText`, …) passed the resolved schema silently, because
+// `"${x}"` is a structurally valid string. A global scan now flags any
+// surviving `${…}` in any post-fill string, tagged `unresolved-placeholder`.
+// =====================================================================
+
+describe("resolved placeholder-leak sweep — string-typed slots (#568)", () => {
+  const base = {
+    treatments: [
+      {
+        name: "t",
+        playerCount: 1,
+        compatibleIntroSequences: [],
+        gameStages: [
+          {
+            name: "stage1",
+            duration: 60,
+            elements: [
+              { type: "prompt", file: "prompts/welcome.prompt.md" },
+              { type: "submitButton" },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+  const clone = () => JSON.parse(JSON.stringify(base)) as typeof base;
+
+  test("rejects a surviving `${field}` in a condition value", () => {
+    const tree = clone();
+    (tree.treatments[0].gameStages[0].elements[1] as Record<string, unknown>) =
+      {
+        type: "submitButton",
+        conditions: [
+          {
+            reference: "0.prompt.welcome.value",
+            comparator: "equals",
+            value: "${leak}",
+          },
+        ],
+      };
+    const result = validateResolvedTreatmentFile(tree);
+    expect(result.success).toBe(false);
+    const issue = result.issues.find(
+      (i) => i.reason === "unresolved-placeholder",
+    );
+    expect(issue).toBeDefined();
+    expect(issue?.message).toContain("unresolved");
+  });
+
+  test("rejects a surviving `${field}` in submitButton buttonText", () => {
+    const tree = clone();
+    (
+      tree.treatments[0].gameStages[0].elements[1] as Record<string, unknown>
+    ).buttonText = "${leak}";
+    const result = validateResolvedTreatmentFile(tree);
+    expect(result.success).toBe(false);
+    expect(
+      result.issues.some((i) => i.reason === "unresolved-placeholder"),
+    ).toBe(true);
+  });
+
+  test("rejects an embedded/partial placeholder in a string slot", () => {
+    const tree = clone();
+    (
+      tree.treatments[0].gameStages[0].elements[1] as Record<string, unknown>
+    ).buttonText = "Click ${leak} to continue";
+    const result = validateResolvedTreatmentFile(tree);
+    expect(result.success).toBe(false);
+    expect(
+      result.issues.some((i) => i.reason === "unresolved-placeholder"),
+    ).toBe(true);
+  });
+
+  test("skipUnresolved filters a leaked buttonText (authoring context)", () => {
+    const tree = clone();
+    (
+      tree.treatments[0].gameStages[0].elements[1] as Record<string, unknown>
+    ).buttonText = "${leak}";
+    const result = validateResolvedTreatmentFile(tree, {
+      skipUnresolved: true,
+    });
+    expect(result.success).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
+  test("does NOT flag a literal `$` that isn't a `${...}` placeholder", () => {
+    const tree = clone();
+    (
+      tree.treatments[0].gameStages[0].elements[1] as Record<string, unknown>
+    ).buttonText = "Pay $5 to continue";
+    const result = validateResolvedTreatmentFile(tree);
+    expect(result.success).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
+  test("deduped against per-field guards: a prompt.file leak reports once", () => {
+    // The prompt.file guard (resolvedElementSchema) and the global sweep both
+    // see the same leaked string at the same path — it must be reported once,
+    // preferring the guard's specific message.
+    const tree = clone();
+    (
+      tree.treatments[0].gameStages[0].elements[0] as Record<string, unknown>
+    ).file = "${unbound}";
+    const result = validateResolvedTreatmentFile(tree);
+    expect(result.success).toBe(false);
+    const leakIssues = result.issues.filter(
+      (i) =>
+        i.reason === "unresolved-placeholder" &&
+        JSON.stringify(i.path) ===
+          JSON.stringify([
+            "treatments",
+            0,
+            "gameStages",
+            0,
+            "elements",
+            0,
+            "file",
+          ]),
+    );
+    expect(leakIssues).toHaveLength(1);
+    // The guard's specific message wins, not the generic sweep message.
+    expect(leakIssues[0]?.message).toContain("prompt.file");
+  });
+
+  test("dedup vs a numeric-slot schema error: reported once, and NOT tagged unresolved-placeholder", () => {
+    // A numeric slot (`displayTime`) with a leaked `${x}` fails the resolved
+    // schema as "Expected number, received string" (reason undefined). The
+    // sweep sees the same string at the same path but must NOT add a second
+    // issue. Corollary: because the surviving issue isn't tagged, a numeric
+    // leak is NOT filtered by skipUnresolved (it hard-errors even in authoring
+    // — the pre-existing numeric-placeholder behavior, unchanged here).
+    const tree = clone();
+    (
+      tree.treatments[0].gameStages[0].elements[1] as Record<string, unknown>
+    ).displayTime = "${x}";
+    const path = JSON.stringify([
+      "treatments",
+      0,
+      "gameStages",
+      0,
+      "elements",
+      1,
+      "displayTime",
+    ]);
+    const result = validateResolvedTreatmentFile(tree);
+    expect(result.success).toBe(false);
+    const atPath = result.issues.filter((i) => JSON.stringify(i.path) === path);
+    expect(atPath).toHaveLength(1);
+    expect(atPath[0]?.reason).toBeUndefined();
+
+    // skipUnresolved does NOT filter it (untagged), so it still errors.
+    const skipped = validateResolvedTreatmentFile(tree, {
+      skipUnresolved: true,
+    });
+    expect(skipped.success).toBe(false);
+  });
+
+  test("catches a leak nested in urlParams[].value (recursive walk into array-of-objects)", () => {
+    const tree = clone();
+    (tree.treatments[0].gameStages[0].elements[1] as Record<string, unknown>) =
+      {
+        type: "qualtrics",
+        url: "https://survey.example.com/s",
+        urlParams: [
+          { key: "ok", value: "literal" },
+          { key: "pid", value: "${leak}" },
+        ],
+      };
+    const result = validateResolvedTreatmentFile(tree);
+    expect(result.success).toBe(false);
+    const issue = result.issues.find(
+      (i) =>
+        i.reason === "unresolved-placeholder" &&
+        JSON.stringify(i.path) ===
+          JSON.stringify([
+            "treatments",
+            0,
+            "gameStages",
+            0,
+            "elements",
+            1,
+            "urlParams",
+            1,
+            "value",
+          ]),
+    );
+    expect(issue).toBeDefined();
+  });
+
+  test("catches a leak nested in a condition operator tree (all: [...])", () => {
+    const tree = clone();
+    (
+      tree.treatments[0].gameStages[0].elements[1] as Record<string, unknown>
+    ).conditions = {
+      all: [
+        {
+          reference: "0.prompt.welcome.value",
+          comparator: "equals",
+          value: "${leak}",
+        },
+      ],
+    };
+    const result = validateResolvedTreatmentFile(tree);
+    expect(result.success).toBe(false);
+    const issue = result.issues.find(
+      (i) =>
+        i.reason === "unresolved-placeholder" &&
+        JSON.stringify(i.path) ===
+          JSON.stringify([
+            "treatments",
+            0,
+            "gameStages",
+            0,
+            "elements",
+            1,
+            "conditions",
+            "all",
+            0,
+            "value",
+          ]),
+    );
+    expect(issue).toBeDefined();
+  });
+
+  test("does NOT flag a non-identifier `${...}` body (matches fillTemplates grammar)", () => {
+    // `${form.id}` (dot body) is never substituted by fillTemplates (narrow
+    // identifier grammar), so it's a literal string, not a leak. Using the
+    // loose `${...}` regex here would falsely reject a previously-valid study
+    // (#568 review).
+    const tree = clone();
+    (
+      tree.treatments[0].gameStages[0].elements[1] as Record<string, unknown>
+    ).buttonText = "Submit ${form.id}";
+    const result = validateResolvedTreatmentFile(tree);
+    expect(result.success).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+
+  test("does NOT scan the file-level templates: block (definitions keep placeholders)", () => {
+    // A not-yet-stripped `templates:` block legitimately contains `${field}`
+    // placeholders; the resolved schema tolerates it (`z.unknown()`), so the
+    // sweep must skip it rather than false-positive on every definition
+    // (#568 review).
+    const tree = clone() as Record<string, unknown>;
+    tree.templates = [
+      { name: "greeting", content: { buttonText: "${unbound}" } },
+    ];
+    const result = validateResolvedTreatmentFile(tree);
+    expect(result.success).toBe(true);
+    expect(result.issues).toEqual([]);
+  });
+});
+
 describe("resolvedTreatmentFileSchema schema is exported", () => {
   // Quick sanity check that the new schema is wired through the
   // module's exports (matches the test in promptFile.test for

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -32,6 +32,62 @@ import {
 // literal by the time we reach the post-fill schema.
 const FIELD_PLACEHOLDER_RE = /\$\{[^}]*\}/;
 
+// The sweep uses the NARROW placeholder grammar (identifier bodies only),
+// matching `fillTemplates` (FIELD_PLACEHOLDER_REGEX in templates/). A leak is
+// specifically an `${identifier}` that fillTemplates WOULD have substituted but
+// didn't (unbound field). A literal like `buttonText: "${form.id}"` (dot body)
+// is never a fill placeholder, so it must NOT be flagged (#568 review).
+const SWEEP_PLACEHOLDER_RE = /\$\{[a-zA-Z0-9_]+\}/;
+
+// #568 — resolved placeholder-leak sweep. The per-field resolved guards
+// (prompt.file, rooms/feeds, showTitle/showNickname) only cover slots
+// someone explicitly checked, and slots whose resolved type is a
+// number/array reject a surviving `"${x}"` by type mismatch. But
+// *string-typed* slots — condition `value` (equals/includes/matches),
+// element `url`/`displayText`/`reference`/`helperText`/`buttonText`/
+// `altText`/`surveyName`, `urlParams[].value` — accept `"${x}"` as a
+// structurally valid string and let it through silently, so at runtime a
+// condition compares against the literal `"${x}"` and never matches, or a
+// truthy string inverts a flag. This walks the whole filled tree and
+// reports any surviving `${…}` in any string, tagged
+// `unresolved-placeholder` (so `skipUnresolved` still filters it in
+// authoring contexts). Mirrors the annotator's hand-rolled global scan
+// (`resolveTask`); see the sweep issue. Findings are deduped against the
+// per-field guards in `validateResolvedTreatmentFile` so a leak is
+// reported once, preferring the guard's more specific message.
+function collectPlaceholderLeaks(
+  node: unknown,
+  path: (string | number)[],
+  out: { path: (string | number)[]; token: string }[],
+): void {
+  if (typeof node === "string") {
+    const match = SWEEP_PLACEHOLDER_RE.exec(node);
+    if (match) out.push({ path, token: match[0] });
+    return;
+  }
+  if (Array.isArray(node)) {
+    node.forEach((item, index) =>
+      collectPlaceholderLeaks(item, [...path, index], out),
+    );
+    return;
+  }
+  if (node && typeof node === "object") {
+    for (const [key, value] of Object.entries(node)) {
+      // Skip the file-level `templates:` / `imports:` blocks. Template
+      // definitions are a lookup table (not runtime content) and legitimately
+      // contain `${field}` placeholders; the resolved schema tolerates a
+      // not-yet-stripped tree (`templates: z.unknown()`), so the sweep must
+      // too, or it false-positives on every placeholder in a definition
+      // (#568 review). Only skipped at the top level (path.length === 0) —
+      // no nested runtime object carries these keys.
+      if (path.length === 0 && (key === "templates" || key === "imports")) {
+        continue;
+      }
+      collectPlaceholderLeaks(value, [...path, key], out);
+    }
+  }
+}
+
 // ----------------------------------------------------------------
 // Resolved condition — no template placeholders in values
 // ----------------------------------------------------------------
@@ -523,20 +579,44 @@ export function validateResolvedTreatmentFile(
   issues: ValidateResolvedIssue[];
 } {
   const result = resolvedTreatmentFileSchema.safeParse(filled);
-  if (result.success) return { success: true, issues: [] };
-  let issues: ValidateResolvedIssue[] = result.error.issues.map((issue) => {
-    const params =
-      issue.code === "custom"
-        ? ((issue as { params?: unknown }).params as
-            | { reason?: string }
-            | undefined)
-        : undefined;
-    return {
-      path: [...issue.path],
-      message: issue.message,
-      reason: params?.reason,
-    };
-  });
+  let issues: ValidateResolvedIssue[] = result.success
+    ? []
+    : result.error.issues.map((issue) => {
+        const params =
+          issue.code === "custom"
+            ? ((issue as { params?: unknown }).params as
+                | { reason?: string }
+                | undefined)
+            : undefined;
+        return {
+          path: [...issue.path],
+          message: issue.message,
+          reason: params?.reason,
+        };
+      });
+
+  // #568 — global placeholder-leak sweep over the raw filled tree. Catches
+  // surviving `${…}` in string-typed slots the resolved schema accepts as
+  // valid strings (condition value, buttonText, url, …). Runs even when the
+  // schema otherwise passes — that's exactly the silent-leak case. Deduped
+  // by path against the per-field guards above (which carry more specific
+  // messages) so a single leak isn't reported twice; a leak the schema
+  // already errored on for another reason (e.g. a numeric slot's "Expected
+  // number") is likewise not double-reported.
+  const leaks: { path: (string | number)[]; token: string }[] = [];
+  collectPlaceholderLeaks(filled, [], leaks);
+  const seenPaths = new Set(issues.map((i) => JSON.stringify(i.path)));
+  for (const leak of leaks) {
+    const key = JSON.stringify(leak.path);
+    if (seenPaths.has(key)) continue;
+    seenPaths.add(key);
+    issues.push({
+      path: leak.path,
+      message: `${leak.path.join(".") || "value"} is an unresolved \`${leak.token}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row, additionalFields, or annotator binding.`,
+      reason: "unresolved-placeholder",
+    });
+  }
+
   if (options.skipUnresolved) {
     issues = issues.filter((i) => i.reason !== "unresolved-placeholder");
   }


### PR DESCRIPTION
Fixes #568

## Problem

The resolved (post-fill) tier is supposed to guarantee no `${field}` placeholder survives before a participant sees anything. But `validateResolvedTreatmentFile` only caught a leak where a **per-field guard** checked it (`prompt.file`, `rooms`/`feeds`, `showTitle`/`showNickname`) or the target type rejected a string (numeric/array slots). **String-typed slots** — condition `value` (equals/includes/matches), element `buttonText`/`url`/`displayText`/`reference`/`altText`/`surveyName`, `urlParams[].value` — accept `"${x}"` as a structurally valid string and let it through **silently**, so at runtime a condition compares against the literal `"${x}"` (never matches) or a truthy string inverts a flag. `validateResolvedTreatmentFile` had no global scan — confirmed by `resolved.ts` and the earlier discussion on #566/#567.

## Fix

A global recursive sweep in `validateResolvedTreatmentFile`: walk the filled tree, flag any string carrying a surviving `${identifier}`, tagged `unresolved-placeholder`, deduped by path against the per-field guards (guard's specific message wins), then apply the `skipUnresolved` filter. Runs even when the schema otherwise passes — that's exactly the silent-leak case. Mirrors — and lets external hosts eventually drop — the annotator's hand-rolled global scan in `resolveTask` (see the annotator migration, talkbench/annotator#224).

## Pre-PR review (3 subagents) — findings folded in

- **Correctness** → sound; surfaced the `templates:`/`imports:` scope issue below.
- **Test coverage** → added numeric-slot dedup, `urlParams[].value` + operator-tree (`all: […]`) nesting, and a "guard message wins" assertion.
- **Security** → net-positive; surfaced the regex-breadth false positive below.

Two review-driven refinements (both with regression tests):

1. **Narrow grammar (was a real false-positive regression).** The sweep uses `/\$\{[a-zA-Z0-9_]+\}/` — matching `fillTemplates`' substitution grammar — not a loose `/\$\{[^}]*\}/`. A leak is specifically an `${identifier}` that `fillTemplates` *would* have substituted but didn't. A literal like `buttonText: "Submit ${form.id}"` (dot body) is never a fill placeholder, so it is **not** flagged (it was valid before this PR and stays valid).
2. **Skips file-level `templates:`/`imports:`.** Template definitions legitimately carry `${field}` placeholders and the resolved schema tolerates a not-yet-stripped tree (`z.unknown()`), so scanning them would false-positive on every definition. Excluded at the top level only.

## Acknowledged limitations (documented, out of scope)

- **Object keys aren't scanned** — only values. Mitigated: `fillTemplates`' serialized-JSON scan catches key placeholders upstream, and `layout` seat keys are schema-validated to integers. No known silent path.
- **Partial substitution** — a wrong/empty binding that leaves no `${}` (e.g. `round_${n}_choice` with `n=""` → `round__choice`) is undetectable by any `${…}`-based check; inherent, matches `fillTemplates`.
- **Numeric slots** — a leaked `displayTime: "${x}"` still surfaces as the schema's "Expected number" (untagged), so it hard-errors even under `skipUnresolved`. Pre-existing numeric-placeholder behavior, unchanged; now pinned by a test.

## Verification

- Full workspace **vitest** (`npm test`): 2055 / 79 / 157 pass. **Playwright CT** (`test:ct:all`): 1872 pass. **Build** (dts typecheck) + **lint**: clean.
- 170 resolved-schema tests, including the sweep, dedup, nesting, and both false-positive regressions.

## Follow-on

Once released, the annotator (talkbench/annotator#224) can drop its bespoke `resolveTask` regex and use `validateResolvedTreatmentFile` directly — this sweep is what brings the shared validator to parity. Related: #566, #567.

🤖 Generated with [Claude Code](https://claude.com/claude-code)