### PR TITLE
fix(markdown): resolve inline image src on the CommonMark AST (#576)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3323,7 +3323,6 @@
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
       "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -3381,7 +3380,6 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -3391,7 +3389,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -3442,7 +3439,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
@@ -4302,7 +4298,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
       "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -4661,7 +4656,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
       "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -5031,7 +5025,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5056,7 +5049,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
       "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -5168,7 +5160,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5189,7 +5180,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
       "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
@@ -5773,7 +5763,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
@@ -6733,7 +6722,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
       "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7421,7 +7409,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
       "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -7675,7 +7662,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
       "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0"
@@ -7720,7 +7706,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
       "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -7756,7 +7741,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
       "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -7919,7 +7903,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
       "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -7941,7 +7924,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
       "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -7964,7 +7946,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
       "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -7985,7 +7966,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
       "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8008,7 +7988,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
       "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8031,7 +8010,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
       "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8052,7 +8030,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
       "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8072,7 +8049,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
       "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8094,7 +8070,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
       "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8115,7 +8090,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
       "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8135,7 +8109,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
       "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8158,7 +8131,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
       "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8175,7 +8147,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
       "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8192,7 +8163,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
       "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8212,7 +8182,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
       "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8232,7 +8201,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
       "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8254,7 +8222,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
       "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8277,7 +8244,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
       "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8294,7 +8260,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
       "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
-      "dev": true,
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -8456,7 +8421,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
@@ -9587,7 +9551,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
       "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -10778,7 +10741,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
       "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -11030,7 +10992,6 @@
       "version": "11.0.5",
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -11078,7 +11039,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
       "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -11233,7 +11193,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
       "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -11248,7 +11207,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
       "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -13422,7 +13380,9 @@
         "js-yaml": "^4.1.0",
         "react-markdown": "^10.1.0",
         "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
         "tinyglobby": "^0.2.16",
+        "unified": "^11.0.0",
         "yaml": "^2.8.3"
       },
       "bin": {
@@ -13433,6 +13393,7 @@
         "@hello-pangea/dnd": "^18.0.1",
         "@playwright/experimental-ct-react": "^1.58.2",
         "@types/js-yaml": "^4.0.9",
+        "@types/mdast": "^4.0.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "eslint": "^9.0.0",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -100,7 +100,9 @@
     "js-yaml": "^4.1.0",
     "react-markdown": "^10.1.0",
     "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
     "tinyglobby": "^0.2.16",
+    "unified": "^11.0.0",
     "yaml": "^2.8.3"
   },
   "peerDependencies": {
@@ -121,6 +123,7 @@
     "@hello-pangea/dnd": "^18.0.1",
     "@playwright/experimental-ct-react": "^1.58.2",
     "@types/js-yaml": "^4.0.9",
+    "@types/mdast": "^4.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "eslint": "^9.0.0",

--- a/packages/stagebook/src/components/form/Markdown.ct.tsx
+++ b/packages/stagebook/src/components/form/Markdown.ct.tsx
@@ -99,16 +99,16 @@ test("resolveURL: does NOT double-encode %XX sequences in the host's already-enc
   expect(src).not.toContain("%252B");
 });
 
-test("resolveURL: encodes spaces in researcher-authored filenames", async ({
+test("resolveURL: encodes spaces in an angle-bracket destination", async ({
   mount,
 }) => {
-  // Markdown source is raw — researchers write paths like
-  // `![](my pic.jpg)`. The fix encodes the path segment(s) before
-  // resolving, so spaces (and other URI-special chars) become
-  // `%20` rather than landing literally in the <img src>.
+  // A space in a bare destination isn't a valid CommonMark image, so the
+  // space form is the angle-bracket destination `<…>`. remark unwraps it to
+  // `folder/my pic.jpg`; the resolver then percent-encodes the segments, so
+  // the space becomes `%20` in the <img src> rather than landing literally.
   const component = await mount(
     <MockMarkdown
-      text="![photo](folder/my pic.jpg)"
+      text="![photo](<folder/my pic.jpg>)"
       baseUrl="https://example.com/"
     />,
   );
@@ -193,6 +193,167 @@ test("resolveURL: encodes non-ASCII characters in path", async ({ mount }) => {
   );
   const src = await component.locator("img").getAttribute("src");
   expect(src).toBe("https://example.com/caf%C3%A9.png");
+});
+
+// -- CommonMark image forms resolve on the AST (#576) --
+//
+// The renderer resolves image `src` on react-markdown's CommonMark AST instead
+// of a pre-render regex, so every valid image form — titled, angle-bracket,
+// balanced parens, wrapped alt — parses correctly and resolves against the
+// asset base. Each of these rows was broken under the old regex.
+
+test("resolveURL: a titled image resolves the path and keeps the title", async ({
+  mount,
+}) => {
+  // The old regex captured `cat.jpg "My cat"` as the path and 404'd. remark
+  // parses the title out, so the path resolves and the title lands on the img.
+  const component = await mount(
+    <MockMarkdown
+      text={'![a](cat.jpg "My cat")'}
+      baseUrl="https://example.com/"
+    />,
+  );
+  const img = component.locator("img");
+  await expect(img).toHaveAttribute("src", "https://example.com/cat.jpg");
+  await expect(img).toHaveAttribute("title", "My cat");
+});
+
+test("resolveURL: an angle-bracket destination resolves", async ({ mount }) => {
+  const component = await mount(
+    <MockMarkdown text="![a](<my pic.png>)" baseUrl="https://example.com/" />,
+  );
+  const src = await component.locator("img").getAttribute("src");
+  expect(src).toBe("https://example.com/my%20pic.png");
+});
+
+test("resolveURL: a balanced-paren filename resolves (parens kept)", async ({
+  mount,
+}) => {
+  // The old regex stopped the destination at the first `)`, truncating to
+  // `image(1`. remark balances the parens, so the whole name resolves.
+  const component = await mount(
+    <MockMarkdown text="![a](image(1).png)" baseUrl="https://example.com/" />,
+  );
+  const src = await component.locator("img").getAttribute("src");
+  expect(src).toBe("https://example.com/image(1).png");
+});
+
+test("resolveURL: alt text wrapping across lines still resolves the image", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <MockMarkdown
+      text={"![alt spanning\ntwo lines](x.png)"}
+      baseUrl="https://example.com/"
+    />,
+  );
+  const src = await component.locator("img").getAttribute("src");
+  expect(src).toBe("https://example.com/x.png");
+});
+
+test("resolveURL: a reference-style image resolves against its definition", async ({
+  mount,
+}) => {
+  // react-markdown resolves `![alt][ref]` against its `[ref]: path` definition
+  // and renders an <img>, so the asset resolver runs on it — the enumerator
+  // (getMarkdownImageReferences) flags these in lockstep.
+  const component = await mount(
+    <MockMarkdown
+      text={"![Figure 1][fig1]\n\n[fig1]: diagrams/figure1.png"}
+      baseUrl="https://example.com/"
+    />,
+  );
+  await expect(component.locator("img")).toHaveAttribute(
+    "src",
+    "https://example.com/diagrams/figure1.png",
+  );
+});
+
+test("resolveURL: an image inside a fenced code block is NOT rewritten", async ({
+  mount,
+}) => {
+  // The image syntax is shown as a code EXAMPLE, so it renders as literal text:
+  // no <img>, and — the old bug — the resolved CDN URL must not leak into the
+  // displayed code.
+  const component = await mount(
+    <MockMarkdown
+      text={"```md\n![logo](images/logo.png)\n```"}
+      baseUrl="https://example.com/"
+    />,
+  );
+  await expect(component.locator("img")).toHaveCount(0);
+  await expect(component.locator("pre")).toContainText(
+    "![logo](images/logo.png)",
+  );
+  await expect(component.locator("pre")).not.toContainText("example.com");
+});
+
+test("resolveURL: an escaped \\![…] is not an image and is not rewritten", async ({
+  mount,
+}) => {
+  // `\!` escapes the bang, so CommonMark renders `!` + a link (not an image).
+  // No <img> is produced, and the link keeps its raw href — the asset resolver
+  // only ever touches image src, so the CDN base never appears.
+  const component = await mount(
+    <MockMarkdown
+      text={"\\![logo](images/logo.png)"}
+      baseUrl="https://example.com/"
+    />,
+  );
+  await expect(component.locator("img")).toHaveCount(0);
+  await expect(component.locator("a")).toHaveAttribute(
+    "href",
+    "images/logo.png",
+  );
+});
+
+test("resolveURL: a javascript: destination is neutralized, never resolved", async ({
+  mount,
+}) => {
+  // react-markdown's default url sanitizer zeroes `javascript:` before the img
+  // component, so it can't reach the DOM as an executable src and the asset
+  // resolver never runs on it — no `javascript:`, no CDN base.
+  const component = await mount(
+    <MockMarkdown
+      text="![x](javascript:alert(1))"
+      baseUrl="https://example.com/"
+    />,
+  );
+  const src = (await component.locator("img").getAttribute("src")) ?? "";
+  expect(src).not.toContain("javascript:");
+  expect(src).not.toContain("example.com");
+});
+
+test("resolveURL: an asset:// markdown image is not resolved (renders empty)", async ({
+  mount,
+}) => {
+  // react-markdown strips the `asset:` scheme (not in its safe-protocol list)
+  // to "" before the img component, so it renders empty rather than resolving
+  // against the CDN base. Platform `asset://` refs belong in an element's
+  // `file:` field, not a markdown body — this pins that intentional behavior.
+  const component = await mount(
+    <MockMarkdown
+      text="![a](asset://kit/logo.png)"
+      baseUrl="https://example.com/"
+    />,
+  );
+  const src = (await component.locator("img").getAttribute("src")) ?? "";
+  expect(src).not.toContain("example.com");
+  expect(src).not.toContain("asset:");
+});
+
+test("a long `![`×N run renders as text without hanging (no regex ReDoS)", async ({
+  mount,
+}) => {
+  // The old pre-render regex was O(n²) on a `![![![…` run (the issue measured
+  // ~2.3s at 60k). Resolving on the AST deletes that regex; react-markdown
+  // parses the run in near-linear time, so this mounts promptly, yields no
+  // image, and leaks no resolved URL.
+  const component = await mount(
+    <MockMarkdown text={"![".repeat(20_000)} baseUrl="https://example.com/" />,
+  );
+  await expect(component.locator("img")).toHaveCount(0);
+  await expect(component.locator("p")).not.toContainText("example.com");
 });
 
 test("img renders with inline max-width: 100% and height: auto so it can't overflow the prompt (issue #211)", async ({

--- a/packages/stagebook/src/components/form/Markdown.test.ts
+++ b/packages/stagebook/src/components/form/Markdown.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "vitest";
-import { computeSafeRel } from "./Markdown.js";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { computeSafeRel, resolveImageSrc, Markdown } from "./Markdown.js";
 
 // External-link `rel` contract: markdown links that open in a new
 // tab (target="_blank") must receive `rel="noopener noreferrer"`
@@ -38,5 +40,146 @@ describe("computeSafeRel", () => {
     const out = computeSafeRel("_blank", "noopener");
     expect(out).toContain("noopener");
     expect(out).toContain("noreferrer");
+  });
+});
+
+// Image src resolution (#576, #431). `resolveImageSrc` runs on the `src`
+// react-markdown hands the `img` component: titles / `<…>` / balanced parens
+// already handled by remark, dangerous protocols already sanitized to `""`, and
+// — crucial here — the destination already `encodeURI`-encoded (spaces and
+// non-ASCII → `%XX`). So these tests pass react-markdown-STYLE inputs (with the
+// space/non-ASCII already encoded); the function only finishes the URI-
+// structural chars and resolves. End-to-end DOM behavior lives in Markdown.ct.tsx.
+describe("resolveImageSrc", () => {
+  const base = (p: string) => `https://cdn.example.com/dir/${p}`;
+
+  test("no resolver → src passes through unchanged", () => {
+    expect(resolveImageSrc("images/x.png", undefined)).toBe("images/x.png");
+  });
+
+  test("empty or undefined src → returned as-is (no resolver call)", () => {
+    let called = false;
+    const spy = (p: string) => {
+      called = true;
+      return base(p);
+    };
+    expect(resolveImageSrc("", spy)).toBe("");
+    expect(resolveImageSrc(undefined, spy)).toBeUndefined();
+    expect(called).toBe(false);
+  });
+
+  test("finishes encoding the URI-structural chars remark leaves raw (#431)", () => {
+    // `#`, `?`, `+`, `&`, `=` … would corrupt the path as a URL.
+    expect(resolveImageSrc("a/b/round#3.png", base)).toBe(
+      "https://cdn.example.com/dir/a/b/round%233.png",
+    );
+    expect(resolveImageSrc("confused?.png", base)).toBe(
+      "https://cdn.example.com/dir/confused%3F.png",
+    );
+    expect(resolveImageSrc("version+1.png", base)).toBe(
+      "https://cdn.example.com/dir/version%2B1.png",
+    );
+    expect(resolveImageSrc("a&b=c.png", base)).toBe(
+      "https://cdn.example.com/dir/a%26b%3Dc.png",
+    );
+  });
+
+  test("encodes the full URL_TO_PATH_UNSAFE set: $ , ; @ : too", () => {
+    // Guards the whole character class against an accidental narrowing. `:`
+    // must not be in a leading scheme position (that would read as absolute),
+    // so it sits mid-path here.
+    expect(resolveImageSrc("dir/a$b,c;d@e:f.png", base)).toBe(
+      "https://cdn.example.com/dir/dir/a%24b%2Cc%3Bd%40e%3Af.png",
+    );
+  });
+
+  test("preserves `/` separators and does not touch balanced parens", () => {
+    expect(resolveImageSrc("a/b/c/image.png", base)).toBe(
+      "https://cdn.example.com/dir/a/b/c/image.png",
+    );
+    expect(resolveImageSrc("image(1).png", base)).toBe(
+      "https://cdn.example.com/dir/image(1).png",
+    );
+  });
+
+  test("does not re-encode remark's %XX (space / non-ASCII already encoded)", () => {
+    // react-markdown gives `my pic.png` as `my%20pic.png` and `café.png` as
+    // `caf%C3%A9.png`; re-encoding the `%` would 404 (the #431 double-encode).
+    expect(resolveImageSrc("my%20pic.png", base)).toBe(
+      "https://cdn.example.com/dir/my%20pic.png",
+    );
+    expect(resolveImageSrc("caf%C3%A9.png", base)).toBe(
+      "https://cdn.example.com/dir/caf%C3%A9.png",
+    );
+  });
+
+  test("does not double-encode a host's already-encoded base (#431)", () => {
+    const resolved = resolveImageSrc(
+      "images/test.png",
+      (p) => `https://file%2B.example.cdn.net/${p}`,
+    );
+    expect(resolved).toContain("%2B");
+    expect(resolved).not.toContain("%252B");
+  });
+
+  test("absolute http(s) src → passed through, not resolved against the base", () => {
+    const spy = (p: string) => `SHOULD_NOT_RESOLVE/${p}`;
+    expect(resolveImageSrc("http://other.example/a.png", spy)).toBe(
+      "http://other.example/a.png",
+    );
+    expect(resolveImageSrc("https://other.example/a.png", spy)).toBe(
+      "https://other.example/a.png",
+    );
+  });
+
+  test("other URI schemes (data:, asset:) → passed through unchanged", () => {
+    const spy = (p: string) => `SHOULD_NOT_RESOLVE/${p}`;
+    expect(resolveImageSrc("data:image/png;base64,AAAA", spy)).toBe(
+      "data:image/png;base64,AAAA",
+    );
+    expect(resolveImageSrc("asset://kit/logo.png", spy)).toBe(
+      "asset://kit/logo.png",
+    );
+  });
+
+  test("protocol-relative //host src → passed through unchanged", () => {
+    const spy = (p: string) => `SHOULD_NOT_RESOLVE/${p}`;
+    expect(resolveImageSrc("//cdn.example.com/a.png", spy)).toBe(
+      "//cdn.example.com/a.png",
+    );
+  });
+
+  test("resolver returning a non-http/data URL → falls back to the raw path", () => {
+    // Defense in depth: react-markdown already strips `javascript:` to "", but
+    // if a host resolver ever produced a non-fetchable URL we emit the raw path
+    // rather than a surprising src.
+    expect(resolveImageSrc("x.png", () => "javascript:alert(1)")).toBe("x.png");
+    expect(resolveImageSrc("x.png", () => "ftp://h/x.png")).toBe("x.png");
+  });
+
+  test("resolver returning a data: URL is accepted", () => {
+    expect(resolveImageSrc("x.png", () => "data:image/png;base64,AAAA")).toBe(
+      "data:image/png;base64,AAAA",
+    );
+  });
+});
+
+// Renderer ReDoS regression (#576). The deleted pre-render regex was O(n²) on a
+// `![![![…` run (the issue measured ~2.3s at 60k, in the participant's browser).
+// Resolving on the AST removes it; react-markdown parses the run in near-linear
+// time. A node-side SSR render gives a reliable clock (unlike a browser CT),
+// so we can assert a hard bound comfortably below the old cost. Keep the input
+// as `![`×N — the exact pattern the old regex choked on; do NOT switch it to
+// `![](x…`, which would instead exercise a pre-existing (out-of-scope) remark
+// super-linear case and could hang the test.
+describe("Markdown renderer perf", () => {
+  test("a `![`×60000 run renders as text without the old regex blowup", () => {
+    const start = performance.now();
+    const html = renderToStaticMarkup(
+      React.createElement(Markdown, { text: "![".repeat(60_000) }),
+    );
+    const elapsedMs = performance.now() - start;
+    expect(html).not.toContain("<img");
+    expect(elapsedMs).toBeLessThan(2000);
   });
 });

--- a/packages/stagebook/src/components/form/Markdown.test.ts
+++ b/packages/stagebook/src/components/form/Markdown.test.ts
@@ -113,6 +113,17 @@ describe("resolveImageSrc", () => {
     );
   });
 
+  test("encodes a literal `%` that isn't a valid %XX escape", () => {
+    // react-markdown leaves an invalid escape (`50%off.png`) raw; without this
+    // the server would choke on `%of`. A valid `%XX` is still preserved.
+    expect(resolveImageSrc("50%off.png", base)).toBe(
+      "https://cdn.example.com/dir/50%25off.png",
+    );
+    expect(resolveImageSrc("100%25done.png", base)).toBe(
+      "https://cdn.example.com/dir/100%25done.png",
+    );
+  });
+
   test("does not double-encode a host's already-encoded base (#431)", () => {
     const resolved = resolveImageSrc(
       "images/test.png",

--- a/packages/stagebook/src/components/form/Markdown.tsx
+++ b/packages/stagebook/src/components/form/Markdown.tsx
@@ -2,7 +2,6 @@ import React, { useId } from "react";
 import { useIsRTL } from "../StagebookProvider.js";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { encodeAssetPath } from "../../utils/encodeAssetPath.js";
 
 export interface MarkdownProps {
   text: string;
@@ -226,6 +225,67 @@ export function computeSafeRel(
   return rel ? `${rel} noopener noreferrer` : "noopener noreferrer";
 }
 
+// Characters that `encodeURIComponent` percent-encodes but CommonMark's URL
+// encoding (below) does NOT — i.e. `encodeURIComponent`'s set MINUS
+// `encodeURI`'s set, with `/` removed so path separators survive. A stagebook
+// image destination is a raw FILE PATH, so these URI-structural characters must
+// be encoded or they corrupt the path once joined to the host base: `#` starts
+// a fragment, `?` a query, `+` decodes to a space on many servers, etc.
+const URL_TO_PATH_UNSAFE = /[#$&+,:;=?@]/g;
+
+/**
+ * Resolve an inline markdown image's `src` against the host's asset base.
+ *
+ * We resolve on the CommonMark AST rather than by pre-rewriting the raw text
+ * with a regex (the old approach, see #576): `react-markdown` hands us the
+ * parsed destination — titles (`![a](x.png "t")`), `<…>` angle-bracket paths,
+ * balanced parens (`image(1).png`), and wrapped alt text are all handled by
+ * remark — so every valid image form resolves, fenced-code / escaped-`\!`
+ * examples never get rewritten, and there is no untrusted-text regex to ReDoS.
+ * react-markdown has also already applied its default URL sanitizer, so a
+ * `javascript:` destination arrives here as `""`.
+ *
+ * Only genuinely relative paths are resolved:
+ * - An absolute destination that survived react-markdown's URL sanitizer —
+ *   `http(s):` or a protocol-relative `//host` — already points somewhere, so
+ *   it passes through unchanged. (react-markdown strips schemes it deems unsafe,
+ *   including `javascript:`, `data:`, and `asset:`, to `""` BEFORE this runs, so
+ *   those arrive as `""` and render nothing — platform `asset://` references
+ *   belong in an element's `file:` field, not a markdown body.)
+ * - For a relative path, `src` is ALREADY `encodeURI`-encoded by react-markdown
+ *   (spaces and non-ASCII → `%XX`), which is exactly what we want for those —
+ *   re-encoding would double-encode the `%` (the #431 hazard). We only finish
+ *   the job by encoding the URI-structural characters react-markdown leaves
+ *   raw ({@link URL_TO_PATH_UNSAFE}) so the final result matches per-segment
+ *   `encodeURIComponent`, then hand that to the host's `resolveURL`. `/` and
+ *   the existing `%XX` are preserved, so the host's already-encoded base isn't
+ *   double-encoded either.
+ * - If the resolver returns something that isn't a fetchable `http(s):` /
+ *   `data:` URL, we fall back to the raw path rather than emit a surprising src.
+ *
+ * Exported for direct unit testing (same rationale as `computeSafeRel`). SECURITY
+ * PRECONDITION: the scheme-passthrough below is only safe because this always
+ * runs downstream of react-markdown's URL sanitizer (which has already zeroed
+ * dangerous schemes). Don't reuse it on unsanitized input.
+ */
+export function resolveImageSrc(
+  src: string | undefined,
+  resolveURL: ((path: string) => string) | undefined,
+): string | undefined {
+  if (!resolveURL || typeof src !== "string" || src === "") return src;
+  // Absolute / scheme-prefixed / protocol-relative destinations aren't resolved
+  // against the asset base — they already point somewhere. (Any unsafe scheme
+  // was already stripped to "" upstream — see the SECURITY PRECONDITION above.)
+  if (/^[a-z][a-z0-9+.-]*:/i.test(src) || src.startsWith("//")) return src;
+  const encodedPath = src.replace(
+    URL_TO_PATH_UNSAFE,
+    (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+  const resolved = resolveURL(encodedPath);
+  if (!/^(?:https?:|data:)/i.test(resolved)) return src;
+  return resolved;
+}
+
 // Only `text-decoration: underline` stays inline — the base color
 // AND the `:hover` / `:focus-visible` / `:visited` overrides all
 // live in the scoped <style> block. Putting the base color inline
@@ -331,36 +391,6 @@ const taskListCheckboxCheckedStyle: React.CSSProperties = {
 
 export function Markdown({ text, resolveURL }: MarkdownProps) {
   const isRTL = useIsRTL();
-  let displayText = text;
-
-  // Rewrite relative image paths if a resolver is provided
-  if (resolveURL) {
-    displayText = text?.replace(
-      /!\[(.*?)\]\((.*?)\)/g,
-      (_match, alt: string, path: string) => {
-        // Skip absolute URLs
-        if (path.startsWith("http://") || path.startsWith("https://")) {
-          return `![${alt}](${path})`;
-        }
-        // Encode the markdown source path before handing it to the
-        // host's resolver — researchers write raw filesystem paths
-        // (`images/my pic.jpg`), while the host's resolver returns an
-        // already-encoded base. Encoding the resolved URL would
-        // double-encode the host's intentional `%XX` sequences
-        // (e.g. VS Code's `asWebviewUri` `%2B` → `%252B`). See #431.
-        const resolved = resolveURL(encodeAssetPath(path));
-        // Reject non-http protocols (e.g., javascript:)
-        if (
-          !resolved.startsWith("http://") &&
-          !resolved.startsWith("https://") &&
-          !resolved.startsWith("data:")
-        ) {
-          return `![${alt}](${path})`; // fall back to original path
-        }
-        return `![${alt}](${resolved})`;
-      },
-    );
-  }
 
   // Per-instance class for pseudo-class rules. The previous
   // `id="markdown"` was a duplicate-id bug on any page rendering
@@ -542,12 +572,13 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
             // Inline max-width keeps markdown-embedded images inside
             // the prompt container on any host, regardless of what
             // reset the host chose. See issue #211.
-            img: ({ node: _node, ...props }) => (
+            img: ({ node: _node, src, ...props }) => (
               <img
                 style={imgStyle}
                 loading="lazy"
                 decoding="async"
                 {...props}
+                src={resolveImageSrc(src, resolveURL)}
                 alt={props.alt ?? ""}
               />
             ),
@@ -592,7 +623,7 @@ export function Markdown({ text, resolveURL }: MarkdownProps) {
             },
           }}
         >
-          {displayText}
+          {text}
         </ReactMarkdown>
       </div>
     </>

--- a/packages/stagebook/src/components/form/Markdown.tsx
+++ b/packages/stagebook/src/components/form/Markdown.tsx
@@ -231,7 +231,16 @@ export function computeSafeRel(
 // image destination is a raw FILE PATH, so these URI-structural characters must
 // be encoded or they corrupt the path once joined to the host base: `#` starts
 // a fragment, `?` a query, `+` decodes to a space on many servers, etc.
-const URL_TO_PATH_UNSAFE = /[#$&+,:;=?@]/g;
+//
+// Also matches a `%` that is NOT already part of a valid `%XX` escape, so a
+// literal percent in a filename (`50%off.png`) becomes `%25` instead of an
+// invalid escape. A `%` that DOES precede two hex digits is left alone — it's
+// react-markdown's own encoding of a space/non-ASCII char (`caf%C3%A9.png`) or
+// an author-written escape, so re-encoding it would double-encode (the #431
+// hazard). A filename whose literal name contains a `%XX`-shaped run is
+// therefore ambiguous and not distinguishable here — an accepted edge of
+// resolving on react-markdown's already-normalized `src` rather than raw text.
+const URL_TO_PATH_UNSAFE = /%(?![0-9A-Fa-f]{2})|[#$&+,:;=?@]/g;
 
 /**
  * Resolve an inline markdown image's `src` against the host's asset base.

--- a/packages/stagebook/src/utils/referencedAssets.test.ts
+++ b/packages/stagebook/src/utils/referencedAssets.test.ts
@@ -578,30 +578,42 @@ describe("getMarkdownImageReferences — basic collection", () => {
   });
 });
 
-describe("getMarkdownImageReferences — destination forms (renderer semantics)", () => {
-  test("keeps spaces within a bare path (renderer resolves them)", () => {
-    // Markdown.ct.tsx tests exactly this: `![](folder/my pic.jpg)` resolves to
-    // `.../folder/my%20pic.jpg`, so the space-bearing path is a real dependency.
-    const refs = getMarkdownImageReferences("![photo](folder/my pic.jpg)");
+describe("getMarkdownImageReferences — destination forms (CommonMark semantics)", () => {
+  // The enumerator parses the SAME CommonMark grammar the renderer uses (#576),
+  // so it reports the destination the renderer actually requests — titles
+  // stripped, `<…>` unwrapped, balanced parens kept, whitespace trimmed.
+
+  test("a bare (unescaped) space destination is NOT an image", () => {
+    // CommonMark stops a non-`<…>` destination at the first space, so
+    // `![photo](folder/my pic.jpg)` renders as literal text, not an image —
+    // the renderer requests nothing, so neither do we. Use `<…>` for spaces.
+    expect(getMarkdownImageReferences("![photo](folder/my pic.jpg)")).toEqual(
+      [],
+    );
+  });
+
+  test("an angle-bracket destination unwraps to the path (spaces allowed)", () => {
+    // Mirrors the renderer's space-in-path component test: `<folder/my pic.jpg>`
+    // resolves to `.../folder/my%20pic.jpg`, so the unwrapped path is the real
+    // dependency.
+    const refs = getMarkdownImageReferences("![a](<folder/my pic.jpg>)");
     expect(refs).toHaveLength(1);
     expect(refs[0].path).toBe("folder/my pic.jpg");
   });
 
-  test("matches bracketed alt text (allows `]` when not before `(`)", () => {
+  test("matches bracketed alt text (balanced `]` inside the label)", () => {
     const refs = getMarkdownImageReferences("![Figure [A]](images/a.png)");
     expect(refs).toHaveLength(1);
     expect(refs[0]).toMatchObject({ alt: "Figure [A]", path: "images/a.png" });
   });
 
-  test("reports a padded destination verbatim (renderer requests it padded)", () => {
-    // The renderer passes the raw capture to encodeAssetPath, so padded parens
-    // 404 at runtime — reporting the trimmed path would hide that break.
+  test("trims surrounding whitespace inside the parens", () => {
     const refs = getMarkdownImageReferences("![a](  images/x.png  )");
     expect(refs).toHaveLength(1);
-    expect(refs[0].path).toBe("  images/x.png  ");
+    expect(refs[0].path).toBe("images/x.png");
   });
 
-  test("a padded URL/scheme is still excluded (exclusion runs on a trimmed copy)", () => {
+  test("a padded URL/scheme is still excluded", () => {
     const md = [
       "![a](  https://cdn.example.com/x.png  )",
       "![b](  asset://kit/y.png  )",
@@ -610,19 +622,33 @@ describe("getMarkdownImageReferences — destination forms (renderer semantics)"
     expect(getMarkdownImageReferences(md)).toEqual([]);
   });
 
-  test("captures a title verbatim — titles are not a supported form", () => {
-    // The renderer's naive rewrite grabs everything up to the first `)` as the
-    // destination, so a titled image resolves to a missing file. Reporting the
-    // verbatim destination surfaces that (rather than hiding it by stripping).
+  test("strips a title — the destination is the path, not the whole capture", () => {
+    // A titled image now resolves against the asset base (the renderer parses
+    // the title out), so we report the clean path — not the old verbatim
+    // `images/x.png "My title"` that used to 404.
     const refs = getMarkdownImageReferences('![a](images/x.png "My title")');
-    expect(refs.map((r) => r.path)).toEqual(['images/x.png "My title"']);
+    expect(refs.map((r) => r.path)).toEqual(["images/x.png"]);
   });
 
-  test("captures an angle-bracket destination verbatim — also unsupported", () => {
-    // Stagebook's renderer resolves bare space paths (above), so `<…>` is
-    // unnecessary AND unsupported; the brackets land in the destination.
+  test("unwraps an angle-bracket destination", () => {
     const refs = getMarkdownImageReferences("![a](<my pic.png>)");
-    expect(refs.map((r) => r.path)).toEqual(["<my pic.png>"]);
+    expect(refs.map((r) => r.path)).toEqual(["my pic.png"]);
+  });
+
+  test("keeps balanced parens inside a bare destination", () => {
+    const refs = getMarkdownImageReferences("![a](image(1).png)");
+    expect(refs.map((r) => r.path)).toEqual(["image(1).png"]);
+  });
+
+  test("alt text may wrap across lines (still one image)", () => {
+    const refs = getMarkdownImageReferences(
+      "![alt spanning\ntwo lines](x.png)",
+    );
+    expect(refs).toHaveLength(1);
+    expect(refs[0]).toMatchObject({
+      alt: "alt spanning\ntwo lines",
+      path: "x.png",
+    });
   });
 });
 
@@ -741,10 +767,10 @@ describe("getMarkdownImageReferences — fenced code blocks", () => {
     ]);
   });
 
-  test("4+ spaces is an indented code block, not a fence (not tracked)", () => {
-    // A 4-space indent is a different construct; the `` ``` `` is literal code,
-    // so the fence never opens and the following image is still scanned. This
-    // pins the documented limitation.
+  test("4+ spaces is an indented code block, not a fence", () => {
+    // A 4-space indent is an indented code block, so the `` ``` `` lines are
+    // literal code and never open a fence; the unindented image line in between
+    // is an ordinary paragraph and is collected (correct CommonMark).
     const md = ["    ```", "![a](x.png)", "    ```"].join("\n");
     expect(getMarkdownImageReferences(md).map((r) => r.path)).toEqual([
       "x.png",
@@ -753,13 +779,15 @@ describe("getMarkdownImageReferences — fenced code blocks", () => {
 });
 
 describe("getMarkdownImageReferences — alt text and edge cases", () => {
-  test("captures alt text verbatim including punctuation and escaped brackets", () => {
+  test("captures alt text with punctuation; a `\\]` escape renders as `]`", () => {
+    // CommonMark resolves the escape, so the reported alt is the rendered text
+    // (`]`), matching what a screen reader would announce.
     const refs = getMarkdownImageReferences(
       '![Figure 1: "cats" \\] end](x.png)',
     );
     expect(refs).toHaveLength(1);
     expect(refs[0]).toMatchObject({
-      alt: 'Figure 1: "cats" \\] end',
+      alt: 'Figure 1: "cats" ] end',
       path: "x.png",
     });
   });
@@ -769,9 +797,9 @@ describe("getMarkdownImageReferences — alt text and edge cases", () => {
   });
 
   test("a very long alt (accessibility description) does not drop the image", () => {
-    // The linear scan imposes no length cap, so a paragraph-length alt still
-    // resolves its destination — the file is a real dependency regardless.
-    const longAlt = "A ".repeat(5000).trim();
+    // A paragraph-length alt (well under the body length cap) still resolves its
+    // destination — the file is a real dependency regardless of alt length.
+    const longAlt = "A ".repeat(2000).trim();
     const refs = getMarkdownImageReferences(`![${longAlt}](images/chart.png)`);
     expect(refs).toHaveLength(1);
     expect(refs[0]).toMatchObject({ alt: longAlt, path: "images/chart.png" });
@@ -790,23 +818,74 @@ describe("getMarkdownImageReferences — alt text and edge cases", () => {
   test("column of a second image accounts for a title on the first", () => {
     const md = '![a](x.png "t") ![b](y.png)';
     const refs = getMarkdownImageReferences(md);
-    // The first destination is captured verbatim up to the first `)`.
-    expect(refs.map((r) => r.path)).toEqual(['x.png "t"', "y.png"]);
+    // The first image's title is parsed out, so its path is the clean `x.png`.
+    expect(refs.map((r) => r.path)).toEqual(["x.png", "y.png"]);
     // `![a](x.png "t") ` is 16 chars, so the second image starts at column 16.
     expect(refs.map((r) => r.column)).toEqual([0, 16]);
   });
 });
 
-describe("getMarkdownImageReferences — documented non-goals", () => {
-  test("reference-style images are not matched", () => {
-    const md = ["![alt][ref]", "", "[ref]: real.png"].join("\n");
-    expect(getMarkdownImageReferences(md)).toEqual([]);
+describe("getMarkdownImageReferences — reference-style images", () => {
+  // The renderer (react-markdown) resolves reference-style images against their
+  // `[id]: url` definition, so the enumerator must too (#576 lockstep).
+
+  test("full reference `![alt][id]` resolves to its definition", () => {
+    const md = "![Figure 1][fig1]\n\n[fig1]: diagrams/figure1.png";
+    expect(getMarkdownImageReferences(md)).toEqual<MarkdownImageReference[]>([
+      { path: "diagrams/figure1.png", alt: "Figure 1", line: 0, column: 0 },
+    ]);
   });
 
+  test("collapsed `![id][]` and shortcut `![id]` resolve too", () => {
+    expect(
+      getMarkdownImageReferences("![fig][]\n\n[fig]: a.png").map((r) => r.path),
+    ).toEqual(["a.png"]);
+    expect(
+      getMarkdownImageReferences("![fig]\n\n[fig]: b.png").map((r) => r.path),
+    ).toEqual(["b.png"]);
+  });
+
+  test("reference matches its definition case-insensitively", () => {
+    // mdast normalizes identifiers, so `[Fig1]` resolves against `[fig1]:`.
+    const refs = getMarkdownImageReferences("![x][Fig1]\n\n[fig1]: c.png");
+    expect(refs.map((r) => r.path)).toEqual(["c.png"]);
+  });
+
+  test("first definition wins when an identifier is defined twice", () => {
+    const md = "![x][r]\n\n[r]: first.png\n\n[r]: second.png";
+    expect(getMarkdownImageReferences(md).map((r) => r.path)).toEqual([
+      "first.png",
+    ]);
+  });
+
+  test("an unresolved reference (no definition) is not matched", () => {
+    expect(getMarkdownImageReferences("![alt][missing]")).toEqual([]);
+  });
+
+  test("a reference whose definition is a URL/scheme is excluded", () => {
+    const md = "![a][r]\n\n[r]: https://cdn.example.com/x.png";
+    expect(getMarkdownImageReferences(md)).toEqual([]);
+  });
+});
+
+describe("getMarkdownImageReferences — documented non-goals", () => {
   test("raw <img> HTML is not matched (renderer loads no rehype-raw)", () => {
     expect(getMarkdownImageReferences('<img src="pic.png" alt="x">')).toEqual(
       [],
     );
+  });
+
+  test("an image inside an inline code span is not matched", () => {
+    // The image syntax is inside a `` `code span` ``, so it's literal text —
+    // the renderer shows it, doesn't request it. (A behavior the old scan
+    // couldn't see; the CommonMark parse excludes it for free.)
+    expect(getMarkdownImageReferences("Use `![a](x.png)` inline")).toEqual([]);
+  });
+
+  test("an image on a 4-space-indented (code block) line is not matched", () => {
+    // A 4-space indent is an indented code block, so `![a](x.png)` is literal
+    // code, not an image request.
+    expect(getMarkdownImageReferences("    ![a](x.png)")).toEqual([]);
   });
 
   test("excludes an uppercase ASSET:// scheme", () => {
@@ -820,6 +899,10 @@ describe("getMarkdownImageReferences — documented non-goals", () => {
     expect(getMarkdownImageReferences("![a](mailto:foo@example.com)")).toEqual(
       [],
     );
+  });
+
+  test("excludes a javascript: destination", () => {
+    expect(getMarkdownImageReferences("![a](javascript:alert(1))")).toEqual([]);
   });
 });
 
@@ -848,24 +931,59 @@ describe("getMarkdownImageReferences — line endings and positions", () => {
   });
 });
 
+describe("getMarkdownImageReferences — length guard", () => {
+  // remark/micromark has super-linear worst cases on adversarial input (most
+  // sharply its emphasis resolver on a `*_*_…` run). This runs server-side, so a
+  // length cap (well above any realistic prompt) bounds the parse. An over-cap
+  // body is not enumerated — an accepted false negative (enumeration is advisory;
+  // a missed image surfaces as a runtime 404, and the renderer would choke on the
+  // same oversized body regardless).
+
+  test("a body over the length cap yields [] even if it holds a valid image", () => {
+    const image = "\n![a](real.png)";
+    const md = "x".repeat(10_001 - image.length) + image;
+    expect(md.length).toBeGreaterThan(10_000);
+    expect(getMarkdownImageReferences(md)).toEqual([]);
+  });
+
+  test("a valid image in a body at the cap is still collected", () => {
+    const image = "\n\n![a](real.png)";
+    const md = "x".repeat(10_000 - image.length) + image;
+    expect(md.length).toBe(10_000);
+    expect(getMarkdownImageReferences(md).map((r) => r.path)).toEqual([
+      "real.png",
+    ]);
+  });
+});
+
 describe("getMarkdownImageReferences — resistance to adversarial input", () => {
-  // Each is a single untrusted line crafted to blow up a backtracking matcher:
-  // the `![…` repetitions give O(n) match-starts that each scan to end-of-line,
-  // so a regex is O(n²). The linear `indexOf` scan does one forward pass. All
-  // must finish near-instantly and find nothing.
+  // A real CommonMark parse handles the `![…`/`![](x…` multi-start patterns (that
+  // make a backtracking regex O(n²)) in near-linear time, and the length cap
+  // bounds remark's OWN super-linear cases — most sharply the emphasis resolver
+  // on a `*_*_…` run (unbounded, this hangs ~90s at 100 KB). Each oversized line
+  // below exceeds the cap, so the guard short-circuits before parsing.
   test.each([
     ["long whitespace run, no close", "![](x" + " ".repeat(100_000)],
     ["repeated `![` with no `]`", "![".repeat(80_000)],
-    ["repeated `![a` with no `]`", "![a".repeat(60_000)],
     ["repeated `![](x` with no `)`", "![](x".repeat(50_000)],
+    ["emphasis `*_` run (remark's worst case)", "*_".repeat(50_000)],
     ["`)` then many `![` starts", "](x)" + "![".repeat(80_000)],
-  ])("resolves quickly: %s", (_label, line) => {
+  ])("over-cap adversarial body resolves instantly: %s", (_label, line) => {
     const start = performance.now();
     const refs = getMarkdownImageReferences(line);
     const elapsedMs = performance.now() - start;
     expect(refs).toEqual([]);
-    // Linear matching finishes in well under a second; the uncapped quadratic
-    // took ~6-16s at these sizes.
     expect(elapsedMs).toBeLessThan(1000);
+  });
+
+  test("a large under-cap emphasis run stays bounded (the cap's whole point)", () => {
+    // `*_*_…` is remark's sharpest super-linear input. Sized well under the cap
+    // so the guard does NOT fire and the real parse runs; it must stay bounded.
+    const line = "*_".repeat(4_000); // 8_000 chars < the length cap
+    const start = performance.now();
+    const refs = getMarkdownImageReferences(line);
+    const elapsedMs = performance.now() - start;
+    expect(refs).toEqual([]);
+    expect(elapsedMs).toBeLessThan(3000);
   });
 });

--- a/packages/stagebook/src/utils/referencedAssets.ts
+++ b/packages/stagebook/src/utils/referencedAssets.ts
@@ -1,3 +1,7 @@
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import type { Nodes } from "mdast";
+
 // Which element types have file-like fields, and which fields they are.
 // This table is the single source of truth for "what counts as a local asset
 // reference" — callers (VS Code extension file-existence checks, annotator
@@ -126,9 +130,40 @@ export function collectAssetPrefixes(treatmentFile: unknown): string[] {
 // catches `data:` (common in markdown) and every other scheme.
 const URI_SCHEME_PATTERN = /^[a-z][a-z0-9+.-]*:/i;
 
+// Perf guard for the CommonMark parse below. remark/micromark is linear on
+// normal prose, but has super-linear (O(n²)) worst cases on adversarial input —
+// most sharply its emphasis (attention) resolver on a `*_*_*_…` run: ~0.6s to
+// parse a 10 KB run, ~1.5s at 16 KB, ~4s at 32 KB, ~90s at 100 KB. This runs
+// SERVER-SIDE (preflight / manager / annotator / the VS Code extension host),
+// so an unbounded parse of a hostile researcher-authored body would block the
+// event loop and starve co-tenants. Real prompt bodies are a few KB (the repo's
+// largest is ~2.4 KB), so this cap (~1600 words) sits well above any realistic
+// prompt while keeping even the worst observed parse under ~1s. A skipped
+// over-cap body simply isn't enumerated — the renderer parses the same body, so
+// an oversized adversarial body is a rendering-time problem regardless, and
+// preflight enumeration is advisory (a missed image surfaces as a runtime 404,
+// not silent corruption). The cap is deliberately coarse: it bounds the worst
+// case we can observe rather than proving no super-linear case exists past it.
+const MAX_MARKDOWN_LENGTH = 10_000;
+
+// A `unified` processor configured for CommonMark parsing only — NO remark-gfm.
+// The renderer (`Markdown.tsx`) parses with GFM, but GFM only ever *wraps*
+// inline images (in table cells, task-list items, strikethrough) — it never
+// changes the set of `image` nodes, their `url`/`alt`, or their positions
+// (verified against a GFM-heavy fixture). Omitting the extension keeps the
+// image set identical to the renderer's while sidestepping GFM's even worse
+// super-linear blow-up on adversarial input (~33× the core-CommonMark cost).
+// The one known exception is negligible: an image that is the ENTIRE body of a
+// GFM footnote definition (`[^f]: ![a](x.png)` with nothing else on the line)
+// — core CommonMark reads that as a link definition, so the renderer shows the
+// image but this doesn't report it. Any surrounding text makes it a paragraph
+// and the image is found; a real footnote is essentially never a bare image.
+const markdownParser = unified().use(remarkParse);
+
 /** One inline image reference found in a markdown body. */
 export interface MarkdownImageReference {
-  /** The image destination path exactly as authored in the markdown. */
+  /** The image destination path, CommonMark-parsed (titles, `<…>` angle
+   *  brackets, and surrounding whitespace already stripped). */
   path: string;
   /** The image's alt text (may be an empty string). */
   alt: string;
@@ -148,6 +183,62 @@ function isCollectableMarkdownImagePath(path: string): boolean {
   return true;
 }
 
+// One image found in the tree, normalized to a raw destination + alt + 0-based
+// position. Covers both inline (`![alt](url)`) and reference (`![alt][id]`)
+// images, so the two are collected uniformly.
+interface ParsedImage {
+  url: string;
+  alt: string;
+  line: number;
+  column: number;
+}
+
+// First pass: map every link/image reference definition (`[id]: url`) by its
+// (normalized, case-insensitive) identifier. Per CommonMark the FIRST
+// definition for an identifier wins, so we never overwrite.
+function collectDefinitions(node: Nodes, into: Map<string, string>): void {
+  if (node.type === "definition") {
+    if (!into.has(node.identifier)) into.set(node.identifier, node.url);
+  }
+  if ("children" in node) {
+    for (const child of node.children) collectDefinitions(child, into);
+  }
+}
+
+// Second pass: collect every inline and reference image in document (tree)
+// order. Images are phrasing leaves, but they appear inside paragraphs, table
+// cells, list items, blockquotes, links, etc., so we descend through any node
+// that has `children`. Reference images (`![alt][id]`) are resolved against
+// `definitions` — the renderer (react-markdown) resolves them too, so we must,
+// to stay in lockstep. (An UNDEFINED reference never parses to an
+// `imageReference` node in the first place, so it's excluded for free.)
+function collectImages(
+  node: Nodes,
+  definitions: Map<string, string>,
+  into: ParsedImage[],
+): void {
+  if (node.type === "image" || node.type === "imageReference") {
+    const url =
+      node.type === "image" ? node.url : definitions.get(node.identifier);
+    if (url !== undefined) {
+      const start = node.position?.start;
+      into.push({
+        url,
+        alt: node.alt ?? "",
+        // mdast positions are 1-based line/column; convert to the 0-based
+        // convention callers map into editor locations. Position is always
+        // present when parsing from a string, but default defensively.
+        line: start ? start.line - 1 : 0,
+        column: start ? start.column - 1 : 0,
+      });
+    }
+    return;
+  }
+  if ("children" in node) {
+    for (const child of node.children) collectImages(child, definitions, into);
+  }
+}
+
 /**
  * Enumerate the local-asset paths referenced by inline `![alt](path)` images
  * in a markdown body — the piece `getReferencedAssets` can't see, because
@@ -156,118 +247,60 @@ function isCollectableMarkdownImagePath(path: string): boolean {
  * Pure and I/O-free: callers that already hold a prompt body (the VS Code
  * extension, the runner's preflight, the manager) pass it in and merge the
  * result with `getReferencedAssets(treatment)` for the full dependency set.
- * The returned `path` is the raw authored string — resolution against a base
+ * The returned `path` is the parsed destination — resolution against a base
  * (treatment-relative, CDN-root, …) is a consumer concern and deliberately
  * left out here, exactly as `getReferencedAssets` returns raw paths.
  *
- * Mirrors what the RENDERER actually resolves rather than strict CommonMark:
- * `Markdown.tsx` rewrites images with the naive `/!\[(.*?)\]\((.*?)\)/` — alt
- * runs to the first `](`, the destination to the first `)` — then feeds that
- * destination to the host `resolveURL`. This scan reproduces that exactly, so
- * it catches every file the renderer will request (and thus every one that can
- * 404): a bare path may contain spaces (`![](my pic.jpg)`, a tested renderer
- * case) and a `]` may appear in the alt (`![Figure [A]](a.png)`). Titles and
- * `<…>` angle destinations are NOT special-cased — the renderer doesn't parse
- * them out, so they land in the destination verbatim (and, being unsupported,
- * resolve to a missing file, which is then correctly surfaced). Reference-style
- * images (`![a][ref]`) and raw `<img>` HTML stay out of scope: the renderer
- * resolves neither (the Markdown component loads no `rehype-raw`).
+ * Parses with the SAME CommonMark grammar the renderer (`Markdown.tsx` →
+ * `react-markdown`) uses, so it flags exactly what the renderer requests (#576).
+ * This means proper CommonMark semantics, not a regex/substring approximation:
+ * titles are stripped (`![a](x.png "t")` → `x.png`), `<…>` angle destinations
+ * are unwrapped (`![a](<my pic.png>)` → `my pic.png`), balanced parens survive
+ * (`image(1).png`), surrounding whitespace is trimmed, bracketed alt is handled
+ * (`![Figure [A]](a.png)`), and alt text may wrap across lines. A destination
+ * containing an unescaped space is NOT an image (`![a](my pic.jpg)` renders as
+ * literal text) and is therefore not reported — the angle-bracket form is the
+ * supported way to embed a space. Reference-style images (`![alt][id]`,
+ * collapsed `![id][]`, shortcut `![id]`) ARE reported — the renderer resolves
+ * them against their `[id]: url` definition, so we resolve them the same way.
  *
  * Excludes the same non-local forms as `getReferencedAssets` (`${…}`
  * placeholders, `http(s)://`, protocol-relative `//`, `asset:`) plus every
- * other URI scheme (`data:`, `blob:`, …), evaluated on a whitespace-trimmed
- * copy so a *padded* URL/scheme is still excluded. The reported `path` is the
- * destination VERBATIM (surrounding whitespace kept) — the renderer requests
- * exactly that, so padded parens resolve to a missing file that this then
- * flags. Non-string / empty input yields `[]`.
+ * other URI scheme (`data:`, `blob:`, …). Non-string / empty input yields `[]`.
  *
  * Not counted, because the renderer wouldn't render them as an image request:
- * - a `\![…](…)` with an escaped bang (CommonMark renders literal text);
- * - images inside fenced code blocks (```` ``` ```` or `~~~`, any info string,
- *   indented up to 3 spaces) — a fence closes only on a line of the same char
- *   at least as long as the opener, so a nested shorter fence doesn't end it.
- * Not tracked (rare, and each mirrors a renderer or block-parser edge we don't
- * reproduce): images whose alt text WRAPS across lines (the renderer's own
- * single-line rewrite regex also misses these, so they're already broken),
- * fences nested inside a blockquote/list, 4-space indented code blocks, and
- * `![](…)` inside a single-line `` `code span` ``.
+ * an escaped bang (`\![…](…)`, literal text), images inside fenced or indented
+ * code blocks and code spans, an unresolved reference (`![a][missing]` with no
+ * definition), and raw `<img>` HTML (the Markdown component loads no
+ * `rehype-raw`) — all handled for free by the CommonMark parse. Positions are
+ * the mdast node's 0-based line/column (UTF-16) of the leading `!`.
  *
- * The scan is a linear `indexOf` walk (no backtracking regex, no length caps):
- * a `![![![…` run — where a backtracking matcher retries from every `![` and
- * goes O(n²) — costs one forward pass here, so an untrusted prompt body can't
- * trigger a ReDoS, and a long accessibility alt never disqualifies its image.
+ * A real parse replaces the old substring scan: there is no regex over
+ * untrusted text, and a `![![…` run resolves in near-linear time. A length cap
+ * ({@link MAX_MARKDOWN_LENGTH}) bounds remark's super-linear worst cases on an
+ * adversarial body (see that constant); an over-cap body yields `[]`.
  */
 export function getMarkdownImageReferences(
   markdown: unknown,
 ): MarkdownImageReference[] {
   if (typeof markdown !== "string" || markdown.length === 0) return [];
+  if (markdown.length > MAX_MARKDOWN_LENGTH) return [];
+
+  const tree = markdownParser.parse(markdown);
+  const definitions = new Map<string, string>();
+  collectDefinitions(tree, definitions);
+  const images: ParsedImage[] = [];
+  collectImages(tree, definitions, images);
+
   const results: MarkdownImageReference[] = [];
-  // Split on `\r?\n` so a CRLF file doesn't leave a trailing `\r` on every
-  // line; line numbers stay aligned with what an editor shows.
-  const lines = markdown.split(/\r?\n/);
-  // When inside a fenced code block, the opener's fence char + length; else null.
-  let fence: { char: string; len: number } | null = null;
-  for (let lineNo = 0; lineNo < lines.length; lineNo++) {
-    const line = lines[lineNo];
-    // A fence may be indented up to 3 spaces (CommonMark); 4+ spaces is an
-    // indented code block, a different construct we don't track.
-    const fenceMatch = /^ {0,3}(`{3,}|~{3,})/.exec(line);
-    if (fence) {
-      // A closing fence is the same char, ≥ the opener's length, with nothing
-      // but trailing whitespace after it (an info string is opener-only).
-      if (
-        fenceMatch &&
-        fenceMatch[1][0] === fence.char &&
-        fenceMatch[1].length >= fence.len &&
-        line.slice(fenceMatch[0].length).trim() === ""
-      ) {
-        fence = null;
-      }
-      // Every line up to and including the close is code — never an image.
-      continue;
-    }
-    if (fenceMatch) {
-      fence = { char: fenceMatch[1][0], len: fenceMatch[1].length };
-      continue;
-    }
-    let i = 0;
-    while (i < line.length) {
-      const bang = line.indexOf("![", i);
-      if (bang < 0) break;
-      // Shortest alt: the first `](` after the bang opens the destination.
-      const destOpen = line.indexOf("](", bang + 2);
-      // No `](` anywhere later on this line means no image can complete — the
-      // early break is what keeps a `![![![…` run linear instead of O(n²).
-      if (destOpen < 0) break;
-      // Shortest destination: up to the first `)` (matching the renderer's
-      // naive `.*?`, which stops there too).
-      const destClose = line.indexOf(")", destOpen + 2);
-      if (destClose < 0) break;
-      // Skip an escaped bang (`\![…]`): an odd backslash run before the `!`
-      // makes CommonMark render literal text — no image request.
-      let backslashes = 0;
-      for (let k = bang - 1; k >= 0 && line[k] === "\\"; k--) backslashes++;
-      if (backslashes % 2 === 0) {
-        // Report the destination VERBATIM — the renderer passes this exact
-        // substring to `encodeAssetPath`/`resolveURL`, so padded parens
-        // (`![](  x.png  )`) request `%20%20x.png%20%20` and 404. Reporting the
-        // trimmed `x.png` would validate a file the broken image never loads.
-        // The exclusion test runs on a TRIMMED copy so the anchored `^http(s)`
-        // / `^asset:` / empty checks still reject a *padded* URL or blank ref.
-        const path = line.slice(destOpen + 2, destClose);
-        if (isCollectableMarkdownImagePath(path.trim())) {
-          results.push({
-            path,
-            alt: line.slice(bang + 2, destOpen),
-            line: lineNo,
-            column: bang,
-          });
-        }
-      }
-      // Continue after this image's `)` — mirrors the renderer consuming the
-      // whole `![…](…)` (including an escaped one) before matching again.
-      i = destClose + 1;
-    }
+  for (const image of images) {
+    if (!isCollectableMarkdownImagePath(image.url)) continue;
+    results.push({
+      path: image.url,
+      alt: image.alt,
+      line: image.line,
+      column: image.column,
+    });
   }
   return results;
 }

--- a/packages/stagebook/tsup.config.ts
+++ b/packages/stagebook/tsup.config.ts
@@ -15,4 +15,11 @@ export default defineConfig({
   splitting: true,
   clean: true,
   sourcemap: true,
+  // `unified` / `remark-parse` (used by `getMarkdownImageReferences` in the
+  // root entry) are ESM-only. Externalized, the generated `dist/index.cjs`
+  // `require()`s them and throws for CJS consumers (no `require` export /
+  // broken named-export interop). Bundling them — and their transitive
+  // micromark/mdast tree, which isn't a direct dependency so is inlined
+  // anyway — keeps the CJS build self-contained. See #576.
+  noExternal: ["unified", "remark-parse"],
 });


### PR DESCRIPTION
## What & why

`Markdown.tsx` resolved inline image paths with a **pre-render regex rewrite** (`/!\[(.*?)\]\((.*?)\)/g`) run over the raw markdown *before* react-markdown. That regex isn't CommonMark-correct, so several valid image forms resolved to broken URLs, it rewrote inside fenced code blocks / after `\!` (leaking the resolved CDN URL into displayed code), and it carried a **client-side O(n²) ReDoS** on a `![![![…` run — in the *participant's* browser.

This resolves image `src` on react-markdown's real **CommonMark AST** via an `img` component override, and retargets the `getMarkdownImageReferences` enumerator (#575) to parse the **same grammar** so it flags exactly what the renderer requests. The regex — and its ReDoS — is deleted.

Fixes #576.

> Stacked on #575 (`feat/markdown-image-assets`). The enumerator and renderer move to correct CommonMark together, per the issue.

## Renderer (`Markdown.tsx`)

- Delete the regex rewrite; pass the raw body to `<ReactMarkdown>` and resolve `src` in the `img` component via new exported `resolveImageSrc`.
- remark now parses titles, `<…>` angle destinations, balanced parens, bracketed/wrapped alt, fenced code, and escapes — so every previously-broken form resolves:

  | Input | Old regex | Now |
  |-------|-----------|-----|
  | `![a](cat.jpg "My cat")` | requests `cat.jpg%20%22My%20cat%22` | `cat.jpg` + `title` |
  | `![a](<my pic.png>)` | requests `%3Cmy%20pic.png%3E` | `my pic.png` |
  | `![a](image(1).png)` | truncated to `image(1` | `image(1).png` |
  | alt wrapping two lines | not matched | resolves |
  | `![](x)` in a ``` fence / after `\!` | CDN URL leaks into code | literal text, no rewrite |

- **Encoding (#431 preserved):** react-markdown already `encodeURI`-encodes the src (spaces / non-ASCII → `%XX`). Re-running `encodeAssetPath` (encodeURIComponent) would double-encode the `%`. So `resolveImageSrc` only finishes the URI-structural chars react-markdown leaves raw — the `encodeURIComponent`∖`encodeURI` set-difference `[#$&+,:;=?@]`, minus `/` — reaching per-segment `encodeURIComponent`-equivalence without touching existing `%XX` or the host's already-encoded base. Verified identical to the old resolver across 20+ filenames (the only divergence is a pathological `colon:x.png`, now treated as a scheme URL — which makes the renderer *consistent* with the enumerator, both excluding it).
- Protocol safety unchanged: react-markdown's default urlTransform still strips `javascript:`/`data:` to `""` before the component; `resolveImageSrc` additionally falls back to the raw path if a resolver ever returns a non-`http(s)`/`data` URL.

## Enumerator (`getMarkdownImageReferences`)

- Parse with `unified().use(remarkParse)` and walk `image` + `imageReference` nodes instead of a hand-rolled substring scan — so it matches the renderer by construction (titles stripped, `<…>` unwrapped, balanced parens kept, whitespace trimmed, wrapped alt handled, fenced/escaped/code-span/`<img>` excluded for free).
- **Reference-style images** (`![a][ref]`, collapsed `![id][]`, shortcut `![id]`) are now resolved against their `[id]: url` definition — the AST renderer resolves them, so the enumerator must too (found in review; the old regex renderer didn't, so #575 had listed them out of scope).
- **No GFM:** GFM only ever *wraps* images (table cells, task-list items, strikethrough) — it never changes the `image` set, url/alt, or positions (verified against a GFM-heavy fixture) — but has a far worse superlinear worst case. Core CommonMark keeps the image set identical while staying bounded. (One negligible exception, documented: an image that is the *entire* body of a GFM footnote definition.)
- **Perf guard (`MAX_MARKDOWN_LENGTH = 10_000`):** remark/micromark has O(n²) worst cases — sharpest is its **emphasis resolver on a `*_*_…` run (~90 s at 100 KB)**, a different class than the `![](x…` runs I first benchmarked (thanks to the security review). Since this runs server-side/preflight, the cap (~1600 words, far above any real prompt — the repo's largest is 2.4 KB) bounds the worst observed parse to under ~1 s. Over-cap bodies aren't enumerated (advisory; a missed image surfaces as a runtime 404). The cap is deliberately coarse — it bounds the worst case we can observe, not a proof no super-linear case exists past it.
- Bug-for-bug tests (verbatim titles/angle destinations, first-`)` truncation, bare-space paths) replaced with CommonMark-correct expectations.

## Behavior changes / scope notes (transparency)

- **`asset://` in markdown *bodies*** now renders empty: react-markdown strips the scheme before the img component, so it isn't resolved against the base (the old regex renderer resolved it via `resolveURL`). It was untested and unused in examples; platform assets belong in an element's `file:` field. Pinned by a test and documented.
- The **renderer** still uses remark-gfm (it renders tables/task-lists), so it retains a *pre-existing* superlinear parse on adversarial bodies — unchanged by this PR and out of scope (fixing it means bounding/replacing the whole markdown parse; flagged by the security review as pre-existing). This PR removes the **regex** ReDoS the issue measured (`![`×60000: ~2.3 s → ~150 ms).

## Tests

- `Markdown.ct.tsx`: titled / angle-bracket / balanced-paren / wrapped-alt images resolve; fenced-code and `\!` render as literal text with no CDN leak; `javascript:` and `asset://` neutralized; `![`×N renders without hanging; the space test moved to the `<…>` form.
- `Markdown.test.ts`: `resolveImageSrc` unit tests (full `URL_TO_PATH_UNSAFE` set, no `%XX` / base double-encode, scheme/`//`/data passthrough, non-http/data fallback) + a node-timed renderer perf guard (`![`×60000 < 2 s).
- `referencedAssets.test.ts`: CommonMark-correct destination forms, reference-style resolution (full/collapsed/shortcut/undefined/case-insensitive/first-def-wins), code-span & indented-code exclusion, length-guard boundary, and adversarial inputs incl. the emphasis `*_` run.
- Full vitest (2126) + Playwright CT green (only pre-existing webkit shuffle/focus-ring flakes, pass on retry); lint + build clean.

## New deps

`remark-parse` + `unified` promoted to `dependencies` (already transitive via `react-markdown`); `@types/mdast` to `devDependencies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
