### PR TITLE
feat(viewer): keep the current stage and participant when switching treatments

### DIFF
--- a/packages/stagebook/src/viewer/components/Viewer.hotkeys.ct.tsx
+++ b/packages/stagebook/src/viewer/components/Viewer.hotkeys.ct.tsx
@@ -37,6 +37,24 @@ test("⌥↓ / ⌥↑ switch the previewed treatment", async ({ mount }) => {
   await expect(picker).toHaveValue("treatment:0");
 });
 
+test("switching treatments keeps the current stage (cross-treatment comparison)", async ({
+  mount,
+}) => {
+  const component = await mount(<MockViewer />);
+  const picker = component.getByRole("combobox", { name: "Part to preview" });
+  const counter = component.getByText(/^\d+ \/ 3$/);
+
+  // Advance to the second stage of treatment A, then switch to treatment B:
+  // the stage counter must stay put so the researcher lands on the same stage
+  // of the new treatment, rather than being bounced back to stage 1.
+  await component.press("Alt+ArrowRight");
+  await expect(counter).toHaveText("2 / 3");
+
+  await component.press("Alt+ArrowDown");
+  await expect(picker).toHaveValue("treatment:1");
+  await expect(counter).toHaveText("2 / 3");
+});
+
 test("⌥<digit> selects a player position and ignores out-of-range digits", async ({
   mount,
 }) => {

--- a/packages/stagebook/src/viewer/components/Viewer.tsx
+++ b/packages/stagebook/src/viewer/components/Viewer.tsx
@@ -15,7 +15,12 @@ import {
   useScrollAwareness,
   isRTLLocale,
 } from "../../components/index.js";
-import { buildUnits, initialUnitKey, type ViewerUnit } from "../lib/steps.js";
+import {
+  buildUnits,
+  initialUnitKey,
+  unitKindFromKey,
+  type ViewerUnit,
+} from "../lib/steps.js";
 import { ViewerStateStore } from "../lib/store.js";
 import { createViewerContext } from "../lib/context.js";
 import { useViewerHotkeys } from "../lib/hotkeys.js";
@@ -115,18 +120,6 @@ export function Viewer({
   const handleResetStage = useCallback(() => {
     setStageResetVersion((v) => v + 1);
   }, []);
-  // When the file changes, keep the current selection if it still exists —
-  // an in-place refresh (VS Code save, same study) must NOT yank the user off
-  // the intro they were previewing back to a treatment (#485 review). Only when
-  // the selected unit is gone (study swapped, or the researcher deleted it) do
-  // we fall back to the host's landing selection.
-  useEffect(() => {
-    setSelectedUnitKey((prev) =>
-      units.some((u) => u.key === prev)
-        ? prev
-        : initialUnitKey(units, selectedIntroIndex, selectedTreatmentIndex),
-    );
-  }, [treatmentFile, units, selectedIntroIndex, selectedTreatmentIndex]);
   const [position, setPosition] = useState(0);
   const [store] = useState(() => new ViewerStateStore());
   const stageContainerRef = useRef<HTMLDivElement | null>(null);
@@ -147,20 +140,28 @@ export function Viewer({
     }
   }, [steps.length, stageIndex]);
 
-  // Give the newly-selected unit a clean slate: submitted flags + elapsed time
-  // are keyed by numeric stageIndex, so without clearing them an intro's
-  // submitted[0] would make the treatment's first stage read as already-
-  // submitted (waiting overlay). The wipe only fires on an actual unit switch —
-  // an in-place refresh keeps the same key, so saved responses persist.
-  //
-  // We deliberately KEEP the current stageIndex and position across a switch so
-  // a researcher can compare the same stage (and participant) across treatments
-  // — the whole point of the picker. stageIndex is clamped to the new unit's
-  // step count by the effect above, and position is clamped for display via
-  // clampedPosition below, so neither can go out of range.
+  // In-place refresh (VS Code save, same study): keep the current selection if
+  // it still exists — must NOT yank the user off the intro they were previewing
+  // back to a treatment (#485 review). Only when the selected unit is gone
+  // (study swapped, or the unit deleted) do we fall back to the host's landing
+  // selection — and since that's a genuinely different unit, give it a clean
+  // slate the same way selectUnit does (clear the store, restart at step 0).
   useEffect(() => {
+    if (units.some((u) => u.key === selectedUnitKey)) return;
     store.clearAll();
-  }, [selectedUnitKey, store]);
+    setStageIndex(0);
+    setPosition(0);
+    setSelectedUnitKey(
+      initialUnitKey(units, selectedIntroIndex, selectedTreatmentIndex),
+    );
+  }, [
+    treatmentFile,
+    units,
+    selectedIntroIndex,
+    selectedTreatmentIndex,
+    selectedUnitKey,
+    store,
+  ]);
 
   // Subscribe to store changes so the UI re-renders.
   // The version is included in ctx memo deps below so that
@@ -206,6 +207,23 @@ export function Viewer({
   // <select> and the Alt+↑/↓ hotkey share one path.
   const selectUnit = useCallback(
     (key: string) => {
+      // Clear the mock store synchronously, BEFORE the re-render mounts the new
+      // unit's stage, so read-once elements (e.g. Timeline seeds its selections
+      // from the store once on mount, then owns them locally) initialize from an
+      // empty store rather than the previous unit's saved values. Deferring the
+      // wipe to an effect would clear AFTER the remount had already read the old
+      // store, leaking the prior treatment's state. (Mirrors the inspector's
+      // Reset-stage flow above: mutate the store, then force the remount.)
+      store.clearAll();
+      // Keep the current stage + participant only when comparing like with like
+      // (treatment↔treatment, intro↔intro) — the whole point of the picker.
+      // A cross-phase switch (e.g. treatment→intro) isn't a comparison, and a
+      // preserved deep index would open the new unit on its trailing transition,
+      // skipping its first authored step — so restart those at the beginning.
+      if (unitKindFromKey(key) !== unitKindFromKey(selectedUnitKey)) {
+        setStageIndex(0);
+        setPosition(0);
+      }
       setSelectedUnitKey(key);
       if (key.startsWith("treatment:")) {
         onTreatmentIndexChange?.(Number(key.slice("treatment:".length)));
@@ -213,7 +231,7 @@ export function Viewer({
         onIntroIndexChange?.(Number(key.slice("intro:".length)));
       }
     },
-    [onTreatmentIndexChange, onIntroIndexChange],
+    [store, selectedUnitKey, onTreatmentIndexChange, onIntroIndexChange],
   );
 
   // Unit keys in the order the <optgroup> picker shows them, so Alt+↑/↓ walks

--- a/packages/stagebook/src/viewer/components/Viewer.tsx
+++ b/packages/stagebook/src/viewer/components/Viewer.tsx
@@ -147,16 +147,18 @@ export function Viewer({
     }
   }, [steps.length, stageIndex]);
 
-  // Restart at the first step whenever the selected unit changes, and give the
-  // new unit a clean slate: submitted flags + elapsed time are keyed by numeric
-  // stageIndex, so without clearing them an intro's submitted[0] would make the
-  // treatment's first stage read as already-submitted (waiting overlay), and a
-  // stale participant `position` could exceed the new unit's playerCount
-  // (#485 review). The store wipe only fires on an actual unit switch — an
-  // in-place refresh keeps the same key, so saved responses persist as before.
+  // Give the newly-selected unit a clean slate: submitted flags + elapsed time
+  // are keyed by numeric stageIndex, so without clearing them an intro's
+  // submitted[0] would make the treatment's first stage read as already-
+  // submitted (waiting overlay). The wipe only fires on an actual unit switch —
+  // an in-place refresh keeps the same key, so saved responses persist.
+  //
+  // We deliberately KEEP the current stageIndex and position across a switch so
+  // a researcher can compare the same stage (and participant) across treatments
+  // — the whole point of the picker. stageIndex is clamped to the new unit's
+  // step count by the effect above, and position is clamped for display via
+  // clampedPosition below, so neither can go out of range.
   useEffect(() => {
-    setStageIndex(0);
-    setPosition(0);
     store.clearAll();
   }, [selectedUnitKey, store]);
 
@@ -487,7 +489,16 @@ export function Viewer({
               <div ref={stageContainerRef} style={stageContainerStyle}>
                 <StagebookProvider value={ctx}>
                   <Stage
-                    key={`stage-${String(stageIndex)}-${String(stageResetVersion)}`}
+                    // The unit key is part of the remount key so that switching
+                    // treatments at the SAME stage index still gives the stage a
+                    // fresh mount: read-once elements (e.g. Timeline seeds its
+                    // selections from the store once, then owns them) and the
+                    // StageConditionGate advance latch would otherwise survive
+                    // the switch and show the previous treatment's state over the
+                    // cleared store. (setStageIndex(0) used to force this
+                    // incidentally; now that we preserve the stage index for
+                    // cross-treatment comparison, we key on the unit explicitly.)
+                    key={`stage-${selectedUnitKey}-${String(stageIndex)}-${String(stageResetVersion)}`}
                     stage={stageConfig}
                     onSubmit={handleSubmit}
                     scrollMode="host"

--- a/packages/stagebook/src/viewer/components/introSequencesOptional.test.tsx
+++ b/packages/stagebook/src/viewer/components/introSequencesOptional.test.tsx
@@ -199,6 +199,59 @@ function twoTreatmentsFile(playerCount = 1): TreatmentFileType {
   } as unknown as TreatmentFileType;
 }
 
+/** Two treatments (same KIND) with different player counts, for the position
+ *  round-trip: pass through the smaller one and back. */
+function treatmentsWithPlayerCounts(a: number, b: number): TreatmentFileType {
+  const stage = (n: string) => ({
+    name: n,
+    duration: 60,
+    elements: [{ type: "submitButton" }],
+  });
+  return {
+    treatments: [
+      {
+        name: "A",
+        locale: "en",
+        playerCount: a,
+        gameStages: [stage("A1"), stage("A2")],
+      },
+      {
+        name: "B",
+        locale: "en",
+        playerCount: b,
+        gameStages: [stage("B1"), stage("B2")],
+      },
+    ],
+  } as unknown as TreatmentFileType;
+}
+
+/** An intro sequence (one authored step) plus a treatment with three game
+ *  stages, to exercise a cross-phase switch from a deep treatment stage. */
+function introPlusDeepTreatmentFile(): TreatmentFileType {
+  const stage = (n: string) => ({
+    name: n,
+    duration: 60,
+    elements: [{ type: "submitButton" }],
+  });
+  return {
+    introSequences: [
+      {
+        name: "intro1",
+        locale: "en",
+        introSteps: [{ name: "welcome", elements: [{ type: "submitButton" }] }],
+      },
+    ],
+    treatments: [
+      {
+        name: "A",
+        locale: "en",
+        playerCount: 1,
+        gameStages: [stage("A1"), stage("A2"), stage("A3")],
+      },
+    ],
+  } as unknown as TreatmentFileType;
+}
+
 /** Treatment A has three game stages, B has one — to exercise the clamp when
  *  switching to a treatment with fewer stages than the current index. */
 function unevenTreatmentsFile(): TreatmentFileType {
@@ -452,14 +505,16 @@ describe("switching treatments preserves the stage position", () => {
   });
 
   it("remounts the stage on switch so read-once element state cannot leak", () => {
-    // The store is cleared on switch, but that alone does not reset elements
-    // that seed local state from the store once on mount and then own it (e.g.
-    // Timeline). Keeping the stage index means the <Stage> would reconcile
-    // rather than remount, so such an element would keep the previous
-    // treatment's state over the cleared store. Guard the fix at the mechanism
-    // level: an element that reconciles across the switch (same type + position)
-    // must become a FRESH DOM node — which only happens if the subtree
-    // remounted, which is exactly what resets read-once local state.
+    // Read-once elements (e.g. Timeline) seed their local state from the store
+    // once on mount and then own it, ignoring later store changes. Preserving
+    // the stage index means the <Stage> must be REMOUNTED on a unit switch, or
+    // such an element would keep the previous treatment's state. (Freshness of
+    // that remount — reading the already-cleared store rather than stale values
+    // — is guaranteed by selectUnit clearing synchronously before the re-render;
+    // that clear is guarded by the "clears the store" test above. Here we guard
+    // the other half: that a remount actually happens.) An element that
+    // reconciles across the switch (same type + position) must become a FRESH
+    // DOM node, which only happens when the subtree remounts.
     const { container, unmount } = render(
       <Viewer
         treatmentFile={twoTreatmentsFile()}
@@ -517,14 +572,15 @@ describe("switching treatments preserves the participant position", () => {
     unmount();
   });
 
-  it("restores the position after a round-trip through a smaller unit", () => {
+  it("restores the position after a round-trip through a smaller treatment", () => {
     // Proves the position is preserved INTERNALLY (not just clamped for
-    // display): pick position 2 on a 3-player treatment, pass through a
-    // 1-player intro (which can only show position 0), then return — the
-    // original position 2 must come back.
+    // display): pick position 2 on a 3-player treatment, switch to a 1-player
+    // treatment (which can only show position 0), then switch back — the
+    // original position 2 must come back. The round-trip stays within the
+    // treatment phase so preservation applies (a cross-phase hop would reset).
     const { container, unmount } = render(
       <Viewer
-        treatmentFile={introPlusTreatmentFile(3)}
+        treatmentFile={treatmentsWithPlayerCounts(3, 1)}
         getTextContent={getText}
         getAssetURL={getAsset}
         selectedIntroIndex={0}
@@ -541,12 +597,49 @@ describe("switching treatments preserves the participant position", () => {
     });
     expect(positionSelect().value).toBe("2");
 
-    selectUnit(container, "intro:0");
+    selectUnit(container, "treatment:1");
+    expect(positionSelect().options).toHaveLength(1);
     expect(positionSelect().value).toBe("0");
 
     selectUnit(container, "treatment:0");
     expect(positionSelect().options).toHaveLength(3);
     expect(positionSelect().value).toBe("2");
+    unmount();
+  });
+});
+
+describe("cross-phase switches restart at the first step", () => {
+  it("opens an intro at its first step when leaving a deep treatment stage", () => {
+    // Preserving the stage index only makes sense for like-with-like comparison
+    // (treatment↔treatment). Jumping from a deep treatment stage to an intro is
+    // a phase change, not a comparison: a preserved index would clamp onto the
+    // intro's trailing transition and skip its first authored step. The switch
+    // must restart the intro at step 0.
+    const { container, unmount } = render(
+      <Viewer
+        treatmentFile={introPlusDeepTreatmentFile()}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+      />,
+    );
+
+    // Start on the treatment (initialUnitKey prefers it) and go to its last
+    // game stage (index 2).
+    selectStage(container, 2);
+    expect(currentStageIndex(container)).toBe("2");
+
+    // Switch to the intro: it must open at step 0 (its authored welcome step),
+    // not be clamped to the intro's transition.
+    selectUnit(container, "intro:0");
+    expect(currentStageIndex(container)).toBe("0");
+    expect(
+      container.querySelector('main [data-testid="submitButton"]'),
+    ).not.toBeNull();
+    expect(
+      container.querySelector('[data-testid="viewer-transition"]'),
+    ).toBeNull();
     unmount();
   });
 });

--- a/packages/stagebook/src/viewer/components/introSequencesOptional.test.tsx
+++ b/packages/stagebook/src/viewer/components/introSequencesOptional.test.tsx
@@ -71,6 +71,31 @@ function selectUnit(container: HTMLElement, key: string): void {
   });
 }
 
+/** The StageNav <select> — the one whose options are numeric step indices
+ *  (the part picker's values are "treatment:N"; a 1-player position select
+ *  only has option "0"). */
+function stageNav(container: HTMLElement): HTMLSelectElement {
+  const nav = Array.from(container.querySelectorAll("select")).find((sel) =>
+    Array.from(sel.options).some((o) => o.value === "1"),
+  );
+  if (!nav) throw new Error("stage nav not found");
+  return nav;
+}
+
+/** Navigate the stage <select> to the given step index. */
+function selectStage(container: HTMLElement, index: number): void {
+  const nav = stageNav(container);
+  act(() => {
+    nav.value = String(index);
+    nav.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+/** The current step index the StageNav is showing. */
+function currentStageIndex(container: HTMLElement): string {
+  return stageNav(container).value;
+}
+
 const noop = () => {};
 const getText = () => Promise.resolve("# x");
 const getAsset = (p: string) => p;
@@ -151,6 +176,50 @@ function introHeTreatmentEnFile(): TreatmentFileType {
         playerCount: 1,
         gameStages: [
           { name: "s1", duration: 60, elements: [{ type: "submitButton" }] },
+        ],
+      },
+    ],
+  } as unknown as TreatmentFileType;
+}
+
+/** Two treatments, each with two game stages that carry a submit button. Lets
+ *  a test advance to the second stage, then switch treatments to check the
+ *  stage position is preserved (cross-treatment comparison) and the store is
+ *  cleared (the landed stage is fresh). */
+function twoTreatmentsFile(playerCount = 1): TreatmentFileType {
+  const stages = (prefix: string) => [
+    { name: `${prefix}1`, duration: 60, elements: [{ type: "submitButton" }] },
+    { name: `${prefix}2`, duration: 60, elements: [{ type: "submitButton" }] },
+  ];
+  return {
+    treatments: [
+      { name: "A", locale: "en", playerCount, gameStages: stages("A") },
+      { name: "B", locale: "en", playerCount, gameStages: stages("B") },
+    ],
+  } as unknown as TreatmentFileType;
+}
+
+/** Treatment A has three game stages, B has one — to exercise the clamp when
+ *  switching to a treatment with fewer stages than the current index. */
+function unevenTreatmentsFile(): TreatmentFileType {
+  return {
+    treatments: [
+      {
+        name: "A",
+        locale: "en",
+        playerCount: 1,
+        gameStages: [
+          { name: "A1", duration: 60, elements: [{ type: "submitButton" }] },
+          { name: "A2", duration: 60, elements: [{ type: "submitButton" }] },
+          { name: "A3", duration: 60, elements: [{ type: "submitButton" }] },
+        ],
+      },
+      {
+        name: "B",
+        locale: "en",
+        playerCount: 1,
+        gameStages: [
+          { name: "B1", duration: 60, elements: [{ type: "submitButton" }] },
         ],
       },
     ],
@@ -315,6 +384,169 @@ describe("unit-switch state hygiene", () => {
     selectUnit(container, "intro:0");
     expect(positionSelect().options).toHaveLength(1);
     expect(positionSelect().value).toBe("0");
+    unmount();
+  });
+});
+
+describe("switching treatments preserves the stage position", () => {
+  it("stays on the same game stage across a switch (and clears the store)", () => {
+    const { container, unmount } = render(
+      <Viewer
+        treatmentFile={twoTreatmentsFile()}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+      />,
+    );
+    const main = () => container.querySelector("main")!;
+
+    // On treatment A, advance to the second game stage (index 1) and submit it.
+    selectStage(container, 1);
+    expect(currentStageIndex(container)).toBe("1");
+    const submit = main().querySelector<HTMLButtonElement>(
+      '[data-testid="submitButton"]',
+    );
+    expect(submit).not.toBeNull();
+    act(() => {
+      submit!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(main().textContent).toContain("Waiting for other participants");
+
+    // Switch to treatment B: land on the SAME stage index (1) so a researcher
+    // can compare the same stage across treatments...
+    selectUnit(container, "treatment:1");
+    expect(currentStageIndex(container)).toBe("1");
+    // ...and that stage must be fresh — the store is cleared on switch, so B's
+    // stage 1 does NOT inherit A's submitted[1] (the waiting overlay).
+    expect(main().textContent).not.toContain("Waiting for other participants");
+    expect(main().querySelector('[data-testid="submitButton"]')).not.toBeNull();
+    unmount();
+  });
+
+  it("clamps into range when the new treatment has fewer stages", () => {
+    const { container, unmount } = render(
+      <Viewer
+        treatmentFile={unevenTreatmentsFile()}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+      />,
+    );
+
+    // On treatment A (3 game stages), stand on the last game stage (index 2).
+    selectStage(container, 2);
+    expect(currentStageIndex(container)).toBe("2");
+
+    // Switch to treatment B (1 game stage → 2 steps incl. transition): index 2
+    // no longer exists, so the viewer clamps into range and still renders —
+    // it must not blank (a null render drops the <main>).
+    selectUnit(container, "treatment:1");
+    expect(container.querySelector("main")).not.toBeNull();
+    // B has one game stage + a transition (2 steps), so index 2 clamps to the
+    // last valid step (1) — NOT back to the first stage (the old reset would
+    // give "0").
+    expect(currentStageIndex(container)).toBe("1");
+    unmount();
+  });
+
+  it("remounts the stage on switch so read-once element state cannot leak", () => {
+    // The store is cleared on switch, but that alone does not reset elements
+    // that seed local state from the store once on mount and then own it (e.g.
+    // Timeline). Keeping the stage index means the <Stage> would reconcile
+    // rather than remount, so such an element would keep the previous
+    // treatment's state over the cleared store. Guard the fix at the mechanism
+    // level: an element that reconciles across the switch (same type + position)
+    // must become a FRESH DOM node — which only happens if the subtree
+    // remounted, which is exactly what resets read-once local state.
+    const { container, unmount } = render(
+      <Viewer
+        treatmentFile={twoTreatmentsFile()}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+      />,
+    );
+    const submitNode = () =>
+      container.querySelector('main [data-testid="submitButton"]');
+
+    // Sit on stage index 1 of treatment A (a plain, unsubmitted stage).
+    selectStage(container, 1);
+    const before = submitNode();
+    expect(before).not.toBeNull();
+
+    // Switch to treatment B: same stage index...
+    selectUnit(container, "treatment:1");
+    expect(currentStageIndex(container)).toBe("1");
+    const after = submitNode();
+    expect(after).not.toBeNull();
+    // ...but a different element instance — the stage subtree remounted, so any
+    // read-once local state started fresh from the (cleared) store.
+    expect(after).not.toBe(before);
+    unmount();
+  });
+});
+
+describe("switching treatments preserves the participant position", () => {
+  it("keeps the selected position when the new treatment has enough players", () => {
+    const { container, unmount } = render(
+      <Viewer
+        treatmentFile={twoTreatmentsFile(2)}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+      />,
+    );
+    const positionSelect = () =>
+      container.querySelector("#position-select") as HTMLSelectElement;
+
+    // On treatment A, pick participant 1.
+    act(() => {
+      positionSelect().value = "1";
+      positionSelect().dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(positionSelect().value).toBe("1");
+
+    // Switch to treatment B (also 2 players): the position must be preserved,
+    // not reset to 0 — so a researcher compares the same participant.
+    selectUnit(container, "treatment:1");
+    expect(positionSelect().value).toBe("1");
+    unmount();
+  });
+
+  it("restores the position after a round-trip through a smaller unit", () => {
+    // Proves the position is preserved INTERNALLY (not just clamped for
+    // display): pick position 2 on a 3-player treatment, pass through a
+    // 1-player intro (which can only show position 0), then return — the
+    // original position 2 must come back.
+    const { container, unmount } = render(
+      <Viewer
+        treatmentFile={introPlusTreatmentFile(3)}
+        getTextContent={getText}
+        getAssetURL={getAsset}
+        selectedIntroIndex={0}
+        selectedTreatmentIndex={0}
+      />,
+    );
+    const positionSelect = () =>
+      container.querySelector("#position-select") as HTMLSelectElement;
+
+    expect(positionSelect().options).toHaveLength(3);
+    act(() => {
+      positionSelect().value = "2";
+      positionSelect().dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(positionSelect().value).toBe("2");
+
+    selectUnit(container, "intro:0");
+    expect(positionSelect().value).toBe("0");
+
+    selectUnit(container, "treatment:0");
+    expect(positionSelect().options).toHaveLength(3);
+    expect(positionSelect().value).toBe("2");
     unmount();
   });
 });

--- a/packages/stagebook/src/viewer/lib/steps.test.ts
+++ b/packages/stagebook/src/viewer/lib/steps.test.ts
@@ -4,6 +4,7 @@ import {
   localeForPhase,
   buildUnits,
   initialUnitKey,
+  unitKindFromKey,
 } from "./steps.js";
 
 describe("flattenSteps", () => {
@@ -465,5 +466,27 @@ describe("initialUnitKey", () => {
 
   it("returns a treatment key as last resort when there are no units", () => {
     expect(initialUnitKey([], 0, 3)).toBe("treatment:3");
+  });
+});
+
+describe("unitKindFromKey", () => {
+  it("returns the phase prefix before the index", () => {
+    expect(unitKindFromKey("treatment:2")).toBe("treatment");
+    expect(unitKindFromKey("intro:0")).toBe("intro");
+    expect(unitKindFromKey("consent:1")).toBe("consent");
+  });
+
+  it("distinguishes same-phase from cross-phase switches", () => {
+    // Same kind → comparison (preserve stage); different kind → phase change.
+    expect(
+      unitKindFromKey("treatment:0") === unitKindFromKey("treatment:5"),
+    ).toBe(true);
+    expect(unitKindFromKey("treatment:0") === unitKindFromKey("intro:0")).toBe(
+      false,
+    );
+  });
+
+  it("returns the whole string when there is no index suffix", () => {
+    expect(unitKindFromKey("treatment")).toBe("treatment");
   });
 });

--- a/packages/stagebook/src/viewer/lib/steps.ts
+++ b/packages/stagebook/src/viewer/lib/steps.ts
@@ -324,3 +324,14 @@ export function initialUnitKey(
   if (units.some((u) => u.key === wantIntro)) return wantIntro;
   return units[0]?.key ?? wantTreatment;
 }
+
+/**
+ * The phase a unit key belongs to — the prefix before its index, e.g.
+ * "treatment" for "treatment:2" (see the `${kind}:${i}` keys built above).
+ * Switching between units of the same kind is a comparison (keep the stage and
+ * participant); switching kinds is a phase change (restart at the first step).
+ */
+export function unitKindFromKey(key: string): string {
+  const colon = key.indexOf(":");
+  return colon === -1 ? key : key.slice(0, colon);
+}


### PR DESCRIPTION
Fixes #571

## What

Switching the previewed treatment in the viewer no longer snaps back to the first stage — it **preserves the current stage index and participant position**, so a researcher can compare the same stage (and participant) across treatments. This is the main reason to switch treatments in the previewer.

## Why the reset was safe to drop

The unit-switch effect used to `setStageIndex(0)` + `setPosition(0)` + `store.clearAll()`. The clean-slate work (so the new unit's stage doesn't inherit the previous unit's `submitted[N]`/elapsed) is done entirely by `store.clearAll()`, which is keyed by numeric stage index and independent of the current index. The two resets were incidental.

- `stageIndex` stays in range via the existing clamp effect (switching to a shorter treatment lands on its last valid step, not a crash/blank).
- `position` stays in range via `clampedPosition` (display clamp); the raw value round-trips (pass through a 1-player unit and back → original position restored).

## State hygiene (the subtle bit)

Because the stage index is now preserved, the `<Stage>` must still **remount** on a unit switch. Otherwise read-once elements — `Timeline` seeds its selections from the store once on mount and then owns them — and the `StageConditionGate` advance latch would survive the switch and show the previous treatment's state over the cleared store. Fix: key the stage remount on the selected unit, not just the stage index. This restores the clean slate `setStageIndex(0)` used to provide incidentally (and now works at every stage index, not only stage 0).

## Tests

- **jsdom** (`introSequencesOptional.test.tsx`): switch-at-stage-N keeps stage N + store cleared; clamp-into-range for a shorter treatment; **remount-on-switch guard** (read-once state can't leak); position preserved to an equal-size treatment; position round-trip through a 1-player unit.
- **Playwright CT** (`Viewer.hotkeys.ct.tsx`): advance to stage 2, ⌥↓ to the next treatment, counter stays `2 / 3`.
- Each new guard was verified to fail when its fix is reverted (real regressions, not tautologies).

## Review

Pre-PR review by three subagents (correctness / test-coverage / security). Correctness surfaced the read-once/latch remount issue (fixed here); coverage surfaced the missing position tests + a too-loose clamp assertion (both addressed); security: clean (preview-only in-memory UI state). Full suite green: 2060 library vitest, viewer CT, lint, and dts build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)