### PR TITLE
feat(types): split resolved/runtime discussion type from the widened authoring type

### DIFF
--- a/packages/stagebook/src/components/Stage.tsx
+++ b/packages/stagebook/src/components/Stage.tsx
@@ -11,7 +11,7 @@ import { ScrollIndicator } from "./scroll/ScrollIndicator.js";
 import { useScrollAwareness } from "./scroll/useScrollAwareness.js";
 import { PlaybackProvider } from "./playback/PlaybackProvider.js";
 import { ElementErrorBoundary } from "./ElementErrorBoundary.js";
-import type { DiscussionType } from "../schemas/treatment.js";
+import type { ResolvedDiscussionType } from "../schemas/resolved.js";
 import type { Condition } from "./conditions/ConditionsConditionalRender.js";
 
 // Max-width per element type — wider for surveys/qualtrics/video
@@ -73,7 +73,7 @@ export interface StageConfig {
   name: string;
   duration?: number;
   elements: ElementConfig[];
-  discussion?: DiscussionType;
+  discussion?: ResolvedDiscussionType;
   /**
    * Stage-level conditions (#183). When any condition evaluates to
    * false at mount the stage is skipped; when a condition flips to
@@ -192,7 +192,7 @@ function ElementsColumn({
 
 // Check whether the current position should see the discussion
 function positionAllowsDiscussion(
-  discussion: DiscussionType | undefined,
+  discussion: ResolvedDiscussionType | undefined,
   position: number | undefined,
 ): boolean {
   if (!discussion) return false;

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -6,7 +6,8 @@ import React, {
   useEffect,
   useRef,
 } from "react";
-import type { DiscussionType, ReferenceType } from "../schemas/treatment.js";
+import type { ReferenceType } from "../schemas/treatment.js";
+import type { ResolvedDiscussionType } from "../schemas/resolved.js";
 import { parseDottedReference } from "../schemas/reference.js";
 import {
   getReferenceKeyAndPath,
@@ -137,7 +138,21 @@ export interface StagebookContext {
   setAllowIdle?: (allow: boolean) => void;
 
   // Platform-provided renderers for service-coupled elements
-  renderDiscussion?: (config: DiscussionType) => React.ReactNode;
+  /**
+   * Renders the live discussion (video/audio/text call) for a stage.
+   *
+   * `config` is a {@link ResolvedDiscussionType}: `showTitle`/`showNickname`
+   * are real booleans and `rooms`/`layout.feeds` are concrete arrays — never a
+   * surviving `${field}` placeholder string. Stagebook's own viewer guarantees
+   * this by gating on `validateResolvedTreatmentFile` before this seam. **A host
+   * implementing this callback with its own expansion pipeline must likewise run
+   * `validateResolvedTreatmentFile` (with `skipUnresolved` off) on the fully
+   * bound treatment before rendering** — otherwise an unbound placeholder could
+   * reach `config` typed as a `boolean` and silently invert a blind-arm
+   * title/nickname manipulation (the narrowed type is runtime-backed, not
+   * compiler-enforced at the producer).
+   */
+  renderDiscussion?: (config: ResolvedDiscussionType) => React.ReactNode;
   /**
    * Renders a shared text input with collaborative editing semantics.
    * Called by `prompt` elements with `shared: true` and an openResponse

--- a/packages/stagebook/src/schemas/index.ts
+++ b/packages/stagebook/src/schemas/index.ts
@@ -155,6 +155,7 @@ export {
   resolvedConditionSchema,
   resolvedConditionsSchema,
   validateResolvedTreatmentFile,
+  type ResolvedDiscussionType,
   type ResolvedElementType,
   type ResolvedStageType,
   type ResolvedIntroExitStepType,

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -294,47 +294,55 @@ export type ResolvedElementType = z.infer<typeof resolvedElementSchema>;
 // we add a superRefine here that flags any placeholder string still
 // present after fillTemplates ran. Catches typos and missing fields
 // that would otherwise reach runtime components.
-const resolvedDiscussionSchema = discussionSchema.superRefine((data, ctx) => {
-  if (typeof data.rooms === "string") {
-    ctx.addIssue({
-      code: z.ZodIssueCode.custom,
-      path: ["rooms"],
-      message: `discussion.rooms is an unresolved \`${data.rooms}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
-      params: { reason: "unresolved-placeholder" },
-    });
-  }
-  // `showNickname` / `showTitle` accept a `${field}` placeholder pre-fill
-  // (#565). A string reaching the resolved shape means the template field was
-  // never bound — flag it instead of letting the widened `boolean | string`
-  // type carry a placeholder into a runtime component.
-  for (const flag of ["showNickname", "showTitle"] as const) {
-    if (typeof data[flag] === "string") {
+const resolvedDiscussionSchema = discussionSchema
+  .superRefine((data, ctx) => {
+    if (typeof data.rooms === "string") {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: [flag],
-        message: `discussion.${flag} is an unresolved \`${data[flag]}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
+        path: ["rooms"],
+        message: `discussion.rooms is an unresolved \`${data.rooms}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
         params: { reason: "unresolved-placeholder" },
       });
     }
-  }
-  if (data.layout && typeof data.layout === "object") {
-    for (const [seat, layoutDef] of Object.entries(data.layout)) {
-      if (
-        layoutDef &&
-        typeof layoutDef === "object" &&
-        "feeds" in layoutDef &&
-        typeof layoutDef.feeds === "string"
-      ) {
+    // `showNickname` / `showTitle` accept a `${field}` placeholder pre-fill
+    // (#565). A string reaching the resolved shape means the template field was
+    // never bound — flag it instead of letting the widened `boolean | string`
+    // type carry a placeholder into a runtime component.
+    for (const flag of ["showNickname", "showTitle"] as const) {
+      if (typeof data[flag] === "string") {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
-          path: ["layout", seat, "feeds"],
-          message: `discussion.layout[${seat}].feeds is an unresolved \`${layoutDef.feeds}\` placeholder. The template field was not bound during fillTemplates.`,
+          path: [flag],
+          message: `discussion.${flag} is an unresolved \`${data[flag]}\` placeholder. The template field was not bound during fillTemplates — check the broadcast row or additionalFields.`,
           params: { reason: "unresolved-placeholder" },
         });
       }
     }
-  }
-});
+    if (data.layout && typeof data.layout === "object") {
+      for (const [seat, layoutDef] of Object.entries(data.layout)) {
+        if (
+          layoutDef &&
+          typeof layoutDef === "object" &&
+          "feeds" in layoutDef &&
+          typeof layoutDef.feeds === "string"
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["layout", seat, "feeds"],
+            message: `discussion.layout[${seat}].feeds is an unresolved \`${layoutDef.feeds}\` placeholder. The template field was not bound during fillTemplates.`,
+            params: { reason: "unresolved-placeholder" },
+          });
+        }
+      }
+    }
+  })
+  // Narrow the schema's OUTPUT type (not just runtime-refine) so schema-derived
+  // resolved types (`ResolvedStageType`/`ResolvedTreatmentType`) expose the same
+  // narrowed `discussion` as `StageConfig`/`ViewerStep` — no cast needed at the
+  // seam (#570 review). Sound because the superRefine above rejects any string
+  // in `showTitle`/`showNickname`/`rooms`/`layout[].feeds`, so a passing value
+  // already matches `ResolvedDiscussionType`.
+  .transform((data): ResolvedDiscussionType => data as ResolvedDiscussionType);
 
 // #567 — the narrowed, runtime discussion type. `discussionSchema` accepts
 // `${field}` placeholders, so `DiscussionType` is widened (`showTitle: boolean
@@ -353,10 +361,12 @@ export type ResolvedDiscussionType = Omit<
 > & {
   showNickname: boolean;
   showTitle: boolean;
-  rooms?: DiscussionRoomType[];
+  rooms?: [DiscussionRoomType, ...DiscussionRoomType[]];
   layout?: Record<
     string,
-    Omit<LayoutDefinitionType, "feeds"> & { feeds: LayoutFeedType[] }
+    Omit<LayoutDefinitionType, "feeds"> & {
+      feeds: [LayoutFeedType, ...LayoutFeedType[]];
+    }
   >;
 };
 
@@ -386,6 +396,12 @@ type _ResolvedDiscussionNarrowed = AssertTrue<
       HasNoStringMember<ResolvedDiscussionType["rooms"]>,
       HasNoStringMember<
         NonNullable<ResolvedDiscussionType["layout"]>[string]["feeds"]
+      >,
+      // Schema-derived path: the `.transform` above must narrow
+      // `resolvedStageSchema`'s output too, so `ResolvedStageType.discussion`
+      // is `ResolvedDiscussionType`, not the widened `DiscussionType` (#570).
+      IsExactlyBoolean<
+        NonNullable<ResolvedStageType["discussion"]>["showTitle"]
       >,
     ]
   >

--- a/packages/stagebook/src/schemas/resolved.ts
+++ b/packages/stagebook/src/schemas/resolved.ts
@@ -23,6 +23,10 @@ import {
   referenceSchema,
   promptFilePathSchema,
   validateConditionRules,
+  type DiscussionType,
+  type DiscussionRoomType,
+  type LayoutFeedType,
+  type LayoutDefinitionType,
 } from "./treatment.js";
 
 // Detects `${field}` placeholders that survived `fillTemplates` —
@@ -331,6 +335,62 @@ const resolvedDiscussionSchema = discussionSchema.superRefine((data, ctx) => {
     }
   }
 });
+
+// #567 — the narrowed, runtime discussion type. `discussionSchema` accepts
+// `${field}` placeholders, so `DiscussionType` is widened (`showTitle: boolean
+// | string`, `rooms: DiscussionRoomType[] | string`, `layout[].feeds` widened).
+// That authoring type is right pre-fill, but the RUNTIME seam (renderDiscussion,
+// StageConfig, the viewer step model) only ever sees a *resolved* config:
+// `resolvedDiscussionSchema` above rejects any surviving placeholder and the
+// file-level sweep (#569) is the backstop, so the value handed to those
+// consumers is guaranteed placeholder-free. Narrow the placeholder-bearing
+// fields back to their concrete shapes here so hosts get a real `boolean`/array
+// and the compiler stops them mishandling a would-be placeholder string. The
+// authoring-preview path (SkeletonPlaceholder) keeps the widened `DiscussionType`.
+export type ResolvedDiscussionType = Omit<
+  DiscussionType,
+  "showNickname" | "showTitle" | "rooms" | "layout"
+> & {
+  showNickname: boolean;
+  showTitle: boolean;
+  rooms?: DiscussionRoomType[];
+  layout?: Record<
+    string,
+    Omit<LayoutDefinitionType, "feeds"> & { feeds: LayoutFeedType[] }
+  >;
+};
+
+// Compile-time guards (#567): fail the dts build if any placeholder-bearing
+// slot re-widens on the resolved type — the point of the split is that the
+// runtime seam sees real booleans/arrays, never a `${…}` string. Booleans are
+// the load-bearing case (a `boolean | string` re-widening silently inverts
+// `if (showTitle)`), but we also pin `rooms` and the fragile nested
+// `layout[].feeds` mapped type (a `LayoutDefinitionType` refactor could
+// otherwise re-widen it unnoticed). Zero runtime footprint.
+type AssertTrue<T extends true> = T;
+type IsExactlyBoolean<T> = [T] extends [boolean]
+  ? [boolean] extends [T]
+    ? true
+    : false
+  : false;
+type HasNoStringMember<T> = [Extract<T, string>] extends [never] ? true : false;
+type AllTrue<T extends readonly boolean[]> = T[number] extends true
+  ? true
+  : false;
+/* eslint-disable @typescript-eslint/no-unused-vars */
+type _ResolvedDiscussionNarrowed = AssertTrue<
+  AllTrue<
+    [
+      IsExactlyBoolean<ResolvedDiscussionType["showTitle"]>,
+      IsExactlyBoolean<ResolvedDiscussionType["showNickname"]>,
+      HasNoStringMember<ResolvedDiscussionType["rooms"]>,
+      HasNoStringMember<
+        NonNullable<ResolvedDiscussionType["layout"]>[string]["feeds"]
+      >,
+    ]
+  >
+>;
+/* eslint-enable @typescript-eslint/no-unused-vars */
 
 export const resolvedStageSchema = z.object({
   name: nameSchema,

--- a/packages/stagebook/src/schemas/treatment.ts
+++ b/packages/stagebook/src/schemas/treatment.ts
@@ -562,6 +562,15 @@ export const discussionSchema = z
   });
 export type DiscussionType = z.infer<typeof discussionSchema>;
 
+// Sub-types of the discussion config, exported so `ResolvedDiscussionType`
+// (resolved.ts) can narrow the placeholder-bearing fields back to their
+// concrete runtime shapes (#567). `DiscussionRoomType` and `LayoutFeedType`
+// are the same in authoring and resolved form; only the *container* fields
+// (`rooms`, `layout[].feeds`) carry the `| string` placeholder widening.
+export type DiscussionRoomType = z.infer<typeof discussionRoomSchema>;
+export type LayoutFeedType = z.infer<typeof layoutFeedSchema>;
+export type LayoutDefinitionType = z.infer<typeof layoutDefinitionSchema>;
+
 // ------------------ Template contexts ------------------ //
 const templateFieldKeysSchema = z
   .string()

--- a/packages/stagebook/src/viewer/lib/steps.ts
+++ b/packages/stagebook/src/viewer/lib/steps.ts
@@ -1,6 +1,6 @@
 import type {
   ElementType,
-  DiscussionType,
+  ResolvedDiscussionType,
   ConditionType,
 } from "../../schemas/index.js";
 
@@ -12,7 +12,7 @@ export interface ViewerStep {
   name: string;
   elements: ElementType[];
   duration?: number;
-  discussion?: DiscussionType;
+  discussion?: ResolvedDiscussionType;
   /** Researcher-facing notes on the stage (never shown to participants). */
   notes?: string;
   /** Stage-level conditions (#183). Evaluated by StageConditionGate. */
@@ -77,7 +77,7 @@ interface Treatment {
     conditions?: ConditionType[];
     duration?: number;
     elements: ElementType[];
-    discussion?: DiscussionType;
+    discussion?: ResolvedDiscussionType;
   }[];
   exitSequence?: StepShape[];
 }


### PR DESCRIPTION
Fixes #567

## Problem

`discussionSchema` accepts `${field}` placeholders (#565/#284), so `DiscussionType` is **widened** — `showTitle`/`showNickname: boolean | string`, `rooms: DiscussionRoomType[] | string`, `layout[].feeds` widened. That authoring type is correct pre-fill, but the **runtime** seam reused it: `renderDiscussion` ([StagebookProvider.tsx](packages/stagebook/src/components/StagebookProvider.tsx)), `StageConfig.discussion` ([Stage.tsx](packages/stagebook/src/components/Stage.tsx)), and the viewer step model ([steps.ts](packages/stagebook/src/viewer/lib/steps.ts)) received `boolean | string`. So a host could do `if (config.showTitle)` on a leftover placeholder string (truthy) and **silently invert a blind-arm title/nickname manipulation** — the compile-time counterpart of the runtime hole #566/#568/#569 closed.

## Fix (type-only — no runtime behavior change)

Introduce `ResolvedDiscussionType` that narrows the four placeholder-bearing fields to their concrete post-fill shapes (`boolean`, `DiscussionRoomType[]`, concrete `feeds`), and point the runtime consumers at it. The authoring-preview path (`SkeletonPlaceholder`) intentionally keeps the widened `DiscussionType`.

**Soundness:** every value reaching the seam is already placeholder-free — the viewer's `computePreviewState` gates on both fillTemplates' unresolved check **and** a strict `validateResolvedTreatmentFile` (the `resolvedDiscussionSchema` per-field guards + the #569 sweep) before a stage is built. The narrowing is runtime-backed. (It is *not* compiler-enforced producer-side — the authoring schema infers `any` via `altTemplateContext` — exactly as for the existing `ResolvedStageType`/`ResolvedElementType`.)

**Compile-time guard:** a zero-runtime `AssertTrue<...>` block fails the `dts` build (the unconditional CI `build` job) if **any** of the four fields re-widens. Verified non-vacuous for all four (re-widening each → build fails; revert → passes).

## Pre-PR review (3 subagents) — findings folded in

- **Correctness** → **sound, no defects.** Confirmed the internal double-gate, the `Omit`+re-add definition (all four fields, optionality preserved), a complete cascade, and a non-vacuous guard.
- **Test coverage** → extended the guard from the two booleans to also pin `rooms` and the fragile nested `layout.feeds` mapped type.
- **Security** → **sound (runtime-backed).** Added JSDoc on `renderDiscussion` documenting the external-host contract (validate before rendering). Confirmed the callback narrowing is **not breaking** (param contravariance keeps `(c: DiscussionType) => …` assignable).

## Notes for consumers

- `renderDiscussion` param narrows `DiscussionType` → `ResolvedDiscussionType`: safe (hosts receive a stricter, safer param).
- `StageConfig.discussion` / `ViewerStep.discussion` become stricter **inputs** — a host constructing one from a raw widened `DiscussionType` value would now get an assignability error (expected: the value is resolved there).
- Out of scope (pre-existing): the discussion-*element* seam `Element.tsx` uses `renderDiscussion?.(element as never)` and is not covered by this type; `<Viewer>` used directly (bypassing `PreviewHost`) does not self-validate. Neither is touched here.

## Verification

- **Build** (dts typecheck, the type gate) clean; **lint** clean; raw `tsc` error count identical to main (142 = 142 → zero new type errors; the 142 are pre-existing `.ct.tsx` config noise).
- Full **vitest** 2055 / 79 / 157. **CT** 1868–1869/1872 — the handful of failures are shifting webkit timing flakes (Prompt shuffle / Timeline wheel-pan / MediaPlayer / Markdown), none touching discussion; a zero-runtime type change cannot cause them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)