### PR TITLE
Bump stagebook to 0.25.0

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "stagebook-vscode",
   "displayName": "Stagebook",
   "description": "Validation, syntax highlighting, and preview for Stagebook treatment and prompt files",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "publisher": "talkbench",
   "private": true,
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -297,7 +297,7 @@
     },
     "apps/vscode": {
       "name": "stagebook-vscode",
-      "version": "0.24.1",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "react": "^19.2.4",
@@ -13381,7 +13381,7 @@
       }
     },
     "packages/stagebook": {
-      "version": "0.24.1",
+      "version": "0.25.0",
       "license": "MIT",
       "dependencies": {
         "@hello-pangea/dnd": "^18.0.1",

--- a/packages/stagebook/package.json
+++ b/packages/stagebook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagebook",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "Schemas, validators, utilities, and components for interactive social science experiments",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Minor release: inline-markdown image dependency enumeration, and markdown image rendering moved onto the CommonMark AST.

## What's in

- **#575** — new `getMarkdownImageReferences` export enumerates inline `![](…)` image dependencies inside prompt bodies (the gap `getReferencedAssets` didn't cover), so preflight / manager / runner and the VS Code extension can verify them before a session. The renderer now resolves image `src` on react-markdown's real CommonMark AST instead of a regex rewrite — fixing titled / `<…>` angle / balanced-paren / wrapped-alt image paths and deleting a client-side ReDoS.
- **#572** — the viewer keeps the current stage and participant when switching treatments instead of resetting.
- **#570** — the resolved/runtime discussion type is split from the widened authoring type.
- **#569** — resolved string slots are swept for surviving `${field}` placeholders (a misconfigured placeholder now surfaces as a clear error).
- **#566** — `${field}` placeholders are accepted for discussion `showTitle` / `showNickname`.

## Compatibility

- **Additive:** new `getMarkdownImageReferences` export; `${field}` now accepted for discussion `showTitle`/`showNickname`.
- **Behavior changes (CommonMark correctness):** a bare-space markdown image path (`![](my pic.jpg)`) now renders as literal text, not an image — use the angle-bracket form (`![](<my pic.jpg>)`) or `%20`. Titled / angle / balanced-paren / wrapped-alt image paths that previously broke now resolve, and `asset://` images inside a prompt body resolve against mounted prefixes again.
- **Stricter validation:** a treatment with a surviving `${field}` placeholder in a resolved string slot now errors instead of silently passing (#569).