### PR TITLE
test: pin the Prompt → renderSharedNotepad config pass-through

### DIFF
--- a/packages/stagebook/src/components/elements/Prompt.test.tsx
+++ b/packages/stagebook/src/components/elements/Prompt.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { describe, test, expect, vi, afterEach, beforeAll } from "vitest";
+import React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { Prompt } from "./Prompt.js";
+import { openResponse } from "./fixtures/prompts.js";
+
+beforeAll(() => {
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+});
+
+let root: Root | undefined;
+let container: HTMLDivElement | undefined;
+
+afterEach(() => {
+  if (root) act(() => root!.unmount());
+  root = undefined;
+  container = undefined;
+});
+
+function render(node: React.ReactElement): HTMLDivElement {
+  container = document.createElement("div");
+  root = createRoot(container);
+  act(() => root!.render(node));
+  return container;
+}
+
+// The renderSharedNotepad pass-through is pinned here in jsdom rather than
+// in Prompt.ct.tsx: Playwright CT proxies function props across the mount
+// boundary as async message channels, so a render prop can't hand JSX back
+// to the browser-side component and the slot would never render.
+describe("Prompt shared mode (renderSharedNotepad slot)", () => {
+  test("passes { padName, defaultText, rows } to the slot (#580)", () => {
+    const renderSharedNotepad = vi.fn(() => <div data-testid="notepad-slot" />);
+    const dom = render(
+      <Prompt
+        {...openResponse}
+        name="testShared"
+        shared={true}
+        value=""
+        save={() => {}}
+        renderSharedNotepad={renderSharedNotepad}
+      />,
+    );
+
+    // Last call, not first: Prompt initializes its display order via a
+    // set-state-during-render pass, so an early call may precede the
+    // response items being threaded through.
+    expect(renderSharedNotepad).toHaveBeenLastCalledWith({
+      padName: "testShared",
+      defaultText: "Please enter your response here.",
+      rows: 3,
+    });
+    expect(dom.querySelector('[data-testid="notepad-slot"]')).not.toBeNull();
+    // Shared mode renders the slot INSTEAD of stagebook's own textarea.
+    expect(dom.querySelector("textarea")).toBeNull();
+  });
+
+  // The docs promise defaultText is the prompt file's `> ` lines
+  // newline-joined; the single-item fixture can't distinguish join("\n")
+  // from responses[0], so pin the join explicitly.
+  test("newline-joins multiple placeholder lines into defaultText", () => {
+    const renderSharedNotepad = vi.fn(() => <div data-testid="notepad-slot" />);
+    render(
+      <Prompt
+        {...openResponse}
+        responseItems={["First line.", "Second line."]}
+        name="testShared"
+        shared={true}
+        value=""
+        save={() => {}}
+        renderSharedNotepad={renderSharedNotepad}
+      />,
+    );
+
+    expect(renderSharedNotepad).toHaveBeenLastCalledWith({
+      padName: "testShared",
+      defaultText: "First line.\nSecond line.",
+      rows: 3,
+    });
+  });
+
+  test("does not call the slot when shared is false", () => {
+    const renderSharedNotepad = vi.fn(() => <div data-testid="notepad-slot" />);
+    const dom = render(
+      <Prompt
+        {...openResponse}
+        name="testSolo"
+        value=""
+        save={() => {}}
+        renderSharedNotepad={renderSharedNotepad}
+      />,
+    );
+
+    expect(renderSharedNotepad).not.toHaveBeenCalled();
+    expect(dom.querySelector("textarea")).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes #580

## What

Adds `Prompt.test.tsx` (jsdom) pinning the host contract documented in #581's docs: a `shared: true` openResponse prompt calls the `renderSharedNotepad` slot with exactly `{ padName, defaultText, rows }`, where `defaultText` is the prompt file's `> ` lines newline-joined. Three cases:

- shared → slot called with the exact config, slot content renders, no textarea
- multi-line placeholder → `defaultText` is `"\n"`-joined (a single-item fixture can't distinguish `join("\n")` from `responses[0]`)
- non-shared → slot never called, textarea renders

Exact-object matching is intentional contract-pinning: adding or renaming a key in the slot config should fail this test.

## Why jsdom, not Prompt.ct.tsx

Playwright CT proxies function props across the mount boundary as async message channels — a render prop can't hand JSX back to the browser-side component, so the slot never renders under CT (verified empirically; it's also why the existing CT shared-mode test can only assert the textarea is absent). The jsdom form follows the `ImageElement.test.tsx` harness conventions and gives a real `vi.fn()` spy.

## Verification

- Guard verified by mutation: temporarily dropping `defaultText` from the call site makes the test fail; restoring goes green.
- Pre-PR subagent reviews (correctness / coverage+security): correctness confirmed the assertion is deterministic (the settled last call always carries the threaded response items; openResponse never shuffles) and flagged two inert excess props, dropped; coverage suggested the newline-join case, added; security clean.
- Local: lint + all vitest workspaces green (2,382 tests); full `test:ct:all` run had 2 chromium Timeline failures that pass in isolation (unrelated interaction-test flakes; this diff is a jsdom test only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)