### PR TITLE
docs: shared-notepad defaultText is placeholder-only

### DIFF
--- a/docs/engineer/api-reference.md
+++ b/docs/engineer/api-reference.md
@@ -292,11 +292,11 @@ Requires StagebookProvider. Dispatches to the appropriate element component base
 
 ### Render Slots (platform-provided)
 
-| Slot                  | Config                       | When Used                                                                                 |
-| --------------------- | ---------------------------- | ----------------------------------------------------------------------------------------- |
-| `renderSurvey`        | `{ surveyName, onComplete }` | `type: "survey"` element (deprecated — pending removal once a module-reuse pattern lands) |
-| `renderDiscussion`    | Full `DiscussionType` config | Stage with `discussion` block                                                             |
-| `renderSharedNotepad` | `{ padName }`                | `shared: true` open-response prompt                                                       |
+| Slot                  | Config                             | When Used                                                                                                                               |
+| --------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `renderSurvey`        | `{ surveyName, onComplete }`       | `type: "survey"` element (deprecated — pending removal once a module-reuse pattern lands)                                               |
+| `renderDiscussion`    | Full `DiscussionType` config       | Stage with `discussion` block                                                                                                           |
+| `renderSharedNotepad` | `{ padName, defaultText?, rows? }` | `shared: true` open-response prompt. `defaultText` is placeholder-only: hint text, never seeded into the shared document or saved value |
 
 ### Conditional Components
 

--- a/docs/engineer/architecture.md
+++ b/docs/engineer/architecture.md
@@ -40,7 +40,12 @@ interface StagebookContext {
 
   // Platform-provided renderers for service-coupled elements
   renderDiscussion?: (config: DiscussionType) => React.ReactNode;
-  renderSharedNotepad?: (config: { padName: string }) => React.ReactNode;
+  // defaultText is placeholder-only: hint text, never seeded content
+  renderSharedNotepad?: (config: {
+    padName: string;
+    defaultText?: string;
+    rows?: number;
+  }) => React.ReactNode;
   /** @deprecated pending removal once a module-reuse pattern lands */
   renderSurvey?: (config: {
     surveyName: string;
@@ -106,11 +111,11 @@ Stagebook provides `useTextContent(path)` — a hook that wraps `getTextContent`
 
 Some elements depend on external services. Stagebook validates config, manages layout, and handles conditional rendering — but the platform supplies the actual component:
 
-| Slot                  | When used                          | What the platform provides                           |
-| --------------------- | ---------------------------------- | ---------------------------------------------------- |
-| `renderDiscussion`    | Stage has `discussion` block       | Video call or text chat component                    |
+| Slot                  | When used                                                                                 | What the platform provides                           |
+| --------------------- | ----------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `renderDiscussion`    | Stage has `discussion` block                                                              | Video call or text chat component                    |
 | `renderSurvey`        | `type: "survey"` element (deprecated — pending removal once a module-reuse pattern lands) | Survey UI component that calls `onComplete(results)` |
-| `renderSharedNotepad` | `shared: true` open-response prompt | Collaborative text editor                            |
+| `renderSharedNotepad` | `shared: true` open-response prompt                                                       | Collaborative text editor                            |
 
 All slots are optional. If not provided, the element renders nothing.
 

--- a/docs/engineer/integration-guide.md
+++ b/docs/engineer/integration-guide.md
@@ -653,15 +653,21 @@ The `config` parameter is the full `discussion` object from the treatment YAML, 
 
 ### Shared Notepad
 
-Collaborative text editors (e.g., Etherpad) are used by `shared: true` open-response prompts. (The standalone `sharedNotepad` element type was removed in #250.)
+Collaborative text editors (e.g., a Yjs-backed CodeMirror, or Etherpad) are used by `shared: true` open-response prompts. (The standalone `sharedNotepad` element type was removed in #250.)
 
 ```typescript
 const context: StagebookContext = {
-  renderSharedNotepad: ({ padName }) => (
-    <EtherpadEmbed padName={padName} />
+  renderSharedNotepad: ({ padName, defaultText, rows }) => (
+    <YourCollaborativeEditor
+      padName={padName}
+      placeholder={defaultText}
+      rows={rows}
+    />
   ),
 };
 ```
+
+`defaultText` carries the prompt file's `> ` placeholder lines and is **placeholder-only**: render it as ephemeral hint text (e.g. a CodeMirror `placeholder()` extension) that disappears once anyone types. Do not seed it into the shared document — it is never part of the saved/exported value, matching how non-shared open-response prompts treat placeholder text.
 
 ### Progressive adoption
 

--- a/docs/engineer/platform-requirements.md
+++ b/docs/engineer/platform-requirements.md
@@ -485,10 +485,10 @@ The platform must:
 
 - Provide a collaborative text editor
 - Sync edits in real-time across all participants
-- Support default text initialization
+- Render `defaultText` as **placeholder text only** — grey hint text that disappears once anyone types, matching non-shared open-response prompts. Do not seed it into the shared document; it must never appear in the saved/exported value.
 - Persist content for the stage duration
 
-**Services used in deliberation-empirica**: Etherpad
+**Services used**: Etherpad (deliberation-empirica); Yjs/CodeMirror coedit service (TalkBench runner)
 
 Provide via: `renderSharedNotepad(config)` on StagebookProvider.
 

--- a/docs/researcher/elements.md
+++ b/docs/researcher/elements.md
@@ -548,14 +548,21 @@ A collaborative text editor where multiple participants edit a single saved valu
 
 Where `prompts/group_notes.prompt.md` is a minimal openResponse file:
 
-```yaml
+```markdown
 ---
 type: openResponse
 ---
+
 # Group notes
 
 (Optional framing for the notepad goes in the body.)
+
+---
+
+> Start typing your group's notes here
 ```
+
+Placeholder text (the `> ` line) works exactly as in a non-shared open response: it appears as grey hint text inside the editor and disappears once anyone types. It is a hint only — it is never seeded into the shared document as starting text and is never part of the saved value.
 
 The host platform implements the collaborative semantics via the `renderSharedNotepad` context slot. The standalone `sharedNotepad` element type was removed in #250; shared prompts are the single path now.
 

--- a/packages/stagebook/src/components/StagebookProvider.tsx
+++ b/packages/stagebook/src/components/StagebookProvider.tsx
@@ -158,6 +158,11 @@ export interface StagebookContext {
    * Called by `prompt` elements with `shared: true` and an openResponse
    * prompt file. (The standalone `sharedNotepad` element type was removed
    * in #250 — shared prompts are now the single path.)
+   *
+   * `defaultText` is placeholder-ONLY: render it as ephemeral hint text
+   * that disappears once anyone types, matching non-shared open response.
+   * Never seed it into the shared document — it must not appear in the
+   * saved/exported value.
    */
   renderSharedNotepad?: (config: {
     padName: string;


### PR DESCRIPTION
Fixes #579

## What

Records the semantics decision from talkbench/runner#311: for `shared: true` open-response prompts, the `defaultText` passed to the `renderSharedNotepad` slot is **placeholder-only** — ephemeral hint text that disappears once anyone types, never seeded into the shared document, never part of the saved/exported value. This matches non-shared open response, where the prompt file's `> ` lines render as the textarea's HTML `placeholder`.

- **docs/researcher/elements.md** — shared-notepad example now shows a `> ` placeholder line (in a proper third `---` section — the previous example was a two-section file the parser rejects) and states the semantics. The corrected example validates clean via `stagebook validate - --type=prompt`.
- **docs/engineer/platform-requirements.md** — replaces the "Support default text initialization" requirement (which implied seeding) with the placeholder-only contract; services line now mentions the TalkBench runner's Yjs/CodeMirror coedit alongside Etherpad.
- **docs/engineer/architecture.md**, **docs/engineer/api-reference.md** — correct the stale `{ padName }`-only slot signature to the real `{ padName, defaultText?, rows? }` (already shipped on main; docs catching up).
- **docs/engineer/integration-guide.md** — updated example destructuring all three config fields + host contract paragraph.
- **StagebookProvider.tsx** — JSDoc-only: states the contract on the slot for IntelliSense. No behavioral change.

## Review

Three pre-PR subagent reviews (correctness / test coverage / security) ran against this diff:

- Correctness caught the invalid researcher example (missing `---` response-section delimiter) — fixed and validated before opening.
- Test coverage: no tests needed for a docs/JSDoc diff; the researcher example's shape is already covered by `promptFile.test.ts` fixtures. One gap filed as follow-up: #580 (nothing pins the Prompt → `renderSharedNotepad` config pass-through the docs now promise).
- Security: no findings.

Local: lint + all vitest workspaces green. Playwright CT not run — markdown + comment-only diff, no runtime surface.

Related: talkbench/runner#311 (placeholder implementation), talkbench/runner#421 (caption → "Shared" chip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)